### PR TITLE
Add Natvis support for interop data.

### DIFF
--- a/src/openloco/NatvisFile.natvis
+++ b/src/openloco/NatvisFile.natvis
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?> 
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="openloco::interop::loco_global&lt;*&gt;">
+    <DisplayString>{{size = {_Mylast - _Myfirst}}}</DisplayString>
+    <Expand>
+      <Item Name="[size]">_Mylast - _Myfirst</Item>
+      <ArrayItems>
+        <Size>_Mylast - _Myfirst</Size>
+        <ValuePointer>_Myfirst</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+  <Type Name="openloco::interop::loco_global&lt;*&gt;">
+    <DisplayString>{*_Myptr}</DisplayString>
+    <Expand>
+      <Item Name="[ptr]">_Myptr</Item>
+    </Expand>
+  </Type>
+</AutoVisualizer>

--- a/src/openloco/interop/interop.hpp
+++ b/src/openloco/interop/interop.hpp
@@ -134,10 +134,20 @@ namespace openloco::interop
     template<typename T, uintptr_t TAddress>
     struct loco_global
     {
+    public:
         typedef T type;
         typedef type* pointer;
         typedef type& reference;
         typedef const type& const_reference;
+
+    private:
+        pointer _Myptr;
+
+    public:
+        loco_global()
+        {
+            _Myptr = &(addr<TAddress, T>());
+        }
 
         operator reference()
         {
@@ -268,11 +278,23 @@ namespace openloco::interop
     template<typename T, size_t TCount, uintptr_t TAddress>
     struct loco_global<T[TCount], TAddress>
     {
+    public:
         typedef T type;
         typedef type* pointer;
         typedef type& reference;
         typedef const type& const_reference;
         typedef loco_global_iterator<T> iterator;
+
+    private:
+        pointer _Myfirst;
+        pointer _Mylast;
+
+    public:
+        loco_global()
+        {
+            _Myfirst = get();
+            _Mylast = _Myfirst + TCount;
+        }
 
         operator pointer()
         {

--- a/src/openloco/openloco.vcxproj
+++ b/src/openloco/openloco.vcxproj
@@ -126,6 +126,9 @@
     <ClInclude Include="interop\interop.hpp" />
     <ClInclude Include="station.h" />
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="NatvisFile.natvis" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{42A6B551-4EC5-4B66-A130-628622CD98C4}</ProjectGuid>
     <RootNamespace>openloco</RootNamespace>


### PR DESCRIPTION
This will allow the debugger to show all data of our loco_global interop class. The only downside is I had to add pointers in order to get it to show anything.

Example:
The debugger can show us the contents of
```
static loco_global<company[max_companies], 0x00531784> _companies;
```
as seen in the screenshot:
![devenv_2018-05-23_18-30-58](https://user-images.githubusercontent.com/5415177/40438408-4c998110-5eb8-11e8-8b84-83e4b4313b69.jpg)
