### PR TITLE
Make zooming to cursor more reliable

### DIFF
--- a/src/openloco/window.cpp
+++ b/src/openloco/window.cpp
@@ -389,7 +389,7 @@ namespace openloco::ui
         get_map_coordinates_from_pos(mouse_x, mouse_y, 0, map_x, map_y);
 
         // Get viewport coordinates centring around the tile.
-        int32_t base_height = map::tile_element_height(*map_x, *map_y);
+        int32_t base_height = map::tile_element_height(*map_x, *map_y) & 0xFFFF;
         int16_t dest_x, dest_y;
         viewport* v = this->viewports[0];
         centre_2d_coordinates(*map_x, *map_y, base_height, &dest_x, &dest_y, v);
@@ -408,7 +408,7 @@ namespace openloco::ui
     {
         // Get viewport coordinates centring around the tile.
         int16_t dest_x, dest_y;
-        int32_t base_height = map::tile_element_height(map_x, map_y);
+        int32_t base_height = map::tile_element_height(map_x, map_y) & 0xFFFF;
         viewport* v = this->viewports[0];
         centre_2d_coordinates(map_x, map_y, base_height, &dest_x, &dest_y, v);
 

--- a/src/openloco/window.h
+++ b/src/openloco/window.h
@@ -255,8 +255,8 @@ namespace openloco::ui
     struct viewport_config
     {
         uint16_t viewport_target_sprite; // 0x0
-        uint16_t saved_view_x;           // 0x2
-        uint16_t saved_view_y;           // 0x4
+        int16_t saved_view_x;            // 0x2
+        int16_t saved_view_y;            // 0x4
     };
 
     struct window


### PR DESCRIPTION
The saved_view members of the `viewport_config` struct were typed unsigned, while it appears they should be signed.

This fixes part of #226, but it's still more jittery than I would like. I'll do some more debugging eventually, but help is also welcome.