### PR TITLE
[RFC] Refactor and remove global variables

### DIFF
--- a/src/openloco/audio/audio.cpp
+++ b/src/openloco/audio/audio.cpp
@@ -485,7 +485,7 @@ namespace openloco::audio
     static sound_object* get_sound_object(sound_id id)
     {
         auto idx = (int32_t)id & ~0x8000;
-        return g_objectmgr.get<sound_object>(idx);
+        return g_ctx.get<objectmanager>().get<sound_object>(idx);
     }
 
     static viewport* find_best_viewport_for_sound(viewport_pos vpos)

--- a/src/openloco/audio/audio.cpp
+++ b/src/openloco/audio/audio.cpp
@@ -485,7 +485,7 @@ namespace openloco::audio
     static sound_object* get_sound_object(sound_id id)
     {
         auto idx = (int32_t)id & ~0x8000;
-        return objectmgr::get<sound_object>(idx);
+        return g_objectmgr.get<sound_object>(idx);
     }
 
     static viewport* find_best_viewport_for_sound(viewport_pos vpos)

--- a/src/openloco/audio/audio.cpp
+++ b/src/openloco/audio/audio.cpp
@@ -465,8 +465,8 @@ namespace openloco::audio
             {
                 cfg.audio.device = _devices[index];
             }
-            config::write_new_config(g_env);
-            reinitialise(g_env);
+            config::write_new_config(g_ctx.get<environment>());
+            reinitialise(g_ctx.get<environment>());
         }
     }
 

--- a/src/openloco/audio/audio.cpp
+++ b/src/openloco/audio/audio.cpp
@@ -635,7 +635,7 @@ namespace openloco::audio
                     return;
                 }
 
-                volume += calculate_volume_from_viewport(id, { loc.x, loc.y }, map::g_tilemgr, *viewport);
+                volume += calculate_volume_from_viewport(id, { loc.x, loc.y }, g_ctx.get<map::tilemanager>(), *viewport);
                 pan = viewport->map_to_ui(vpos).x;
                 if (volume < -10000)
                 {

--- a/src/openloco/audio/audio.cpp
+++ b/src/openloco/audio/audio.cpp
@@ -534,11 +534,11 @@ namespace openloco::audio
         }
     }
 
-    static int32_t calculate_volume_from_viewport(sound_id id, const map::map_pos3& mpos, const viewport& viewport)
+    static int32_t calculate_volume_from_viewport(sound_id id, const map::map_pos3& mpos, const map::tilemanager& tilemgr, const viewport& viewport)
     {
         auto volume = 0;
         auto zVol = 0;
-        auto tile = map::tilemgr::get(mpos);
+        auto tile = tilemgr.get(mpos);
         if (!tile.is_null())
         {
             auto surface = tile.surface();
@@ -635,7 +635,7 @@ namespace openloco::audio
                     return;
                 }
 
-                volume += calculate_volume_from_viewport(id, { loc.x, loc.y }, *viewport);
+                volume += calculate_volume_from_viewport(id, { loc.x, loc.y }, map::g_tilemgr, *viewport);
                 pan = viewport->map_to_ui(vpos).x;
                 if (volume < -10000)
                 {

--- a/src/openloco/audio/audio.cpp
+++ b/src/openloco/audio/audio.cpp
@@ -318,10 +318,10 @@ namespace openloco::audio
         std::generate(_vehicle_channels.begin(), _vehicle_channels.end(), []() { return vehicle_channel(); });
     }
 
-    static void reinitialise()
+    static void reinitialise(const environment& env)
     {
         dispose_dsound();
-        initialise_dsound();
+        initialise_dsound(env);
     }
 
     static size_t get_device_index(const std::string_view& deviceName)
@@ -346,7 +346,7 @@ namespace openloco::audio
     }
 
     // 0x00404E53
-    void initialise_dsound()
+    void initialise_dsound(const environment& env)
     {
         const char* deviceName = nullptr;
         const auto& cfg = config::get_new();
@@ -382,7 +382,7 @@ namespace openloco::audio
             _vehicle_channels[i] = vehicle_channel(channel(4 + i));
         }
 
-        auto css1path = environment::get_path(environment::path_id::css1);
+        auto css1path = env.get_path(environment::path_id::css1);
         _samples = load_sounds_from_css(css1path);
         _audio_initialised = 1;
     }
@@ -465,8 +465,8 @@ namespace openloco::audio
             {
                 cfg.audio.device = _devices[index];
             }
-            config::write_new_config();
-            reinitialise();
+            config::write_new_config(g_env);
+            reinitialise(g_env);
         }
     }
 
@@ -930,7 +930,7 @@ namespace openloco::audio
     }
 
     // 0x0048AC66
-    void play_title_screen_music()
+    void play_title_screen_music(const environment& env)
     {
 #if defined(__APPLE__) && defined(__MACH__)
         call(0x0048AC66);
@@ -940,7 +940,7 @@ namespace openloco::audio
         {
             if (!is_channel_playing(channel_id::title))
             {
-                auto path = environment::get_path(path_id::css5);
+                auto path = env.get_path(environment::path_id::css5);
                 if (load_channel(channel_id::title, path, 0))
                 {
                     play_channel(channel_id::title, 1, -500, 0, 0);

--- a/src/openloco/audio/audio.h
+++ b/src/openloco/audio/audio.h
@@ -8,6 +8,7 @@ struct Mix_Chunk;
 
 namespace openloco
 {
+    class thingmanager;
     struct vehicle;
 }
 
@@ -79,7 +80,7 @@ namespace openloco::audio
 
     void pause_sound();
     void unpause_sound();
-    void play_sound(vehicle* t);
+    void play_sound(const vehicle& v);
     void play_sound(sound_id id, loc16 loc);
     void play_sound(sound_id id, loc16 loc, int32_t pan);
     void play_sound(sound_id id, int32_t pan);
@@ -92,7 +93,7 @@ namespace openloco::audio
     void set_channel_volume(channel_id id, int32_t volume);
     bool is_channel_playing(channel_id id);
 
-    void update_vehicle_noise();
+    void update_vehicle_noise(thingmanager& thingmgr);
     void stop_vehicle_noise();
 
     void update_ambient_noise();

--- a/src/openloco/audio/audio.h
+++ b/src/openloco/audio/audio.h
@@ -8,6 +8,7 @@ struct Mix_Chunk;
 
 namespace openloco
 {
+    class environment;
     class thingmanager;
     struct vehicle;
 }
@@ -67,7 +68,7 @@ namespace openloco::audio
     };
     constexpr int32_t num_reserved_channels = 4 + 10;
 
-    void initialise_dsound();
+    void initialise_dsound(const environment& env);
     void dispose_dsound();
 
     const std::vector<std::string>& get_devices();
@@ -99,7 +100,7 @@ namespace openloco::audio
     void update_ambient_noise();
     void play_background_music();
     void stop_background_music();
-    void play_title_screen_music();
+    void play_title_screen_music(const environment& env);
 
     /**
      * Converts a Locomotion volume range to SDL2.

--- a/src/openloco/audio/vehicle_channel.h
+++ b/src/openloco/audio/vehicle_channel.h
@@ -6,6 +6,11 @@
 #include "audio.h"
 #include "channel.h"
 
+namespace openloco
+{
+    class thingmanager;
+}
+
 namespace openloco::audio
 {
     struct channel_attributes
@@ -32,8 +37,8 @@ namespace openloco::audio
 
         bool is_free() const { return _vehicle_id == thing_id::null; }
 
-        void begin(thing_id_t vid);
-        void update();
+        void begin(const vehicle& v);
+        void update(thingmanager& thingmgr);
         void stop();
     };
 }

--- a/src/openloco/companymgr.cpp
+++ b/src/openloco/companymgr.cpp
@@ -2,104 +2,102 @@
 #include "interop/interop.hpp"
 #include "openloco.h"
 
+using namespace openloco;
 using namespace openloco::interop;
 
-namespace openloco::companymgr
+companymanager openloco::g_companymgr;
+
+static loco_global<company_id_t[2], 0x00525E3C> _player_company;
+static loco_global<company[max_companies], 0x00531784> _companies;
+static loco_global<uint8_t, 0x00525FCB> _byte_525FCB;
+static loco_global<company_id_t, 0x009C68EB> _updating_company_id;
+
+static loco_global<uint8_t, 0x00526214> _company_competition_delay;
+static loco_global<uint8_t, 0x00525FB7> _company_max_competing;
+static loco_global<uint8_t, 0x00525E3C> _byte_525E3C;
+static loco_global<uint8_t, 0x00525E3D> _byte_525E3D;
+
+company_id_t companymanager::updating_company_id() const
 {
-    static loco_global<company_id_t[2], 0x00525E3C> _player_company;
-    static loco_global<company[max_companies], 0x00531784> _companies;
-    static loco_global<uint8_t, 0x00525FCB> _byte_525FCB;
-    static loco_global<company_id_t, 0x009C68EB> _updating_company_id;
+    return _updating_company_id;
+}
 
-    static loco_global<uint8_t, 0x00526214> _company_competition_delay;
-    static loco_global<uint8_t, 0x00525FB7> _company_max_competing;
-    static loco_global<uint8_t, 0x00525E3C> _byte_525E3C;
-    static loco_global<uint8_t, 0x00525E3D> _byte_525E3D;
+void companymanager::updating_company_id(company_id_t id)
+{
+    _updating_company_id = id;
+}
 
-    static void produce_companies();
+std::array<company, max_companies>& companymanager::companies()
+{
+    auto arr = (std::array<company, max_companies>*)_companies.get();
+    return *arr;
+}
 
-    company_id_t updating_company_id()
+company* companymanager::get(company_id_t id)
+{
+    auto index = id;
+    if (index < _companies.size())
     {
-        return _updating_company_id;
+        return &_companies[index];
     }
+    return nullptr;
+}
 
-    void updating_company_id(company_id_t id)
-    {
-        _updating_company_id = id;
-    }
+company_id_t companymanager::get_controlling_id() const
+{
+    return _player_company[0];
+}
 
-    std::array<company, max_companies>& companies()
+// 0x00430319
+void companymanager::update()
+{
+    if (!is_editor_mode())
     {
-        auto arr = (std::array<company, max_companies>*)_companies.get();
-        return *arr;
-    }
-
-    company* get(company_id_t id)
-    {
-        auto index = id;
-        if (index < _companies.size())
+        company_id_t id = scenario_ticks() & 0x0F;
+        auto company = get(id);
+        if (company != nullptr && !is_player_company(id) && !company->empty())
         {
-            return &_companies[index];
+            updating_company_id(id);
+            company->ai_think();
         }
-        return nullptr;
-    }
 
-    company_id_t get_controlling_id()
-    {
-        return _player_company[0];
-    }
-
-    // 0x00430319
-    void update()
-    {
-        if (!is_editor_mode())
+        _byte_525FCB++;
+        if (_byte_525FCB >= 192)
         {
-            company_id_t id = scenario_ticks() & 0x0F;
-            auto company = get(id);
-            if (company != nullptr && !is_player_company(id) && !company->empty())
-            {
-                updating_company_id(id);
-                company->ai_think();
-            }
-
-            _byte_525FCB++;
-            if (_byte_525FCB >= 192)
-            {
-                _byte_525FCB = 0;
-                produce_companies();
-            }
+            _byte_525FCB = 0;
+            produce_companies();
         }
     }
+}
 
-    static void sub_42F9AC()
-    {
-        call(0x0042F9AC);
-    }
+void companymanager::sub_42F9AC()
+{
+    call(0x0042F9AC);
+}
 
-    // 0x004306D1
-    static void produce_companies()
+// 0x004306D1
+void companymanager::produce_companies()
+{
+    if (_company_competition_delay == 0 && _company_max_competing != 0)
     {
-        if (_company_competition_delay == 0 && _company_max_competing != 0)
+        int32_t companies_active = 0;
+        for (const auto& company : companies())
         {
-            int32_t companies_active = 0;
-            for (const auto& company : companies())
+            auto id = company.id();
+            if (!company.empty() && id != _byte_525E3C && id != _byte_525E3D)
             {
-                auto id = company.id();
-                if (!company.empty() && id != _byte_525E3C && id != _byte_525E3D)
-                {
-                    companies_active++;
-                }
+                companies_active++;
             }
+        }
 
-            auto& prng = gprng();
+        auto& prng = gprng();
 
-            if (prng.rand_next(16) == 0)
+        if (prng.rand_next(16) == 0)
+        {
+            if (prng.rand_next(_company_max_competing) + 1 > companies_active)
             {
-                if (prng.rand_next(_company_max_competing) + 1 > companies_active)
-                {
-                    // Creates new company.
-                    sub_42F9AC();
-                }
+                // Creates new company.
+                sub_42F9AC();
             }
         }
     }

--- a/src/openloco/companymgr.cpp
+++ b/src/openloco/companymgr.cpp
@@ -5,8 +5,6 @@
 using namespace openloco;
 using namespace openloco::interop;
 
-companymanager openloco::g_companymgr;
-
 static loco_global<company_id_t[2], 0x00525E3C> _player_company;
 static loco_global<company[max_companies], 0x00531784> _companies;
 static loco_global<uint8_t, 0x00525FCB> _byte_525FCB;

--- a/src/openloco/companymgr.h
+++ b/src/openloco/companymgr.h
@@ -11,6 +11,9 @@ namespace openloco
     class companymanager
     {
     public:
+        companymanager() = default;
+        companymanager(const companymanager&) = delete;
+
         company_id_t updating_company_id() const;
         void updating_company_id(company_id_t id);
 

--- a/src/openloco/companymgr.h
+++ b/src/openloco/companymgr.h
@@ -26,6 +26,4 @@ namespace openloco
         void produce_companies();
         void sub_42F9AC();
     };
-
-    extern companymanager g_companymgr;
 }

--- a/src/openloco/companymgr.h
+++ b/src/openloco/companymgr.h
@@ -4,15 +4,25 @@
 #include <array>
 #include <cstddef>
 
-namespace openloco::companymgr
+namespace openloco
 {
     constexpr size_t max_companies = 15;
 
-    company_id_t updating_company_id();
-    void updating_company_id(company_id_t id);
+    class companymanager
+    {
+    public:
+        company_id_t updating_company_id() const;
+        void updating_company_id(company_id_t id);
 
-    std::array<company, max_companies>& companies();
-    company* get(company_id_t id);
-    company_id_t get_controlling_id();
-    void update();
+        std::array<company, max_companies>& companies();
+        company* get(company_id_t id);
+        company_id_t get_controlling_id() const;
+        void update();
+
+    private:
+        void produce_companies();
+        void sub_42F9AC();
+    };
+
+    extern companymanager g_companymgr;
 }

--- a/src/openloco/config.cpp
+++ b/src/openloco/config.cpp
@@ -52,12 +52,12 @@ namespace openloco::config
     void write()
     {
         call(0x00441BB8);
-        write_new_config();
+        write_new_config(g_env);
     }
 
-    new_config& read_new_config()
+    new_config& read_new_config(const environment& env)
     {
-        auto configPath = environment::get_path(environment::path_id::openloco_yml);
+        auto configPath = env.get_path(environment::path_id::openloco_yml);
 
         if (!fs::exists(configPath))
             return _new_config;
@@ -93,9 +93,9 @@ namespace openloco::config
         return _new_config;
     }
 
-    void write_new_config()
+    void write_new_config(const environment& env)
     {
-        auto configPath = environment::get_path(environment::path_id::openloco_yml);
+        auto configPath = env.get_path(environment::path_id::openloco_yml);
         auto dir = configPath.parent_path();
         if (!fs::is_directory(dir))
         {

--- a/src/openloco/config.cpp
+++ b/src/openloco/config.cpp
@@ -15,6 +15,7 @@
 #include "config.h"
 #include "environment.h"
 #include "interop/interop.hpp"
+#include "openloco.h"
 #include "utility/yaml.hpp"
 
 using namespace openloco::interop;
@@ -52,7 +53,7 @@ namespace openloco::config
     void write()
     {
         call(0x00441BB8);
-        write_new_config(g_env);
+        write_new_config(g_ctx.get<environment>());
     }
 
     new_config& read_new_config(const environment& env)

--- a/src/openloco/config.h
+++ b/src/openloco/config.h
@@ -3,6 +3,11 @@
 #include <cstdint>
 #include <string>
 
+namespace openloco
+{
+    class environment;
+}
+
 namespace openloco::config
 {
 #pragma pack(push, 1)
@@ -114,7 +119,7 @@ namespace openloco::config
     new_config& get_new();
 
     config_t& read();
-    new_config& read_new_config();
+    new_config& read_new_config(const environment& env);
     void write();
-    void write_new_config();
+    void write_new_config(const environment& env);
 }

--- a/src/openloco/environment.cpp
+++ b/src/openloco/environment.cpp
@@ -9,268 +9,262 @@
 #include <fstream>
 #include <iostream>
 
+using namespace openloco;
 using namespace openloco::interop;
 
-namespace openloco::environment
+environment openloco::g_env;
+
+static loco_global<char[260], 0x009D118E> _path_buffer;
+static loco_global<char[257], 0x0050B0CE> _path_install;
+static loco_global<char[257], 0x0050B1CF> _path_saves_single_player;
+static loco_global<char[257], 0x0050B2EC> _path_saves_two_player;
+static loco_global<char[257], 0x0050B406> _path_scenarios;
+static loco_global<char[257], 0x0050B518> _path_landscapes;
+static loco_global<char[257], 0x0050B635> _path_objects;
+
+bool environment::validate_loco_install_path(const fs::path& path) const
 {
-    loco_global<char[260], 0x009D118E> _path_buffer;
-    loco_global<char[257], 0x0050B0CE> _path_install;
-    loco_global<char[257], 0x0050B1CF> _path_saves_single_player;
-    loco_global<char[257], 0x0050B2EC> _path_saves_two_player;
-    loco_global<char[257], 0x0050B406> _path_scenarios;
-    loco_global<char[257], 0x0050B518> _path_landscapes;
-    loco_global<char[257], 0x0050B635> _path_objects;
-
-    static fs::path get_base_path(path_id id);
-    static fs::path get_sub_path(path_id id);
-#ifndef _WIN32
-    static fs::path find_similar_file(const fs::path& path);
-#endif
-
-    static bool validate_loco_install_path(const fs::path& path)
+    if (path.empty())
     {
-        if (path.empty())
-        {
-            return false;
-        }
-        else
-        {
-            auto g1Path = path / get_sub_path(path_id::g1);
-            bool g1Exists = fs::exists(g1Path);
+        return false;
+    }
+    else
+    {
+        auto g1Path = path / get_sub_path(path_id::g1);
+        bool g1Exists = fs::exists(g1Path);
 #ifndef _WIN32
-            if (!g1Exists)
-            {
-                g1Path = find_similar_file(g1Path);
-                g1Exists = !g1Path.empty();
-            }
+        if (!g1Exists)
+        {
+            g1Path = find_similar_file(g1Path);
+            g1Exists = !g1Path.empty();
+        }
 #endif
-            return g1Exists;
+        return g1Exists;
+    }
+}
+
+openloco::fs::path environment::auto_detect_loco_install_path()
+{
+    static constexpr const char* searchPaths[] = {
+        "C:/Program Files (x86)/Atari/Locomotion",
+        "C:/GOG Games/Chris Sawyer's Locomotion",
+    };
+
+    std::cout << "Searching for Locomotion install path..." << std::endl;
+    for (auto path : searchPaths)
+    {
+        if (validate_loco_install_path(path))
+        {
+            std::cout << "  found: " << path << std::endl;
+            return path;
         }
     }
+    return fs::path();
+}
 
-    static fs::path auto_detect_loco_install_path()
+openloco::fs::path environment::resolve_loco_install_path()
+{
+    auto& cfg = config::get_new();
+    auto path = fs::path(cfg.loco_install_path);
+    if (!path.empty())
     {
-        static constexpr const char* searchPaths[] = {
-            "C:/Program Files (x86)/Atari/Locomotion",
-            "C:/GOG Games/Chris Sawyer's Locomotion",
-        };
-
-        std::cout << "Searching for Locomotion install path..." << std::endl;
-        for (auto path : searchPaths)
+        if (validate_loco_install_path(path))
         {
-            if (validate_loco_install_path(path))
-            {
-                std::cout << "  found: " << path << std::endl;
-                return path;
-            }
+            config::write_new_config(*this);
+            return path;
         }
-        return fs::path();
+        std::cerr << "Configured install path for Locomotion is missing Data/g1.DAT." << std::endl;
     }
 
-    static fs::path resolve_loco_install_path()
+    path = auto_detect_loco_install_path();
+    if (!path.empty())
     {
-        auto& cfg = config::get_new();
-        auto path = fs::path(cfg.loco_install_path);
-        if (!path.empty())
-        {
-            if (validate_loco_install_path(path))
-            {
-                config::write_new_config();
-                return path;
-            }
-            std::cerr << "Configured install path for Locomotion is missing Data/g1.DAT." << std::endl;
-        }
-
-        path = auto_detect_loco_install_path();
-        if (!path.empty())
+#ifdef _OPENLOCO_USE_BOOST_FS_
+        cfg.loco_install_path = path.make_preferred().string();
+#else
+        cfg.loco_install_path = path.make_preferred().u8string();
+#endif
+        config::write_new_config(*this);
+        return path;
+    }
+    else
+    {
+        std::cerr << "Unable to find install path for Locomotion." << std::endl
+                  << "You will need to manually provide it." << std::endl;
+        ui::show_message_box("OpenLoco", "Select your Locomotion install path.");
+        path = platform::prompt_directory("Select your Locomotion install path.");
+        if (validate_loco_install_path(path))
         {
 #ifdef _OPENLOCO_USE_BOOST_FS_
             cfg.loco_install_path = path.make_preferred().string();
 #else
             cfg.loco_install_path = path.make_preferred().u8string();
 #endif
-            config::write_new_config();
+            config::write_new_config(*this);
             return path;
         }
-        else
-        {
-            std::cerr << "Unable to find install path for Locomotion." << std::endl
-                      << "You will need to manually provide it." << std::endl;
-            ui::show_message_box("OpenLoco", "Select your Locomotion install path.");
-            path = platform::prompt_directory("Select your Locomotion install path.");
-            if (validate_loco_install_path(path))
-            {
-#ifdef _OPENLOCO_USE_BOOST_FS_
-                cfg.loco_install_path = path.make_preferred().string();
-#else
-                cfg.loco_install_path = path.make_preferred().u8string();
-#endif
-                config::write_new_config();
-                return path;
-            }
 
-            std::cerr << "Path is missing g1.dat." << std::endl;
-            ui::show_message_box("OpenLoco", "Path is missing Data/g1.DAT.");
-            std::exit(-1);
-        }
+        std::cerr << "Path is missing g1.dat." << std::endl;
+        ui::show_message_box("OpenLoco", "Path is missing Data/g1.DAT.");
+        std::exit(-1);
     }
+}
 
-    static fs::path get_loco_install_path()
-    {
-        return _path_install.get();
-    }
+openloco::fs::path environment::get_loco_install_path() const
+{
+    return _path_install.get();
+}
 
 #ifndef _WIN32
-    /**
+/**
      * Performs a case-insensitive search on the containing directory of
      * the given file and returns the first match.
      */
-    static fs::path find_similar_file(const fs::path& path)
+openloco::fs::path environment::find_similar_file(const fs::path& path) const
+{
+    try
     {
-        try
+        auto expectedFilename = path.filename().generic_string();
+        auto directory = path.parent_path();
+        for (auto& item : fs::directory_iterator(directory))
         {
-            auto expectedFilename = path.filename().generic_string();
-            auto directory = path.parent_path();
-            for (auto& item : fs::directory_iterator(directory))
+            auto& p = item.path();
+            if (utility::iequals(p.filename().generic_string(), expectedFilename))
             {
-                auto& p = item.path();
-                if (utility::iequals(p.filename().generic_string(), expectedFilename))
-                {
-                    return p;
-                }
+                return p;
             }
         }
-        catch (const std::exception&)
-        {
-            // Ignore errors when searching, most common will be that the
-            // parent directory does not exist
-        }
-        return fs::path();
     }
+    catch (const std::exception&)
+    {
+        // Ignore errors when searching, most common will be that the
+        // parent directory does not exist
+    }
+    return fs::path();
+}
 #endif // _WIN32
 
-    // 0x004416B5
-    fs::path get_path(path_id id)
+// 0x004416B5
+openloco::fs::path environment::get_path(environment::path_id id) const
+{
+    auto basePath = get_base_path(id);
+    auto subPath = get_sub_path(id);
+    auto result = basePath / subPath;
+    if (!fs::exists(result))
     {
-        auto basePath = get_base_path(id);
-        auto subPath = get_sub_path(id);
-        auto result = basePath / subPath;
-        if (!fs::exists(result))
-        {
 #ifndef _WIN32
-            auto similarResult = find_similar_file(result);
-            if (similarResult.empty())
-            {
-                std::cerr << "File not found: " << result << std::endl;
-            }
-            else
-            {
-                result = similarResult;
-            }
-#else
-
+        auto similarResult = find_similar_file(result);
+        if (similarResult.empty())
+        {
             std::cerr << "File not found: " << result << std::endl;
-#endif
         }
-        return result;
-    }
-
-    template<typename T>
-    static void set_directory(T& buffer, fs::path path)
-    {
-#ifdef _OPENLOCO_USE_BOOST_FS_
-        utility::strcpy_safe(buffer, path.make_preferred().string().c_str());
+        else
+        {
+            result = similarResult;
+        }
 #else
-        utility::strcpy_safe(buffer, path.make_preferred().u8string().c_str());
+
+        std::cerr << "File not found: " << result << std::endl;
 #endif
     }
+    return result;
+}
 
-    // 0x004412CE
-    void resolve_paths()
+template<typename T>
+static void set_directory(T& buffer, openloco::fs::path path)
+{
+#ifdef _OPENLOCO_USE_BOOST_FS_
+    utility::strcpy_safe(buffer, path.make_preferred().string().c_str());
+#else
+    utility::strcpy_safe(buffer, path.make_preferred().u8string().c_str());
+#endif
+}
+
+// 0x004412CE
+void environment::resolve_paths()
+{
+    auto basePath = resolve_loco_install_path();
+    set_directory(_path_install, basePath);
+    set_directory(_path_saves_single_player, basePath / "Single Player Saved Games/");
+    set_directory(_path_saves_two_player, basePath / "Two Player Saved Games/");
+    set_directory(_path_scenarios, basePath / "Scenarios/*.SC5");
+    set_directory(_path_landscapes, basePath / "Scenarios/Landscapes/*.SC5");
+    set_directory(_path_objects, basePath / "ObjData/*.DAT");
+}
+
+openloco::fs::path environment::get_base_path(path_id id) const
+{
+    switch (id)
     {
-        auto basePath = resolve_loco_install_path();
-        set_directory(_path_install, basePath);
-        set_directory(_path_saves_single_player, basePath / "Single Player Saved Games/");
-        set_directory(_path_saves_two_player, basePath / "Two Player Saved Games/");
-        set_directory(_path_scenarios, basePath / "Scenarios/*.SC5");
-        set_directory(_path_landscapes, basePath / "Scenarios/Landscapes/*.SC5");
-        set_directory(_path_objects, basePath / "ObjData/*.DAT");
+        case path_id::plugin1:
+        case path_id::plugin2:
+        case path_id::gamecfg:
+        case path_id::scores:
+        case path_id::openloco_yml:
+            return platform::get_user_directory();
+        default:
+            return get_loco_install_path();
     }
+}
 
-    static fs::path get_base_path(path_id id)
+openloco::fs::path environment::get_sub_path(environment::path_id id) const
+{
+    static constexpr const char* paths[] = {
+        "Data/g1.DAT",
+        "plugin.dat",
+        "plugin2.dat",
+        "Data/CSS1.DAT",
+        "Data/CSS2.DAT",
+        "Data/CSS3.DAT",
+        "Data/CSS4.DAT",
+        "Data/CSS5.DAT",
+        "game.cfg",
+        "Data/KANJI.DAT",
+        "Data/20s1.DAT",
+        "Data/20s2.DAT",
+        "Data/20s4.DAT",
+        "Data/50s1.DAT",
+        "Data/50s2.DAT",
+        "Data/70s1.DAT",
+        "Data/70s2.DAT",
+        "Data/70s3.DAT",
+        "Data/80s1.DAT",
+        "Data/90s1.DAT",
+        "Data/90s2.DAT",
+        "Data/rag3.DAT",
+        "Data/Chrysanthemum.DAT",
+        "Data/Eugenia.DAT",
+        "Data/Rag2.DAT",
+        "Data/Rag1.DAT",
+        "Data/20s3.DAT",
+        "Data/40s1.DAT",
+        "Data/40s2.DAT",
+        "Data/50s3.DAT",
+        "Data/40s3.DAT",
+        "Data/80s2.DAT",
+        "Data/60s1.DAT",
+        "Data/80s3.DAT",
+        "Data/60s2.DAT",
+        "Data/60s3.DAT",
+        "Data/80s4.DAT",
+        "Data/20s5.DAT",
+        "Data/20s6.DAT",
+        "Data/title.dat",
+        "scores.dat",
+        "Scenarios/Boulder Breakers.SC5",
+        "Data/TUT1024_1.DAT",
+        "Data/TUT1024_2.DAT",
+        "Data/TUT1024_3.DAT",
+        "Data/TUT800_1.DAT",
+        "Data/TUT800_2.DAT",
+        "Data/TUT800_3.DAT",
+        "openloco.yml"
+    };
+
+    size_t index = (size_t)id;
+    if (index >= utility::length(paths))
     {
-        switch (id)
-        {
-            case path_id::plugin1:
-            case path_id::plugin2:
-            case path_id::gamecfg:
-            case path_id::scores:
-            case path_id::openloco_yml:
-                return platform::get_user_directory();
-            default:
-                return get_loco_install_path();
-        }
+        throw std::runtime_error("Invalid path_id: " + std::to_string((int32_t)id));
     }
-
-    static fs::path get_sub_path(path_id id)
-    {
-        static constexpr const char* paths[] = {
-            "Data/g1.DAT",
-            "plugin.dat",
-            "plugin2.dat",
-            "Data/CSS1.DAT",
-            "Data/CSS2.DAT",
-            "Data/CSS3.DAT",
-            "Data/CSS4.DAT",
-            "Data/CSS5.DAT",
-            "game.cfg",
-            "Data/KANJI.DAT",
-            "Data/20s1.DAT",
-            "Data/20s2.DAT",
-            "Data/20s4.DAT",
-            "Data/50s1.DAT",
-            "Data/50s2.DAT",
-            "Data/70s1.DAT",
-            "Data/70s2.DAT",
-            "Data/70s3.DAT",
-            "Data/80s1.DAT",
-            "Data/90s1.DAT",
-            "Data/90s2.DAT",
-            "Data/rag3.DAT",
-            "Data/Chrysanthemum.DAT",
-            "Data/Eugenia.DAT",
-            "Data/Rag2.DAT",
-            "Data/Rag1.DAT",
-            "Data/20s3.DAT",
-            "Data/40s1.DAT",
-            "Data/40s2.DAT",
-            "Data/50s3.DAT",
-            "Data/40s3.DAT",
-            "Data/80s2.DAT",
-            "Data/60s1.DAT",
-            "Data/80s3.DAT",
-            "Data/60s2.DAT",
-            "Data/60s3.DAT",
-            "Data/80s4.DAT",
-            "Data/20s5.DAT",
-            "Data/20s6.DAT",
-            "Data/title.dat",
-            "scores.dat",
-            "Scenarios/Boulder Breakers.SC5",
-            "Data/TUT1024_1.DAT",
-            "Data/TUT1024_2.DAT",
-            "Data/TUT1024_3.DAT",
-            "Data/TUT800_1.DAT",
-            "Data/TUT800_2.DAT",
-            "Data/TUT800_3.DAT",
-            "openloco.yml"
-        };
-
-        size_t index = (size_t)id;
-        if (index >= utility::length(paths))
-        {
-            throw std::runtime_error("Invalid path_id: " + std::to_string((int32_t)id));
-        }
-        return paths[(size_t)id];
-    }
+    return paths[(size_t)id];
 }

--- a/src/openloco/environment.cpp
+++ b/src/openloco/environment.cpp
@@ -12,8 +12,6 @@
 using namespace openloco;
 using namespace openloco::interop;
 
-environment openloco::g_env;
-
 static loco_global<char[260], 0x009D118E> _path_buffer;
 static loco_global<char[257], 0x0050B0CE> _path_install;
 static loco_global<char[257], 0x0050B1CF> _path_saves_single_player;

--- a/src/openloco/environment.h
+++ b/src/openloco/environment.h
@@ -84,6 +84,4 @@ namespace openloco
         fs::path get_base_path(path_id id) const;
         fs::path get_sub_path(path_id id) const;
     };
-
-    extern environment g_env;
 }

--- a/src/openloco/environment.h
+++ b/src/openloco/environment.h
@@ -6,7 +6,7 @@
 #include <experimental/filesystem>
 #endif
 
-namespace openloco::environment
+namespace openloco
 {
 #ifdef _OPENLOCO_USE_BOOST_FS_
     namespace fs = boost::filesystem;
@@ -14,59 +14,76 @@ namespace openloco::environment
     namespace fs = std::experimental::filesystem;
 #endif
 
-    enum class path_id
+    class environment
     {
-        g1,
-        plugin1,
-        plugin2,
-        css1, // Sound effects
-        css2, // Wind (mountains)
-        css3, // Ocean
-        css4, // Jungle
-        css5, // Title music
-        gamecfg,
-        kanji,
-        music_20s1,
-        music_20s2,
-        music_20s4,
-        music_50s1,
-        music_50s2,
-        music_70s1,
-        music_70s2,
-        music_70s3,
-        music_80s1,
-        music_90s1,
-        music_90s2,
-        music_rag3,
-        music_chrysanthemum,
-        music_eugenia,
-        music_rag2,
-        music_rag1,
-        music_20s3,
-        music_40s1,
-        music_40s2,
-        music_50s3,
-        music_40s3,
-        music_80s2,
-        music_60s1,
-        music_80s3,
-        music_60s2,
-        music_60s3,
-        music_80s4,
-        music_20s5,
-        music_20s6,
-        title,
-        scores,
-        boulder_breakers,
-        tut1024_1,
-        tut1024_2,
-        tut1024_3,
-        tut800_1,
-        tut800_2,
-        tut800_3,
-        openloco_yml,
+    public:
+        enum class path_id
+        {
+            g1,
+            plugin1,
+            plugin2,
+            css1, // Sound effects
+            css2, // Wind (mountains)
+            css3, // Ocean
+            css4, // Jungle
+            css5, // Title music
+            gamecfg,
+            kanji,
+            music_20s1,
+            music_20s2,
+            music_20s4,
+            music_50s1,
+            music_50s2,
+            music_70s1,
+            music_70s2,
+            music_70s3,
+            music_80s1,
+            music_90s1,
+            music_90s2,
+            music_rag3,
+            music_chrysanthemum,
+            music_eugenia,
+            music_rag2,
+            music_rag1,
+            music_20s3,
+            music_40s1,
+            music_40s2,
+            music_50s3,
+            music_40s3,
+            music_80s2,
+            music_60s1,
+            music_80s3,
+            music_60s2,
+            music_60s3,
+            music_80s4,
+            music_20s5,
+            music_20s6,
+            title,
+            scores,
+            boulder_breakers,
+            tut1024_1,
+            tut1024_2,
+            tut1024_3,
+            tut800_1,
+            tut800_2,
+            tut800_3,
+            openloco_yml,
+        };
+
+        fs::path get_path(path_id id) const;
+        void resolve_paths();
+
+    private:
+        bool validate_loco_install_path(const fs::path& path) const;
+        fs::path auto_detect_loco_install_path();
+        fs::path resolve_loco_install_path();
+        fs::path get_loco_install_path() const;
+#ifndef _WIN32
+        fs::path find_similar_file(const fs::path& path) const;
+#endif
+        fs::path get_base_path(path_id id) const;
+        fs::path get_sub_path(path_id id) const;
     };
 
-    fs::path get_path(path_id id);
-    void resolve_paths();
+    extern environment g_env;
 }

--- a/src/openloco/graphics/gfx.cpp
+++ b/src/openloco/graphics/gfx.cpp
@@ -64,9 +64,9 @@ namespace openloco::gfx
     }
 
     // 0x0044733C
-    void load_g1()
+    void load_g1(const environment& env)
     {
-        auto g1Path = environment::get_path(environment::path_id::g1);
+        auto g1Path = env.get_path(environment::path_id::g1);
 #ifdef _OPENLOCO_USE_BOOST_FS_
         std::ifstream stream(g1Path.make_preferred().string(), std::ios::in | std::ios::binary);
 #else

--- a/src/openloco/graphics/gfx.h
+++ b/src/openloco/graphics/gfx.h
@@ -4,6 +4,11 @@
 #include "../openloco.h"
 #include <cstdint>
 
+namespace openloco
+{
+    class environment;
+}
+
 namespace openloco::gfx
 {
 #pragma pack(push, 1)
@@ -78,7 +83,7 @@ namespace openloco::gfx
 
     drawpixelinfo_t& screen_dpi();
 
-    void load_g1();
+    void load_g1(const environment& env);
     void clear(drawpixelinfo_t& dpi, uint32_t fill);
     void clear_single(drawpixelinfo_t& dpi, uint8_t paletteId);
 

--- a/src/openloco/gui.cpp
+++ b/src/openloco/gui.cpp
@@ -73,7 +73,8 @@ namespace openloco::gui
             window->enabled_widgets = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5) | (1 << 6) | (1 << 7) | (1 << 8) | (1 << 9) | (1 << 10) | (1 << 11) | (1 << 12);
             window->init_scroll_widgets();
 
-            auto skin = openloco::g_objectmgr.get<interface_skin_object>();
+            auto& objectmgr = g_ctx.get<objectmanager>();
+            auto skin = objectmgr.get<interface_skin_object>();
             if (skin != nullptr)
             {
                 window->colours[0] = skin->colour_12;

--- a/src/openloco/gui.cpp
+++ b/src/openloco/gui.cpp
@@ -73,7 +73,7 @@ namespace openloco::gui
             window->enabled_widgets = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5) | (1 << 6) | (1 << 7) | (1 << 8) | (1 << 9) | (1 << 10) | (1 << 11) | (1 << 12);
             window->init_scroll_widgets();
 
-            auto skin = openloco::objectmgr::get<interface_skin_object>();
+            auto skin = openloco::g_objectmgr.get<interface_skin_object>();
             if (skin != nullptr)
             {
                 window->colours[0] = skin->colour_12;

--- a/src/openloco/gui.cpp
+++ b/src/openloco/gui.cpp
@@ -22,7 +22,7 @@ namespace openloco::gui
     loco_global<openloco::ui::widget_t[64], 0x00509c20> _mainWindowWidgets;
 
     // 0x00438A6C
-    void init()
+    void init(ui::viewportmanager& viewportmgr)
     {
         const int32_t uiWidth = ui::width();
         const int32_t uiHeight = ui::height();
@@ -39,7 +39,7 @@ namespace openloco::gui
             (ui::window_event_list*)0x004FA1F4);
         window->widgets = _mainWindowWidgets;
         addr<0x00e3f0b8, int32_t>() = 0; // gCurrentRotation?
-        openloco::ui::viewportmgr::create(window, window->x, window->y, window->width, window->height, false, 0, 6143, 6143, 480);
+        viewportmgr.create(window, window->x, window->y, window->width, window->height, false, 0, 6143, 6143, 480);
 
         addr<0x00F2533F, int8_t>() = 0; // grid lines
         addr<0x0112C2e1, int8_t>() = 0;

--- a/src/openloco/gui.h
+++ b/src/openloco/gui.h
@@ -1,7 +1,12 @@
 #pragma once
 
+namespace openloco::ui
+{
+    class viewportmanager;
+}
+
 namespace openloco::gui
 {
-    void init();
+    void init(ui::viewportmanager& viewportmgr);
     void resize();
 }

--- a/src/openloco/industry.cpp
+++ b/src/openloco/industry.cpp
@@ -2,9 +2,11 @@
 #include "interop/interop.hpp"
 #include "map/tilemgr.h"
 #include "objects/objectmgr.h"
+#include "openloco.h"
 #include "utility/numeric.hpp"
 #include <algorithm>
 
+using namespace openloco;
 using namespace openloco::interop;
 using namespace openloco::map;
 
@@ -36,12 +38,13 @@ namespace openloco
     }
 
     // 0x00453275
-    void industry::update(const map::tilemanager& tilemgr)
+    void industry::update(context& ctx)
     {
         if (!(flags & industry_flags::flag_01) && var_11 == 0xFF)
         {
             // Run tile loop for 100 iterations
-            auto obj = g_objectmgr.get(*this);
+            auto obj = ctx.get<objectmanager>().get(*this);
+            auto& tilemgr = ctx.get<tilemanager>();
             for (int i = 0; i < 100; i++)
             {
                 const auto& surface = tilemgr.get(tile_loop.current()).surface();

--- a/src/openloco/industry.cpp
+++ b/src/openloco/industry.cpp
@@ -21,7 +21,7 @@ namespace openloco
         return name == string_ids::null;
     }
 
-    static bool find_5(surface_element* surface)
+    static bool find_5(const surface_element* surface)
     {
         auto element = surface;
         while (!element->is_last())
@@ -36,7 +36,7 @@ namespace openloco
     }
 
     // 0x00453275
-    void industry::update()
+    void industry::update(const map::tilemanager& tilemgr)
     {
         if (!(flags & industry_flags::flag_01) && var_11 == 0xFF)
         {
@@ -44,7 +44,7 @@ namespace openloco
             auto obj = g_objectmgr.get(*this);
             for (int i = 0; i < 100; i++)
             {
-                const auto& surface = tilemgr::get(tile_loop.current()).surface();
+                const auto& surface = tilemgr.get(tile_loop.current()).surface();
                 if (surface != nullptr)
                 {
                     if (surface->data()[0] & 0x80)

--- a/src/openloco/industry.cpp
+++ b/src/openloco/industry.cpp
@@ -16,11 +16,6 @@ namespace openloco
         return (industry_id_t)(this - first);
     }
 
-    industry_object* industry::object() const
-    {
-        return objectmgr::get<industry_object>(object_id);
-    }
-
     bool industry::empty() const
     {
         return name == string_ids::null;
@@ -46,7 +41,7 @@ namespace openloco
         if (!(flags & industry_flags::flag_01) && var_11 == 0xFF)
         {
             // Run tile loop for 100 iterations
-            auto obj = object();
+            auto obj = g_objectmgr.get(*this);
             for (int i = 0; i < 100; i++)
             {
                 const auto& surface = tilemgr::get(tile_loop.current()).surface();

--- a/src/openloco/industry.h
+++ b/src/openloco/industry.h
@@ -48,7 +48,6 @@ namespace openloco
         uint8_t pad_1A7[0x453 - 0x1A7];
 
         industry_id_t id() const;
-        industry_object* object() const;
         bool empty() const;
 
         void update();

--- a/src/openloco/industry.h
+++ b/src/openloco/industry.h
@@ -8,6 +8,11 @@
 #include <cstdint>
 #include <limits>
 
+namespace openloco::map
+{
+    class tilemanager;
+}
+
 namespace openloco
 {
     using namespace map;
@@ -50,7 +55,7 @@ namespace openloco
         industry_id_t id() const;
         bool empty() const;
 
-        void update();
+        void update(const map::tilemanager& tilemgr);
         void sub_454A43(coord_t x, coord_t y, uint8_t bl, uint8_t bh, uint8_t dl);
     };
 #pragma pack(pop)

--- a/src/openloco/industry.h
+++ b/src/openloco/industry.h
@@ -15,6 +15,8 @@ namespace openloco::map
 
 namespace openloco
 {
+    class context;
+
     using namespace map;
     using industry_id_t = uint16_t;
 
@@ -55,7 +57,7 @@ namespace openloco
         industry_id_t id() const;
         bool empty() const;
 
-        void update(const map::tilemanager& tilemgr);
+        void update(context& ctx);
         void sub_454A43(coord_t x, coord_t y, uint8_t bl, uint8_t bh, uint8_t dl);
     };
 #pragma pack(pop)

--- a/src/openloco/industrymgr.cpp
+++ b/src/openloco/industrymgr.cpp
@@ -6,8 +6,6 @@
 using namespace openloco;
 using namespace openloco::interop;
 
-industrymanager openloco::g_industrymgr;
-
 static loco_global<industry[max_industries], 0x005C455C> _industries;
 
 std::array<industry, max_industries>& industrymanager::industries()

--- a/src/openloco/industrymgr.cpp
+++ b/src/openloco/industrymgr.cpp
@@ -26,7 +26,7 @@ industry* industrymanager::get(industry_id_t id)
 }
 
 // 0x00453234
-void industrymanager::update(companymanager& companymgr)
+void industrymanager::update(companymanager& companymgr, map::tilemanager& tilemgr)
 {
     if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
     {
@@ -35,7 +35,7 @@ void industrymanager::update(companymanager& companymgr)
         {
             if (!industry.empty())
             {
-                industry.update();
+                industry.update(tilemgr);
             }
         }
     }

--- a/src/openloco/industrymgr.cpp
+++ b/src/openloco/industrymgr.cpp
@@ -26,16 +26,16 @@ industry* industrymanager::get(industry_id_t id)
 }
 
 // 0x00453234
-void industrymanager::update(companymanager& companymgr, map::tilemanager& tilemgr)
+void industrymanager::update(context& ctx)
 {
     if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
     {
-        companymgr.updating_company_id(company_id::neutral);
+        ctx.get<companymanager>().updating_company_id(company_id::neutral);
         for (auto& industry : industries())
         {
             if (!industry.empty())
             {
-                industry.update(tilemgr);
+                industry.update(ctx);
             }
         }
     }

--- a/src/openloco/industrymgr.h
+++ b/src/openloco/industrymgr.h
@@ -4,6 +4,11 @@
 #include <array>
 #include <cstddef>
 
+namespace openloco::map
+{
+    class tilemanager;
+}
+
 namespace openloco
 {
     class companymanager;
@@ -15,7 +20,7 @@ namespace openloco
     public:
         std::array<industry, max_industries>& industries();
         industry* get(industry_id_t id);
-        void update(companymanager& companymgr);
+        void update(companymanager& companymgr, map::tilemanager& tilemgr);
         void update_monthly();
     };
 

--- a/src/openloco/industrymgr.h
+++ b/src/openloco/industrymgr.h
@@ -4,12 +4,20 @@
 #include <array>
 #include <cstddef>
 
-namespace openloco::industrymgr
+namespace openloco
 {
+    class companymanager;
+
     constexpr size_t max_industries = 128;
 
-    std::array<industry, max_industries>& industries();
-    industry* get(industry_id_t id);
-    void update();
-    void update_monthly();
+    class industrymanager
+    {
+    public:
+        std::array<industry, max_industries>& industries();
+        industry* get(industry_id_t id);
+        void update(companymanager& companymgr);
+        void update_monthly();
+    };
+
+    extern industrymanager g_industrymgr;
 }

--- a/src/openloco/industrymgr.h
+++ b/src/openloco/industrymgr.h
@@ -11,7 +11,7 @@ namespace openloco::map
 
 namespace openloco
 {
-    class companymanager;
+    class context;
 
     constexpr size_t max_industries = 128;
 
@@ -20,7 +20,7 @@ namespace openloco
     public:
         std::array<industry, max_industries>& industries();
         industry* get(industry_id_t id);
-        void update(companymanager& companymgr, map::tilemanager& tilemgr);
+        void update(context& ctx);
         void update_monthly();
     };
 

--- a/src/openloco/industrymgr.h
+++ b/src/openloco/industrymgr.h
@@ -23,6 +23,4 @@ namespace openloco
         void update(context& ctx);
         void update_monthly();
     };
-
-    extern industrymanager g_industrymgr;
 }

--- a/src/openloco/input/mouse_input.cpp
+++ b/src/openloco/input/mouse_input.cpp
@@ -1178,7 +1178,7 @@ namespace openloco::input
         if (_mapSelectionFlags & (1 << 6))
         {
             _mapSelectionFlags &= (uint16_t) ~(1 << 6);
-            auto station = g_stationmgr.get(_F252A4);
+            auto station = g_ctx.get<stationmanager>().get(_F252A4);
             if (!station->empty())
             {
                 station->invalidate();

--- a/src/openloco/input/mouse_input.cpp
+++ b/src/openloco/input/mouse_input.cpp
@@ -1178,7 +1178,7 @@ namespace openloco::input
         if (_mapSelectionFlags & (1 << 6))
         {
             _mapSelectionFlags &= (uint16_t) ~(1 << 6);
-            auto station = stationmgr::get(_F252A4);
+            auto station = g_stationmgr.get(_F252A4);
             if (!station->empty())
             {
                 station->invalidate();

--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -13,6 +13,7 @@
 #include "../graphics/gfx.h"
 #include "../gui.h"
 #include "../input.h"
+#include "../map/tilemgr.h"
 #include "../objects/objectmgr.h"
 #include "../platform/platform.h"
 #include "../station.h"
@@ -841,7 +842,7 @@ void openloco::interop::register_hooks()
         [](registers& regs) -> uint8_t {
             auto v = *((openloco::vehicle*)regs.esi);
             auto obj = *(g_objectmgr.get(v));
-            v.secondary_animation_update(g_thingmgr, obj);
+            v.secondary_animation_update(map::g_tilemgr, g_thingmgr, obj);
             return 0;
         });
 

--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -230,7 +230,7 @@ typedef struct FindFileData
 class Session
 {
 public:
-    std::vector<openloco::environment::fs::path> fileList;
+    std::vector<openloco::fs::path> fileList;
 };
 
 #define FILE_ATTRIBUTE_DIRECTORY 0x10
@@ -242,10 +242,10 @@ static Session* CDECL fn_FindFirstFile(char* lpFileName, FindFileData* out)
 
     Session* data = new Session;
 
-    openloco::environment::fs::path path = lpFileName;
+    openloco::fs::path path = lpFileName;
     path.remove_filename();
 
-    openloco::environment::fs::directory_iterator iter(path), end;
+    openloco::fs::directory_iterator iter(path), end;
 
     while (iter != end)
     {
@@ -259,7 +259,7 @@ static Session* CDECL fn_FindFirstFile(char* lpFileName, FindFileData* out)
     utility::strcpy_safe(out->cFilename, data->fileList[0].filename().u8string().c_str());
 #endif
 
-    if (openloco::environment::fs::is_directory(data->fileList[0]))
+    if (openloco::fs::is_directory(data->fileList[0]))
     {
         out->dwFileAttributes = FILE_ATTRIBUTE_DIRECTORY;
     }
@@ -287,7 +287,7 @@ static bool CDECL fn_FindNextFile(Session* data, FindFileData* out)
     utility::strcpy_safe(out->cFilename, data->fileList[0].filename().u8string().c_str());
 #endif
 
-    if (openloco::environment::fs::is_directory(data->fileList[0]))
+    if (openloco::fs::is_directory(data->fileList[0]))
     {
         out->dwFileAttributes = FILE_ATTRIBUTE_DIRECTORY;
     }
@@ -701,10 +701,8 @@ void openloco::interop::register_hooks()
     register_hook(
         0x004416B5,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-            using namespace openloco::environment;
-
             auto buffer = (char*)0x009D0D72;
-            auto path = get_path((path_id)regs.ebx);
+            auto path = g_env.get_path((environment::path_id)regs.ebx);
 #ifdef _OPENLOCO_USE_BOOST_FS_
             // TODO: use utility::strlcpy with the buffer size instead of std::strcpy, if possible
             std::strcpy(buffer, path.make_preferred().string().c_str());

--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -20,6 +20,7 @@
 #include "../things/vehicle.h"
 #include "../ui.h"
 #include "../utility/string.hpp"
+#include "../viewportmgr.h"
 #include "../windowmgr.h"
 #include "interop.hpp"
 
@@ -808,7 +809,7 @@ void openloco::interop::register_hooks()
     register_hook(
         0x00438A6C,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-            gui::init();
+            gui::init(ui::g_viewportmgr);
             return 0;
         });
 

--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -803,14 +803,14 @@ void openloco::interop::register_hooks()
         0x004BA8D4,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             auto v = (openloco::vehicle*)regs.esi;
-            v->sub_4BA8D4(g_thingmgr);
+            v->sub_4BA8D4(g_ctx.get<thingmanager>());
             return 0;
         });
 
     register_hook(
         0x00438A6C,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-            gui::init(ui::g_viewportmgr);
+            gui::init(g_ctx.get<ui::viewportmanager>());
             return 0;
         });
 
@@ -841,8 +841,8 @@ void openloco::interop::register_hooks()
         0x004AB655,
         [](registers& regs) -> uint8_t {
             auto v = *((openloco::vehicle*)regs.esi);
-            auto obj = *(g_objectmgr.get(v));
-            v.secondary_animation_update(map::g_tilemgr, g_thingmgr, obj);
+            auto& obj = *(g_ctx.get<objectmanager>().get(v));
+            v.secondary_animation_update(g_ctx.get<map::tilemanager>(), g_ctx.get<thingmanager>(), obj);
             return 0;
         });
 

--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -13,6 +13,7 @@
 #include "../graphics/gfx.h"
 #include "../gui.h"
 #include "../input.h"
+#include "../objects/objectmgr.h"
 #include "../platform/platform.h"
 #include "../station.h"
 #include "../things/thingmgr.h"
@@ -839,9 +840,9 @@ void openloco::interop::register_hooks()
     register_hook(
         0x004AB655,
         [](registers& regs) -> uint8_t {
-            auto v = (openloco::vehicle*)regs.esi;
-            v->secondary_animation_update(g_thingmgr);
-
+            auto v = *((openloco::vehicle*)regs.esi);
+            auto obj = *(g_objectmgr.get(v));
+            v.secondary_animation_update(g_thingmgr, obj);
             return 0;
         });
 

--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -15,6 +15,7 @@
 #include "../input.h"
 #include "../platform/platform.h"
 #include "../station.h"
+#include "../things/thingmgr.h"
 #include "../things/vehicle.h"
 #include "../ui.h"
 #include "../utility/string.hpp"
@@ -665,7 +666,7 @@ static void register_audio_hooks()
     register_hook(
         0x0048A4BF,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-            audio::play_sound((vehicle*)regs.esi);
+            audio::play_sound(*((vehicle*)regs.esi));
             return 0;
         });
     register_hook(
@@ -801,7 +802,7 @@ void openloco::interop::register_hooks()
         0x004BA8D4,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             auto v = (openloco::vehicle*)regs.esi;
-            v->sub_4BA8D4();
+            v->sub_4BA8D4(g_thingmgr);
             return 0;
         });
 
@@ -839,7 +840,7 @@ void openloco::interop::register_hooks()
         0x004AB655,
         [](registers& regs) -> uint8_t {
             auto v = (openloco::vehicle*)regs.esi;
-            v->secondary_animation_update();
+            v->secondary_animation_update(g_thingmgr);
 
             return 0;
         });

--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -704,7 +704,7 @@ void openloco::interop::register_hooks()
         0x004416B5,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             auto buffer = (char*)0x009D0D72;
-            auto path = g_env.get_path((environment::path_id)regs.ebx);
+            auto path = g_ctx.get<environment>().get_path((environment::path_id)regs.ebx);
 #ifdef _OPENLOCO_USE_BOOST_FS_
             // TODO: use utility::strlcpy with the buffer size instead of std::strcpy, if possible
             std::strcpy(buffer, path.make_preferred().string().c_str());

--- a/src/openloco/localisation/stringmgr.cpp
+++ b/src/openloco/localisation/stringmgr.cpp
@@ -4,6 +4,7 @@
 #include "../interop/interop.hpp"
 #include "../objects/currency_object.h"
 #include "../objects/objectmgr.h"
+#include "../openloco.h"
 #include "../townmgr.h"
 #include "argswrapper.hpp"
 #include "string_ids.h"
@@ -217,7 +218,7 @@ namespace openloco::stringmgr
             value = -value;
         }
 
-        currency_object* currency = g_objectmgr.get<currency_object>();
+        currency_object* currency = g_ctx.get<objectmanager>().get<currency_object>();
 
         int64_t localised_value = value * (1ULL << currency->factor);
 

--- a/src/openloco/localisation/stringmgr.cpp
+++ b/src/openloco/localisation/stringmgr.cpp
@@ -564,14 +564,14 @@ namespace openloco::stringmgr
         {
             id -= TOWN_NAMES_START;
             uint16_t town_id = args.pop16();
-            auto town = townmgr::get(town_id);
+            auto town = g_townmgr.get(town_id);
             void* town_name = (void*)&town->name;
             return format_string(buffer, id, town_name);
         }
         else if (id == TOWN_NAMES_END)
         {
             uint16_t town_id = args.pop16();
-            auto town = townmgr::get(town_id);
+            auto town = g_townmgr.get(town_id);
             return format_string(buffer, town->name, nullptr);
         }
         else

--- a/src/openloco/localisation/stringmgr.cpp
+++ b/src/openloco/localisation/stringmgr.cpp
@@ -565,14 +565,14 @@ namespace openloco::stringmgr
         {
             id -= TOWN_NAMES_START;
             uint16_t town_id = args.pop16();
-            auto town = g_townmgr.get(town_id);
+            auto town = g_ctx.get<townmanager>().get(town_id);
             void* town_name = (void*)&town->name;
             return format_string(buffer, id, town_name);
         }
         else if (id == TOWN_NAMES_END)
         {
             uint16_t town_id = args.pop16();
-            auto town = g_townmgr.get(town_id);
+            auto town = g_ctx.get<townmanager>().get(town_id);
             return format_string(buffer, town->name, nullptr);
         }
         else

--- a/src/openloco/localisation/stringmgr.cpp
+++ b/src/openloco/localisation/stringmgr.cpp
@@ -217,7 +217,7 @@ namespace openloco::stringmgr
             value = -value;
         }
 
-        currency_object* currency = objectmgr::get<currency_object>();
+        currency_object* currency = g_objectmgr.get<currency_object>();
 
         int64_t localised_value = value * (1ULL << currency->factor);
 

--- a/src/openloco/map/tile.cpp
+++ b/src/openloco/map/tile.cpp
@@ -100,6 +100,11 @@ surface_element* tile::surface()
     return result;
 }
 
+const surface_element* tile::surface() const
+{
+    return ((tile*)this)->surface();
+}
+
 namespace openloco::map
 {
     /**

--- a/src/openloco/map/tile.cpp
+++ b/src/openloco/map/tile.cpp
@@ -22,11 +22,6 @@ bool tile_element_base::is_last() const
     return (_flags & element_flags::last) != 0;
 }
 
-building_object* building_element::object() const
-{
-    return objectmgr::get<building_object>(object_id());
-}
-
 tile::tile(tile_coord_t x, tile_coord_t y, tile_element* data)
     : _data(data)
     , x(x)

--- a/src/openloco/map/tile.cpp
+++ b/src/openloco/map/tile.cpp
@@ -27,11 +27,6 @@ building_object* building_element::object() const
     return objectmgr::get<building_object>(object_id());
 }
 
-industry* industry_element::industry() const
-{
-    return industrymgr::get(industry_id());
-}
-
 tile::tile(tile_coord_t x, tile_coord_t y, tile_element* data)
     : _data(data)
     , x(x)

--- a/src/openloco/map/tile.h
+++ b/src/openloco/map/tile.h
@@ -4,11 +4,6 @@
 #include <cstdint>
 #include <limits>
 
-namespace openloco
-{
-    struct building_object;
-}
-
 namespace openloco::map
 {
     using coord_t = int16_t;
@@ -196,7 +191,6 @@ namespace openloco::map
         bool has_40() const { return (_type & 0x40) != 0; }
         bool has_80() const { return (_type & 0x80) != 0; }
         uint8_t object_id() const { return _4; }
-        building_object* object() const;
         uint8_t var_5b() const { return _5 & 3; }
     };
 

--- a/src/openloco/map/tile.h
+++ b/src/openloco/map/tile.h
@@ -242,5 +242,6 @@ namespace openloco::map
 
         size_t index_of(const tile_element_base* element) const;
         surface_element* surface();
+        const surface_element* surface() const;
     };
 }

--- a/src/openloco/map/tile.h
+++ b/src/openloco/map/tile.h
@@ -7,7 +7,6 @@
 namespace openloco
 {
     struct building_object;
-    struct industry;
 }
 
 namespace openloco::map
@@ -211,7 +210,6 @@ namespace openloco::map
 
     public:
         uint8_t industry_id() const { return _4; }
-        openloco::industry* industry() const;
     };
 
     struct unk1_element : public tile_element_base

--- a/src/openloco/map/tilemgr.cpp
+++ b/src/openloco/map/tilemgr.cpp
@@ -4,8 +4,6 @@
 using namespace openloco::map;
 using namespace openloco::interop;
 
-tilemanager openloco::map::g_tilemgr;
-
 static loco_global<tile_element * [0x30004], 0x00E40134> _tiles;
 
 tile tilemanager::get(map_pos pos)

--- a/src/openloco/map/tilemgr.cpp
+++ b/src/openloco/map/tilemgr.cpp
@@ -1,32 +1,43 @@
 #include "tilemgr.h"
 #include "../interop/interop.hpp"
 
+using namespace openloco::map;
 using namespace openloco::interop;
 
-namespace openloco::map::tilemgr
+tilemanager openloco::map::g_tilemgr;
+
+static loco_global<tile_element * [0x30004], 0x00E40134> _tiles;
+
+tile tilemanager::get(map_pos pos)
 {
-    static loco_global<tile_element * [0x30004], 0x00E40134> _tiles;
+    return get(pos.x, pos.y);
+}
 
-    tile get(map_pos pos)
+const tile tilemanager::get(map_pos pos) const
+{
+    return ((tilemanager*)this)->get(pos);
+}
+
+tile tilemanager::get(coord_t x, coord_t y)
+{
+    tile_coord_t tileX = x / 32;
+    tile_coord_t tileY = y / 32;
+
+    size_t index = ((y << 9) | x) >> 5;
+    auto data = _tiles[index];
+    if (data == (tile_element*)0xFFFFFFFF)
     {
-        return get(pos.x, pos.y);
+        data = nullptr;
     }
+    return tile(tileX, tileY, data);
+}
 
-    tile get(coord_t x, coord_t y)
-    {
-        tile_coord_t tileX = x / 32;
-        tile_coord_t tileY = y / 32;
+const tile tilemanager::get(coord_t x, coord_t y) const 
+{
+    return ((tilemanager*)this)->get(x, y);
+}
 
-        size_t index = ((y << 9) | x) >> 5;
-        auto data = _tiles[index];
-        if (data == (tile_element*)0xFFFFFFFF)
-        {
-            data = nullptr;
-        }
-        return tile(tileX, tileY, data);
-    }
-
-    /**
+/**
     * Return the absolute height of an element, given its (x,y) coordinates
     *
     * ax: x
@@ -35,147 +46,146 @@ namespace openloco::map::tilemgr
     * return edx >> 16: waterHeight
     * loco: 0x0067297 rct2: 0x00662783 (numbers different)
     */
-    std::tuple<int16_t, int16_t> get_height(coord_t x, coord_t y)
+std::tuple<int16_t, int16_t> tilemanager::get_height(coord_t x, coord_t y) const
+{
+    // Off the map
+    if ((unsigned)x >= 12287 || (unsigned)y >= 12287)
+        return std::make_tuple(16, 0);
+
+    // Truncate subtile coordinates
+    auto xTile = x & 0xFFE0;
+    auto yTile = y & 0xFFE0;
+
+    // Get the surface element for the tile
+    auto surfaceEl = get(xTile, yTile).surface();
+
+    if (surfaceEl == nullptr)
     {
-        // Off the map
-        if ((unsigned)x >= 12287 || (unsigned)y >= 12287)
-            return std::make_tuple(16, 0);
+        return std::make_tuple(16, 0);
+    }
 
-        // Truncate subtile coordinates
-        auto xTile = x & 0xFFE0;
-        auto yTile = y & 0xFFE0;
+    int16_t waterHeight = surfaceEl->water() * 16;
+    int16_t height = surfaceEl->base_z() * 4;
 
-        // Get the surface element for the tile
-        auto surfaceEl = get(xTile, yTile).surface();
+    auto slope = surfaceEl->slope_corners();
+    int8_t quad = 0, quad_extra = 0; // which quadrant the element is in?
+                                     // quad_extra is for extra height tiles
 
-        if (surfaceEl == nullptr)
-        {
-            return std::make_tuple(16, 0);
-        }
+    uint8_t TILE_SIZE = 31;
 
-        int16_t waterHeight = surfaceEl->water() * 16;
-        int16_t height = surfaceEl->base_z() * 4;
+    // Subtile coords
+    auto xl = x & 0x1f;
+    auto yl = y & 0x1f;
 
-        auto slope = surfaceEl->slope_corners();
-        int8_t quad = 0, quad_extra = 0; // which quadrant the element is in?
-                                         // quad_extra is for extra height tiles
+    // Slope logic:
+    // Each of the four bits in slope represents that corner being raised
+    // slope == 15 (all four bits) is not used and slope == 0 is flat
+    // If the extra_height bit is set, then the slope goes up two z-levels
 
-        uint8_t TILE_SIZE = 31;
+    // We arbitrarily take the SW corner to be closest to the viewer
 
-        // Subtile coords
-        auto xl = x & 0x1f;
-        auto yl = y & 0x1f;
-
-        // Slope logic:
-        // Each of the four bits in slope represents that corner being raised
-        // slope == 15 (all four bits) is not used and slope == 0 is flat
-        // If the extra_height bit is set, then the slope goes up two z-levels
-
-        // We arbitrarily take the SW corner to be closest to the viewer
-
-        // One corner up
-        if (slope == surface_slope::n_corner_up || slope == surface_slope::e_corner_up || slope == surface_slope::s_corner_up || slope == surface_slope::w_corner_up)
-        {
-            switch (slope)
-            {
-                case surface_slope::n_corner_up:
-                    quad = xl + yl - TILE_SIZE;
-                    break;
-                case surface_slope::e_corner_up:
-                    quad = xl - yl;
-                    break;
-                case surface_slope::s_corner_up:
-                    quad = TILE_SIZE - yl - xl;
-                    break;
-                case surface_slope::w_corner_up:
-                    quad = yl - xl;
-                    break;
-            }
-            // If the element is in the quadrant with the slope, raise its height
-            if (quad > 0)
-            {
-                height += quad / 2;
-            }
-        }
-
-        // One side up
+    // One corner up
+    if (slope == surface_slope::n_corner_up || slope == surface_slope::e_corner_up || slope == surface_slope::s_corner_up || slope == surface_slope::w_corner_up)
+    {
         switch (slope)
         {
-            case surface_slope::ne_side_up:
-                height += xl / 2 + 1;
+            case surface_slope::n_corner_up:
+                quad = xl + yl - TILE_SIZE;
                 break;
-            case surface_slope::se_side_up:
-                height += (TILE_SIZE - yl) / 2;
+            case surface_slope::e_corner_up:
+                quad = xl - yl;
                 break;
-            case surface_slope::nw_side_up:
-                height += yl / 2;
-                height++;
+            case surface_slope::s_corner_up:
+                quad = TILE_SIZE - yl - xl;
                 break;
-            case surface_slope::sw_side_up:
-                height += (TILE_SIZE - xl) / 2;
+            case surface_slope::w_corner_up:
+                quad = yl - xl;
                 break;
         }
-
-        // One corner down
-        if ((slope == surface_slope::w_corner_dn) || (slope == surface_slope::s_corner_dn) || (slope == surface_slope::e_corner_dn) || (slope == surface_slope::n_corner_dn))
+        // If the element is in the quadrant with the slope, raise its height
+        if (quad > 0)
         {
-            switch (slope)
-            {
-                case surface_slope::w_corner_dn:
-                    quad_extra = xl + TILE_SIZE - yl;
-                    quad = xl - yl;
-                    break;
-                case surface_slope::s_corner_dn:
-                    quad_extra = xl + yl;
-                    quad = xl + yl - TILE_SIZE - 1;
-                    break;
-                case surface_slope::e_corner_dn:
-                    quad_extra = TILE_SIZE - xl + yl;
-                    quad = yl - xl;
-                    break;
-                case surface_slope::n_corner_dn:
-                    quad_extra = (TILE_SIZE - xl) + (TILE_SIZE - yl);
-                    quad = TILE_SIZE - yl - xl - 1;
-                    break;
-            }
-
-            if (surfaceEl->is_slope_dbl_height())
-            {
-                height += quad_extra / 2;
-                height++;
-                return std::make_tuple(height, waterHeight);
-            }
-            // This tile is essentially at the next height level
-            height += 0x10;
-            // so we move *down* the slope
-            if (quad < 0)
-            {
-                height += quad / 2;
-            }
+            height += quad / 2;
         }
-
-        // Valleys
-        if ((slope == surface_slope::w_e_valley) || (slope == surface_slope::n_s_valley))
-        {
-            switch (slope)
-            {
-                case surface_slope::w_e_valley:
-                    if (xl + yl <= TILE_SIZE + 1)
-                    {
-                        return std::make_tuple(height, waterHeight);
-                    }
-                    quad = TILE_SIZE - xl - yl;
-                    break;
-                case surface_slope::n_s_valley:
-                    quad = xl - yl;
-                    break;
-            }
-            if (quad > 0)
-            {
-                height += quad / 2;
-            }
-        }
-
-        return std::make_tuple(height, waterHeight);
     }
+
+    // One side up
+    switch (slope)
+    {
+        case surface_slope::ne_side_up:
+            height += xl / 2 + 1;
+            break;
+        case surface_slope::se_side_up:
+            height += (TILE_SIZE - yl) / 2;
+            break;
+        case surface_slope::nw_side_up:
+            height += yl / 2;
+            height++;
+            break;
+        case surface_slope::sw_side_up:
+            height += (TILE_SIZE - xl) / 2;
+            break;
+    }
+
+    // One corner down
+    if ((slope == surface_slope::w_corner_dn) || (slope == surface_slope::s_corner_dn) || (slope == surface_slope::e_corner_dn) || (slope == surface_slope::n_corner_dn))
+    {
+        switch (slope)
+        {
+            case surface_slope::w_corner_dn:
+                quad_extra = xl + TILE_SIZE - yl;
+                quad = xl - yl;
+                break;
+            case surface_slope::s_corner_dn:
+                quad_extra = xl + yl;
+                quad = xl + yl - TILE_SIZE - 1;
+                break;
+            case surface_slope::e_corner_dn:
+                quad_extra = TILE_SIZE - xl + yl;
+                quad = yl - xl;
+                break;
+            case surface_slope::n_corner_dn:
+                quad_extra = (TILE_SIZE - xl) + (TILE_SIZE - yl);
+                quad = TILE_SIZE - yl - xl - 1;
+                break;
+        }
+
+        if (surfaceEl->is_slope_dbl_height())
+        {
+            height += quad_extra / 2;
+            height++;
+            return std::make_tuple(height, waterHeight);
+        }
+        // This tile is essentially at the next height level
+        height += 0x10;
+        // so we move *down* the slope
+        if (quad < 0)
+        {
+            height += quad / 2;
+        }
+    }
+
+    // Valleys
+    if ((slope == surface_slope::w_e_valley) || (slope == surface_slope::n_s_valley))
+    {
+        switch (slope)
+        {
+            case surface_slope::w_e_valley:
+                if (xl + yl <= TILE_SIZE + 1)
+                {
+                    return std::make_tuple(height, waterHeight);
+                }
+                quad = TILE_SIZE - xl - yl;
+                break;
+            case surface_slope::n_s_valley:
+                quad = xl - yl;
+                break;
+        }
+        if (quad > 0)
+        {
+            height += quad / 2;
+        }
+    }
+
+    return std::make_tuple(height, waterHeight);
 }

--- a/src/openloco/map/tilemgr.h
+++ b/src/openloco/map/tilemgr.h
@@ -4,9 +4,17 @@
 #include <cstdint>
 #include <tuple>
 
-namespace openloco::map::tilemgr
+namespace openloco::map
 {
-    tile get(map_pos pos);
-    tile get(coord_t x, coord_t y);
-    std::tuple<int16_t, int16_t> get_height(coord_t x, coord_t y);
+    class tilemanager
+    {
+    public:
+        tile get(map_pos pos);
+        const tile get(map_pos pos) const;
+        tile get(coord_t x, coord_t y);
+        const tile get(coord_t x, coord_t y) const;
+        std::tuple<int16_t, int16_t> get_height(coord_t x, coord_t y) const;
+    };
+
+    extern tilemanager g_tilemgr;
 }

--- a/src/openloco/map/tilemgr.h
+++ b/src/openloco/map/tilemgr.h
@@ -18,6 +18,4 @@ namespace openloco::map
         const tile get(coord_t x, coord_t y) const;
         std::tuple<int16_t, int16_t> get_height(coord_t x, coord_t y) const;
     };
-
-    extern tilemanager g_tilemgr;
 }

--- a/src/openloco/map/tilemgr.h
+++ b/src/openloco/map/tilemgr.h
@@ -9,6 +9,9 @@ namespace openloco::map
     class tilemanager
     {
     public:
+        tilemanager() = default;
+        tilemanager(const tilemanager&) = delete;
+
         tile get(map_pos pos);
         const tile get(map_pos pos) const;
         tile get(coord_t x, coord_t y);

--- a/src/openloco/messagemgr.cpp
+++ b/src/openloco/messagemgr.cpp
@@ -1,23 +1,23 @@
 #include "messagemgr.h"
 #include "interop/interop.hpp"
 
+using namespace openloco;
 using namespace openloco::interop;
 
-namespace openloco::messagemgr
+messagemanager openloco::g_messagemgr;
+
+void messagemanager::post(
+    message_type type,
+    company_id_t companyId,
+    uint16_t subjectIdA,
+    uint16_t subjectIdB,
+    uint16_t subjectIdC)
 {
-    void post(
-        message_type type,
-        company_id_t companyId,
-        uint16_t subjectIdA,
-        uint16_t subjectIdB,
-        uint16_t subjectIdC)
-    {
-        registers regs;
-        regs.al = (uint8_t)type;
-        regs.ah = companyId;
-        regs.bx = subjectIdA;
-        regs.cx = subjectIdB;
-        regs.dx = subjectIdC;
-        call(0x004285BA, regs);
-    }
+    registers regs;
+    regs.al = (uint8_t)type;
+    regs.ah = companyId;
+    regs.bx = subjectIdA;
+    regs.cx = subjectIdB;
+    regs.dx = subjectIdC;
+    call(0x004285BA, regs);
 }

--- a/src/openloco/messagemgr.cpp
+++ b/src/openloco/messagemgr.cpp
@@ -4,8 +4,6 @@
 using namespace openloco;
 using namespace openloco::interop;
 
-messagemanager openloco::g_messagemgr;
-
 void messagemanager::post(
     message_type type,
     company_id_t companyId,

--- a/src/openloco/messagemgr.h
+++ b/src/openloco/messagemgr.h
@@ -10,21 +10,23 @@ namespace openloco
         cargo_now_accepted = 9,
         cargo_no_longer_accepted = 10,
     };
-}
 
-namespace openloco::messagemgr
-{
+    class messagemanager
+    {
+    public:
+        // 0x004285BA
+        // al: type
+        // ah: companyId
+        // bx: subjectId A (station)
+        // cx: subjectId B (cargo)
+        // dx: subjectId C
+        void post(
+            message_type type,
+            company_id_t companyId,
+            uint16_t subjectIdA,
+            uint16_t subjectIdB,
+            uint16_t subjectIdC = 0xFFFF);
+    };
 
-    // 0x004285BA
-    // al: type
-    // ah: companyId
-    // bx: subjectId A (station)
-    // cx: subjectId B (cargo)
-    // dx: subjectId C
-    void post(
-        message_type type,
-        company_id_t companyId,
-        uint16_t subjectIdA,
-        uint16_t subjectIdB,
-        uint16_t subjectIdC = 0xFFFF);
+    extern messagemanager g_messagemgr;
 }

--- a/src/openloco/messagemgr.h
+++ b/src/openloco/messagemgr.h
@@ -27,6 +27,4 @@ namespace openloco
             uint16_t subjectIdB,
             uint16_t subjectIdC = 0xFFFF);
     };
-
-    extern messagemanager g_messagemgr;
 }

--- a/src/openloco/objects/objectmgr.cpp
+++ b/src/openloco/objects/objectmgr.cpp
@@ -1,6 +1,7 @@
 #include "objectmgr.h"
 #include "../industry.h"
 #include "../interop/interop.hpp"
+#include "../things/vehicle.h"
 #include <vector>
 
 using namespace openloco;
@@ -112,6 +113,11 @@ currency_object* objectmanager::get()
 industry_object* objectmanager::get(const industry& i)
 {
     return get<industry_object>(i.object_id);
+}
+
+vehicle_object* objectmanager::get(const vehicle& v)
+{
+    return get<vehicle_object>(v.object_id);
 }
 
 size_t objectmanager::get_max_objects(object_type type)

--- a/src/openloco/objects/objectmgr.cpp
+++ b/src/openloco/objects/objectmgr.cpp
@@ -1,228 +1,234 @@
 #include "objectmgr.h"
+#include "../industry.h"
 #include "../interop/interop.hpp"
 #include <vector>
 
+using namespace openloco;
 using namespace openloco::interop;
 
-namespace openloco::objectmgr
+objectmanager openloco::g_objectmgr;
+
+static loco_global<object_repository_item[64], 0x4FE0B8> object_repository;
+static loco_global<interface_skin_object * [1], 0x0050C3D0> _interfaceObjects;
+static loco_global<sound_object * [128], 0x0050C3D4> _soundObjects;
+static loco_global<currency_object * [1], 0x0050C5D4> _currencyObjects;
+static loco_global<steam_object * [32], 0x0050C5D8> _steamObjects;
+static loco_global<rock_object * [8], 0x0050C658> _rockObjects;
+static loco_global<water_object * [1], 0x0050C678> _waterObjects;
+static loco_global<land_object * [32], 0x0050C67C> _landObjects;
+static loco_global<town_names_object * [1], 0x0050C6FC> _townNamesObjects;
+static loco_global<cargo_object * [32], 0x0050C700> _cargoObjects;
+static loco_global<wall_object * [32], 0x0050C780> _wallObjects;
+static loco_global<train_signal_object * [16], 0x0050C800> _trainSignalObjects;
+static loco_global<level_crossing_object * [4], 0x0050C840> _levelCrossingObjects;
+static loco_global<street_light_object * [1], 0x0050C850> _streetLightObjects;
+static loco_global<tunnel_object * [16], 0x0050C854> _tunnelObjects;
+static loco_global<bridge_object * [8], 0x0050C894> _bridgeObjects;
+static loco_global<train_station_object * [16], 0x0050C8B4> _trainStationObjects;
+static loco_global<track_extra_object * [8], 0x0050C8F4> _trackExtraObjects;
+static loco_global<track_object * [8], 0x0050C914> _trackObjects;
+static loco_global<road_station_object * [16], 0x0050C934> _roadStationObjects;
+static loco_global<road_extra_object * [4], 0x0050C974> _roadExtraObjects;
+static loco_global<road_object * [8], 0x0050C984> _roadObjects;
+static loco_global<airport_object * [8], 0x0050C9A4> _airportObjects;
+static loco_global<dock_object * [8], 0x0050C9C4> _dockObjects;
+static loco_global<vehicle_object * [224], 0x0050C9E4> _vehicleObjects;
+static loco_global<tree_object * [64], 0x0050CD64> _treeObjects;
+static loco_global<snow_object * [1], 0x0050CE64> _snowObjects;
+static loco_global<climate_object * [1], 0x0050CE68> _climateObjects;
+static loco_global<hill_shapes_object * [1], 0x0050CE6C> _hillShapeObjects;
+static loco_global<building_object * [128], 0x0050CE70> _buildingObjects;
+static loco_global<scaffolding_object * [1], 0x0050D070> _scaffoldingObjects;
+static loco_global<industry_object * [16], 0x0050D074> _industryObjects;
+static loco_global<region_object * [1], 0x0050D0B4> _regionObjects;
+static loco_global<competitors_object * [32], 0x0050D0B8> _competitorsObjects;
+static loco_global<scenario_text_object * [1], 0x0050D138> _scenarioTextObjects;
+
+// 0x00470F3C
+void objectmanager::load_index()
 {
-    loco_global<object_repository_item[64], 0x4FE0B8> object_repository;
-    loco_global<interface_skin_object * [1], 0x0050C3D0> _interfaceObjects;
-    loco_global<sound_object * [128], 0x0050C3D4> _soundObjects;
-    loco_global<currency_object * [1], 0x0050C5D4> _currencyObjects;
-    loco_global<steam_object * [32], 0x0050C5D8> _steamObjects;
-    loco_global<rock_object * [8], 0x0050C658> _rockObjects;
-    loco_global<water_object * [1], 0x0050C678> _waterObjects;
-    loco_global<land_object * [32], 0x0050C67C> _landObjects;
-    loco_global<town_names_object * [1], 0x0050C6FC> _townNamesObjects;
-    loco_global<cargo_object * [32], 0x0050C700> _cargoObjects;
-    loco_global<wall_object * [32], 0x0050C780> _wallObjects;
-    loco_global<train_signal_object * [16], 0x0050C800> _trainSignalObjects;
-    loco_global<level_crossing_object * [4], 0x0050C840> _levelCrossingObjects;
-    loco_global<street_light_object * [1], 0x0050C850> _streetLightObjects;
-    loco_global<tunnel_object * [16], 0x0050C854> _tunnelObjects;
-    loco_global<bridge_object * [8], 0x0050C894> _bridgeObjects;
-    loco_global<train_station_object * [16], 0x0050C8B4> _trainStationObjects;
-    loco_global<track_extra_object * [8], 0x0050C8F4> _trackExtraObjects;
-    loco_global<track_object * [8], 0x0050C914> _trackObjects;
-    loco_global<road_station_object * [16], 0x0050C934> _roadStationObjects;
-    loco_global<road_extra_object * [4], 0x0050C974> _roadExtraObjects;
-    loco_global<road_object * [8], 0x0050C984> _roadObjects;
-    loco_global<airport_object * [8], 0x0050C9A4> _airportObjects;
-    loco_global<dock_object * [8], 0x0050C9C4> _dockObjects;
-    loco_global<vehicle_object * [224], 0x0050C9E4> _vehicleObjects;
-    loco_global<tree_object * [64], 0x0050CD64> _treeObjects;
-    loco_global<snow_object * [1], 0x0050CE64> _snowObjects;
-    loco_global<climate_object * [1], 0x0050CE68> _climateObjects;
-    loco_global<hill_shapes_object * [1], 0x0050CE6C> _hillShapeObjects;
-    loco_global<building_object * [128], 0x0050CE70> _buildingObjects;
-    loco_global<scaffolding_object * [1], 0x0050D070> _scaffoldingObjects;
-    loco_global<industry_object * [16], 0x0050D074> _industryObjects;
-    loco_global<region_object * [1], 0x0050D0B4> _regionObjects;
-    loco_global<competitors_object * [32], 0x0050D0B8> _competitorsObjects;
-    loco_global<scenario_text_object * [1], 0x0050D138> _scenarioTextObjects;
+    call(0x00470F3C);
+}
 
-    // 0x00470F3C
-    void load_index()
+template<>
+interface_skin_object* objectmanager::get()
+{
+    if (_interfaceObjects[0] == (void*)-1)
     {
-        call(0x00470F3C);
+        return nullptr;
     }
 
-    template<>
-    interface_skin_object* get()
-    {
-        if (_interfaceObjects[0] == (void*)-1)
-        {
-            return nullptr;
-        }
+    return _interfaceObjects[0];
+}
 
-        return _interfaceObjects[0];
-    }
+template<>
+sound_object* objectmanager::get(size_t id)
+{
+    return _soundObjects[id];
+}
 
-    template<>
-    sound_object* get(size_t id)
-    {
-        return _soundObjects[id];
-    }
+template<>
+steam_object* objectmanager::get(size_t id)
+{
+    return _steamObjects[id];
+}
 
-    template<>
-    steam_object* get(size_t id)
-    {
-        return _steamObjects[id];
-    }
+template<>
+cargo_object* objectmanager::get(size_t id)
+{
+    return _cargoObjects[id];
+}
 
-    template<>
-    cargo_object* get(size_t id)
-    {
-        return _cargoObjects[id];
-    }
+template<>
+road_station_object* objectmanager::get(size_t id)
+{
+    return _roadStationObjects[id];
+}
 
-    template<>
-    road_station_object* get(size_t id)
-    {
-        return _roadStationObjects[id];
-    }
+template<>
+vehicle_object* objectmanager::get(size_t id)
+{
+    return _vehicleObjects[id];
+}
 
-    template<>
-    vehicle_object* get(size_t id)
-    {
-        return _vehicleObjects[id];
-    }
+template<>
+building_object* objectmanager::get(size_t id)
+{
+    return _buildingObjects[id];
+}
 
-    template<>
-    building_object* get(size_t id)
-    {
-        return _buildingObjects[id];
-    }
+template<>
+industry_object* objectmanager::get(size_t id)
+{
+    return _industryObjects[id];
+}
 
-    template<>
-    industry_object* get(size_t id)
-    {
-        return _industryObjects[id];
-    }
+template<>
+currency_object* objectmanager::get()
+{
+    return _currencyObjects[0];
+}
 
-    template<>
-    currency_object* get()
-    {
-        return _currencyObjects[0];
-    }
+industry_object* objectmanager::get(const industry& i)
+{
+    return get<industry_object>(i.object_id);
+}
 
-    size_t get_max_objects(object_type type)
-    {
-        static size_t counts[] = {
-            1,   // interface,
-            128, // sound,
-            1,   // currency,
-            32,  // steam,
-            8,   // rock,
-            1,   // water,
-            32,  // surface,
-            1,   // town_names,
-            32,  // cargo,
-            32,  // wall,
-            16,  // train_signal,
-            4,   // level_crossing,
-            1,   // street_light,
-            16,  // tunnel,
-            8,   // bridge,
-            16,  // train_station,
-            8,   // track_extra,
-            8,   // track,
-            16,  // road_station,
-            4,   // road_extra,
-            8,   // road,
-            8,   // airport,
-            8,   // dock,
-            224, // vehicle,
-            64,  // tree,
-            1,   // snow,
-            1,   // climate,
-            1,   // hill_shapes,
-            128, // building,
-            1,   // scaffolding,
-            16,  // industry,
-            1,   // region,
-            32,  // competitors,
-            1    // scenario_text,
-        };
-        return counts[(size_t)type];
+size_t objectmanager::get_max_objects(object_type type)
+{
+    static size_t counts[] = {
+        1,   // interface,
+        128, // sound,
+        1,   // currency,
+        32,  // steam,
+        8,   // rock,
+        1,   // water,
+        32,  // surface,
+        1,   // town_names,
+        32,  // cargo,
+        32,  // wall,
+        16,  // train_signal,
+        4,   // level_crossing,
+        1,   // street_light,
+        16,  // tunnel,
+        8,   // bridge,
+        16,  // train_station,
+        8,   // track_extra,
+        8,   // track,
+        16,  // road_station,
+        4,   // road_extra,
+        8,   // road,
+        8,   // airport,
+        8,   // dock,
+        224, // vehicle,
+        64,  // tree,
+        1,   // snow,
+        1,   // climate,
+        1,   // hill_shapes,
+        128, // building,
+        1,   // scaffolding,
+        16,  // industry,
+        1,   // region,
+        32,  // competitors,
+        1    // scenario_text,
     };
+    return counts[(size_t)type];
+};
 
-    /*
-    static void printHeader(header data)
+/*
+static void printHeader(header data)
+{
+    printf("(%02X | %02X << 6) ", data.type & 0x3F, data.type >> 6);
+    printf("%02X ", data.pad_01[0]);
+    printf("%02X ", data.pad_01[1]);
+    printf("%02X ", data.pad_01[2]);
+
+    char name[8 + 1] = { 0 };
+    memcpy(name, data.var_04, 8);
+    printf("'%s', ", name);
+
+    printf("%08X ", data.checksum);
+}
+*/
+
+objectmanager::object_index_entry objectmanager::object_index_entry::read(std::byte** ptr)
+{
+    object_index_entry entry = { 0 };
+
+    entry._header = (header*)*ptr;
+    *ptr += sizeof(header);
+
+    entry._filename = (char*)*ptr;
+    *ptr += strlen(entry._filename) + 1;
+
+    // decoded_chunk_size
+    //header2* h2 = (header2*)ptr;
+    *ptr += sizeof(header2);
+
+    entry._name = (char*)*ptr;
+    *ptr += strlen(entry._name) + 1;
+
+    //header3* h3 = (header3*)ptr;
+    *ptr += sizeof(header3);
+
+    uint8_t* countA = (uint8_t*)*ptr;
+    *ptr += sizeof(uint8_t);
+    for (int n = 0; n < *countA; n++)
     {
-        printf("(%02X | %02X << 6) ", data.type & 0x3F, data.type >> 6);
-        printf("%02X ", data.pad_01[0]);
-        printf("%02X ", data.pad_01[1]);
-        printf("%02X ", data.pad_01[2]);
-
-        char name[8 + 1] = { 0 };
-        memcpy(name, data.var_04, 8);
-        printf("'%s', ", name);
-
-        printf("%08X ", data.checksum);
-    }
-    */
-
-    object_index_entry object_index_entry::read(std::byte** ptr)
-    {
-        object_index_entry entry = { 0 };
-
-        entry._header = (header*)*ptr;
+        //header* subh = (header*)ptr;
         *ptr += sizeof(header);
-
-        entry._filename = (char*)*ptr;
-        *ptr += strlen(entry._filename) + 1;
-
-        // decoded_chunk_size
-        //header2* h2 = (header2*)ptr;
-        *ptr += sizeof(header2);
-
-        entry._name = (char*)*ptr;
-        *ptr += strlen(entry._name) + 1;
-
-        //header3* h3 = (header3*)ptr;
-        *ptr += sizeof(header3);
-
-        uint8_t* countA = (uint8_t*)*ptr;
-        *ptr += sizeof(uint8_t);
-        for (int n = 0; n < *countA; n++)
-        {
-            //header* subh = (header*)ptr;
-            *ptr += sizeof(header);
-        }
-
-        uint8_t* countB = (uint8_t*)*ptr;
-        *ptr += sizeof(uint8_t);
-        for (int n = 0; n < *countB; n++)
-        {
-            //header* subh = (header*)ptr;
-            *ptr += sizeof(header);
-        }
-
-        return entry;
     }
 
-    static loco_global<std::byte*, 0x0050D13C> _installedObjectList;
-    static loco_global<uint32_t, 0x0112A110> _installedObjectCount;
-
-    uint32_t getNumInstalledObjects()
+    uint8_t* countB = (uint8_t*)*ptr;
+    *ptr += sizeof(uint8_t);
+    for (int n = 0; n < *countB; n++)
     {
-        return *_installedObjectCount;
+        //header* subh = (header*)ptr;
+        *ptr += sizeof(header);
     }
 
-    std::vector<std::pair<uint32_t, object_index_entry>> getAvailableObjects(object_type type)
+    return entry;
+}
+
+static loco_global<std::byte*, 0x0050D13C> _installedObjectList;
+static loco_global<uint32_t, 0x0112A110> _installedObjectCount;
+
+uint32_t objectmanager::getNumInstalledObjects()
+{
+    return *_installedObjectCount;
+}
+
+std::vector<std::pair<uint32_t, objectmanager::object_index_entry>> objectmanager::getAvailableObjects(object_type type)
+{
+    auto ptr = (std::byte*)_installedObjectList;
+    std::vector<std::pair<uint32_t, object_index_entry>> list;
+
+    for (uint32_t i = 0; i < _installedObjectCount; i++)
     {
-        auto ptr = (std::byte*)_installedObjectList;
-        std::vector<std::pair<uint32_t, object_index_entry>> list;
-
-        for (uint32_t i = 0; i < _installedObjectCount; i++)
-        {
-            auto entry = object_index_entry::read(&ptr);
-            if (entry._header->get_type() == type)
-                list.emplace_back(std::pair<uint32_t, object_index_entry>(i, entry));
-        }
-
-        return list;
+        auto entry = object_index_entry::read(&ptr);
+        if (entry._header->get_type() == type)
+            list.emplace_back(std::pair<uint32_t, object_index_entry>(i, entry));
     }
+
+    return list;
 }

--- a/src/openloco/objects/objectmgr.cpp
+++ b/src/openloco/objects/objectmgr.cpp
@@ -7,8 +7,6 @@
 using namespace openloco;
 using namespace openloco::interop;
 
-objectmanager openloco::g_objectmgr;
-
 static loco_global<object_repository_item[64], 0x4FE0B8> object_repository;
 static loco_global<interface_skin_object * [1], 0x0050C3D0> _interfaceObjects;
 static loco_global<sound_object * [128], 0x0050C3D4> _soundObjects;

--- a/src/openloco/objects/objectmgr.h
+++ b/src/openloco/objects/objectmgr.h
@@ -47,6 +47,8 @@ namespace openloco
     };
 
     struct industry;
+    struct vehicle;
+
     struct object;
     struct object_entry_extended;
     struct cargo_object;
@@ -103,6 +105,7 @@ namespace openloco
         T* get(size_t id);
 
         industry_object* get(const industry& i);
+        vehicle_object* get(const vehicle& v);
 
 #pragma pack(push, 1)
         struct header

--- a/src/openloco/objects/objectmgr.h
+++ b/src/openloco/objects/objectmgr.h
@@ -95,6 +95,9 @@ namespace openloco
     class objectmanager
     {
     public:
+        objectmanager() = default;
+        objectmanager(const objectmanager&) = delete;
+
         void load_index();
         size_t get_max_objects(object_type type);
 
@@ -163,6 +166,4 @@ namespace openloco
     industry_object* objectmanager::get(size_t id);
     template<>
     currency_object* objectmanager::get();
-
-    extern objectmanager g_objectmgr;
 }

--- a/src/openloco/objects/objectmgr.h
+++ b/src/openloco/objects/objectmgr.h
@@ -46,6 +46,7 @@ namespace openloco
         scenario_text,
     };
 
+    struct industry;
     struct object;
     struct object_entry_extended;
     struct cargo_object;
@@ -88,71 +89,77 @@ namespace openloco
         object* objects;
         uint32_t* object_entry_extendeds;
     };
-}
 
-namespace openloco::objectmgr
-{
-    void load_index();
-    size_t get_max_objects(object_type type);
+    class objectmanager
+    {
+    public:
+        void load_index();
+        size_t get_max_objects(object_type type);
 
-    template<typename T>
-    T* get();
+        template<typename T>
+        T* get();
 
-    template<typename T>
-    T* get(size_t id);
+        template<typename T>
+        T* get(size_t id);
 
-    template<>
-    interface_skin_object* get();
-    template<>
-    steam_object* get(size_t id);
-    template<>
-    cargo_object* get(size_t id);
-    template<>
-    road_station_object* get(size_t id);
-    template<>
-    vehicle_object* get(size_t id);
-    template<>
-    building_object* get(size_t id);
-    template<>
-    industry_object* get(size_t id);
-    template<>
-    currency_object* get();
+        industry_object* get(const industry& i);
 
 #pragma pack(push, 1)
-    struct header
-    {
-        uint8_t type;
-        uint8_t pad_01[3];
-        uint8_t var_04[8];
-        uint32_t checksum;
-
-        constexpr object_type get_type()
+        struct header
         {
-            return static_cast<object_type>(type & 0x3F);
-        }
-    };
+            uint8_t type;
+            uint8_t pad_01[3];
+            uint8_t var_04[8];
+            uint32_t checksum;
 
-    struct header2
-    {
-        uint8_t pad_00[0x04 - 0x00];
-    };
+            constexpr object_type get_type()
+            {
+                return static_cast<object_type>(type & 0x3F);
+            }
+        };
 
-    struct header3
-    {
-        uint32_t var_00;      // image count?
-        uint8_t pad_04[0x08]; // competitor stats?
-    };
+        struct header2
+        {
+            uint8_t pad_00[0x04 - 0x00];
+        };
 
-    struct object_index_entry
-    {
-        header* _header;
-        char* _filename;
-        char* _name;
+        struct header3
+        {
+            uint32_t var_00;      // image count?
+            uint8_t pad_04[0x08]; // competitor stats?
+        };
 
-        static object_index_entry read(std::byte** ptr);
-    };
+        struct object_index_entry
+        {
+            header* _header;
+            char* _filename;
+            char* _name;
+
+            static object_index_entry read(std::byte** ptr);
+        };
 #pragma pack(pop)
 
-    uint32_t getNumInstalledObjects();
-    std::vector<std::pair<uint32_t, object_index_entry>> getAvailableObjects(object_type type);
+        uint32_t getNumInstalledObjects();
+        std::vector<std::pair<uint32_t, object_index_entry>> getAvailableObjects(object_type type);
+    };
+
+    // Specialisations
+    template<>
+    interface_skin_object* objectmanager::get();
+    template<>
+    steam_object* objectmanager::get(size_t id);
+    template<>
+    cargo_object* objectmanager::get(size_t id);
+    template<>
+    road_station_object* objectmanager::get(size_t id);
+    template<>
+    vehicle_object* objectmanager::get(size_t id);
+    template<>
+    building_object* objectmanager::get(size_t id);
+    template<>
+    industry_object* objectmanager::get(size_t id);
+    template<>
+    currency_object* objectmanager::get();
+
+    extern objectmanager g_objectmgr;
 }

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -62,9 +62,13 @@ context::context()
 {
     _companymgr = std::make_unique<companymanager>();
     _industrymgr = std::make_unique<industrymanager>();
-    _messagemgr = std::make_unique<messagemanager>();
+    _objectmgr = std::make_unique<objectmanager>();
     _tilemgr = std::make_unique<map::tilemanager>();
+    _messagemgr = std::make_unique<messagemanager>();
+    _scenariomgr = std::make_unique<scenariomanager>();
+    _stationmgr = std::make_unique<stationmanager>();
     _thingmgr = std::make_unique<thingmanager>();
+    _townmgr = std::make_unique<townmanager>();
     _viewportmgr = std::make_unique<ui::viewportmanager>();
 }
 context::~context() {}
@@ -280,7 +284,7 @@ namespace openloco
         progressb.end();
         config::read();
         g_ctx.get<objectmanager>().load_index();
-        g_scenariomgr.load_index(0);
+        g_ctx.get<scenariomanager>().load_index(0);
         progressb.begin(string_ids::loading, 0);
         progressb.set_progress(60);
         gfx::load_g1(g_env);
@@ -550,8 +554,10 @@ namespace openloco
     // 0x0046ABCB
     static void tick_logic()
     {
-        auto& thingmgr = g_ctx.get<thingmanager>();
         auto& companymgr = g_ctx.get<companymanager>();
+        auto& stationmgr = g_ctx.get<stationmanager>();
+        auto& thingmgr = g_ctx.get<thingmanager>();
+        auto& townmgr = g_ctx.get<townmanager>();
 
         _scenario_ticks++;
         addr<0x00525F64, int32_t>()++;
@@ -559,14 +565,14 @@ namespace openloco
         addr<0x00525FD0, uint32_t>() = _prng->srand_1();
         call(0x004613F0);
         addr<0x00F25374, uint8_t>() = addr<0x009C871C, uint8_t>();
-        date_tick(companymgr, g_stationmgr, g_townmgr);
+        date_tick(companymgr, stationmgr, townmgr);
         call(0x00463ABA);
         call(0x004C56F6);
-        g_townmgr.update(companymgr);
+        townmgr.update(companymgr);
         g_ctx.get<industrymanager>().update(g_ctx);
         thingmgr.update_vehicles(g_ctx);
         sub_46FFCA();
-        g_stationmgr.update(companymgr, g_ctx.get<messagemanager>());
+        stationmgr.update(companymgr, g_ctx.get<messagemanager>());
         thingmgr.update_misc_things();
         sub_46FFCA();
         companymgr.update();

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -249,30 +249,31 @@ namespace openloco
 
     static void initialise()
     {
+        progressbar progressb;
         addr<0x0050C18C, int32_t>() = addr<0x00525348, int32_t>();
         call(0x004078BE);
         call(0x004BF476);
         environment::resolve_paths();
         localisation::enumerateLanguages();
         localisation::loadLanguageFile();
-        progressbar::begin(string_ids::loading, 0);
-        progressbar::set_progress(30);
+        progressb.begin(string_ids::loading, 0);
+        progressb.set_progress(30);
         startup_checks();
-        progressbar::set_progress(40);
+        progressb.set_progress(40);
         call(0x004BE5DE);
-        progressbar::end();
+        progressb.end();
         config::read();
         g_objectmgr.load_index();
         g_scenariomgr.load_index(0);
-        progressbar::begin(string_ids::loading, 0);
-        progressbar::set_progress(60);
+        progressb.begin(string_ids::loading, 0);
+        progressb.set_progress(60);
         gfx::load_g1(g_env);
-        progressbar::set_progress(220);
+        progressb.set_progress(220);
         call(0x004949BC);
-        progressbar::set_progress(235);
-        progressbar::set_progress(250);
+        progressb.set_progress(235);
+        progressb.set_progress(250);
         ui::initialise_cursors();
-        progressbar::end();
+        progressb.end();
         ui::initialise();
         initialise_viewports();
         call(0x004284C8);

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -49,11 +49,18 @@
 
 #pragma warning(disable : 4611) // interaction between '_setjmp' and C++ object destruction is non - portable
 
+using namespace openloco;
 using namespace openloco::interop;
 namespace windowmgr = openloco::ui::windowmgr;
 using input_flags = openloco::input::input_flags;
 using input_state = openloco::input::input_state;
 using window_type = openloco::ui::window_type;
+
+context::context()
+{
+    _tilemgr = std::make_unique<map::tilemanager>();
+}
+context::~context() {}
 
 namespace openloco
 {
@@ -536,6 +543,9 @@ namespace openloco
     // 0x0046ABCB
     static void tick_logic()
     {
+        context ctx;
+        auto tilemgr = ctx.get<map::tilemanager>();
+
         _scenario_ticks++;
         addr<0x00525F64, int32_t>()++;
         addr<0x00525FCC, uint32_t>() = _prng->srand_0();
@@ -546,8 +556,8 @@ namespace openloco
         call(0x00463ABA);
         call(0x004C56F6);
         g_townmgr.update(g_companymgr);
-        g_industrymgr.update(g_companymgr, map::g_tilemgr);
-        g_thingmgr.update_vehicles(g_objectmgr, map::g_tilemgr, ui::g_viewportmgr);
+        g_industrymgr.update(g_companymgr, tilemgr);
+        g_thingmgr.update_vehicles(g_objectmgr, tilemgr, ui::g_viewportmgr);
         sub_46FFCA();
         g_stationmgr.update(g_companymgr, g_messagemgr);
         g_thingmgr.update_misc_things();

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -261,7 +261,7 @@ namespace openloco
         call(0x004BE5DE);
         progressbar::end();
         config::read();
-        objectmgr::load_index();
+        g_objectmgr.load_index();
         scenariomgr::load_index(0);
         progressbar::begin(string_ids::loading, 0);
         progressbar::set_progress(60);

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -43,6 +43,7 @@
 #include "tutorial.h"
 #include "ui.h"
 #include "utility/numeric.hpp"
+#include "viewportmgr.h"
 #include "windowmgr.h"
 
 #pragma warning(disable : 4611) // interaction between '_setjmp' and C++ object destruction is non - portable
@@ -545,7 +546,7 @@ namespace openloco
         call(0x004C56F6);
         g_townmgr.update(g_companymgr);
         g_industrymgr.update(g_companymgr);
-        g_thingmgr.update_vehicles(g_objectmgr);
+        g_thingmgr.update_vehicles(g_objectmgr, ui::g_viewportmgr);
         sub_46FFCA();
         g_stationmgr.update(g_companymgr, g_messagemgr);
         g_thingmgr.update_misc_things();

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -61,6 +61,7 @@ context openloco::g_ctx;
 context::context()
 {
     _companymgr = std::make_unique<companymanager>();
+    _environment = std::make_unique<environment>();
     _industrymgr = std::make_unique<industrymanager>();
     _objectmgr = std::make_unique<objectmanager>();
     _tilemgr = std::make_unique<map::tilemanager>();
@@ -287,7 +288,7 @@ namespace openloco
         g_ctx.get<scenariomanager>().load_index(0);
         progressb.begin(string_ids::loading, 0);
         progressb.set_progress(60);
-        gfx::load_g1(g_env);
+        gfx::load_g1(g_ctx.get<environment>());
         progressb.set_progress(220);
         call(0x004949BC);
         progressb.set_progress(235);
@@ -488,7 +489,7 @@ namespace openloco
                 addr<0x00525F62, int16_t>()++;
                 call(0x0043D9D4);
                 audio::play_background_music();
-                audio::play_title_screen_music(g_env);
+                audio::play_title_screen_music(g_ctx.get<environment>());
                 if (tutorial::state() != tutorial::tutorial_state::none && addr<0x0052532C, int32_t>() == 0 && addr<0x0113E2E4, int32_t>() < 0x40)
                 {
                     tutorial::stop();
@@ -737,8 +738,9 @@ namespace openloco
         std::cout << versionInfo << std::endl;
         try
         {
-            const auto& cfg = config::read_new_config(g_env);
-            g_env.resolve_paths();
+            auto& env = g_ctx.get<environment>();
+            const auto& cfg = config::read_new_config(env);
+            env.resolve_paths();
 
             register_hooks();
             if (sub_4054B9())
@@ -747,7 +749,7 @@ namespace openloco
                 call(0x004078FE);
                 call(0x00407B26);
                 ui::initialise_input();
-                audio::initialise_dsound(g_env);
+                audio::initialise_dsound(env);
                 run();
                 audio::dispose_dsound();
                 ui::dispose_cursors();

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -541,14 +541,14 @@ namespace openloco
         date_tick();
         call(0x00463ABA);
         call(0x004C56F6);
-        townmgr::update();
-        industrymgr::update();
+        townmgr::update(g_companymgr);
+        g_industrymgr.update(g_companymgr);
         thingmgr::update_vehicles();
         sub_46FFCA();
-        stationmgr::update();
+        stationmgr::update(g_companymgr);
         thingmgr::update_misc_things();
         sub_46FFCA();
-        companymgr::update();
+        g_companymgr.update();
         invalidate_map_animations();
         audio::update_vehicle_noise();
         audio::update_ambient_noise();
@@ -584,7 +584,7 @@ namespace openloco
         {
             if (update_day_counter())
             {
-                stationmgr::update_daily();
+                stationmgr::update_daily(g_companymgr);
                 call(0x004B94CF);
                 call(0x00453487);
                 call(0x004284DB);

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -60,6 +60,9 @@ context openloco::g_ctx;
 
 context::context()
 {
+    _companymgr = std::make_unique<companymanager>();
+    _industrymgr = std::make_unique<industrymanager>();
+    _messagemgr = std::make_unique<messagemanager>();
     _tilemgr = std::make_unique<map::tilemanager>();
     _thingmgr = std::make_unique<thingmanager>();
     _viewportmgr = std::make_unique<ui::viewportmanager>();
@@ -548,6 +551,7 @@ namespace openloco
     static void tick_logic()
     {
         auto& thingmgr = g_ctx.get<thingmanager>();
+        auto& companymgr = g_ctx.get<companymanager>();
 
         _scenario_ticks++;
         addr<0x00525F64, int32_t>()++;
@@ -555,17 +559,17 @@ namespace openloco
         addr<0x00525FD0, uint32_t>() = _prng->srand_1();
         call(0x004613F0);
         addr<0x00F25374, uint8_t>() = addr<0x009C871C, uint8_t>();
-        date_tick(g_companymgr, g_stationmgr, g_townmgr);
+        date_tick(companymgr, g_stationmgr, g_townmgr);
         call(0x00463ABA);
         call(0x004C56F6);
-        g_townmgr.update(g_companymgr);
-        g_industrymgr.update(g_ctx);
+        g_townmgr.update(companymgr);
+        g_ctx.get<industrymanager>().update(g_ctx);
         thingmgr.update_vehicles(g_ctx);
         sub_46FFCA();
-        g_stationmgr.update(g_companymgr, g_messagemgr);
+        g_stationmgr.update(companymgr, g_ctx.get<messagemanager>());
         thingmgr.update_misc_things();
         sub_46FFCA();
-        g_companymgr.update();
+        companymgr.update();
         invalidate_map_animations();
         audio::update_vehicle_noise(thingmgr);
         audio::update_ambient_noise();

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -31,6 +31,7 @@
 #include "localisation/languagefiles.h"
 #include "localisation/languages.h"
 #include "localisation/string_ids.h"
+#include "map/tilemgr.h"
 #include "messagemgr.h"
 #include "objects/objectmgr.h"
 #include "openloco.h"
@@ -545,8 +546,8 @@ namespace openloco
         call(0x00463ABA);
         call(0x004C56F6);
         g_townmgr.update(g_companymgr);
-        g_industrymgr.update(g_companymgr);
-        g_thingmgr.update_vehicles(g_objectmgr, ui::g_viewportmgr);
+        g_industrymgr.update(g_companymgr, map::g_tilemgr);
+        g_thingmgr.update_vehicles(g_objectmgr, map::g_tilemgr, ui::g_viewportmgr);
         sub_46FFCA();
         g_stationmgr.update(g_companymgr, g_messagemgr);
         g_thingmgr.update_misc_things();

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -31,6 +31,7 @@
 #include "localisation/languagefiles.h"
 #include "localisation/languages.h"
 #include "localisation/string_ids.h"
+#include "messagemgr.h"
 #include "objects/objectmgr.h"
 #include "openloco.h"
 #include "platform/platform.h"
@@ -76,7 +77,7 @@ namespace openloco
     static void tick_logic(int32_t count);
     static void tick_logic();
     static void tick_wait();
-    static void date_tick();
+    static void date_tick(companymanager& companymgr, stationmanager& stationmgr, townmanager& townmgr);
     static void sub_46FFCA();
 
     std::string get_version_info()
@@ -538,14 +539,14 @@ namespace openloco
         addr<0x00525FD0, uint32_t>() = _prng->srand_1();
         call(0x004613F0);
         addr<0x00F25374, uint8_t>() = addr<0x009C871C, uint8_t>();
-        date_tick();
+        date_tick(g_companymgr, g_stationmgr, g_townmgr);
         call(0x00463ABA);
         call(0x004C56F6);
-        townmgr::update(g_companymgr);
+        g_townmgr.update(g_companymgr);
         g_industrymgr.update(g_companymgr);
         thingmgr::update_vehicles();
         sub_46FFCA();
-        g_stationmgr.update(g_companymgr);
+        g_stationmgr.update(g_companymgr, g_messagemgr);
         thingmgr::update_misc_things();
         sub_46FFCA();
         g_companymgr.update();
@@ -578,13 +579,13 @@ namespace openloco
     }
 
     // 0x004968C7
-    static void date_tick()
+    static void date_tick(companymanager& companymgr, stationmanager& stationmgr, townmanager& townmgr)
     {
         if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
         {
             if (update_day_counter())
             {
-                g_stationmgr.update_daily(g_companymgr);
+                stationmgr.update_daily(companymgr, townmgr);
                 call(0x004B94CF);
                 call(0x00453487);
                 call(0x004284DB);
@@ -600,7 +601,7 @@ namespace openloco
                     // End of every month
                     addr<0x0050A004, uint16_t>() += 2;
                     addr<0x00526243, uint16_t>()++;
-                    townmgr::update_monthly();
+                    townmgr.update_monthly();
                     call(0x0045383B);
                     call(0x0043037B);
                     call(0x0042F213);

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -262,7 +262,7 @@ namespace openloco
         progressbar::end();
         config::read();
         g_objectmgr.load_index();
-        scenariomgr::load_index(0);
+        g_scenariomgr.load_index(0);
         progressbar::begin(string_ids::loading, 0);
         progressbar::set_progress(60);
         gfx::load_g1();
@@ -545,7 +545,7 @@ namespace openloco
         g_industrymgr.update(g_companymgr);
         thingmgr::update_vehicles();
         sub_46FFCA();
-        stationmgr::update(g_companymgr);
+        g_stationmgr.update(g_companymgr);
         thingmgr::update_misc_things();
         sub_46FFCA();
         g_companymgr.update();
@@ -584,7 +584,7 @@ namespace openloco
         {
             if (update_day_counter())
             {
-                stationmgr::update_daily(g_companymgr);
+                g_stationmgr.update_daily(g_companymgr);
                 call(0x004B94CF);
                 call(0x00453487);
                 call(0x004284DB);

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -266,7 +266,7 @@ namespace openloco
         g_scenariomgr.load_index(0);
         progressbar::begin(string_ids::loading, 0);
         progressbar::set_progress(60);
-        gfx::load_g1();
+        gfx::load_g1(g_env);
         progressbar::set_progress(220);
         call(0x004949BC);
         progressbar::set_progress(235);
@@ -467,7 +467,7 @@ namespace openloco
                 addr<0x00525F62, int16_t>()++;
                 call(0x0043D9D4);
                 audio::play_background_music();
-                audio::play_title_screen_music();
+                audio::play_title_screen_music(g_env);
                 if (tutorial::state() != tutorial::tutorial_state::none && addr<0x0052532C, int32_t>() == 0 && addr<0x0113E2E4, int32_t>() < 0x40)
                 {
                     tutorial::stop();
@@ -711,8 +711,8 @@ namespace openloco
         std::cout << versionInfo << std::endl;
         try
         {
-            const auto& cfg = config::read_new_config();
-            environment::resolve_paths();
+            const auto& cfg = config::read_new_config(g_env);
+            g_env.resolve_paths();
 
             register_hooks();
             if (sub_4054B9())
@@ -721,7 +721,7 @@ namespace openloco
                 call(0x004078FE);
                 call(0x00407B26);
                 ui::initialise_input();
-                audio::initialise_dsound();
+                audio::initialise_dsound(g_env);
                 run();
                 audio::dispose_dsound();
                 ui::dispose_cursors();

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -56,9 +56,13 @@ using input_flags = openloco::input::input_flags;
 using input_state = openloco::input::input_state;
 using window_type = openloco::ui::window_type;
 
+context openloco::g_ctx;
+
 context::context()
 {
     _tilemgr = std::make_unique<map::tilemanager>();
+    _thingmgr = std::make_unique<thingmanager>();
+    _viewportmgr = std::make_unique<ui::viewportmanager>();
 }
 context::~context() {}
 
@@ -272,7 +276,7 @@ namespace openloco
         call(0x004BE5DE);
         progressb.end();
         config::read();
-        g_objectmgr.load_index();
+        g_ctx.get<objectmanager>().load_index();
         g_scenariomgr.load_index(0);
         progressb.begin(string_ids::loading, 0);
         progressb.set_progress(60);
@@ -543,8 +547,7 @@ namespace openloco
     // 0x0046ABCB
     static void tick_logic()
     {
-        context ctx;
-        auto tilemgr = ctx.get<map::tilemanager>();
+        auto& thingmgr = g_ctx.get<thingmanager>();
 
         _scenario_ticks++;
         addr<0x00525F64, int32_t>()++;
@@ -556,15 +559,15 @@ namespace openloco
         call(0x00463ABA);
         call(0x004C56F6);
         g_townmgr.update(g_companymgr);
-        g_industrymgr.update(g_companymgr, tilemgr);
-        g_thingmgr.update_vehicles(g_objectmgr, tilemgr, ui::g_viewportmgr);
+        g_industrymgr.update(g_ctx);
+        thingmgr.update_vehicles(g_ctx);
         sub_46FFCA();
         g_stationmgr.update(g_companymgr, g_messagemgr);
-        g_thingmgr.update_misc_things();
+        thingmgr.update_misc_things();
         sub_46FFCA();
         g_companymgr.update();
         invalidate_map_animations();
-        audio::update_vehicle_noise(g_thingmgr);
+        audio::update_vehicle_noise(thingmgr);
         audio::update_ambient_noise();
         call(0x00444387);
 

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -544,7 +544,7 @@ namespace openloco
         call(0x004C56F6);
         g_townmgr.update(g_companymgr);
         g_industrymgr.update(g_companymgr);
-        g_thingmgr.update_vehicles();
+        g_thingmgr.update_vehicles(g_objectmgr);
         sub_46FFCA();
         g_stationmgr.update(g_companymgr, g_messagemgr);
         g_thingmgr.update_misc_things();

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -544,14 +544,14 @@ namespace openloco
         call(0x004C56F6);
         g_townmgr.update(g_companymgr);
         g_industrymgr.update(g_companymgr);
-        thingmgr::update_vehicles();
+        g_thingmgr.update_vehicles();
         sub_46FFCA();
         g_stationmgr.update(g_companymgr, g_messagemgr);
-        thingmgr::update_misc_things();
+        g_thingmgr.update_misc_things();
         sub_46FFCA();
         g_companymgr.update();
         invalidate_map_animations();
-        audio::update_vehicle_noise();
+        audio::update_vehicle_noise(g_thingmgr);
         audio::update_ambient_noise();
         call(0x00444387);
 

--- a/src/openloco/openloco.h
+++ b/src/openloco/openloco.h
@@ -21,7 +21,10 @@ namespace openloco
     class industrymanager;
     class messagemanager;
     class objectmanager;
+    class scenariomanager;
+    class stationmanager;
     class thingmanager;
+    class townmanager;
 
     class context
     {
@@ -31,7 +34,10 @@ namespace openloco
         std::unique_ptr<objectmanager> _objectmgr;
         std::unique_ptr<map::tilemanager> _tilemgr;
         std::unique_ptr<messagemanager> _messagemgr;
+        std::unique_ptr<scenariomanager> _scenariomgr;
+        std::unique_ptr<stationmanager> _stationmgr;
         std::unique_ptr<thingmanager> _thingmgr;
+        std::unique_ptr<townmanager> _townmgr;
         std::unique_ptr<ui::viewportmanager> _viewportmgr;
 
     public:
@@ -56,7 +62,13 @@ namespace openloco
         template<>
         map::tilemanager& get() { return *_tilemgr; }
         template<>
+        scenariomanager& get() { return *_scenariomgr; }
+        template<>
+        stationmanager& get() { return *_stationmgr; }
+        template<>
         thingmanager& get() { return *_thingmgr; }
+        template<>
+        townmanager& get() { return *_townmgr; }
         template<>
         ui::viewportmanager& get() { return *_viewportmgr; }
     };

--- a/src/openloco/openloco.h
+++ b/src/openloco/openloco.h
@@ -10,12 +10,25 @@ namespace openloco::map
     class tilemanager;
 }
 
+namespace openloco::ui
+{
+    class viewportmanager;
+}
+
 namespace openloco
 {
+    class companymanager;
+    class objectmanager;
+    class thingmanager;
+
     class context
     {
     private:
+        std::unique_ptr<companymanager> _companymgr;
+        std::unique_ptr<objectmanager> _objectmgr;
         std::unique_ptr<map::tilemanager> _tilemgr;
+        std::unique_ptr<thingmanager> _thingmgr;
+        std::unique_ptr<ui::viewportmanager> _viewportmgr;
 
     public:
         context();
@@ -29,8 +42,18 @@ namespace openloco
         const T& get() const { return ((context*)this)->get<T>(); }
 
         template<>
+        companymanager& get() { return *_companymgr; }
+        template<>
+        objectmanager& get() { return *_objectmgr; }
+        template<>
         map::tilemanager& get() { return *_tilemgr; }
+        template<>
+        thingmanager& get() { return *_thingmgr; }
+        template<>
+        ui::viewportmanager& get() { return *_viewportmgr; }
     };
+
+    extern context g_ctx;
 
     namespace screen_flags
     {

--- a/src/openloco/openloco.h
+++ b/src/openloco/openloco.h
@@ -18,6 +18,7 @@ namespace openloco::ui
 namespace openloco
 {
     class companymanager;
+    class environment;
     class industrymanager;
     class messagemanager;
     class objectmanager;
@@ -30,6 +31,7 @@ namespace openloco
     {
     private:
         std::unique_ptr<companymanager> _companymgr;
+        std::unique_ptr<environment> _environment;
         std::unique_ptr<industrymanager> _industrymgr;
         std::unique_ptr<objectmanager> _objectmgr;
         std::unique_ptr<map::tilemanager> _tilemgr;
@@ -53,6 +55,8 @@ namespace openloco
 
         template<>
         companymanager& get() { return *_companymgr; }
+        template<>
+        environment& get() { return *_environment; }
         template<>
         industrymanager& get() { return *_industrymgr; }
         template<>

--- a/src/openloco/openloco.h
+++ b/src/openloco/openloco.h
@@ -5,8 +5,33 @@
 #include <functional>
 #include <string>
 
+namespace openloco::map
+{
+    class tilemanager;
+}
+
 namespace openloco
 {
+    class context
+    {
+    private:
+        std::unique_ptr<map::tilemanager> _tilemgr;
+
+    public:
+        context();
+        context(const context&) = delete;
+        ~context();
+
+        template<typename T>
+        T& get();
+
+        template<typename T>
+        const T& get() const { return ((context*)this)->get<T>(); }
+
+        template<>
+        map::tilemanager& get() { return *_tilemgr; }
+    };
+
     namespace screen_flags
     {
         constexpr uint8_t title = 1 << 0;

--- a/src/openloco/openloco.h
+++ b/src/openloco/openloco.h
@@ -18,6 +18,8 @@ namespace openloco::ui
 namespace openloco
 {
     class companymanager;
+    class industrymanager;
+    class messagemanager;
     class objectmanager;
     class thingmanager;
 
@@ -25,8 +27,10 @@ namespace openloco
     {
     private:
         std::unique_ptr<companymanager> _companymgr;
+        std::unique_ptr<industrymanager> _industrymgr;
         std::unique_ptr<objectmanager> _objectmgr;
         std::unique_ptr<map::tilemanager> _tilemgr;
+        std::unique_ptr<messagemanager> _messagemgr;
         std::unique_ptr<thingmanager> _thingmgr;
         std::unique_ptr<ui::viewportmanager> _viewportmgr;
 
@@ -43,6 +47,10 @@ namespace openloco
 
         template<>
         companymanager& get() { return *_companymgr; }
+        template<>
+        industrymanager& get() { return *_industrymgr; }
+        template<>
+        messagemanager& get() { return *_messagemgr; }
         template<>
         objectmanager& get() { return *_objectmgr; }
         template<>

--- a/src/openloco/progressbar.cpp
+++ b/src/openloco/progressbar.cpp
@@ -1,32 +1,30 @@
 #include "progressbar.h"
 #include "interop/interop.hpp"
 
+using namespace openloco;
 using namespace openloco::interop;
 
-namespace openloco::progressbar
+// 0x004CF5C5
+// eax: maximum
+void progressbar::begin(string_id stringId, int32_t edx)
 {
-    // 0x004CF5C5
-    // eax: maximum
-    void begin(string_id stringId, int32_t edx)
-    {
-        registers regs;
-        regs.eax = stringId;
-        regs.edx = edx;
-        call(0x004CF5C5, regs);
-    }
+    registers regs;
+    regs.eax = stringId;
+    regs.edx = edx;
+    call(0x004CF5C5, regs);
+}
 
-    // 0x004CF621
-    // eax: value
-    void set_progress(int32_t value)
-    {
-        registers regs;
-        regs.eax = value;
-        call(0x004CF621, regs);
-    }
+// 0x004CF621
+// eax: value
+void progressbar::set_progress(int32_t value)
+{
+    registers regs;
+    regs.eax = value;
+    call(0x004CF621, regs);
+}
 
-    // 0x004CF60B
-    void end()
-    {
-        call(0x004CF60B);
-    }
+// 0x004CF60B
+void progressbar::end()
+{
+    call(0x004CF60B);
 }

--- a/src/openloco/progressbar.h
+++ b/src/openloco/progressbar.h
@@ -3,9 +3,13 @@
 #include "localisation/stringmgr.h"
 #include <cstdint>
 
-namespace openloco::progressbar
+namespace openloco
 {
-    void begin(string_id stringId, int32_t edx);
-    void set_progress(int32_t value);
-    void end();
+    class progressbar
+    {
+    public:
+        void begin(string_id stringId, int32_t edx);
+        void set_progress(int32_t value);
+        void end();
+    };
 }

--- a/src/openloco/scenariomgr.cpp
+++ b/src/openloco/scenariomgr.cpp
@@ -4,8 +4,6 @@
 using namespace openloco;
 using namespace openloco::interop;
 
-scenariomanager openloco::g_scenariomgr;
-
 // 0x0044452F
 void scenariomanager::load_index(uint8_t al)
 {

--- a/src/openloco/scenariomgr.cpp
+++ b/src/openloco/scenariomgr.cpp
@@ -1,15 +1,15 @@
 #include "scenariomgr.h"
 #include "interop/interop.hpp"
 
+using namespace openloco;
 using namespace openloco::interop;
 
-namespace openloco::scenariomgr
+scenariomanager openloco::g_scenariomgr;
+
+// 0x0044452F
+void scenariomanager::load_index(uint8_t al)
 {
-    // 0x0044452F
-    void load_index(uint8_t al)
-    {
-        registers regs;
-        regs.al = al;
-        call(0x0044452F, regs);
-    }
+    registers regs;
+    regs.al = al;
+    call(0x0044452F, regs);
 }

--- a/src/openloco/scenariomgr.h
+++ b/src/openloco/scenariomgr.h
@@ -9,6 +9,4 @@ namespace openloco
     public:
         void load_index(uint8_t al);
     };
-
-    extern scenariomanager g_scenariomgr;
 }

--- a/src/openloco/scenariomgr.h
+++ b/src/openloco/scenariomgr.h
@@ -2,7 +2,13 @@
 
 #include <cstdint>
 
-namespace openloco::scenariomgr
+namespace openloco
 {
-    void load_index(uint8_t al);
+    class scenariomanager
+    {
+    public:
+        void load_index(uint8_t al);
+    };
+
+    extern scenariomanager g_scenariomgr;
 }

--- a/src/openloco/station.cpp
+++ b/src/openloco/station.cpp
@@ -30,7 +30,7 @@ namespace openloco
     }
 
     // 0x00492640
-    void station::update(companymanager& companymgr)
+    void station::update(companymanager& companymgr, messagemanager& messagemgr)
     {
         uint32_t currentAcceptedCargo = calc_accepted_cargo();
         uint32_t originallyAcceptedCargo = 0;
@@ -57,7 +57,7 @@ namespace openloco
                     bool acceptedNow = (currentAcceptedCargo & (1 << cargoId)) != 0;
                     if (acceptedBefore && !acceptedNow)
                     {
-                        messagemgr::post(
+                        messagemgr.post(
                             message_type::cargo_no_longer_accepted,
                             owner,
                             id(),
@@ -65,7 +65,7 @@ namespace openloco
                     }
                     else if (!acceptedBefore && acceptedNow)
                     {
-                        messagemgr::post(
+                        messagemgr.post(
                             message_type::cargo_now_accepted,
                             owner,
                             id(),

--- a/src/openloco/station.cpp
+++ b/src/openloco/station.cpp
@@ -30,7 +30,7 @@ namespace openloco
     }
 
     // 0x00492640
-    void station::update()
+    void station::update(companymanager& companymgr)
     {
         uint32_t currentAcceptedCargo = calc_accepted_cargo();
         uint32_t originallyAcceptedCargo = 0;
@@ -49,7 +49,7 @@ namespace openloco
 
         if (originallyAcceptedCargo != currentAcceptedCargo)
         {
-            if (owner == companymgr::get_controlling_id())
+            if (owner == companymgr.get_controlling_id())
             {
                 for (uint32_t cargoId = 0; cargoId < max_cargo_stats; cargoId++)
                 {

--- a/src/openloco/station.h
+++ b/src/openloco/station.h
@@ -8,6 +8,8 @@
 
 namespace openloco
 {
+    class companymanager;
+
     using station_id_t = uint16_t;
 
     namespace station_id
@@ -64,7 +66,7 @@ namespace openloco
 
         bool empty() const { return name == string_ids::null; }
         station_id_t id() const;
-        void update();
+        void update(companymanager& companymgr);
         uint32_t calc_accepted_cargo(uint16_t ax = 0xFFFF);
         void sub_48F7D1();
         bool update_cargo();

--- a/src/openloco/station.h
+++ b/src/openloco/station.h
@@ -9,6 +9,7 @@
 namespace openloco
 {
     class companymanager;
+    class messagemanager;
 
     using station_id_t = uint16_t;
 
@@ -66,7 +67,7 @@ namespace openloco
 
         bool empty() const { return name == string_ids::null; }
         station_id_t id() const;
-        void update(companymanager& companymgr);
+        void update(companymanager& companymgr, messagemanager& messagemgr);
         uint32_t calc_accepted_cargo(uint16_t ax = 0xFFFF);
         void sub_48F7D1();
         bool update_cargo();

--- a/src/openloco/stationmgr.cpp
+++ b/src/openloco/stationmgr.cpp
@@ -6,107 +6,107 @@
 #include "window.h"
 #include "windowmgr.h"
 
+using namespace openloco;
 using namespace openloco::interop;
 using namespace openloco::ui;
 
-namespace openloco::stationmgr
+stationmanager openloco::g_stationmgr;
+
+static loco_global<station[max_stations], 0x005E6EDC> _stations;
+
+std::array<station, max_stations>& stationmanager::stations()
 {
-    static loco_global<station[max_stations], 0x005E6EDC> _stations;
+    auto arr = (std::array<station, max_stations>*)_stations.get();
+    return *arr;
+}
 
-    std::array<station, max_stations>& stations()
+station* stationmanager::get(station_id_t id)
+{
+    auto index = (size_t)id;
+    if (index < _stations.size())
     {
-        auto arr = (std::array<station, max_stations>*)_stations.get();
-        return *arr;
+        return &_stations[index];
     }
+    return nullptr;
+}
 
-    station* get(station_id_t id)
+// 0x0048B1FA
+void stationmanager::update(companymanager& companymgr)
+{
+    if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
     {
-        auto index = (size_t)id;
-        if (index < _stations.size())
+        station_id_t id = scenario_ticks() & 0x3FF;
+        auto station = get(id);
+        if (station != nullptr && !station->empty())
         {
-            return &_stations[index];
-        }
-        return nullptr;
-    }
-
-    // 0x0048B1FA
-    void update(companymanager& companymgr)
-    {
-        if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
-        {
-            station_id_t id = scenario_ticks() & 0x3FF;
-            auto station = get(id);
-            if (station != nullptr && !station->empty())
-            {
-                station->update(companymgr);
-            }
+            station->update(companymgr);
         }
     }
+}
 
-    // 0x00437F29
-    // arg0: ah
-    // arg1: al
-    static void sub_437F29(companymanager& companymgr, company_id_t cid, uint8_t arg1)
-    {
-        constexpr uint8_t byte_4F9462[] = { 0, 31, 10, 7, 31, 10, 31, 31, 11 };
-        auto company = companymgr.get(cid);
-        company->var_8BB0[arg1] = byte_4F9462[arg1];
-    }
+// 0x00437F29
+// arg0: ah
+// arg1: al
+void stationmanager::sub_437F29(companymanager& companymgr, company_id_t cid, uint8_t arg1)
+{
+    constexpr uint8_t byte_4F9462[] = { 0, 31, 10, 7, 31, 10, 31, 31, 11 };
+    auto company = companymgr.get(cid);
+    company->var_8BB0[arg1] = byte_4F9462[arg1];
+}
 
-    static void sub_49E1F1(station_id_t id)
+void stationmanager::sub_49E1F1(station_id_t id)
+{
+    auto w = windowmgr::find(window_type::construction);
+    if (w != nullptr && w->current_tab == 1)
     {
-        auto w = windowmgr::find(window_type::construction);
-        if (w != nullptr && w->current_tab == 1)
+        if ((addr<0x00522096, uint8_t>() & 8) && addr<0x01135F70, int32_t>() == id)
         {
-            if ((addr<0x00522096, uint8_t>() & 8) && addr<0x01135F70, int32_t>() == id)
-            {
-                addr<0x01135F70, int32_t>() = -1;
-                w->invalidate();
-            }
+            addr<0x01135F70, int32_t>() = -1;
+            w->invalidate();
+        }
+    }
+}
+
+// 0x0048B244
+void stationmanager::update_daily(companymanager& companymgr)
+{
+    for (auto& town : townmgr::towns())
+    {
+        if (!town.empty())
+        {
+            town.flags &= ~town_flags::rating_adjusted;
         }
     }
 
-    // 0x0048B244
-    void update_daily(companymanager& companymgr)
+    for (auto& station : stations())
     {
-        for (auto& town : townmgr::towns())
+        if (!station.empty())
         {
-            if (!town.empty())
+            if (station.var_1CE == 0)
             {
-                town.flags &= ~town_flags::rating_adjusted;
-            }
-        }
-
-        for (auto& station : stations())
-        {
-            if (!station.empty())
-            {
-                if (station.var_1CE == 0)
+                station.var_29++;
+                if (station.var_29 != 5 && is_player_company(station.owner))
                 {
-                    station.var_29++;
-                    if (station.var_29 != 5 && is_player_company(station.owner))
-                    {
-                        sub_437F29(companymgr, station.owner, 8);
-                    }
-                    if (station.var_29 >= 10)
-                    {
-                        sub_49E1F1(station.id());
-                        station.invalidate();
-                        station.sub_48F7D1();
-                    }
+                    sub_437F29(companymgr, station.owner, 8);
                 }
-                else
+                if (station.var_29 >= 10)
                 {
-                    station.var_29 = 0;
+                    sub_49E1F1(station.id());
+                    station.invalidate();
+                    station.sub_48F7D1();
                 }
-                if (station.update_cargo())
+            }
+            else
+            {
+                station.var_29 = 0;
+            }
+            if (station.update_cargo())
+            {
+                auto town = townmgr::get(station.town);
+                if (town != nullptr && !(town->flags & town_flags::rating_adjusted))
                 {
-                    auto town = townmgr::get(station.town);
-                    if (town != nullptr && !(town->flags & town_flags::rating_adjusted))
-                    {
-                        town->flags |= town_flags::rating_adjusted;
-                        town->adjust_company_rating(station.owner, 1);
-                    }
+                    town->flags |= town_flags::rating_adjusted;
+                    town->adjust_company_rating(station.owner, 1);
                 }
             }
         }

--- a/src/openloco/stationmgr.cpp
+++ b/src/openloco/stationmgr.cpp
@@ -31,7 +31,7 @@ station* stationmanager::get(station_id_t id)
 }
 
 // 0x0048B1FA
-void stationmanager::update(companymanager& companymgr)
+void stationmanager::update(companymanager& companymgr, messagemanager& messagemgr)
 {
     if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
     {
@@ -39,7 +39,7 @@ void stationmanager::update(companymanager& companymgr)
         auto station = get(id);
         if (station != nullptr && !station->empty())
         {
-            station->update(companymgr);
+            station->update(companymgr, messagemgr);
         }
     }
 }
@@ -68,9 +68,9 @@ void stationmanager::sub_49E1F1(station_id_t id)
 }
 
 // 0x0048B244
-void stationmanager::update_daily(companymanager& companymgr)
+void stationmanager::update_daily(companymanager& companymgr, townmanager& townmgr)
 {
-    for (auto& town : townmgr::towns())
+    for (auto& town : townmgr.towns())
     {
         if (!town.empty())
         {
@@ -102,7 +102,7 @@ void stationmanager::update_daily(companymanager& companymgr)
             }
             if (station.update_cargo())
             {
-                auto town = townmgr::get(station.town);
+                auto town = townmgr.get(station.town);
                 if (town != nullptr && !(town->flags & town_flags::rating_adjusted))
                 {
                     town->flags |= town_flags::rating_adjusted;

--- a/src/openloco/stationmgr.cpp
+++ b/src/openloco/stationmgr.cpp
@@ -30,7 +30,7 @@ namespace openloco::stationmgr
     }
 
     // 0x0048B1FA
-    void update()
+    void update(companymanager& companymgr)
     {
         if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
         {
@@ -38,7 +38,7 @@ namespace openloco::stationmgr
             auto station = get(id);
             if (station != nullptr && !station->empty())
             {
-                station->update();
+                station->update(companymgr);
             }
         }
     }
@@ -46,10 +46,10 @@ namespace openloco::stationmgr
     // 0x00437F29
     // arg0: ah
     // arg1: al
-    static void sub_437F29(company_id_t cid, uint8_t arg1)
+    static void sub_437F29(companymanager& companymgr, company_id_t cid, uint8_t arg1)
     {
         constexpr uint8_t byte_4F9462[] = { 0, 31, 10, 7, 31, 10, 31, 31, 11 };
-        auto company = companymgr::get(cid);
+        auto company = companymgr.get(cid);
         company->var_8BB0[arg1] = byte_4F9462[arg1];
     }
 
@@ -67,7 +67,7 @@ namespace openloco::stationmgr
     }
 
     // 0x0048B244
-    void update_daily()
+    void update_daily(companymanager& companymgr)
     {
         for (auto& town : townmgr::towns())
         {
@@ -86,7 +86,7 @@ namespace openloco::stationmgr
                     station.var_29++;
                     if (station.var_29 != 5 && is_player_company(station.owner))
                     {
-                        sub_437F29(station.owner, 8);
+                        sub_437F29(companymgr, station.owner, 8);
                     }
                     if (station.var_29 >= 10)
                     {

--- a/src/openloco/stationmgr.cpp
+++ b/src/openloco/stationmgr.cpp
@@ -10,8 +10,6 @@ using namespace openloco;
 using namespace openloco::interop;
 using namespace openloco::ui;
 
-stationmanager openloco::g_stationmgr;
-
 static loco_global<station[max_stations], 0x005E6EDC> _stations;
 
 std::array<station, max_stations>& stationmanager::stations()

--- a/src/openloco/stationmgr.h
+++ b/src/openloco/stationmgr.h
@@ -27,6 +27,4 @@ namespace openloco
         void sub_437F29(companymanager& companymgr, company_id_t cid, uint8_t arg1);
         void sub_49E1F1(station_id_t id);
     };
-
-    extern stationmanager g_stationmgr;
 }

--- a/src/openloco/stationmgr.h
+++ b/src/openloco/stationmgr.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "company.h"
 #include "station.h"
 #include <array>
 #include <cstddef>
@@ -9,12 +10,22 @@ namespace openloco
     class companymanager;
 }
 
-namespace openloco::stationmgr
+namespace openloco
 {
     constexpr size_t max_stations = 1024;
 
-    std::array<station, max_stations>& stations();
-    station* get(station_id_t id);
-    void update(companymanager& companymgr);
-    void update_daily(companymanager& companymgr);
+    class stationmanager
+    {
+    public:
+        std::array<station, max_stations>& stations();
+        station* get(station_id_t id);
+        void update(companymanager& companymgr);
+        void update_daily(companymanager& companymgr);
+
+    private:
+        void sub_437F29(companymanager& companymgr, company_id_t cid, uint8_t arg1);
+        void sub_49E1F1(station_id_t id);
+    };
+
+    extern stationmanager g_stationmgr;
 }

--- a/src/openloco/stationmgr.h
+++ b/src/openloco/stationmgr.h
@@ -4,12 +4,17 @@
 #include <array>
 #include <cstddef>
 
+namespace openloco
+{
+    class companymanager;
+}
+
 namespace openloco::stationmgr
 {
     constexpr size_t max_stations = 1024;
 
     std::array<station, max_stations>& stations();
     station* get(station_id_t id);
-    void update();
-    void update_daily();
+    void update(companymanager& companymgr);
+    void update_daily(companymanager& companymgr);
 }

--- a/src/openloco/stationmgr.h
+++ b/src/openloco/stationmgr.h
@@ -8,6 +8,7 @@
 namespace openloco
 {
     class companymanager;
+    class townmanager;
 }
 
 namespace openloco
@@ -19,8 +20,8 @@ namespace openloco
     public:
         std::array<station, max_stations>& stations();
         station* get(station_id_t id);
-        void update(companymanager& companymgr);
-        void update_daily(companymanager& companymgr);
+        void update(companymanager& companymgr, messagemanager& messagemgr);
+        void update_daily(companymanager& companymgr, townmanager& townmgr);
 
     private:
         void sub_437F29(companymanager& companymgr, company_id_t cid, uint8_t arg1);

--- a/src/openloco/things/misc.cpp
+++ b/src/openloco/things/misc.cpp
@@ -5,11 +5,10 @@
 #include "thingmgr.h"
 
 using namespace openloco;
-using namespace openloco::objectmgr;
 
 steam_object* openloco::exhaust::object() const
 {
-    return objectmgr::get<steam_object>(object_id & 0x7F);
+    return g_objectmgr.get<steam_object>(object_id & 0x7F);
 }
 
 // 0x0044080C

--- a/src/openloco/things/misc.cpp
+++ b/src/openloco/things/misc.cpp
@@ -12,11 +12,11 @@ steam_object* openloco::exhaust::object() const
 }
 
 // 0x0044080C
-exhaust* openloco::exhaust::create(thingmanager& thingmgr, loc16 loc, uint8_t type)
+exhaust* openloco::exhaust::create(const map::tilemanager& tilemgr, thingmanager& thingmgr, loc16 loc, uint8_t type)
 {
     if ((uint16_t)loc.x > 12287 || (uint16_t)loc.y > 12287)
         return nullptr;
-    auto surface = openloco::map::tilemgr::get(loc.x & 0xFFE0, loc.y & 0xFFE0).surface();
+    auto surface = tilemgr.get(loc.x & 0xFFE0, loc.y & 0xFFE0).surface();
 
     if (surface == nullptr)
         return nullptr;

--- a/src/openloco/things/misc.cpp
+++ b/src/openloco/things/misc.cpp
@@ -2,13 +2,14 @@
 #include "../map/tilemgr.h"
 #include "../objects/objectmgr.h"
 #include "../objects/steam_object.h"
+#include "../openloco.h"
 #include "thingmgr.h"
 
 using namespace openloco;
 
 steam_object* openloco::exhaust::object() const
 {
-    return g_objectmgr.get<steam_object>(object_id & 0x7F);
+    return g_ctx.get<objectmanager>().get<steam_object>(object_id & 0x7F);
 }
 
 // 0x0044080C

--- a/src/openloco/things/misc.cpp
+++ b/src/openloco/things/misc.cpp
@@ -12,7 +12,7 @@ steam_object* openloco::exhaust::object() const
 }
 
 // 0x0044080C
-exhaust* openloco::exhaust::create(loc16 loc, uint8_t type)
+exhaust* openloco::exhaust::create(thingmanager& thingmgr, loc16 loc, uint8_t type)
 {
     if ((uint16_t)loc.x > 12287 || (uint16_t)loc.y > 12287)
         return nullptr;
@@ -24,7 +24,7 @@ exhaust* openloco::exhaust::create(loc16 loc, uint8_t type)
     if (loc.z <= surface->base_z() * 4)
         return nullptr;
 
-    auto _exhaust = static_cast<exhaust*>(thingmgr::create_thing());
+    auto _exhaust = static_cast<exhaust*>(thingmgr.create_thing());
 
     if (_exhaust != nullptr)
     {
@@ -46,9 +46,9 @@ exhaust* openloco::exhaust::create(loc16 loc, uint8_t type)
 }
 
 // 0x00440BEB
-smoke* openloco::smoke::create(loc16 loc)
+smoke* openloco::smoke::create(thingmanager& thingmgr, loc16 loc)
 {
-    auto t = static_cast<smoke*>(thingmgr::create_thing());
+    auto t = static_cast<smoke*>(thingmgr.create_thing());
     if (t != nullptr)
     {
         t->var_14 = 44;

--- a/src/openloco/things/misc.h
+++ b/src/openloco/things/misc.h
@@ -5,6 +5,8 @@
 
 namespace openloco
 {
+    class thingmanager;
+
 #pragma pack(push, 1)
     struct exhaust : thing_base
     {
@@ -20,7 +22,7 @@ namespace openloco
 
         steam_object* object() const;
 
-        static exhaust* create(loc16 loc, uint8_t type);
+        static exhaust* create(thingmanager& thingmgr, loc16 loc, uint8_t type);
     };
 
     struct smoke : thing_base
@@ -28,7 +30,7 @@ namespace openloco
         uint8_t pad_20[0x28 - 0x20];
         uint16_t var_28;
 
-        static smoke* create(loc16 loc);
+        static smoke* create(thingmanager& thingmgr, loc16 loc);
     };
 #pragma pack(pop)
 }

--- a/src/openloco/things/misc.h
+++ b/src/openloco/things/misc.h
@@ -3,6 +3,11 @@
 #include "../objects/steam_object.h"
 #include "thing.h"
 
+namespace openloco::map
+{
+    class tilemanager;
+}
+
 namespace openloco
 {
     class thingmanager;
@@ -22,7 +27,7 @@ namespace openloco
 
         steam_object* object() const;
 
-        static exhaust* create(thingmanager& thingmgr, loc16 loc, uint8_t type);
+        static exhaust* create(const map::tilemanager& tilemgr, thingmanager& thingmgr, loc16 loc, uint8_t type);
     };
 
     struct smoke : thing_base

--- a/src/openloco/things/thing.cpp
+++ b/src/openloco/things/thing.cpp
@@ -20,7 +20,7 @@ void thing_base::move_to(loc16 loc)
 }
 
 // 0x004CBB01
-void openloco::thing_base::invalidate_sprite()
+void openloco::thing_base::invalidate_sprite(const ui::viewportmanager& viewportmgr)
 {
     if (sprite_left == (int16_t)0x8000u)
     {
@@ -31,7 +31,7 @@ void openloco::thing_base::invalidate_sprite()
     int16_t top = sprite_top;
     int16_t right = sprite_right;
     int16_t bottom = sprite_bottom;
-    for (auto& viewport : openloco::ui::viewportmgr::viewports())
+    for (const auto& viewport : viewportmgr.viewports())
     {
         if (viewport == nullptr)
             break;

--- a/src/openloco/things/thing.h
+++ b/src/openloco/things/thing.h
@@ -4,6 +4,11 @@
 #include <cstdint>
 #include <limits>
 
+namespace openloco::ui
+{
+    class viewportmanager;
+}
+
 namespace openloco
 {
     using thing_id_t = uint16_t;
@@ -50,7 +55,7 @@ namespace openloco
         uint8_t sprite_pitch;  // 0x1F
 
         void move_to(loc16 loc);
-        void invalidate_sprite();
+        void invalidate_sprite(const ui::viewportmanager& viewportmgr);
     };
 
     struct vehicle_bogie;

--- a/src/openloco/things/thingmgr.cpp
+++ b/src/openloco/things/thingmgr.cpp
@@ -47,7 +47,7 @@ thing_base* thingmanager::create_thing()
 }
 
 // 0x004A8826
-void thingmanager::update_vehicles(objectmanager& objectmgr, const ui::viewportmanager& viewportmgr)
+void thingmanager::update_vehicles(objectmanager& objectmgr, const map::tilemanager& tilemgr, const ui::viewportmanager& viewportmgr)
 {
     if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
     {
@@ -55,7 +55,7 @@ void thingmanager::update_vehicles(objectmanager& objectmgr, const ui::viewportm
         while (v != nullptr)
         {
             auto next = v->next_vehicle(*this);
-            v->update_head(objectmgr, *this, viewportmgr);
+            v->update_head(objectmgr, tilemgr, *this, viewportmgr);
             v = next;
         }
     }

--- a/src/openloco/things/thingmgr.cpp
+++ b/src/openloco/things/thingmgr.cpp
@@ -5,8 +5,6 @@
 using namespace openloco;
 using namespace openloco::interop;
 
-thingmanager openloco::g_thingmgr;
-
 static loco_global<thing_id_t[num_thing_lists], 0x00525E40> _heads;
 static loco_global<thing[max_things], 0x006DB6DC> _things;
 
@@ -47,7 +45,7 @@ thing_base* thingmanager::create_thing()
 }
 
 // 0x004A8826
-void thingmanager::update_vehicles(objectmanager& objectmgr, const map::tilemanager& tilemgr, const ui::viewportmanager& viewportmgr)
+void thingmanager::update_vehicles(context& ctx)
 {
     if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
     {
@@ -55,7 +53,7 @@ void thingmanager::update_vehicles(objectmanager& objectmgr, const map::tilemana
         while (v != nullptr)
         {
             auto next = v->next_vehicle(*this);
-            v->update_head(objectmgr, tilemgr, *this, viewportmgr);
+            v->update_head(ctx);
             v = next;
         }
     }

--- a/src/openloco/things/thingmgr.cpp
+++ b/src/openloco/things/thingmgr.cpp
@@ -47,7 +47,7 @@ thing_base* thingmanager::create_thing()
 }
 
 // 0x004A8826
-void thingmanager::update_vehicles(objectmanager& objectmgr)
+void thingmanager::update_vehicles(objectmanager& objectmgr, const ui::viewportmanager& viewportmgr)
 {
     if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
     {
@@ -55,7 +55,7 @@ void thingmanager::update_vehicles(objectmanager& objectmgr)
         while (v != nullptr)
         {
             auto next = v->next_vehicle(*this);
-            v->update_head(objectmgr, *this);
+            v->update_head(objectmgr, *this, viewportmgr);
             v = next;
         }
     }

--- a/src/openloco/things/thingmgr.cpp
+++ b/src/openloco/things/thingmgr.cpp
@@ -2,61 +2,67 @@
 #include "../interop/interop.hpp"
 #include "../openloco.h"
 
+using namespace openloco;
 using namespace openloco::interop;
 
-namespace openloco::thingmgr
+thingmanager openloco::g_thingmgr;
+
+static loco_global<thing_id_t[num_thing_lists], 0x00525E40> _heads;
+static loco_global<thing[max_things], 0x006DB6DC> _things;
+
+thing_id_t thingmanager::first_id(thing_list list)
 {
-    loco_global<thing_id_t[num_thing_lists], 0x00525E40> _heads;
-    loco_global<thing[max_things], 0x006DB6DC> _things;
+    return _heads[(size_t)list];
+}
 
-    thing_id_t first_id(thing_list list)
+template<>
+vehicle* thingmanager::first()
+{
+    return get<vehicle>(first_id(thing_list::vehicle));
+}
+
+template<>
+thing_base* thingmanager::get(thing_id_t id)
+{
+    thing_base* result = nullptr;
+    if (id < max_things)
     {
-        return _heads[(size_t)list];
+        return &_things.get()[id];
     }
+    return result;
+}
 
-    template<>
-    vehicle* first()
-    {
-        return get<vehicle>(first_id(thing_list::vehicle));
-    }
+template<typename T>
+T* thingmanager::get(thing_id_t id)
+{
+    return static_cast<T*>(get<thing_base>(id));
+}
 
-    template<>
-    thing_base* get(thing_id_t id)
+// 0x004700A5
+thing_base* thingmanager::create_thing()
+{
+    registers regs;
+    call(0x004700A5, regs);
+    return (thing_base*)regs.esi;
+}
+
+// 0x004A8826
+void thingmanager::update_vehicles()
+{
+    if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
     {
-        thing_base* result = nullptr;
-        if (id < max_things)
+        auto v = first<vehicle>();
+        while (v != nullptr)
         {
-            return &_things.get()[id];
-        }
-        return result;
-    }
-
-    // 0x004700A5
-    thing_base* create_thing()
-    {
-        registers regs;
-        call(0x004700A5, regs);
-        return (thing_base*)regs.esi;
-    }
-
-    // 0x004A8826
-    void update_vehicles()
-    {
-        if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
-        {
-            auto v = first<vehicle>();
-            while (v != nullptr)
-            {
-                auto next = v->next_vehicle();
-                v->update_head();
-                v = next;
-            }
+            auto next = v->next_vehicle(*this);
+            v->update_head(*this);
+            v = next;
         }
     }
+}
 
-    // 0x004402F4
-    void update_misc_things()
-    {
-        call(0x004402F4);
-    }
+// 0x004402F4
+void thingmanager::update_misc_things()
+{
+    call(0x004402F4);
 }

--- a/src/openloco/things/thingmgr.cpp
+++ b/src/openloco/things/thingmgr.cpp
@@ -47,7 +47,7 @@ thing_base* thingmanager::create_thing()
 }
 
 // 0x004A8826
-void thingmanager::update_vehicles()
+void thingmanager::update_vehicles(objectmanager& objectmgr)
 {
     if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
     {
@@ -55,7 +55,7 @@ void thingmanager::update_vehicles()
         while (v != nullptr)
         {
             auto next = v->next_vehicle(*this);
-            v->update_head(*this);
+            v->update_head(objectmgr, *this);
             v = next;
         }
     }

--- a/src/openloco/things/thingmgr.h
+++ b/src/openloco/things/thingmgr.h
@@ -6,6 +6,8 @@
 
 namespace openloco
 {
+    class objectmanager;
+
     constexpr size_t num_thing_lists = 6;
     constexpr size_t max_things = 20000;
 
@@ -32,7 +34,7 @@ namespace openloco
 
         thing_base* create_thing();
 
-        void update_vehicles();
+        void update_vehicles(objectmanager& objectmgr);
         void update_misc_things();
     };
 

--- a/src/openloco/things/thingmgr.h
+++ b/src/openloco/things/thingmgr.h
@@ -6,6 +6,7 @@
 
 namespace openloco
 {
+    class context;
     class objectmanager;
 
     constexpr size_t num_thing_lists = 6;
@@ -14,6 +15,9 @@ namespace openloco
     class thingmanager
     {
     public:
+        thingmanager() = default;
+        thingmanager(const thingmanager&) = delete;
+
         enum class thing_list
         {
             null,
@@ -34,9 +38,7 @@ namespace openloco
 
         thing_base* create_thing();
 
-        void update_vehicles(objectmanager& objectmgr, const map::tilemanager& tilemgr, const ui::viewportmanager& viewportmgr);
+        void update_vehicles(context& ctx);
         void update_misc_things();
     };
-
-    extern thingmanager g_thingmgr;
 }

--- a/src/openloco/things/thingmgr.h
+++ b/src/openloco/things/thingmgr.h
@@ -4,37 +4,37 @@
 #include "vehicle.h"
 #include <cstdio>
 
-namespace openloco::thingmgr
+namespace openloco
 {
     constexpr size_t num_thing_lists = 6;
     constexpr size_t max_things = 20000;
 
-    enum class thing_list
+    class thingmanager
     {
-        null,
-        vehicle,
-        misc = 3
+    public:
+        enum class thing_list
+        {
+            null,
+            vehicle,
+            misc = 3
+        };
+
+        template<typename T>
+        T* get(thing_id_t id);
+
+        template<>
+        thing_base* get(thing_id_t id);
+
+        thing_id_t first_id(thing_list list);
+
+        template<typename T>
+        T* first();
+
+        thing_base* create_thing();
+
+        void update_vehicles();
+        void update_misc_things();
     };
 
-    template<typename T>
-    T* get(thing_id_t id);
-
-    template<>
-    thing_base* get(thing_id_t id);
-
-    template<typename T>
-    T* get(thing_id_t id)
-    {
-        return static_cast<T*>(get<thing_base>(id));
-    }
-
-    thing_id_t first_id(thing_list list);
-
-    template<typename T>
-    T* first();
-
-    thing_base* create_thing();
-
-    void update_vehicles();
-    void update_misc_things();
+    extern thingmanager g_thingmgr;
 }

--- a/src/openloco/things/thingmgr.h
+++ b/src/openloco/things/thingmgr.h
@@ -34,7 +34,7 @@ namespace openloco
 
         thing_base* create_thing();
 
-        void update_vehicles(objectmanager& objectmgr);
+        void update_vehicles(objectmanager& objectmgr, const ui::viewportmanager& viewportmgr);
         void update_misc_things();
     };
 

--- a/src/openloco/things/thingmgr.h
+++ b/src/openloco/things/thingmgr.h
@@ -34,7 +34,7 @@ namespace openloco
 
         thing_base* create_thing();
 
-        void update_vehicles(objectmanager& objectmgr, const ui::viewportmanager& viewportmgr);
+        void update_vehicles(objectmanager& objectmgr, const map::tilemanager& tilemgr, const ui::viewportmanager& viewportmgr);
         void update_misc_things();
     };
 

--- a/src/openloco/things/vehicle.cpp
+++ b/src/openloco/things/vehicle.cpp
@@ -71,12 +71,12 @@ vehicle* vehicle::next_car(thingmanager& thingmgr)
     return thingmgr.get<vehicle>(next_car_id);
 }
 
-void vehicle::update_head(objectmanager& objectmgr, thingmanager& thingmgr)
+void vehicle::update_head(objectmanager& objectmgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr)
 {
     auto v = this;
     while (v != nullptr)
     {
-        if (v->update(objectmgr, thingmgr))
+        if (v->update(objectmgr, thingmgr, viewportmgr))
         {
             break;
         }
@@ -84,7 +84,7 @@ void vehicle::update_head(objectmanager& objectmgr, thingmanager& thingmgr)
     }
 }
 
-bool vehicle::update(objectmanager& objectmgr, thingmanager& thingmgr)
+bool vehicle::update(objectmanager& objectmgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr)
 {
     auto vehicleObject = objectmgr.get(*this);
     assert(vehicleObject != nullptr);
@@ -108,7 +108,7 @@ bool vehicle::update(objectmanager& objectmgr, thingmanager& thingmgr)
             break;
         case thing_type::vehicle_body_end:
         case thing_type::vehicle_body_cont:
-            result = sub_4AA1D0(thingmgr, *vehicleObject);
+            result = sub_4AA1D0(thingmgr, *vehicleObject, viewportmgr);
             break;
         case thing_type::vehicle_6:
             result = call(0x004AA24A, regs);
@@ -188,7 +188,7 @@ void vehicle::sub_4BAA76()
 }
 
 // 0x004AA1D0
-int32_t openloco::vehicle::sub_4AA1D0(thingmanager& thingmgr, vehicle_object& vehicleObject)
+int32_t openloco::vehicle::sub_4AA1D0(thingmanager& thingmgr, vehicle_object& vehicleObject, const ui::viewportmanager& viewportmgr)
 {
     registers regs;
     regs.esi = (int32_t)this;
@@ -201,9 +201,9 @@ int32_t openloco::vehicle::sub_4AA1D0(thingmanager& thingmgr, vehicle_object& ve
 
     if (vehicle_var_1136237 | vehicle_var_1136238)
     {
-        invalidate_sprite();
+        invalidate_sprite(viewportmgr);
         sub_4AC255(vehicleObject, vehicle_back_bogie, vehicle_front_bogie);
-        invalidate_sprite();
+        invalidate_sprite(viewportmgr);
     }
     uint32_t backup1136130 = vehicle_var_1136130;
     if (var_5E != 0)
@@ -217,7 +217,7 @@ int32_t openloco::vehicle::sub_4AA1D0(thingmanager& thingmgr, vehicle_object& ve
         vehicle_var_1136130 += var_1136130 * 320 + 500;
     }
     animation_update(thingmgr, vehicleObject);
-    sub_4AAB0B(vehicleObject);
+    sub_4AAB0B(vehicleObject, viewportmgr);
     vehicle_var_1136130 = backup1136130;
     return 0;
 }
@@ -268,7 +268,7 @@ void openloco::vehicle::animation_update(thingmanager& thingmgr, vehicle_object&
 }
 
 // 0x004AAB0B
-void openloco::vehicle::sub_4AAB0B(vehicle_object& vehicle_object)
+void openloco::vehicle::sub_4AAB0B(vehicle_object& vehicle_object, const ui::viewportmanager& viewportmgr)
 {
     int32_t eax = vehicle_var_1136130 >> 3;
     if (var_38 & (1 << 1))
@@ -360,7 +360,7 @@ void openloco::vehicle::sub_4AAB0B(vehicle_object& vehicle_object)
     if (var_46 != al)
     {
         var_46 = al;
-        invalidate_sprite();
+        invalidate_sprite(viewportmgr);
     }
 }
 

--- a/src/openloco/things/vehicle.cpp
+++ b/src/openloco/things/vehicle.cpp
@@ -61,14 +61,14 @@ constexpr int16_t factor503B50[] = {
     84
 };
 
-vehicle* vehicle::next_vehicle()
+vehicle* vehicle::next_vehicle(thingmanager& thingmgr)
 {
-    return thingmgr::get<vehicle>(next_thing_id);
+    return thingmgr.get<vehicle>(next_thing_id);
 }
 
-vehicle* vehicle::next_car()
+vehicle* vehicle::next_car(thingmanager& thingmgr)
 {
-    return thingmgr::get<vehicle>(next_car_id);
+    return thingmgr.get<vehicle>(next_car_id);
 }
 
 vehicle_object* vehicle::object() const
@@ -76,20 +76,20 @@ vehicle_object* vehicle::object() const
     return g_objectmgr.get<vehicle_object>(object_id);
 }
 
-void vehicle::update_head()
+void vehicle::update_head(thingmanager& thingmgr)
 {
     auto v = this;
     while (v != nullptr)
     {
-        if (v->update())
+        if (v->update(thingmgr))
         {
             break;
         }
-        v = v->next_car();
+        v = v->next_car(thingmgr);
     }
 }
 
-bool vehicle::update()
+bool vehicle::update(thingmanager& thingmgr)
 {
     int32_t result = 0;
     registers regs;
@@ -110,7 +110,7 @@ bool vehicle::update()
             break;
         case thing_type::vehicle_body_end:
         case thing_type::vehicle_body_cont:
-            result = sub_4AA1D0();
+            result = sub_4AA1D0(thingmgr);
             break;
         case thing_type::vehicle_6:
             result = call(0x004AA24A, regs);
@@ -122,7 +122,7 @@ bool vehicle::update()
 }
 
 // 0x004BA8D4
-void vehicle::sub_4BA8D4()
+void vehicle::sub_4BA8D4(thingmanager& thingmgr)
 {
     switch (var_5D)
     {
@@ -136,7 +136,7 @@ void vehicle::sub_4BA8D4()
             return;
     }
 
-    auto v = next_car()->next_car()->next_car();
+    auto v = next_car(thingmgr)->next_car(thingmgr)->next_car(thingmgr);
     if (v->type != thing_type::vehicle_6)
     {
         while (true)
@@ -145,8 +145,8 @@ void vehicle::sub_4BA8D4()
             {
                 if ((scenario_ticks() & 3) == 0)
                 {
-                    auto v2 = v->next_car()->next_car();
-                    smoke::create(loc16(v2->x, v2->y, v2->z + 4));
+                    auto v2 = v->next_car(thingmgr)->next_car(thingmgr);
+                    smoke::create(thingmgr, loc16(v2->x, v2->y, v2->z + 4));
                 }
             }
 
@@ -160,13 +160,13 @@ void vehicle::sub_4BA8D4()
                     v->var_6A = 5;
                     sub_4BAA76();
 
-                    auto v2 = v->next_car()->next_car();
+                    auto v2 = v->next_car(thingmgr)->next_car(thingmgr);
                     auto soundId = (audio::sound_id)gprng().rand_next(26, 26 + 5);
                     audio::play_sound(soundId, loc16(v2->x, v2->y, v2->z + 22));
                 }
             }
 
-            v = v->next_car()->next_car()->next_car();
+            v = v->next_car(thingmgr)->next_car(thingmgr)->next_car(thingmgr);
             vehicle* u;
             do
             {
@@ -174,9 +174,9 @@ void vehicle::sub_4BA8D4()
                 {
                     return;
                 }
-                u = v->next_car()->next_car();
+                u = v->next_car(thingmgr)->next_car(thingmgr);
                 if (u->type != thing_type::vehicle_body_end)
-                    v = u->next_car();
+                    v = u->next_car(thingmgr);
             } while (u->type != thing_type::vehicle_body_end);
         }
     }
@@ -190,14 +190,14 @@ void vehicle::sub_4BAA76()
 }
 
 // 0x004AA1D0
-int32_t openloco::vehicle::sub_4AA1D0()
+int32_t openloco::vehicle::sub_4AA1D0(thingmanager& thingmgr)
 {
     registers regs;
     regs.esi = (int32_t)this;
 
     if (var_42 == 2 || var_42 == 3)
     {
-        animation_update();
+        animation_update(thingmgr);
         return 0;
     }
 
@@ -218,13 +218,13 @@ int32_t openloco::vehicle::sub_4AA1D0()
 
         vehicle_var_1136130 += var_1136130 * 320 + 500;
     }
-    animation_update();
+    animation_update(thingmgr);
     sub_4AAB0B();
     vehicle_var_1136130 = backup1136130;
     return 0;
 }
 
-void openloco::vehicle::animation_update()
+void openloco::vehicle::animation_update(thingmanager& thingmgr)
 {
     if (var_38 & (1 << 4))
         return;
@@ -247,28 +247,28 @@ void openloco::vehicle::animation_update()
         case simple_animation_type::steam_puff1:
         case simple_animation_type::steam_puff2:
         case simple_animation_type::steam_puff3:
-            steam_puffs_animation_update(0, vehicleObject->var_24[var_54].var_05 - 0x80);
+            steam_puffs_animation_update(thingmgr, 0, vehicleObject->var_24[var_54].var_05 - 0x80);
             break;
         case simple_animation_type::diesel_exhaust1:
-            diesel_exhaust1_animation_update(0, vehicleObject->var_24[var_54].var_05 - 0x80);
+            diesel_exhaust1_animation_update(thingmgr, 0, vehicleObject->var_24[var_54].var_05 - 0x80);
             break;
         case simple_animation_type::electric_spark1:
-            electric_spark1_animation_update(0, vehicleObject->var_24[var_54].var_05 - 0x80);
+            electric_spark1_animation_update(thingmgr, 0, vehicleObject->var_24[var_54].var_05 - 0x80);
             break;
         case simple_animation_type::electric_spark2:
-            electric_spark2_animation_update(0, vehicleObject->var_24[var_54].var_05 - 0x80);
+            electric_spark2_animation_update(thingmgr, 0, vehicleObject->var_24[var_54].var_05 - 0x80);
             break;
         case simple_animation_type::diesel_exhaust2:
-            diesel_exhaust2_animation_update(0, vehicleObject->var_24[var_54].var_05 - 0x80);
+            diesel_exhaust2_animation_update(thingmgr, 0, vehicleObject->var_24[var_54].var_05 - 0x80);
             break;
         case simple_animation_type::ship_wake:
-            ship_wake_animation_update(0, vehicleObject->var_24[var_54].var_05 - 0x80);
+            ship_wake_animation_update(thingmgr, 0, vehicleObject->var_24[var_54].var_05 - 0x80);
             break;
         default:
             assert(false);
             break;
     }
-    secondary_animation_update();
+    secondary_animation_update(thingmgr);
 }
 
 // 0x004AAB0B
@@ -962,7 +962,7 @@ uint8_t openloco::vehicle::vehicle_update_sprite_yaw_4(int16_t x_offset, int16_t
 }
 
 // 0x004AB655
-void openloco::vehicle::secondary_animation_update()
+void openloco::vehicle::secondary_animation_update(thingmanager& thingmgr)
 {
     auto vehicleObject = object();
     uint8_t var_05 = vehicleObject->var_24[var_54].var_05;
@@ -978,22 +978,22 @@ void openloco::vehicle::secondary_animation_update()
         case simple_animation_type::steam_puff1:
         case simple_animation_type::steam_puff2:
         case simple_animation_type::steam_puff3:
-            steam_puffs_animation_update(1, var_05);
+            steam_puffs_animation_update(thingmgr, 1, var_05);
             break;
         case simple_animation_type::diesel_exhaust1:
-            diesel_exhaust1_animation_update(1, var_05);
+            diesel_exhaust1_animation_update(thingmgr, 1, var_05);
             break;
         case simple_animation_type::electric_spark1:
-            electric_spark1_animation_update(1, var_05);
+            electric_spark1_animation_update(thingmgr, 1, var_05);
             break;
         case simple_animation_type::electric_spark2:
-            electric_spark2_animation_update(1, var_05);
+            electric_spark2_animation_update(thingmgr, 1, var_05);
             break;
         case simple_animation_type::diesel_exhaust2:
-            diesel_exhaust2_animation_update(1, var_05);
+            diesel_exhaust2_animation_update(thingmgr, 1, var_05);
             break;
         case simple_animation_type::ship_wake:
-            ship_wake_animation_update(1, var_05);
+            ship_wake_animation_update(thingmgr, 1, var_05);
             break;
         default:
             assert(false);
@@ -1002,7 +1002,7 @@ void openloco::vehicle::secondary_animation_update()
 }
 
 // 0x004AB688, 0x004AACA5
-void openloco::vehicle::steam_puffs_animation_update(uint8_t num, int8_t var_05)
+void openloco::vehicle::steam_puffs_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05)
 {
     auto vehicleObject = object();
     vehicle* frontBogie = vehicle_front_bogie;
@@ -1072,7 +1072,7 @@ void openloco::vehicle::steam_puffs_animation_update(uint8_t num, int8_t var_05)
     loc.x += xFactor;
     loc.y += yFactor;
 
-    exhaust::create(loc, vehicleObject->animation[num].object_id | (soundCode ? 0 : 0x80));
+    exhaust::create(thingmgr, loc, vehicleObject->animation[num].object_id | (soundCode ? 0 : 0x80));
     if (soundCode == false)
         return;
 
@@ -1167,7 +1167,7 @@ void openloco::vehicle::steam_puffs_animation_update(uint8_t num, int8_t var_05)
 }
 
 // 0x004AB9DD & 0x004AAFFA
-void openloco::vehicle::diesel_exhaust1_animation_update(uint8_t num, int8_t var_05)
+void openloco::vehicle::diesel_exhaust1_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05)
 {
     vehicle* frontBogie = vehicle_front_bogie;
     vehicle* backBogie = vehicle_back_bogie;
@@ -1201,7 +1201,7 @@ void openloco::vehicle::diesel_exhaust1_animation_update(uint8_t num, int8_t var
             static_cast<int16_t>(y + yFactor),
             static_cast<int16_t>(z + vehicleObject->animation[num].height)
         };
-        exhaust::create(loc, vehicleObject->animation[num].object_id);
+        exhaust::create(thingmgr, loc, vehicleObject->animation[num].object_id);
     }
     else
     {
@@ -1248,12 +1248,12 @@ void openloco::vehicle::diesel_exhaust1_animation_update(uint8_t num, int8_t var
         loc.x += xFactor;
         loc.y += yFactor;
 
-        exhaust::create(loc, vehicleObject->animation[num].object_id);
+        exhaust::create(thingmgr, loc, vehicleObject->animation[num].object_id);
     }
 }
 
 // 0x004ABB5A & 0x004AB177
-void openloco::vehicle::diesel_exhaust2_animation_update(uint8_t num, int8_t var_05)
+void openloco::vehicle::diesel_exhaust2_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05)
 {
     vehicle* frontBogie = vehicle_front_bogie;
     vehicle* backBogie = vehicle_back_bogie;
@@ -1324,11 +1324,11 @@ void openloco::vehicle::diesel_exhaust2_animation_update(uint8_t num, int8_t var
     loc.x += xFactor;
     loc.y += yFactor;
 
-    exhaust::create(loc, vehicleObject->animation[num].object_id);
+    exhaust::create(thingmgr, loc, vehicleObject->animation[num].object_id);
 }
 
 // 0x004ABDAD & 0x004AB3CA
-void openloco::vehicle::electric_spark1_animation_update(uint8_t num, int8_t var_05)
+void openloco::vehicle::electric_spark1_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05)
 {
     vehicle* frontBogie = vehicle_front_bogie;
     vehicle* backBogie = vehicle_back_bogie;
@@ -1384,11 +1384,11 @@ void openloco::vehicle::electric_spark1_animation_update(uint8_t num, int8_t var
     loc.x += xFactor;
     loc.y += yFactor;
 
-    exhaust::create(loc, vehicleObject->animation[num].object_id);
+    exhaust::create(thingmgr, loc, vehicleObject->animation[num].object_id);
 }
 
 // 0x004ABEC3 & 0x004AB4E0
-void openloco::vehicle::electric_spark2_animation_update(uint8_t num, int8_t var_05)
+void openloco::vehicle::electric_spark2_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05)
 {
     vehicle* frontBogie = vehicle_front_bogie;
     vehicle* backBogie = vehicle_back_bogie;
@@ -1466,11 +1466,11 @@ void openloco::vehicle::electric_spark2_animation_update(uint8_t num, int8_t var
     loc.x += xFactor;
     loc.y += yFactor;
 
-    exhaust::create(loc, vehicleObject->animation[num].object_id);
+    exhaust::create(thingmgr, loc, vehicleObject->animation[num].object_id);
 }
 
 // 0x004ABC8A & 0x004AB2A7
-void openloco::vehicle::ship_wake_animation_update(uint8_t num, int8_t var_05)
+void openloco::vehicle::ship_wake_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05)
 {
     vehicle* veh_3 = vehicle_1136120;
     auto vehicleObject = object();
@@ -1520,7 +1520,7 @@ void openloco::vehicle::ship_wake_animation_update(uint8_t num, int8_t var_05)
     loc.x += xFactor;
     loc.y += yFactor;
 
-    exhaust::create(loc, vehicleObject->animation[num].object_id);
+    exhaust::create(thingmgr, loc, vehicleObject->animation[num].object_id);
 
     if (vehicleObject->var_113 == 0)
         return;
@@ -1536,5 +1536,5 @@ void openloco::vehicle::ship_wake_animation_update(uint8_t num, int8_t var_05)
     loc.x += xFactor;
     loc.y += yFactor;
 
-    exhaust::create(loc, vehicleObject->animation[num].object_id);
+    exhaust::create(thingmgr, loc, vehicleObject->animation[num].object_id);
 }

--- a/src/openloco/things/vehicle.cpp
+++ b/src/openloco/things/vehicle.cpp
@@ -16,7 +16,6 @@
 
 using namespace openloco;
 using namespace openloco::interop;
-using namespace openloco::objectmgr;
 
 loco_global<vehicle*, 0x01136118> vehicle_1136118;
 loco_global<vehicle*, 0x01136124> vehicle_front_bogie;
@@ -74,7 +73,7 @@ vehicle* vehicle::next_car()
 
 vehicle_object* vehicle::object() const
 {
-    return objectmgr::get<vehicle_object>(object_id);
+    return g_objectmgr.get<vehicle_object>(object_id);
 }
 
 void vehicle::update_head()
@@ -1078,7 +1077,7 @@ void openloco::vehicle::steam_puffs_animation_update(uint8_t num, int8_t var_05)
         return;
 
     var_55++;
-    steam_object* steam_obj = objectmgr::get<steam_object>(vehicleObject->animation[num].object_id);
+    steam_object* steam_obj = g_objectmgr.get<steam_object>(vehicleObject->animation[num].object_id);
     if (var_55 >= ((uint8_t)vehicleObject->animation[num].type) + 1)
     {
         var_55 = 0;

--- a/src/openloco/things/vehicle.cpp
+++ b/src/openloco/things/vehicle.cpp
@@ -71,12 +71,12 @@ vehicle* vehicle::next_car(thingmanager& thingmgr)
     return thingmgr.get<vehicle>(next_car_id);
 }
 
-void vehicle::update_head(objectmanager& objectmgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr)
+void vehicle::update_head(objectmanager& objectmgr, const map::tilemanager& tilemgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr)
 {
     auto v = this;
     while (v != nullptr)
     {
-        if (v->update(objectmgr, thingmgr, viewportmgr))
+        if (v->update(objectmgr, tilemgr, thingmgr, viewportmgr))
         {
             break;
         }
@@ -84,7 +84,7 @@ void vehicle::update_head(objectmanager& objectmgr, thingmanager& thingmgr, cons
     }
 }
 
-bool vehicle::update(objectmanager& objectmgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr)
+bool vehicle::update(objectmanager& objectmgr, const map::tilemanager& tilemgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr)
 {
     auto vehicleObject = objectmgr.get(*this);
     assert(vehicleObject != nullptr);
@@ -108,7 +108,7 @@ bool vehicle::update(objectmanager& objectmgr, thingmanager& thingmgr, const ui:
             break;
         case thing_type::vehicle_body_end:
         case thing_type::vehicle_body_cont:
-            result = sub_4AA1D0(thingmgr, *vehicleObject, viewportmgr);
+            result = sub_4AA1D0(tilemgr, thingmgr, *vehicleObject, viewportmgr);
             break;
         case thing_type::vehicle_6:
             result = call(0x004AA24A, regs);
@@ -188,14 +188,14 @@ void vehicle::sub_4BAA76()
 }
 
 // 0x004AA1D0
-int32_t openloco::vehicle::sub_4AA1D0(thingmanager& thingmgr, vehicle_object& vehicleObject, const ui::viewportmanager& viewportmgr)
+int32_t openloco::vehicle::sub_4AA1D0(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, const ui::viewportmanager& viewportmgr)
 {
     registers regs;
     regs.esi = (int32_t)this;
 
     if (var_42 == 2 || var_42 == 3)
     {
-        animation_update(thingmgr, vehicleObject);
+        animation_update(tilemgr, thingmgr, vehicleObject);
         return 0;
     }
 
@@ -216,13 +216,13 @@ int32_t openloco::vehicle::sub_4AA1D0(thingmanager& thingmgr, vehicle_object& ve
 
         vehicle_var_1136130 += var_1136130 * 320 + 500;
     }
-    animation_update(thingmgr, vehicleObject);
+    animation_update(tilemgr, thingmgr, vehicleObject);
     sub_4AAB0B(vehicleObject, viewportmgr);
     vehicle_var_1136130 = backup1136130;
     return 0;
 }
 
-void openloco::vehicle::animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject)
+void openloco::vehicle::animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject)
 {
     if (var_38 & (1 << 4))
         return;
@@ -243,28 +243,28 @@ void openloco::vehicle::animation_update(thingmanager& thingmgr, vehicle_object&
         case simple_animation_type::steam_puff1:
         case simple_animation_type::steam_puff2:
         case simple_animation_type::steam_puff3:
-            steam_puffs_animation_update(thingmgr, vehicleObject, 0, vehicleObject.var_24[var_54].var_05 - 0x80);
+            steam_puffs_animation_update(tilemgr, thingmgr, vehicleObject, 0, vehicleObject.var_24[var_54].var_05 - 0x80);
             break;
         case simple_animation_type::diesel_exhaust1:
-            diesel_exhaust1_animation_update(thingmgr, vehicleObject, 0, vehicleObject.var_24[var_54].var_05 - 0x80);
+            diesel_exhaust1_animation_update(tilemgr, thingmgr, vehicleObject, 0, vehicleObject.var_24[var_54].var_05 - 0x80);
             break;
         case simple_animation_type::electric_spark1:
-            electric_spark1_animation_update(thingmgr, vehicleObject, 0, vehicleObject.var_24[var_54].var_05 - 0x80);
+            electric_spark1_animation_update(tilemgr, thingmgr, vehicleObject, 0, vehicleObject.var_24[var_54].var_05 - 0x80);
             break;
         case simple_animation_type::electric_spark2:
-            electric_spark2_animation_update(thingmgr, vehicleObject, 0, vehicleObject.var_24[var_54].var_05 - 0x80);
+            electric_spark2_animation_update(tilemgr, thingmgr, vehicleObject, 0, vehicleObject.var_24[var_54].var_05 - 0x80);
             break;
         case simple_animation_type::diesel_exhaust2:
-            diesel_exhaust2_animation_update(thingmgr, vehicleObject, 0, vehicleObject.var_24[var_54].var_05 - 0x80);
+            diesel_exhaust2_animation_update(tilemgr, thingmgr, vehicleObject, 0, vehicleObject.var_24[var_54].var_05 - 0x80);
             break;
         case simple_animation_type::ship_wake:
-            ship_wake_animation_update(thingmgr, vehicleObject, 0, vehicleObject.var_24[var_54].var_05 - 0x80);
+            ship_wake_animation_update(tilemgr, thingmgr, vehicleObject, 0, vehicleObject.var_24[var_54].var_05 - 0x80);
             break;
         default:
             assert(false);
             break;
     }
-    secondary_animation_update(thingmgr, vehicleObject);
+    secondary_animation_update(tilemgr, thingmgr, vehicleObject);
 }
 
 // 0x004AAB0B
@@ -955,7 +955,7 @@ uint8_t openloco::vehicle::vehicle_update_sprite_yaw_4(int16_t x_offset, int16_t
 }
 
 // 0x004AB655
-void openloco::vehicle::secondary_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject)
+void openloco::vehicle::secondary_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject)
 {
     uint8_t var_05 = vehicleObject.var_24[var_54].var_05;
     if (var_05 == 0)
@@ -970,22 +970,22 @@ void openloco::vehicle::secondary_animation_update(thingmanager& thingmgr, vehic
         case simple_animation_type::steam_puff1:
         case simple_animation_type::steam_puff2:
         case simple_animation_type::steam_puff3:
-            steam_puffs_animation_update(thingmgr, vehicleObject, 1, var_05);
+            steam_puffs_animation_update(tilemgr, thingmgr, vehicleObject, 1, var_05);
             break;
         case simple_animation_type::diesel_exhaust1:
-            diesel_exhaust1_animation_update(thingmgr, vehicleObject, 1, var_05);
+            diesel_exhaust1_animation_update(tilemgr, thingmgr, vehicleObject, 1, var_05);
             break;
         case simple_animation_type::electric_spark1:
-            electric_spark1_animation_update(thingmgr, vehicleObject, 1, var_05);
+            electric_spark1_animation_update(tilemgr, thingmgr, vehicleObject, 1, var_05);
             break;
         case simple_animation_type::electric_spark2:
-            electric_spark2_animation_update(thingmgr, vehicleObject, 1, var_05);
+            electric_spark2_animation_update(tilemgr, thingmgr, vehicleObject, 1, var_05);
             break;
         case simple_animation_type::diesel_exhaust2:
-            diesel_exhaust2_animation_update(thingmgr, vehicleObject, 1, var_05);
+            diesel_exhaust2_animation_update(tilemgr, thingmgr, vehicleObject, 1, var_05);
             break;
         case simple_animation_type::ship_wake:
-            ship_wake_animation_update(thingmgr, vehicleObject, 1, var_05);
+            ship_wake_animation_update(tilemgr, thingmgr, vehicleObject, 1, var_05);
             break;
         default:
             assert(false);
@@ -994,7 +994,7 @@ void openloco::vehicle::secondary_animation_update(thingmanager& thingmgr, vehic
 }
 
 // 0x004AB688, 0x004AACA5
-void openloco::vehicle::steam_puffs_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05)
+void openloco::vehicle::steam_puffs_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05)
 {
     vehicle* frontBogie = vehicle_front_bogie;
     vehicle* backBogie = vehicle_back_bogie;
@@ -1063,7 +1063,7 @@ void openloco::vehicle::steam_puffs_animation_update(thingmanager& thingmgr, veh
     loc.x += xFactor;
     loc.y += yFactor;
 
-    exhaust::create(thingmgr, loc, vehicleObject.animation[num].object_id | (soundCode ? 0 : 0x80));
+    exhaust::create(tilemgr, thingmgr, loc, vehicleObject.animation[num].object_id | (soundCode ? 0 : 0x80));
     if (soundCode == false)
         return;
 
@@ -1079,7 +1079,7 @@ void openloco::vehicle::steam_puffs_animation_update(thingmanager& thingmgr, veh
     // Looking for a bridge? or somthing ontop
     if (steam_obj->var_08 & (1 << 2))
     {
-        auto tile = map::tilemgr::get(frontBogie->tile_x, frontBogie->tile_y);
+        auto tile = tilemgr.get(frontBogie->tile_x, frontBogie->tile_y);
 
         for (auto& el : tile)
         {
@@ -1116,7 +1116,7 @@ void openloco::vehicle::steam_puffs_animation_update(thingmanager& thingmgr, veh
 
         int32_t volume = 0 - (veh_3->var_56 >> 9);
 
-        auto height = std::get<0>(map::tilemgr::get_height(loc.x, loc.y));
+        auto height = std::get<0>(tilemgr.get_height(loc.x, loc.y));
 
         if (loc.z <= height)
         {
@@ -1140,7 +1140,7 @@ void openloco::vehicle::steam_puffs_animation_update(thingmanager& thingmgr, veh
 
         int32_t volume = 0 - (veh_3->var_56 >> 9);
 
-        auto height = std::get<0>(map::tilemgr::get_height(loc.x, loc.y));
+        auto height = std::get<0>(tilemgr.get_height(loc.x, loc.y));
 
         if (loc.z <= height)
         {
@@ -1158,7 +1158,7 @@ void openloco::vehicle::steam_puffs_animation_update(thingmanager& thingmgr, veh
 }
 
 // 0x004AB9DD & 0x004AAFFA
-void openloco::vehicle::diesel_exhaust1_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05)
+void openloco::vehicle::diesel_exhaust1_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05)
 {
     vehicle* frontBogie = vehicle_front_bogie;
     vehicle* backBogie = vehicle_back_bogie;
@@ -1191,7 +1191,7 @@ void openloco::vehicle::diesel_exhaust1_animation_update(thingmanager& thingmgr,
             static_cast<int16_t>(y + yFactor),
             static_cast<int16_t>(z + vehicleObject.animation[num].height)
         };
-        exhaust::create(thingmgr, loc, vehicleObject.animation[num].object_id);
+        exhaust::create(tilemgr, thingmgr, loc, vehicleObject.animation[num].object_id);
     }
     else
     {
@@ -1238,12 +1238,12 @@ void openloco::vehicle::diesel_exhaust1_animation_update(thingmanager& thingmgr,
         loc.x += xFactor;
         loc.y += yFactor;
 
-        exhaust::create(thingmgr, loc, vehicleObject.animation[num].object_id);
+        exhaust::create(tilemgr, thingmgr, loc, vehicleObject.animation[num].object_id);
     }
 }
 
 // 0x004ABB5A & 0x004AB177
-void openloco::vehicle::diesel_exhaust2_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05)
+void openloco::vehicle::diesel_exhaust2_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05)
 {
     vehicle* frontBogie = vehicle_front_bogie;
     vehicle* backBogie = vehicle_back_bogie;
@@ -1313,11 +1313,11 @@ void openloco::vehicle::diesel_exhaust2_animation_update(thingmanager& thingmgr,
     loc.x += xFactor;
     loc.y += yFactor;
 
-    exhaust::create(thingmgr, loc, vehicleObject.animation[num].object_id);
+    exhaust::create(tilemgr, thingmgr, loc, vehicleObject.animation[num].object_id);
 }
 
 // 0x004ABDAD & 0x004AB3CA
-void openloco::vehicle::electric_spark1_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05)
+void openloco::vehicle::electric_spark1_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05)
 {
     vehicle* frontBogie = vehicle_front_bogie;
     vehicle* backBogie = vehicle_back_bogie;
@@ -1372,11 +1372,11 @@ void openloco::vehicle::electric_spark1_animation_update(thingmanager& thingmgr,
     loc.x += xFactor;
     loc.y += yFactor;
 
-    exhaust::create(thingmgr, loc, vehicleObject.animation[num].object_id);
+    exhaust::create(tilemgr, thingmgr, loc, vehicleObject.animation[num].object_id);
 }
 
 // 0x004ABEC3 & 0x004AB4E0
-void openloco::vehicle::electric_spark2_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05)
+void openloco::vehicle::electric_spark2_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05)
 {
     vehicle* frontBogie = vehicle_front_bogie;
     vehicle* backBogie = vehicle_back_bogie;
@@ -1453,11 +1453,11 @@ void openloco::vehicle::electric_spark2_animation_update(thingmanager& thingmgr,
     loc.x += xFactor;
     loc.y += yFactor;
 
-    exhaust::create(thingmgr, loc, vehicleObject.animation[num].object_id);
+    exhaust::create(tilemgr, thingmgr, loc, vehicleObject.animation[num].object_id);
 }
 
 // 0x004ABC8A & 0x004AB2A7
-void openloco::vehicle::ship_wake_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05)
+void openloco::vehicle::ship_wake_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05)
 {
     vehicle* veh_3 = vehicle_1136120;
 
@@ -1506,7 +1506,7 @@ void openloco::vehicle::ship_wake_animation_update(thingmanager& thingmgr, vehic
     loc.x += xFactor;
     loc.y += yFactor;
 
-    exhaust::create(thingmgr, loc, vehicleObject.animation[num].object_id);
+    exhaust::create(tilemgr, thingmgr, loc, vehicleObject.animation[num].object_id);
 
     if (vehicleObject.var_113 == 0)
         return;
@@ -1522,5 +1522,5 @@ void openloco::vehicle::ship_wake_animation_update(thingmanager& thingmgr, vehic
     loc.x += xFactor;
     loc.y += yFactor;
 
-    exhaust::create(thingmgr, loc, vehicleObject.animation[num].object_id);
+    exhaust::create(tilemgr, thingmgr, loc, vehicleObject.animation[num].object_id);
 }

--- a/src/openloco/things/vehicle.h
+++ b/src/openloco/things/vehicle.h
@@ -6,6 +6,7 @@
 namespace openloco
 {
     class thingmanager;
+    class objectmanager;
 
     namespace flags_5f
     {
@@ -55,21 +56,20 @@ namespace openloco
         uint8_t pad_6B[0x73 - 0x6B];
         uint8_t var_73; // 0x73 (bit 0 = broken down)
 
-        vehicle_object* object() const;
         vehicle* next_vehicle(thingmanager& thingmgr);
         vehicle* next_car(thingmanager& thingmgr);
 
-        void update_head(thingmanager& thingmgr);
+        void update_head(objectmanager& objectmgr, thingmanager& thingmgr);
         void sub_4BA8D4(thingmanager& thingmgr);
-        void secondary_animation_update(thingmanager& thingmgr);
+        void secondary_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject);
 
     private:
-        bool update(thingmanager& thingmgr);
+        bool update(objectmanager& objectmgr, thingmanager& thingmgr);
         void sub_4BAA76();
-        int32_t sub_4AA1D0(thingmanager& thingmgr);
-        void animation_update(thingmanager& thingmgr);
-        void sub_4AAB0B();
-        void sub_4AC255(vehicle* back_bogie, vehicle* front_bogie);
+        int32_t sub_4AA1D0(thingmanager& thingmgr, vehicle_object& vehicleObject);
+        void animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject);
+        void sub_4AAB0B(vehicle_object& vehicleObject);
+        void sub_4AC255(vehicle_object& vehicleObject, vehicle* back_bogie, vehicle* front_bogie);
         uint16_t sub_4BE368(uint32_t distance);
         uint8_t vehicle_body_update_sprite_pitch_steep_slopes(uint16_t xy_offset, int16_t z_offset);
         uint8_t vehicle_body_update_sprite_pitch(uint16_t xy_offset, int16_t z_offset);
@@ -78,12 +78,12 @@ namespace openloco
         uint8_t vehicle_update_sprite_yaw_2(int16_t x_offset, int16_t y_offset);
         uint8_t vehicle_update_sprite_yaw_3(int16_t x_offset, int16_t y_offset);
         uint8_t vehicle_update_sprite_yaw_4(int16_t x_offset, int16_t y_offset);
-        void steam_puffs_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05);
-        void diesel_exhaust1_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05);
-        void diesel_exhaust2_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05);
-        void electric_spark1_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05);
-        void electric_spark2_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05);
-        void ship_wake_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05);
+        void steam_puffs_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
+        void diesel_exhaust1_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
+        void diesel_exhaust2_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
+        void electric_spark1_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
+        void electric_spark2_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
+        void ship_wake_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
     };
 #pragma pack(pop)
 }

--- a/src/openloco/things/vehicle.h
+++ b/src/openloco/things/vehicle.h
@@ -10,6 +10,7 @@ namespace openloco::map
 
 namespace openloco
 {
+    class context;
     class thingmanager;
     class objectmanager;
 
@@ -64,15 +65,15 @@ namespace openloco
         vehicle* next_vehicle(thingmanager& thingmgr);
         vehicle* next_car(thingmanager& thingmgr);
 
-        void update_head(objectmanager& objectmgr, const map::tilemanager& tilemgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr);
+        void update_head(context& ctx);
         void sub_4BA8D4(thingmanager& thingmgr);
         void secondary_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject);
 
     private:
-        bool update(objectmanager& objectmgr, const map::tilemanager& tilemgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr);
+        bool update(context& ctx);
         void sub_4BAA76();
-        int32_t sub_4AA1D0(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, const ui::viewportmanager& viewportmgr);
-        void animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject);
+        int32_t sub_4AA1D0(context& ctx, vehicle_object& vehicleObject);
+        void animation_update(context& ctx, vehicle_object& vehicleObject);
         void sub_4AAB0B(vehicle_object& vehicleObject, const ui::viewportmanager& viewportmgr);
         void sub_4AC255(vehicle_object& vehicleObject, vehicle* back_bogie, vehicle* front_bogie);
         uint16_t sub_4BE368(uint32_t distance);

--- a/src/openloco/things/vehicle.h
+++ b/src/openloco/things/vehicle.h
@@ -5,6 +5,8 @@
 
 namespace openloco
 {
+    class thingmanager;
+
     namespace flags_5f
     {
         constexpr uint8_t breakdown_pending = 1 << 1;
@@ -53,19 +55,19 @@ namespace openloco
         uint8_t pad_6B[0x73 - 0x6B];
         uint8_t var_73; // 0x73 (bit 0 = broken down)
 
-        vehicle* next_vehicle();
-        vehicle* next_car();
         vehicle_object* object() const;
+        vehicle* next_vehicle(thingmanager& thingmgr);
+        vehicle* next_car(thingmanager& thingmgr);
 
-        void update_head();
-        void sub_4BA8D4();
-        void secondary_animation_update();
+        void update_head(thingmanager& thingmgr);
+        void sub_4BA8D4(thingmanager& thingmgr);
+        void secondary_animation_update(thingmanager& thingmgr);
 
     private:
-        bool update();
+        bool update(thingmanager& thingmgr);
         void sub_4BAA76();
-        int32_t sub_4AA1D0();
-        void animation_update();
+        int32_t sub_4AA1D0(thingmanager& thingmgr);
+        void animation_update(thingmanager& thingmgr);
         void sub_4AAB0B();
         void sub_4AC255(vehicle* back_bogie, vehicle* front_bogie);
         uint16_t sub_4BE368(uint32_t distance);
@@ -76,12 +78,12 @@ namespace openloco
         uint8_t vehicle_update_sprite_yaw_2(int16_t x_offset, int16_t y_offset);
         uint8_t vehicle_update_sprite_yaw_3(int16_t x_offset, int16_t y_offset);
         uint8_t vehicle_update_sprite_yaw_4(int16_t x_offset, int16_t y_offset);
-        void steam_puffs_animation_update(uint8_t num, int8_t var_05);
-        void diesel_exhaust1_animation_update(uint8_t num, int8_t var_05);
-        void diesel_exhaust2_animation_update(uint8_t num, int8_t var_05);
-        void electric_spark1_animation_update(uint8_t num, int8_t var_05);
-        void electric_spark2_animation_update(uint8_t num, int8_t var_05);
-        void ship_wake_animation_update(uint8_t num, int8_t var_05);
+        void steam_puffs_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05);
+        void diesel_exhaust1_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05);
+        void diesel_exhaust2_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05);
+        void electric_spark1_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05);
+        void electric_spark2_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05);
+        void ship_wake_animation_update(thingmanager& thingmgr, uint8_t num, int8_t var_05);
     };
 #pragma pack(pop)
 }

--- a/src/openloco/things/vehicle.h
+++ b/src/openloco/things/vehicle.h
@@ -59,16 +59,16 @@ namespace openloco
         vehicle* next_vehicle(thingmanager& thingmgr);
         vehicle* next_car(thingmanager& thingmgr);
 
-        void update_head(objectmanager& objectmgr, thingmanager& thingmgr);
+        void update_head(objectmanager& objectmgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr);
         void sub_4BA8D4(thingmanager& thingmgr);
         void secondary_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject);
 
     private:
-        bool update(objectmanager& objectmgr, thingmanager& thingmgr);
+        bool update(objectmanager& objectmgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr);
         void sub_4BAA76();
-        int32_t sub_4AA1D0(thingmanager& thingmgr, vehicle_object& vehicleObject);
+        int32_t sub_4AA1D0(thingmanager& thingmgr, vehicle_object& vehicleObject, const ui::viewportmanager& viewportmgr);
         void animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject);
-        void sub_4AAB0B(vehicle_object& vehicleObject);
+        void sub_4AAB0B(vehicle_object& vehicleObject, const ui::viewportmanager& viewportmgr);
         void sub_4AC255(vehicle_object& vehicleObject, vehicle* back_bogie, vehicle* front_bogie);
         uint16_t sub_4BE368(uint32_t distance);
         uint8_t vehicle_body_update_sprite_pitch_steep_slopes(uint16_t xy_offset, int16_t z_offset);

--- a/src/openloco/things/vehicle.h
+++ b/src/openloco/things/vehicle.h
@@ -3,6 +3,11 @@
 #include "../objects/vehicle_object.h"
 #include "thing.h"
 
+namespace openloco::map
+{
+    class tilemanager;
+}
+
 namespace openloco
 {
     class thingmanager;
@@ -59,15 +64,15 @@ namespace openloco
         vehicle* next_vehicle(thingmanager& thingmgr);
         vehicle* next_car(thingmanager& thingmgr);
 
-        void update_head(objectmanager& objectmgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr);
+        void update_head(objectmanager& objectmgr, const map::tilemanager& tilemgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr);
         void sub_4BA8D4(thingmanager& thingmgr);
-        void secondary_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject);
+        void secondary_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject);
 
     private:
-        bool update(objectmanager& objectmgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr);
+        bool update(objectmanager& objectmgr, const map::tilemanager& tilemgr, thingmanager& thingmgr, const ui::viewportmanager& viewportmgr);
         void sub_4BAA76();
-        int32_t sub_4AA1D0(thingmanager& thingmgr, vehicle_object& vehicleObject, const ui::viewportmanager& viewportmgr);
-        void animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject);
+        int32_t sub_4AA1D0(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, const ui::viewportmanager& viewportmgr);
+        void animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject);
         void sub_4AAB0B(vehicle_object& vehicleObject, const ui::viewportmanager& viewportmgr);
         void sub_4AC255(vehicle_object& vehicleObject, vehicle* back_bogie, vehicle* front_bogie);
         uint16_t sub_4BE368(uint32_t distance);
@@ -78,12 +83,12 @@ namespace openloco
         uint8_t vehicle_update_sprite_yaw_2(int16_t x_offset, int16_t y_offset);
         uint8_t vehicle_update_sprite_yaw_3(int16_t x_offset, int16_t y_offset);
         uint8_t vehicle_update_sprite_yaw_4(int16_t x_offset, int16_t y_offset);
-        void steam_puffs_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
-        void diesel_exhaust1_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
-        void diesel_exhaust2_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
-        void electric_spark1_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
-        void electric_spark2_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
-        void ship_wake_animation_update(thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
+        void steam_puffs_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
+        void diesel_exhaust1_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
+        void diesel_exhaust2_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
+        void electric_spark1_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
+        void electric_spark2_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
+        void ship_wake_animation_update(const map::tilemanager& tilemgr, thingmanager& thingmgr, vehicle_object& vehicleObject, uint8_t num, int8_t var_05);
     };
 #pragma pack(pop)
 }

--- a/src/openloco/townmgr.cpp
+++ b/src/openloco/townmgr.cpp
@@ -6,8 +6,6 @@
 using namespace openloco;
 using namespace openloco::interop;
 
-townmanager openloco::g_townmgr;
-
 static loco_global<town[80], 0x005B825C> _towns;
 
 std::array<town, max_towns>& townmanager::towns()

--- a/src/openloco/townmgr.cpp
+++ b/src/openloco/townmgr.cpp
@@ -25,7 +25,7 @@ namespace openloco::townmgr
     }
 
     // 0x00496B6D
-    void update()
+    void update(companymanager& companymgr)
     {
         if ((addr<0x00525E28, uint32_t>() & 1) && !is_editor_mode())
         {
@@ -36,7 +36,7 @@ namespace openloco::townmgr
                 auto town = get(id);
                 if (town != nullptr && !town->empty())
                 {
-                    companymgr::updating_company_id(company_id::neutral);
+                    companymgr.updating_company_id(company_id::neutral);
                     town->update();
                 }
             }

--- a/src/openloco/townmgr.h
+++ b/src/openloco/townmgr.h
@@ -17,6 +17,4 @@ namespace openloco
         void update(companymanager& companymgr);
         void update_monthly();
     };
-
-    extern townmanager g_townmgr;
 }

--- a/src/openloco/townmgr.h
+++ b/src/openloco/townmgr.h
@@ -3,12 +3,17 @@
 #include "town.h"
 #include <array>
 
+namespace openloco
+{
+    class companymanager;
+}
+
 namespace openloco::townmgr
 {
     constexpr size_t max_towns = 80;
 
     std::array<town, max_towns>& towns();
     town* get(town_id_t id);
-    void update();
+    void update(companymanager& companymgr);
     void update_monthly();
 }

--- a/src/openloco/townmgr.h
+++ b/src/openloco/townmgr.h
@@ -6,14 +6,17 @@
 namespace openloco
 {
     class companymanager;
-}
 
-namespace openloco::townmgr
-{
     constexpr size_t max_towns = 80;
 
-    std::array<town, max_towns>& towns();
-    town* get(town_id_t id);
-    void update(companymanager& companymgr);
-    void update_monthly();
+    class townmanager
+    {
+    public:
+        std::array<town, max_towns>& towns();
+        town* get(town_id_t id);
+        void update(companymanager& companymgr);
+        void update_monthly();
+    };
+
+    extern townmanager g_townmgr;
 }

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -342,7 +342,7 @@ namespace openloco::ui
         if (cfg.index != displayIndex)
         {
             cfg.index = displayIndex;
-            config::write_new_config(g_env);
+            config::write_new_config(g_ctx.get<environment>());
         }
     }
 
@@ -358,7 +358,7 @@ namespace openloco::ui
         {
             auto& cfg = config::get_new().display;
             cfg.window_resolution = { width, height };
-            config::write_new_config(g_env);
+            config::write_new_config(g_ctx.get<environment>());
         }
     }
 
@@ -761,7 +761,7 @@ namespace openloco::ui
         {
             auto& cfg = config::get_new();
             cfg.display.mode = mode;
-            config::write_new_config(g_env);
+            config::write_new_config(g_ctx.get<environment>());
         }
     }
 

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -29,6 +29,7 @@
 
 #include "config.h"
 #include "console.h"
+#include "environment.h"
 #include "graphics/gfx.h"
 #include "gui.h"
 #include "input.h"
@@ -341,7 +342,7 @@ namespace openloco::ui
         if (cfg.index != displayIndex)
         {
             cfg.index = displayIndex;
-            config::write_new_config();
+            config::write_new_config(g_env);
         }
     }
 
@@ -357,7 +358,7 @@ namespace openloco::ui
         {
             auto& cfg = config::get_new().display;
             cfg.window_resolution = { width, height };
-            config::write_new_config();
+            config::write_new_config(g_env);
         }
     }
 
@@ -760,7 +761,7 @@ namespace openloco::ui
         {
             auto& cfg = config::get_new();
             cfg.display.mode = mode;
-            config::write_new_config();
+            config::write_new_config(g_env);
         }
     }
 

--- a/src/openloco/viewportmgr.cpp
+++ b/src/openloco/viewportmgr.cpp
@@ -8,8 +8,6 @@
 using namespace openloco::ui;
 using namespace openloco::interop;
 
-viewportmanager openloco::ui::g_viewportmgr;
-
 static loco_global<viewport * [max_viewports], 0x0113D820> _viewports;
 
 const std::array<const viewport*, max_viewports> viewportmanager::viewports() const

--- a/src/openloco/viewportmgr.cpp
+++ b/src/openloco/viewportmgr.cpp
@@ -8,17 +8,23 @@
 using namespace openloco::ui;
 using namespace openloco::interop;
 
-namespace openloco::ui::viewportmgr
+viewportmanager openloco::ui::g_viewportmgr;
+
+static loco_global<viewport * [max_viewports], 0x0113D820> _viewports;
+
+const std::array<const viewport*, max_viewports> viewportmanager::viewports() const
 {
-    loco_global<viewport * [max_viewports], 0x0113D820> _viewports;
+    auto arr = (std::array<const viewport*, max_viewports>*)_viewports.get();
+    return *arr;
+}
 
-    std::array<viewport*, max_viewports> viewports()
-    {
-        auto arr = (std::array<viewport*, max_viewports>*)_viewports.get();
-        return *arr;
-    }
+std::array<viewport*, max_viewports> viewportmanager::viewports()
+{
+    auto arr = (std::array<viewport*, max_viewports>*)_viewports.get();
+    return *arr;
+}
 
-    /* 0x004CA2D0
+/* 0x004CA2D0
      * ax : x
      * eax >> 16 : y
      * bx : width
@@ -33,18 +39,18 @@ namespace openloco::ui::viewportmgr
      * 2.
      * dx : thing_id
      */
-    void create(window* window, int16_t x, int16_t y, uint16_t width, uint16_t height, bool zoom_flag, uint8_t zoom, uint16_t thing_id)
-    {
-        registers regs;
-        regs.dx = (zoom_flag ? ((1 << 30) | (1 << 31)) : (1 << 31)) | thing_id;
-        regs.eax = (y << 16) | x;
-        regs.ebx = (height << 16) | width;
-        regs.cl = zoom;
-        regs.esi = (uint32_t)window;
-        call(0x004ca2d0, regs);
-    }
+void viewportmanager::create(window* window, int16_t x, int16_t y, uint16_t width, uint16_t height, bool zoom_flag, uint8_t zoom, uint16_t thing_id)
+{
+    registers regs;
+    regs.dx = (zoom_flag ? ((1 << 30) | (1 << 31)) : (1 << 31)) | thing_id;
+    regs.eax = (y << 16) | x;
+    regs.ebx = (height << 16) | width;
+    regs.cl = zoom;
+    regs.esi = (uint32_t)window;
+    call(0x004ca2d0, regs);
+}
 
-    /* 0x004CA2D0
+/* 0x004CA2D0
      * ax : x
      * eax >> 16 : y
      * bx : width
@@ -59,16 +65,15 @@ namespace openloco::ui::viewportmgr
      * 2.
      * dx : thing_id
      */
-    void create(window* window, int16_t x, int16_t y, uint16_t width, uint16_t height, bool zoom_flag, uint8_t zoom, uint16_t tile_x, uint16_t tile_y, uint16_t tile_z)
-    {
-        registers regs;
-        regs.edx = (tile_y << 16) | tile_x;
-        regs.ecx = (tile_z << 16) | zoom;
+void viewportmanager::create(window* window, int16_t x, int16_t y, uint16_t width, uint16_t height, bool zoom_flag, uint8_t zoom, uint16_t tile_x, uint16_t tile_y, uint16_t tile_z)
+{
+    registers regs;
+    regs.edx = (tile_y << 16) | tile_x;
+    regs.ecx = (tile_z << 16) | zoom;
 
-        regs.eax = (y << 16) | x;
-        regs.ebx = (height << 16) | width;
-        regs.edx |= zoom_flag ? (1 << 30) : 0;
-        regs.esi = (uint32_t)window;
-        call(0x004ca2d0, regs);
-    }
+    regs.eax = (y << 16) | x;
+    regs.ebx = (height << 16) | width;
+    regs.edx |= zoom_flag ? (1 << 30) : 0;
+    regs.esi = (uint32_t)window;
+    call(0x004ca2d0, regs);
 }

--- a/src/openloco/viewportmgr.h
+++ b/src/openloco/viewportmgr.h
@@ -10,11 +10,12 @@ namespace openloco::ui
     class viewportmanager
     {
     public:
+        viewportmanager() = default;
+        viewportmanager(const viewportmanager&) = delete;
+
         const std::array<const viewport*, max_viewports> viewports() const;
         std::array<viewport*, max_viewports> viewports();
         void create(window* window, int16_t x, int16_t y, uint16_t width, uint16_t height, bool zoom_flag, uint8_t zoom, uint16_t thing_id);
         void create(window* window, int16_t x, int16_t y, uint16_t width, uint16_t height, bool zoom_flag, uint8_t zoom, uint16_t tile_x, uint16_t tile_y, uint16_t tile_z);
     };
-
-    extern viewportmanager g_viewportmgr;
 }

--- a/src/openloco/viewportmgr.h
+++ b/src/openloco/viewportmgr.h
@@ -3,10 +3,18 @@
 #include "window.h"
 #include <array>
 
-namespace openloco::ui::viewportmgr
+namespace openloco::ui
 {
     constexpr size_t max_viewports = 10;
-    std::array<viewport*, max_viewports> viewports();
-    void create(window* window, int16_t x, int16_t y, uint16_t width, uint16_t height, bool zoom_flag, uint8_t zoom, uint16_t thing_id);
-    void create(window* window, int16_t x, int16_t y, uint16_t width, uint16_t height, bool zoom_flag, uint8_t zoom, uint16_t tile_x, uint16_t tile_y, uint16_t tile_z);
+
+    class viewportmanager
+    {
+    public:
+        const std::array<const viewport*, max_viewports> viewports() const;
+        std::array<viewport*, max_viewports> viewports();
+        void create(window* window, int16_t x, int16_t y, uint16_t width, uint16_t height, bool zoom_flag, uint8_t zoom, uint16_t thing_id);
+        void create(window* window, int16_t x, int16_t y, uint16_t width, uint16_t height, bool zoom_flag, uint8_t zoom, uint16_t tile_x, uint16_t tile_y, uint16_t tile_z);
+    };
+
+    extern viewportmanager g_viewportmgr;
 }

--- a/src/openloco/window.cpp
+++ b/src/openloco/window.cpp
@@ -112,7 +112,7 @@ namespace openloco::ui
 
             if (config->viewport_target_sprite != 0xFFFF)
             {
-                auto thing = g_thingmgr.get<thing_base>(config->viewport_target_sprite);
+                auto thing = g_ctx.get<thingmanager>().get<thing_base>(config->viewport_target_sprite);
 
                 int z = (tile_element_height(thing->x, thing->y) & 0xFFFF) - 16;
                 bool underground = (thing->z < z);

--- a/src/openloco/window.cpp
+++ b/src/openloco/window.cpp
@@ -112,7 +112,7 @@ namespace openloco::ui
 
             if (config->viewport_target_sprite != 0xFFFF)
             {
-                auto thing = thingmgr::get<thing_base>(config->viewport_target_sprite);
+                auto thing = g_thingmgr.get<thing_base>(config->viewport_target_sprite);
 
                 int z = (tile_element_height(thing->x, thing->y) & 0xFFFF) - 16;
                 bool underground = (thing->z < z);

--- a/src/openloco/windowmgr.cpp
+++ b/src/openloco/windowmgr.cpp
@@ -236,7 +236,7 @@ namespace openloco::ui::windowmgr
         register_hook(
             0x004CD3D0,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                dispatch_update_all(g_companymgr);
+                dispatch_update_all(g_ctx.get<companymanager>());
                 return 0;
             });
 

--- a/src/openloco/windowmgr.cpp
+++ b/src/openloco/windowmgr.cpp
@@ -236,7 +236,7 @@ namespace openloco::ui::windowmgr
         register_hook(
             0x004CD3D0,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                dispatch_update_all();
+                dispatch_update_all(g_companymgr);
                 return 0;
             });
 
@@ -626,10 +626,10 @@ namespace openloco::ui::windowmgr
     }
 
     // 0x004CD3D0
-    void dispatch_update_all()
+    void dispatch_update_all(companymanager& companymgr)
     {
         _523508++;
-        companymgr::updating_company_id(companymgr::get_controlling_id());
+        companymgr.updating_company_id(companymgr.get_controlling_id());
 
         for (ui::window* w = _windows_end - 1; w >= _windows; w--)
         {

--- a/src/openloco/windowmgr.h
+++ b/src/openloco/windowmgr.h
@@ -5,6 +5,11 @@
 #include "window.h"
 #include <cstddef>
 
+namespace openloco
+{
+    class companymanager;
+}
+
 namespace openloco::ui
 {
     enum class window_type : uint8_t
@@ -98,7 +103,7 @@ namespace openloco::ui::windowmgr
     window* create_window(window_type type, int32_t x, int32_t y, int32_t width, int32_t height, int32_t flags, window_event_list* events);
     window* create_window_centred(window_type type, int32_t width, int32_t height, int32_t flags, window_event_list* events);
     void draw_single(gfx::drawpixelinfo_t* dpi, window* w, int32_t left, int32_t top, int32_t right, int32_t bottom);
-    void dispatch_update_all();
+    void dispatch_update_all(companymanager& companymgr);
     void call_event_viewport_rotate_on_all_windows();
     void relocate_windows();
     void sub_4CEE0B(window* self);

--- a/src/openloco/windows/about.cpp
+++ b/src/openloco/windows/about.cpp
@@ -57,7 +57,7 @@ namespace openloco::ui::about
         window->enabled_widgets = (1 << widx::close) | (1 << widx::music_acknowledgements_btn);
         window->init_scroll_widgets();
 
-        auto interface = g_objectmgr.get<interface_skin_object>();
+        auto interface = g_ctx.get<objectmanager>().get<interface_skin_object>();
         window->colours[0] = interface->colour_0B;
         window->colours[1] = interface->colour_10;
     }

--- a/src/openloco/windows/about.cpp
+++ b/src/openloco/windows/about.cpp
@@ -57,7 +57,7 @@ namespace openloco::ui::about
         window->enabled_widgets = (1 << widx::close) | (1 << widx::music_acknowledgements_btn);
         window->init_scroll_widgets();
 
-        auto interface = objectmgr::get<interface_skin_object>();
+        auto interface = g_objectmgr.get<interface_skin_object>();
         window->colours[0] = interface->colour_0B;
         window->colours[1] = interface->colour_10;
     }

--- a/src/openloco/windows/about_music.cpp
+++ b/src/openloco/windows/about_music.cpp
@@ -68,7 +68,7 @@ namespace openloco::ui::about_music
         window->enabled_widgets = 1 << widx::close;
         window->init_scroll_widgets();
 
-        auto interface = objectmgr::get<interface_skin_object>();
+        auto interface = g_objectmgr.get<interface_skin_object>();
         window->colours[0] = interface->colour_0B;
         window->colours[1] = interface->colour_10;
     }

--- a/src/openloco/windows/about_music.cpp
+++ b/src/openloco/windows/about_music.cpp
@@ -68,7 +68,7 @@ namespace openloco::ui::about_music
         window->enabled_widgets = 1 << widx::close;
         window->init_scroll_widgets();
 
-        auto interface = g_objectmgr.get<interface_skin_object>();
+        auto interface = g_ctx.get<objectmanager>().get<interface_skin_object>();
         window->colours[0] = interface->colour_0B;
         window->colours[1] = interface->colour_10;
     }

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -1327,7 +1327,7 @@ namespace openloco::ui::options
             }
 
             set_format_arg(0xC, string_id, current_measurement_format);
-            set_format_arg(0xA, string_id, objectmgr::get<currency_object>()->name);
+            set_format_arg(0xA, string_id, g_objectmgr.get<currency_object>()->name);
 
             w->activated_widgets &= ~(1 << widx::preferred_currency_for_new_games);
             if (config::get().flags & config::flags::preferred_currency_for_new_games)
@@ -1489,7 +1489,7 @@ namespace openloco::ui::options
             widget_t dropdown = w->widgets[widx::currency];
             dropdown::show(w->x + dropdown.left, w->y + dropdown.top, dropdown.width() - 4, dropdown.height(), w->colours[1], _112C185, 0x80);
             int index = -1;
-            for (auto object : objectmgr::getAvailableObjects(object_type::currency))
+            for (auto object : g_objectmgr.getAvailableObjects(object_type::currency))
             {
                 index++;
                 dropdown::add(index, string_ids::dropdown_stringptr, object.second._name);
@@ -1513,7 +1513,7 @@ namespace openloco::ui::options
             uint8_t* _11364A0 = (uint8_t*)*__11364A0;
 
             int index = -1;
-            for (auto object : objectmgr::getAvailableObjects(object_type::currency))
+            for (auto object : g_objectmgr.getAvailableObjects(object_type::currency))
             {
                 index++;
                 if (index == ax)
@@ -1552,7 +1552,7 @@ namespace openloco::ui::options
             dropdown::show(w->x + dropdown.left, w->y + dropdown.top, dropdown.width() - 4, dropdown.height(), w->colours[1], _112C185, 0x80);
 
             int index = -1;
-            for (auto object : objectmgr::getAvailableObjects(object_type::currency))
+            for (auto object : g_objectmgr.getAvailableObjects(object_type::currency))
             {
                 index++;
                 dropdown::add(index, string_ids::dropdown_stringptr, object.second._name);
@@ -1571,7 +1571,7 @@ namespace openloco::ui::options
             }
 
             int index = -1;
-            for (auto object : objectmgr::getAvailableObjects(object_type::currency))
+            for (auto object : g_objectmgr.getAvailableObjects(object_type::currency))
             {
                 index++;
 
@@ -2078,7 +2078,7 @@ namespace openloco::ui::options
 
     static void sub_4BF8CD()
     {
-        auto ptr = malloc(objectmgr::getNumInstalledObjects());
+        auto ptr = malloc(g_objectmgr.getNumInstalledObjects());
         // TODO: reimplement nullptr check?
 
         __11364A0 = ptr;
@@ -2152,7 +2152,7 @@ namespace openloco::ui::options
         window->frame_no = 0;
         window->var_840 = 0xFFFF;
 
-        auto interface = objectmgr::get<interface_skin_object>();
+        auto interface = g_objectmgr.get<interface_skin_object>();
         window->colours[0] = interface->colour_0B;
         window->colours[1] = interface->colour_10;
 

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -1327,7 +1327,7 @@ namespace openloco::ui::options
             }
 
             set_format_arg(0xC, string_id, current_measurement_format);
-            set_format_arg(0xA, string_id, g_objectmgr.get<currency_object>()->name);
+            set_format_arg(0xA, string_id, g_ctx.get<objectmanager>().get<currency_object>()->name);
 
             w->activated_widgets &= ~(1 << widx::preferred_currency_for_new_games);
             if (config::get().flags & config::flags::preferred_currency_for_new_games)
@@ -1489,7 +1489,7 @@ namespace openloco::ui::options
             widget_t dropdown = w->widgets[widx::currency];
             dropdown::show(w->x + dropdown.left, w->y + dropdown.top, dropdown.width() - 4, dropdown.height(), w->colours[1], _112C185, 0x80);
             int index = -1;
-            for (auto object : g_objectmgr.getAvailableObjects(object_type::currency))
+            for (auto object : g_ctx.get<objectmanager>().getAvailableObjects(object_type::currency))
             {
                 index++;
                 dropdown::add(index, string_ids::dropdown_stringptr, object.second._name);
@@ -1513,7 +1513,7 @@ namespace openloco::ui::options
             uint8_t* _11364A0 = (uint8_t*)*__11364A0;
 
             int index = -1;
-            for (auto object : g_objectmgr.getAvailableObjects(object_type::currency))
+            for (auto object : g_ctx.get<objectmanager>().getAvailableObjects(object_type::currency))
             {
                 index++;
                 if (index == ax)
@@ -1552,7 +1552,7 @@ namespace openloco::ui::options
             dropdown::show(w->x + dropdown.left, w->y + dropdown.top, dropdown.width() - 4, dropdown.height(), w->colours[1], _112C185, 0x80);
 
             int index = -1;
-            for (auto object : g_objectmgr.getAvailableObjects(object_type::currency))
+            for (auto object : g_ctx.get<objectmanager>().getAvailableObjects(object_type::currency))
             {
                 index++;
                 dropdown::add(index, string_ids::dropdown_stringptr, object.second._name);
@@ -1571,7 +1571,7 @@ namespace openloco::ui::options
             }
 
             int index = -1;
-            for (auto object : g_objectmgr.getAvailableObjects(object_type::currency))
+            for (auto object : g_ctx.get<objectmanager>().getAvailableObjects(object_type::currency))
             {
                 index++;
 
@@ -2078,7 +2078,7 @@ namespace openloco::ui::options
 
     static void sub_4BF8CD()
     {
-        auto ptr = malloc(g_objectmgr.getNumInstalledObjects());
+        auto ptr = malloc(g_ctx.get<objectmanager>().getNumInstalledObjects());
         // TODO: reimplement nullptr check?
 
         __11364A0 = ptr;
@@ -2152,7 +2152,7 @@ namespace openloco::ui::options
         window->frame_no = 0;
         window->var_840 = 0xFFFF;
 
-        auto interface = g_objectmgr.get<interface_skin_object>();
+        auto interface = g_ctx.get<objectmanager>().get<interface_skin_object>();
         window->colours[0] = interface->colour_0B;
         window->colours[1] = interface->colour_10;
 

--- a/src/openloco/windows/promptbrowsewnd.cpp
+++ b/src/openloco/windows/promptbrowsewnd.cpp
@@ -6,6 +6,7 @@
 #include <experimental/filesystem>
 #endif
 #include "../audio/audio.h"
+#include "../companymgr.h"
 #include "../graphics/colours.h"
 #include "../input.h"
 #include "../interop/interop.hpp"
@@ -106,7 +107,7 @@ namespace openloco::ui::prompt_browse
                 []() {
                     input::handle_keyboard();
                     audio::update_sounds();
-                    windowmgr::dispatch_update_all();
+                    windowmgr::dispatch_update_all(g_companymgr);
                     call(0x004BEC5B);
                     windowmgr::update();
                     call(0x004C98CF);

--- a/src/openloco/windows/promptbrowsewnd.cpp
+++ b/src/openloco/windows/promptbrowsewnd.cpp
@@ -107,7 +107,7 @@ namespace openloco::ui::prompt_browse
                 []() {
                     input::handle_keyboard();
                     audio::update_sounds();
-                    windowmgr::dispatch_update_all(g_companymgr);
+                    windowmgr::dispatch_update_all(g_ctx.get<companymanager>());
                     call(0x004BEC5B);
                     windowmgr::update();
                     call(0x004C98CF);

--- a/src/openloco/windows/promptokcancelwnd.cpp
+++ b/src/openloco/windows/promptokcancelwnd.cpp
@@ -1,4 +1,5 @@
 #include "../audio/audio.h"
+#include "../companymgr.h"
 #include "../graphics/colours.h"
 #include "../input.h"
 #include "../interop/interop.hpp"
@@ -54,7 +55,7 @@ namespace openloco::ui::windows
                 []() {
                     input::handle_keyboard();
                     audio::update_sounds();
-                    windowmgr::dispatch_update_all();
+                    windowmgr::dispatch_update_all(g_companymgr);
                     call(0x004BEC5B);
                     windowmgr::update();
                     call(0x004C98CF);

--- a/src/openloco/windows/promptokcancelwnd.cpp
+++ b/src/openloco/windows/promptokcancelwnd.cpp
@@ -55,7 +55,7 @@ namespace openloco::ui::windows
                 []() {
                     input::handle_keyboard();
                     audio::update_sounds();
-                    windowmgr::dispatch_update_all(g_companymgr);
+                    windowmgr::dispatch_update_all(g_ctx.get<companymanager>());
                     call(0x004BEC5B);
                     windowmgr::update();
                     call(0x004C98CF);

--- a/src/openloco/windows/stationwnd.cpp
+++ b/src/openloco/windows/stationwnd.cpp
@@ -49,7 +49,7 @@ namespace openloco::ui::windows
             auto& cargo = station.cargo_stats[i];
             if (!cargo.empty())
             {
-                auto cargoObj = objectmgr::get<cargo_object>(i);
+                auto cargoObj = g_objectmgr.get<cargo_object>(i);
                 gfx::draw_string_494BBF(dpi, 1, y, 98, 0, string_ids::wcolour2_stringid2, &cargoObj->name);
 
                 auto rating = cargo.rating;

--- a/src/openloco/windows/stationwnd.cpp
+++ b/src/openloco/windows/stationwnd.cpp
@@ -49,7 +49,7 @@ namespace openloco::ui::windows
             auto& cargo = station.cargo_stats[i];
             if (!cargo.empty())
             {
-                auto cargoObj = g_objectmgr.get<cargo_object>(i);
+                auto cargoObj = g_ctx.get<objectmanager>().get<cargo_object>(i);
                 gfx::draw_string_494BBF(dpi, 1, y, 98, 0, string_ids::wcolour2_stringid2, &cargoObj->name);
 
                 auto rating = cargo.rating;

--- a/src/openloco/windows/stationwnd.cpp
+++ b/src/openloco/windows/stationwnd.cpp
@@ -20,7 +20,7 @@ namespace openloco::ui::windows
 
     static station& get_station(const window& w)
     {
-        return *(g_stationmgr.get(get_station_id(w)));
+        return *(g_ctx.get<stationmanager>().get(get_station_id(w)));
     }
 
     // 0x0048EF02

--- a/src/openloco/windows/stationwnd.cpp
+++ b/src/openloco/windows/stationwnd.cpp
@@ -20,7 +20,7 @@ namespace openloco::ui::windows
 
     static station& get_station(const window& w)
     {
-        return *(stationmgr::get(get_station_id(w)));
+        return *(g_stationmgr.get(get_station_id(w)));
     }
 
     // 0x0048EF02

--- a/src/openloco/windows/textinputwnd.cpp
+++ b/src/openloco/windows/textinputwnd.cpp
@@ -176,7 +176,7 @@ namespace openloco::ui::textinput
 
         if (caller->type == window_type::title_menu)
         {
-            interface_skin_object* interface = objectmgr::get<interface_skin_object>();
+            interface_skin_object* interface = g_objectmgr.get<interface_skin_object>();
             window->colours[0] = interface->colour_0B;
             window->colours[1] = interface->colour_0C;
             window->var_884 = -1;
@@ -184,7 +184,7 @@ namespace openloco::ui::textinput
 
         if (caller->type == window_type::toolbar_time)
         {
-            interface_skin_object* interface = objectmgr::get<interface_skin_object>();
+            interface_skin_object* interface = g_objectmgr.get<interface_skin_object>();
             window->colours[1] = interface->colour_0A;
             window->var_884 = g_companymgr.get_controlling_id();
         }

--- a/src/openloco/windows/textinputwnd.cpp
+++ b/src/openloco/windows/textinputwnd.cpp
@@ -186,7 +186,7 @@ namespace openloco::ui::textinput
         {
             interface_skin_object* interface = g_ctx.get<objectmanager>().get<interface_skin_object>();
             window->colours[1] = interface->colour_0A;
-            window->var_884 = g_companymgr.get_controlling_id();
+            window->var_884 = g_ctx.get<companymanager>().get_controlling_id();
         }
 
         _widgets[widx::title].type = widget_type::caption_25;

--- a/src/openloco/windows/textinputwnd.cpp
+++ b/src/openloco/windows/textinputwnd.cpp
@@ -176,7 +176,7 @@ namespace openloco::ui::textinput
 
         if (caller->type == window_type::title_menu)
         {
-            interface_skin_object* interface = g_objectmgr.get<interface_skin_object>();
+            interface_skin_object* interface = g_ctx.get<objectmanager>().get<interface_skin_object>();
             window->colours[0] = interface->colour_0B;
             window->colours[1] = interface->colour_0C;
             window->var_884 = -1;
@@ -184,7 +184,7 @@ namespace openloco::ui::textinput
 
         if (caller->type == window_type::toolbar_time)
         {
-            interface_skin_object* interface = g_objectmgr.get<interface_skin_object>();
+            interface_skin_object* interface = g_ctx.get<objectmanager>().get<interface_skin_object>();
             window->colours[1] = interface->colour_0A;
             window->var_884 = g_companymgr.get_controlling_id();
         }

--- a/src/openloco/windows/textinputwnd.cpp
+++ b/src/openloco/windows/textinputwnd.cpp
@@ -186,7 +186,7 @@ namespace openloco::ui::textinput
         {
             interface_skin_object* interface = objectmgr::get<interface_skin_object>();
             window->colours[1] = interface->colour_0A;
-            window->var_884 = companymgr::get_controlling_id();
+            window->var_884 = g_companymgr.get_controlling_id();
         }
 
         _widgets[widx::title].type = widget_type::caption_25;

--- a/src/openloco/windows/title_menu.cpp
+++ b/src/openloco/windows/title_menu.cpp
@@ -199,7 +199,7 @@ namespace openloco::ui::windows
             window->widgets[widx::load_game_btn].right = btn_main_size * 3 - 1;
 
             window->widgets[widx::chat_btn].type = ui::widget_type::wt_9;
-            interface_skin_object* skin = g_objectmgr.get<interface_skin_object>();
+            interface_skin_object* skin = g_ctx.get<objectmanager>().get<interface_skin_object>();
             window->widgets[widx::chat_btn].image = skin->img + interface_skin::image_ids::phone;
         }
     }

--- a/src/openloco/windows/title_menu.cpp
+++ b/src/openloco/windows/title_menu.cpp
@@ -199,7 +199,7 @@ namespace openloco::ui::windows
             window->widgets[widx::load_game_btn].right = btn_main_size * 3 - 1;
 
             window->widgets[widx::chat_btn].type = ui::widget_type::wt_9;
-            interface_skin_object* skin = objectmgr::get<interface_skin_object>();
+            interface_skin_object* skin = g_objectmgr.get<interface_skin_object>();
             window->widgets[widx::chat_btn].image = skin->img + interface_skin::image_ids::phone;
         }
     }

--- a/src/openloco/windows/tooltip.cpp
+++ b/src/openloco/windows/tooltip.cpp
@@ -198,7 +198,7 @@ namespace openloco::ui::tooltip
         uint16_t height = window->height;
 
         gfx::draw_rect(dpi, x + 1, y + 1, width - 2, height - 2, 0x2000000 | 45);
-        gfx::draw_rect(dpi, x + 1, y + 1, width - 2, height - 2, 0x2000000 | (116 + objectmgr::get<interface_skin_object>()->colour_08));
+        gfx::draw_rect(dpi, x + 1, y + 1, width - 2, height - 2, 0x2000000 | (116 + g_objectmgr.get<interface_skin_object>()->colour_08));
 
         gfx::draw_rect(dpi, x, y + 2, 1, height - 4, 0x2000000 | 46);
         gfx::draw_rect(dpi, x + width - 1, y + 2, 1, height - 4, 0x2000000 | 46);

--- a/src/openloco/windows/tooltip.cpp
+++ b/src/openloco/windows/tooltip.cpp
@@ -198,7 +198,7 @@ namespace openloco::ui::tooltip
         uint16_t height = window->height;
 
         gfx::draw_rect(dpi, x + 1, y + 1, width - 2, height - 2, 0x2000000 | 45);
-        gfx::draw_rect(dpi, x + 1, y + 1, width - 2, height - 2, 0x2000000 | (116 + g_objectmgr.get<interface_skin_object>()->colour_08));
+        gfx::draw_rect(dpi, x + 1, y + 1, width - 2, height - 2, 0x2000000 | (116 + g_ctx.get<objectmanager>().get<interface_skin_object>()->colour_08));
 
         gfx::draw_rect(dpi, x, y + 2, 1, height - 4, 0x2000000 | 46);
         gfx::draw_rect(dpi, x + width - 1, y + 2, 1, height - 4, 0x2000000 | 46);


### PR DESCRIPTION
One of the problems we have with OpenRCT2 is the large number of global variables that we have. While global variables can be very convenient they are not good code practice and cause issues when they are auto disposed in the incorrect order.

This PR changes all services to be classes instead of methods in namespaces and passes the service instance to all the functions that require it. If a function needs a large number of services then I pass `context` instead which is sort of like a service provider. There are still a few `g_ctx` occurances about but this PR should give you more of an idea of what the code would look like.

The only annoying thing I see at the moment is methods like `vehicle->next()` which now requires passing the thing manager as a parameter as we ~~can not~~ should not store service references on game state objects.