### PR TITLE
Fix #273: Cannot issue vehicle orders

### DIFF
--- a/src/openloco/ui/WindowManager.cpp
+++ b/src/openloco/ui/WindowManager.cpp
@@ -1003,7 +1003,7 @@ namespace openloco::ui::WindowManager
 
     bool isInFront(ui::window* w)
     {
-        for (auto window = w; window < _windowsEnd; window++)
+        for (auto window = w + 1; window < _windowsEnd; window++)
         {
             if ((window->flags & window_flags::stick_to_front) != 0)
                 continue;
@@ -1016,7 +1016,7 @@ namespace openloco::ui::WindowManager
 
     bool isInFrontAlt(ui::window* w)
     {
-        for (auto window = w; window < _windowsEnd; window++)
+        for (auto window = w + 1; window < _windowsEnd; window++)
         {
             if ((window->flags & window_flags::stick_to_front) != 0)
                 continue;

--- a/src/openloco/windows/vehicle.cpp
+++ b/src/openloco/windows/vehicle.cpp
@@ -167,7 +167,7 @@ namespace openloco::ui::vehicle
             w->invalidate();
 
             registers regs2;
-            regs.esi = (uintptr_t)vehicle;
+            regs2.esi = (uintptr_t)vehicle;
             call(0x00470824, regs2);
         }
     }


### PR DESCRIPTION
The bug revealed an off-by-one error in WindowManager::isInFront, which was masking a crash due to a typo.