### PR TITLE
Option to disable title screen music

### DIFF
--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2190,3 +2190,4 @@ strings:
   2135: "{COLOUR BLACK}{INT32_1DP}"
   2136: "{COLOUR WINDOW_2}Zoom to cursor position (experimental)"
   2137: "{SMALLFONT}{COLOUR BLACK}When enabled, zooming in will centre around the cursor, as opposed to the screen centre."
+  2138: "{COLOUR WINDOW_2}Play title screen music"

--- a/src/openloco/audio/audio.cpp
+++ b/src/openloco/audio/audio.cpp
@@ -990,7 +990,7 @@ namespace openloco::audio
     void play_title_screen_music()
     {
         loco_global<uint8_t, 0x0050D555> enable_sound;
-        if (_audio_initialised && (enable_sound & 1) && is_title_mode())
+        if (is_title_mode() && _audio_initialised && (enable_sound & 1) && config::get_new().audio.play_title_music)
         {
             if (!is_channel_playing(channel_id::title))
             {

--- a/src/openloco/audio/audio.cpp
+++ b/src/openloco/audio/audio.cpp
@@ -569,10 +569,10 @@ namespace openloco::audio
     // pan is in UI pixels or known constant
     void play_sound(sound_id id, loc16 loc, int32_t volume, int32_t pan, int32_t frequency)
     {
-        loco_global<uint8_t, 0x0050D555> unk_50D555;
+        loco_global<uint8_t, 0x0050D555> enable_sound;
         loco_global<int32_t, 0x00e3f0b8> current_rotation;
 
-        if (unk_50D555 & 1)
+        if (enable_sound & 1)
         {
             volume += get_volume_for_sound_id(id);
             if (pan == play_at_location)
@@ -989,8 +989,8 @@ namespace openloco::audio
     // 0x0048AC66
     void play_title_screen_music()
     {
-        loco_global<uint8_t, 0x0050D555> unk_50D555;
-        if (_audio_initialised && (unk_50D555 & 1) && is_title_mode())
+        loco_global<uint8_t, 0x0050D555> enable_sound;
+        if (_audio_initialised && (enable_sound & 1) && is_title_mode())
         {
             if (!is_channel_playing(channel_id::title))
             {

--- a/src/openloco/config.cpp
+++ b/src/openloco/config.cpp
@@ -91,6 +91,10 @@ namespace openloco::config
             _new_config.language = config["language"].as<std::string>();
         if (config["breakdowns_disabled"])
             _new_config.breakdowns_disabled = config["breakdowns_disabled"].as<bool>();
+        if (config["scale_factor"])
+            _new_config.scale_factor = config["scale_factor"].as<float>();
+        if (config["zoom_to_cursor"])
+            _new_config.zoom_to_cursor = config["zoom_to_cursor"].as<bool>();
 
         return _new_config;
     }
@@ -153,6 +157,8 @@ namespace openloco::config
         node["loco_install_path"] = _new_config.loco_install_path;
         node["language"] = _new_config.language;
         node["breakdowns_disabled"] = _new_config.breakdowns_disabled;
+        node["scale_factor"] = _new_config.scale_factor;
+        node["zoom_to_cursor"] = _new_config.zoom_to_cursor;
 
 #ifdef _OPENLOCO_USE_BOOST_FS_
         std::ofstream stream(configPath.string());

--- a/src/openloco/config.cpp
+++ b/src/openloco/config.cpp
@@ -81,6 +81,8 @@ namespace openloco::config
         {
             auto& audioConfig = _new_config.audio;
             audioConfig.device = audioNode["device"].as<std::string>("");
+            if (audioNode["play_title_music"])
+                audioConfig.play_title_music = audioNode["play_title_music"].as<bool>();
         }
 
         if (config["loco_install_path"])
@@ -144,6 +146,7 @@ namespace openloco::config
         else
         {
             audioNode["device"] = audioConfig.device;
+            audioNode["play_title_music"] = audioConfig.play_title_music;
         }
         node["audio"] = audioNode;
 

--- a/src/openloco/config.h
+++ b/src/openloco/config.h
@@ -104,6 +104,7 @@ namespace openloco::config
     struct audio_config
     {
         std::string device;
+        bool play_title_music = true;
     };
 
     struct new_config

--- a/src/openloco/localisation/string_ids.h
+++ b/src/openloco/localisation/string_ids.h
@@ -429,4 +429,6 @@ namespace openloco::string_ids
 
     constexpr string_id zoom_to_cursor = 2136;
     constexpr string_id zoom_to_cursor_tip = 2137;
+
+    constexpr string_id play_title_music = 2138;
 }

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -682,7 +682,7 @@ namespace openloco::ui::options
 
     namespace sound
     {
-        static const gfx::ui_size_t _window_size = { 366, 69 };
+        static const gfx::ui_size_t _window_size = { 366, 84 };
 
         namespace widx
         {
@@ -690,6 +690,7 @@ namespace openloco::ui::options
             {
                 audio_device = 10,
                 audio_device_btn,
+                play_title_music,
             };
         }
 
@@ -697,6 +698,7 @@ namespace openloco::ui::options
             common_options_widgets(_window_size, string_ids::options_title_sound),
             make_widget({ 10, 49 }, { 346, 12 }, widget_type::wt_18, 1, string_ids::stringid),
             make_widget({ 344, 50 }, { 11, 10 }, widget_type::wt_11, 1, string_ids::dropdown),
+            make_widget({ 10, 65 }, { 346, 12 }, widget_type::checkbox, 1, string_ids::play_title_music),
             widget_end(),
         };
 
@@ -704,6 +706,7 @@ namespace openloco::ui::options
 
         static void audio_device_mouse_down(ui::window* window);
         static void audio_device_dropdown(ui::window* window, int16_t itemIndex);
+        static void play_title_music_on_mouse_up(ui::window* window);
 
         // 0x004C0217
         static void prepare_draw(window* w)
@@ -730,6 +733,11 @@ namespace openloco::ui::options
                 set_format_arg(0x0, string_id, string_ids::stringptr);
                 set_format_arg(0x2, char*, (char*)audioDeviceName);
             }
+
+            if (config::get_new().audio.play_title_music)
+                w->activated_widgets |= (1 << widx::play_title_music);
+            else
+                w->activated_widgets &= ~(1 << widx::play_title_music);
 
             sub_4C13BE(w);
         }
@@ -758,6 +766,10 @@ namespace openloco::ui::options
                 case common::widx::tab_controls:
                 case common::widx::tab_miscellaneous:
                     options::tab_on_mouse_up(w, wi);
+                    return;
+
+                case widx::play_title_music:
+                    play_title_music_on_mouse_up(w);
                     return;
             }
         }
@@ -817,6 +829,17 @@ namespace openloco::ui::options
         }
 
 #pragma mark -
+
+        static void play_title_music_on_mouse_up(window* w)
+        {
+            auto& cfg = config::get_new();
+            cfg.audio.play_title_music = !cfg.audio.play_title_music;
+            config::write();
+
+            audio::play_title_screen_music();
+
+            w->invalidate();
+        }
 
         // 0x004C04E0
         static void on_update(window* w)
@@ -2279,7 +2302,7 @@ namespace openloco::ui::options
 
             case common::tab::sound:
                 w->disabled_widgets = 0;
-                w->enabled_widgets = (1 << common::widx::close_button) | common::tabWidgets | (1 << sound::widx::audio_device) | (1 << sound::widx::audio_device_btn);
+                w->enabled_widgets = (1 << common::widx::close_button) | common::tabWidgets | (1 << sound::widx::audio_device) | (1 << sound::widx::audio_device_btn) | (1 << sound::widx::play_title_music);
                 w->disabled_widgets = 0;
                 w->event_handlers = &sound::_events;
                 w->widgets = sound::_widgets;


### PR DESCRIPTION
While we could disable in-game music already, the title music could not. Unfortunately, one can get enough of John Broomhall's funky beats, so this PR introduces the option.

I've filed the option under the "audio" tab, rather than the "music" tab, as the latter is not available from the title screen. Perhaps this should be changed in the future.

I also noticed two other options weren't persisting. I've added the necessary fix in a separate commit.