### PR TITLE
Reduce dependencies for Windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
 - ps: >-
     mkdir $env:TEMP\openloco
 
-    Invoke-WebRequest https://github.com/OpenLoco/Dependencies/releases/download/v1.1.0/openloco.dependencies.1.1.0.nupkg -OutFile $env:TEMP\openloco\openloco.dependencies.1.1.0.nupkg
+    Invoke-WebRequest https://github.com/OpenLoco/Dependencies/releases/download/v1.1.1/openloco.dependencies.1.1.1.nupkg -OutFile $env:TEMP\openloco\openloco.dependencies.1.1.1.nupkg
 
     Get-ChildItem $env:TEMP\openloco
 

--- a/src/openloco/openloco.vcxproj
+++ b/src/openloco/openloco.vcxproj
@@ -54,6 +54,6 @@
     </Lib>
   </ItemDefinitionGroup>
   <!-- Include our vcpkg root first, otherwise the machine installed vcpkg will be used -->
-  <Import Project="..\..\packages\OpenLoco.Dependencies.1.1.0\build\native\OpenLoco.Dependencies.targets" Condition="Exists('..\..\packages\OpenLoco.Dependencies.1.1.0\build\native\OpenLoco.Dependencies.targets')" />
+  <Import Project="..\..\packages\OpenLoco.Dependencies.1.1.1\build\native\OpenLoco.Dependencies.targets" Condition="Exists('..\..\packages\OpenLoco.Dependencies.1.1.1\build\native\OpenLoco.Dependencies.targets')" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/openloco/packages.config
+++ b/src/openloco/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="openloco.dependencies" version="1.1.0" targetFramework="native" />
+  <package id="openloco.dependencies" version="1.1.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Currently, the SDL2-mixer dependency carries with it several DLLs adding codec support. As we do not use any of these codecs, they should be disabled in vcpkg similar to how is done for macOS.

This is a companion PR to https://github.com/OpenLoco/Dependencies/pull/2, which has since been merged.

Fixes #267.