### PR TITLE
Build application bundle for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 artefacts/
 bin.*/
+boost/
 lib/
+vcpkg/
 
 ## Visual Studio Code
 .vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,9 @@ matrix:
             - brew install https://raw.githubusercontent.com/OpenLoco/Dependencies/master/macos/boost.rb
           script:
             - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.0/openloco.dependencies.macos.1.1.0.zip -o dependencies.zip
-            - unzip dependencies.zip -d vcpkg/
+            - unzip -q dependencies.zip -d vcpkg/
+            - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.1/macos-x86-static-boost-1.68.0.zip -o boost.zip
+            - unzip -q boost.zip -d boost/
             - mkdir build && cd build
             - cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx
             - make -j2
@@ -68,7 +70,9 @@ matrix:
             - brew install https://raw.githubusercontent.com/OpenLoco/Dependencies/master/macos/boost.rb
           script:
             - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.0/openloco.dependencies.macos.1.1.0.zip -o dependencies.zip
-            - unzip dependencies.zip -d vcpkg/
+            - unzip -q dependencies.zip -d vcpkg/
+            - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.1/macos-x86-static-boost-1.68.0.zip -o boost.zip
+            - unzip -q boost.zip -d boost/
             - mkdir build && cd build
             - cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx
             - make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,3 +81,13 @@ matrix:
 script:
     - mkdir build
     - docker run -v $(pwd):/openloco -w /openloco/build -i -t openrct2/openloco:$DOCKERIMG bash -c "cmake ../ ${OPENLOCO_CMAKE_OPTS} && ninja -k0"
+
+deploy:
+    provider: releases
+    api_key:
+        secure: Kuzqa3+lCSDyGu3HE4k/fRmqoBTs6DYiVnO7olAnvaqJxzE+BNAlgPbZmO+mw83xJY7u6mKrrM2y7chzbsmUqVFgRig9OC2K7aCVTRkxiXwDFGjksedXnYc35kGE+p9wv7sk8JLcoqjrqkhpLAqjdgsT8V+VvlSVWjp4J0DYbR7M4COBSMGxdvmeQwG6VrXjdRy90c4FEffLuWG79J879hqYVkXNW4GnYan6YW7sX/YkUmXTbbrT618Whb90jZwu1njn+qTWRyIb2EQaPdAhjGBBDt9QIhauv6AkyZOgL9C79ltizr1l24pnYexcQVv7QZ5ipBPk4weAzbSeJRaMS15qG7w+qOwwlduBB8YHO3DKKlyvAlXtVdeOj4LeaTIGctGKIO/2320rZeIzAIA59uyveKVyIqJpYlay5AMdoNvy//a4+huSdu9gHnNZJOACMRKUvRW+7T3clW8rBw4d7aO9siabps45Usbu+U1s/XKxVWMR65fXhxQwVh4u+NACUMK5/01L7SNKztw/x3eKf15ekxu+I2yBmWQRNWk0TRl4MV+qHt09hcJUU3rThaeJfHAM+/asgVDUn1e5rzktSGw8xxi1G3vjsBEAKts27+3AdDQRWVWPS9zfr+FNAG9W1C56uDQsnEMHbBXOLQ0Q7b7jxqdnS4kuZIjYPugkYTw=
+    file: build/openloco-macos.zip
+    skip_cleanup: true
+    on:
+        tags: true
+        repo: OpenLoco/OpenLoco

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ matrix:
             - mkdir build && cd build
             - cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx "-DBOOST_ROOT=($pwd)/../boost"
             - make -j2
+            - zip -r openloco-macos.zip openloco.app
+            - curl --progress-bar --upload-file openloco-macos.zip https://transfer.sh/openloco-macos.zip; echo;
         - os: osx
           name: macOS 10.12 Clang (Xcode 9.2)
           osx_image: xcode9.2 # macOS 10.12 (lacks std::byte)

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,14 +50,13 @@ matrix:
             - export HOMEBREW_NO_AUTO_UPDATE=1
           install:
             - brew uninstall --ignore-dependencies boost
-            - brew install https://raw.githubusercontent.com/OpenLoco/Dependencies/master/macos/boost.rb
           script:
             - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.0/openloco.dependencies.macos.1.1.0.zip -o dependencies.zip
             - unzip -q dependencies.zip -d vcpkg/
             - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.1/macos-x86-static-boost-1.68.0.zip -o boost.zip
             - unzip -q boost.zip -d boost/
             - mkdir build && cd build
-            - cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx
+            - cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx "-DBOOST_ROOT=($pwd)/../boost"
             - make -j2
         - os: osx
           name: macOS 10.12 Clang (Xcode 9.2)
@@ -67,14 +66,13 @@ matrix:
             - export HOMEBREW_NO_AUTO_UPDATE=1
           install:
             - brew uninstall --ignore-dependencies boost
-            - brew install https://raw.githubusercontent.com/OpenLoco/Dependencies/master/macos/boost.rb
           script:
             - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.0/openloco.dependencies.macos.1.1.0.zip -o dependencies.zip
             - unzip -q dependencies.zip -d vcpkg/
             - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.1/macos-x86-static-boost-1.68.0.zip -o boost.zip
             - unzip -q boost.zip -d boost/
             - mkdir build && cd build
-            - cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx
+            - cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx "-DBOOST_ROOT=($pwd)/../boost"
             - make -j2
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.9)
+cmake_policy(VERSION 3.9)
 
 set (PROJECT openloco)
 
@@ -229,6 +230,54 @@ endif()
 
 if (APPLE)
     target_link_libraries(${PROJECT} "-framework Cocoa")
+
+    set_target_properties(${PROJECT} PROPERTIES
+        MACOSX_BUNDLE ON
+        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/distribution/macos/Info.plist.in)
+
+    set(MACOSX_BUNDLE_BUNDLE_NAME "OpenLoco")
+    set(MACOSX_BUNDLE_BUNDLE_VERSION "${OPENRCT2_COMMIT_SHA1_SHORT}")
+    set(MACOSX_BUNDLE_COPYRIGHT "OpenLoco is licensed under the MIT License")
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER "io.openloco.OpenLoco")
+    set(MACOSX_BUNDLE_ICON_FILE "AppIcon")
+
+    if(${OPENLOCO_BRANCH} EQUAL master)
+        set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${OPENLOCO_VERSION_TAG}")
+    else()
+        set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${OPENLOCO_VERSION_TAG} ${OPENLOCO_BRANCH}")
+    endif()
+
+    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/distribution/macos/AppIcon.iconset DESTINATION ${CMAKE_BINARY_DIR})
+    set(ICON_TARGET "${CMAKE_BINARY_DIR}/AppIcon.iconset")
+    set(ICON_OUTPUT "${CMAKE_BINARY_DIR}/AppIcon.icns")
+    set(SOURCE_ICON_DIR "${CMAKE_CURRENT_SOURCE_DIR}/resources/logo")
+
+    add_custom_command(OUTPUT ${ICON_OUTPUT}
+        COMMAND cp icon_x16.png   ${ICON_TARGET}/icon_16x16.png
+        COMMAND cp icon_x32.png   ${ICON_TARGET}/icon_16x16@2x.png
+        COMMAND cp icon_x32.png   ${ICON_TARGET}/icon_32x32.png
+        COMMAND cp icon_x64.png   ${ICON_TARGET}/icon_32x32@2x.png
+        COMMAND cp icon_x128.png  ${ICON_TARGET}/icon_128x128.png
+        COMMAND cp icon_x256.png  ${ICON_TARGET}/icon_128x128@2x.png
+        COMMAND cp icon_x256.png  ${ICON_TARGET}/icon_256x256.png
+        COMMAND cp icon_x512.png  ${ICON_TARGET}/icon_256x256@2x.png
+        COMMAND cp icon_x512.png  ${ICON_TARGET}/icon_512x512.png
+        COMMAND cp icon_x1024.png ${ICON_TARGET}/icon_512x512@2x.png
+        COMMAND iconutil -c icns ${ICON_TARGET}
+        WORKING_DIRECTORY ${SOURCE_ICON_DIR})
+
+    set(BUNDLE_RESOURCES ${ICON_OUTPUT})
+    list(APPEND BUNDLE_RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/CHANGELOG.md)
+    list(APPEND BUNDLE_RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/CONTRIBUTORS.MD)
+    set_target_properties(${PROJECT} PROPERTIES RESOURCE "${BUNDLE_RESOURCES}")
+    target_sources(${PROJECT} PUBLIC ${BUNDLE_RESOURCES})
+
+    file(GLOB BUNDLE_LANGUAGES "${CMAKE_CURRENT_SOURCE_DIR}/data/language/*")
+    target_sources(${PROJECT} PUBLIC ${BUNDLE_LANGUAGES})
+    set_property(
+        SOURCE ${BUNDLE_LANGUAGES}
+        PROPERTY MACOSX_PACKAGE_LOCATION "Resources/language"
+    )
 
     try_compile(SUPPORT_STD_BYTE ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/cmake/std_byte.cpp CXX_STANDARD 17)
     if (NOT SUPPORT_STD_BYTE)

--- a/distribution/macos/AppIcon.iconset/Contents.json
+++ b/distribution/macos/AppIcon.iconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "size" : "16x16",
+      "idiom" : "mac",
+      "filename" : "icon_16x16.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "16x16",
+      "idiom" : "mac",
+      "filename" : "icon_16x16@2x.png",
+      "scale" : "2x"
+    },
+    {
+      "size" : "32x32",
+      "idiom" : "mac",
+      "filename" : "icon_32x32.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "32x32",
+      "idiom" : "mac",
+      "filename" : "icon_32x32@2x.png",
+      "scale" : "2x"
+    },
+    {
+      "size" : "128x128",
+      "idiom" : "mac",
+      "filename" : "icon_128x128.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "128x128",
+      "idiom" : "mac",
+      "filename" : "icon_128x128@2x.png",
+      "scale" : "2x"
+    },
+    {
+      "size" : "256x256",
+      "idiom" : "mac",
+      "filename" : "icon_256x256.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "256x256",
+      "idiom" : "mac",
+      "filename" : "icon_256x256@2x.png",
+      "scale" : "2x"
+    },
+    {
+      "size" : "512x512",
+      "idiom" : "mac",
+      "filename" : "icon_512x512.png",
+      "scale" : "1x"
+    },
+    {
+      "size" : "512x512",
+      "idiom" : "mac",
+      "filename" : "icon_512x512@2x.png",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/distribution/macos/Info.plist.in
+++ b/distribution/macos/Info.plist.in
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Executable file -->
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+
+	<key>CFBundleGetInfoString</key>
+	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
+
+	<!-- Icon file -->
+	<key>CFBundleIconFile</key>
+	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
+
+	<!-- Bundle identifier -->
+	<key>CFBundleIdentifier</key>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+
+	<!-- InfoDictionary version -->
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+
+	<!-- Bundle name -->
+	<key>CFBundleName</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+
+	<!-- Bundle OS Type code -->
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+
+	<!-- Bundle versions string, short -->
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+
+	<key>CFBundleSignature</key>
+	<string>????</string>
+
+	<!-- Bundle version -->
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+
+	<!-- Resources should be file-mapped -->
+	<key>CSResourcesFileMapped</key>
+	<true/>
+
+	<!--High Resolution Capable-->
+	<key>NSHighResolutionCapable</key>
+	<true/>
+
+	<!--Copyright (human-readable)-->
+	<key>NSHumanReadableCopyright</key>
+	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+</dict>
+</plist>

--- a/src/openloco/environment.cpp
+++ b/src/openloco/environment.cpp
@@ -207,6 +207,12 @@ namespace openloco::environment
             case path_id::scores:
             case path_id::openloco_yml:
                 return platform::get_user_directory();
+            case path_id::language_files:
+#if defined(__APPLE__) && defined(__MACH__)
+                return platform::GetBundlePath();
+#else
+                return platform::GetCurrentExecutablePath().parent_path() / "data";
+#endif
             default:
                 return get_loco_install_path();
         }
@@ -263,7 +269,8 @@ namespace openloco::environment
             "Data/TUT800_1.DAT",
             "Data/TUT800_2.DAT",
             "Data/TUT800_3.DAT",
-            "openloco.yml"
+            "openloco.yml",
+            "language",
         };
 
         size_t index = (size_t)id;

--- a/src/openloco/environment.h
+++ b/src/openloco/environment.h
@@ -65,6 +65,7 @@ namespace openloco::environment
         tut800_2,
         tut800_3,
         openloco_yml,
+        language_files,
     };
 
     fs::path get_path(path_id id);

--- a/src/openloco/localisation/languagefiles.cpp
+++ b/src/openloco/localisation/languagefiles.cpp
@@ -260,7 +260,7 @@ namespace openloco::localisation
     void loadLanguageFile()
     {
         // First, load en-GB for fallback strings.
-        fs::path languageDir = platform::GetCurrentExecutablePath().parent_path() / "data" / "language";
+        fs::path languageDir = environment::get_path(environment::path_id::language_files);
         fs::path languageFile = languageDir / "en-GB.yml";
         if (!loadLanguageStringTable(languageFile))
             throw std::runtime_error("Could not load the en-GB language file!");

--- a/src/openloco/localisation/languages.cpp
+++ b/src/openloco/localisation/languages.cpp
@@ -1,4 +1,5 @@
 #include "languages.h"
+#include "../environment.h"
 #include "../platform/platform.h"
 #include "../utility/yaml.hpp"
 #include "conversion.h"
@@ -26,7 +27,7 @@ namespace openloco::localisation
         language_descriptors.emplace_back(undefinedLanguage);
 
         // Search the languages dir for YAML language files.
-        fs::path languageDir = platform::GetCurrentExecutablePath().parent_path() / "data" / "language";
+        fs::path languageDir = environment::get_path(environment::path_id::language_files);
         for (auto& entry : fs::directory_iterator(languageDir))
         {
             auto filename = entry.path().string();

--- a/src/openloco/platform/platform.h
+++ b/src/openloco/platform/platform.h
@@ -16,4 +16,7 @@ namespace openloco::platform
     std::string prompt_directory(const std::string& title);
     fs::path GetCurrentExecutablePath();
     std::vector<fs::path> get_drives();
+#if defined(__APPLE__) && defined(__MACH__)
+    fs::path GetBundlePath();
+#endif
 }

--- a/src/openloco/platform/platform.macos.mm
+++ b/src/openloco/platform/platform.macos.mm
@@ -53,4 +53,21 @@ fs::path openloco::platform::GetCurrentExecutablePath()
     }
 }
 
+fs::path openloco::platform::GetBundlePath()
+{
+    @autoreleasepool
+    {
+        NSBundle * bundle = [NSBundle mainBundle];
+        if (bundle)
+        {
+            auto resources = bundle.resourcePath.UTF8String;
+            if (fs::exists(resources))
+            {
+                return resources;
+            }
+        }
+        return fs::path();
+    }
+}
+
 #endif


### PR DESCRIPTION
Application bundles are the user-friendly way of packaging apps on macOS. This PR is working towards including such builds for OpenLoco.

To do:
- [x] Use the OpenLoco icon in the bundle.
- [x] Ship a plist for identification.
- [x] Include changelog and contributor files.
- [x] Automatically upload to tagged releases on GitHub?