### PR TITLE
Fetch more of the repository history for non clang-format builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: c
 before_install:
     - docker pull openrct2/openloco:$DOCKERIMG
 
+install:
+    - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*; fi
+    - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git fetch --unshallow; fi
+
 sudo: required
 dist: trusty
 
@@ -50,6 +54,8 @@ matrix:
             - export HOMEBREW_NO_AUTO_UPDATE=1
           install:
             - brew uninstall --ignore-dependencies boost
+            - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*; fi
+            - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git fetch --unshallow; fi
           script:
             - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.0/openloco.dependencies.macos.1.1.0.zip -o dependencies.zip
             - unzip -q dependencies.zip -d vcpkg/
@@ -68,6 +74,8 @@ matrix:
             - export HOMEBREW_NO_AUTO_UPDATE=1
           install:
             - brew uninstall --ignore-dependencies boost
+            - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*; fi
+            - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git fetch --unshallow; fi
           script:
             - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.0/openloco.dependencies.macos.1.1.0.zip -o dependencies.zip
             - unzip -q dependencies.zip -d vcpkg/


### PR DESCRIPTION
By default, Travis fetches up to 50 commits. This leads to `git describe` not finding any tag to offset against. Fetching the last 1000 commits allows it to work properly on non-master builds as well.

Fixes #283.