### PR TITLE
Add a screenshot to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ An open source re-implementation of Chris Sawyer's Locomotion. A construction an
 
 ---
 
-![](https://user-images.githubusercontent.com/604665/53666655-fcfcb600-3c6e-11e9-96a9-ee1db3977087.png)
+![](https://user-images.githubusercontent.com/604665/55420349-1a2aea00-5577-11e9-87da-78fe5cdb09e1.png)
 
 # Contents
 - 1 - [Introduction](#1-introduction)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ An open source re-implementation of Chris Sawyer's Locomotion. A construction an
 
 ---
 
+![](https://user-images.githubusercontent.com/604665/53666655-fcfcb600-3c6e-11e9-96a9-ee1db3977087.png)
+
 # Contents
 - 1 - [Introduction](#1-introduction)
 - 2 - [Downloading the game (pre-built)](#2-downloading-the-game-pre-built)


### PR DESCRIPTION
A user on Reddit [suggested](https://www.reddit.com/r/locomotion/comments/aw889a/openloco_release_v1902/ehkwrqm/) we add a few screenshot to the GitHub page. I don't want to clutter the readme file too much, but this PR adds a simple one at least, showcasing a macOS build.

Perhaps we should link a few more further down in the file. Any suggestions?

Current screenshot:
![](https://user-images.githubusercontent.com/604665/53666655-fcfcb600-3c6e-11e9-96a9-ee1db3977087.png)