### PR TITLE
Fix string formatting for velocities and dates

### DIFF
--- a/src/openloco/date.cpp
+++ b/src/openloco/date.cpp
@@ -28,12 +28,12 @@ namespace openloco
 
     date current_date()
     {
-        return date(_current_year, (month_id)(*_current_month), _current_day_of_month);
+        return date(_current_year, (month_id)(*_current_month), _current_day_of_month + 1);
     }
 
     void set_date(const date& date)
     {
-        _current_day_of_month = date.day;
+        _current_day_of_month = date.day - 1;
         _current_month = (int8_t)date.month;
         _current_year = date.year;
     }
@@ -101,7 +101,6 @@ namespace openloco
     {
         // clang-format off
         static constexpr std::pair<month_id, uint8_t> month_table[] = {
-            { month_id::january, 0 },
             { month_id::january, 1 },
             { month_id::january, 2 },
             { month_id::january, 3 },
@@ -132,7 +131,7 @@ namespace openloco
             { month_id::january, 28 },
             { month_id::january, 29 },
             { month_id::january, 30 },
-            { month_id::february, 0 },
+            { month_id::january, 31 },
             { month_id::february, 1 },
             { month_id::february, 2 },
             { month_id::february, 3 },
@@ -161,7 +160,7 @@ namespace openloco
             { month_id::february, 26 },
             { month_id::february, 27 },
             { month_id::february, 28 },
-            { month_id::march, 0 },
+            { month_id::february, 29 },
             { month_id::march, 1 },
             { month_id::march, 2 },
             { month_id::march, 3 },
@@ -192,7 +191,7 @@ namespace openloco
             { month_id::march, 28 },
             { month_id::march, 29 },
             { month_id::march, 30 },
-            { month_id::april, 0 },
+            { month_id::march, 31 },
             { month_id::april, 1 },
             { month_id::april, 2 },
             { month_id::april, 3 },
@@ -222,7 +221,7 @@ namespace openloco
             { month_id::april, 27 },
             { month_id::april, 28 },
             { month_id::april, 29 },
-            { month_id::may, 0 },
+            { month_id::april, 30 },
             { month_id::may, 1 },
             { month_id::may, 2 },
             { month_id::may, 3 },
@@ -253,7 +252,7 @@ namespace openloco
             { month_id::may, 28 },
             { month_id::may, 29 },
             { month_id::may, 30 },
-            { month_id::june, 0 },
+            { month_id::may, 31 },
             { month_id::june, 1 },
             { month_id::june, 2 },
             { month_id::june, 3 },
@@ -283,7 +282,7 @@ namespace openloco
             { month_id::june, 27 },
             { month_id::june, 28 },
             { month_id::june, 29 },
-            { month_id::july, 0 },
+            { month_id::june, 30 },
             { month_id::july, 1 },
             { month_id::july, 2 },
             { month_id::july, 3 },
@@ -314,7 +313,7 @@ namespace openloco
             { month_id::july, 28 },
             { month_id::july, 29 },
             { month_id::july, 30 },
-            { month_id::august, 0 },
+            { month_id::july, 31 },
             { month_id::august, 1 },
             { month_id::august, 2 },
             { month_id::august, 3 },
@@ -345,7 +344,7 @@ namespace openloco
             { month_id::august, 28 },
             { month_id::august, 29 },
             { month_id::august, 30 },
-            { month_id::september, 0 },
+            { month_id::august, 31 },
             { month_id::september, 1 },
             { month_id::september, 2 },
             { month_id::september, 3 },
@@ -375,7 +374,7 @@ namespace openloco
             { month_id::september, 27 },
             { month_id::september, 28 },
             { month_id::september, 29 },
-            { month_id::october, 0 },
+            { month_id::september, 30 },
             { month_id::october, 1 },
             { month_id::october, 2 },
             { month_id::october, 3 },
@@ -406,7 +405,7 @@ namespace openloco
             { month_id::october, 28 },
             { month_id::october, 29 },
             { month_id::october, 30 },
-            { month_id::november, 0 },
+            { month_id::october, 31 },
             { month_id::november, 1 },
             { month_id::november, 2 },
             { month_id::november, 3 },
@@ -436,7 +435,7 @@ namespace openloco
             { month_id::november, 27 },
             { month_id::november, 28 },
             { month_id::november, 29 },
-            { month_id::december, 0 },
+            { month_id::november, 30 },
             { month_id::december, 1 },
             { month_id::december, 2 },
             { month_id::december, 3 },
@@ -467,6 +466,7 @@ namespace openloco
             { month_id::december, 28 },
             { month_id::december, 29 },
             { month_id::december, 30 },
+            { month_id::december, 31 },
         };
         // clang-format on
         return month_table[dayOfYear];

--- a/src/openloco/localisation/argswrapper.hpp
+++ b/src/openloco/localisation/argswrapper.hpp
@@ -33,6 +33,16 @@ namespace openloco::stringmgr
             return value;
         }
 
+        int16_t popS16()
+        {
+            if (args == nullptr)
+                return 0;
+
+            uint16_t value = *(int16_t*)args;
+            args = (int16_t*)args + 1;
+            return value;
+        }
+
         uint32_t pop32()
         {
             if (args == nullptr)
@@ -40,6 +50,16 @@ namespace openloco::stringmgr
 
             uint32_t value = *(uint32_t*)args;
             args = (uint32_t*)args + 1;
+            return value;
+        }
+
+        int32_t popS32()
+        {
+            if (args == nullptr)
+                return 0;
+
+            int32_t value = *(int32_t*)args;
+            args = (int32_t*)args + 1;
             return value;
         }
 

--- a/src/openloco/localisation/stringmgr.cpp
+++ b/src/openloco/localisation/stringmgr.cpp
@@ -283,43 +283,43 @@ namespace openloco::stringmgr
                 {
                     case control_codes::int32_grouped:
                     {
-                        int32_t value = args.pop32();
+                        int32_t value = args.popS32();
                         buffer = format_int32_grouped(value, buffer);
                         break;
                     }
 
                     case control_codes::int32_ungrouped:
                     {
-                        int32_t value = args.pop32();
+                        int32_t value = args.popS32();
                         buffer = format_int32_ungrouped(value, buffer);
                         break;
                     }
 
                     case control_codes::int16_decimals:
                     {
-                        int16_t value = args.pop16();
+                        int16_t value = args.popS16();
                         buffer = format_short_with_decimals(value, buffer);
                         break;
                     }
 
                     case control_codes::int32_decimals:
                     {
-                        int32_t value = args.pop32();
+                        int32_t value = args.popS32();
                         buffer = format_int_with_decimals(value, buffer);
                         break;
                     }
 
                     case control_codes::int16_grouped:
                     {
-                        int16_t value = args.pop16();
+                        int16_t value = args.popS16();
                         buffer = format_int32_grouped(value, buffer);
                         break;
                     }
 
                     case control_codes::uint16_ungrouped:
                     {
-                        uint16_t value = args.pop16();
-                        buffer = format_int32_ungrouped((int32_t)value, buffer);
+                        int32_t value = args.pop16();
+                        buffer = format_int32_ungrouped(value, buffer);
                         break;
                     }
 
@@ -333,7 +333,7 @@ namespace openloco::stringmgr
                     case control_codes::currency48:
                     {
                         uint32_t value_low = (uint32_t)args.pop32();
-                        int32_t value_high = (int16_t)args.pop16();
+                        int32_t value_high = args.popS16();
                         int64_t value = (value_high * (1ULL << 32)) | value_low;
                         buffer = formatCurrency(value, buffer);
                         break;
@@ -397,7 +397,7 @@ namespace openloco::stringmgr
                     {
                         auto measurement_format = config::get().measurement_format;
 
-                        uint32_t value = args.pop16();
+                        int32_t value = args.popS16();
 
                         const char* unit;
                         if (measurement_format == config::measurement_format::imperial)
@@ -458,7 +458,7 @@ namespace openloco::stringmgr
 
                     case control_codes::height:
                     {
-                        int32_t value = (int16_t)args.pop16();
+                        int32_t value = args.popS16();
 
                         bool show_height_as_units = config::get().flags & config::flags::show_height_as_units;
                         uint8_t measurement_format = config::get().measurement_format;


### PR DESCRIPTION
As [reported on Gitter](https://gitter.im/OpenLoco/OpenLoco?at=5c7c10424a65f754735a70d6):

> ![image](https://user-images.githubusercontent.com/737603/53701598-0583f680-3dff-11e9-83dc-c432665cfd16.png)
> My "Engine Flippers" used to read "-1mph Max Speed", now they read "65,535mph Max Speed". 

Might be nicer to have a syntax similar to the ObjectManager. E.g. `pop<int16_t>()`.