### PR TITLE
Fix #306: Click sound on both mouseup and mousedown events

### DIFF
--- a/src/openloco/input/mouse_input.cpp
+++ b/src/openloco/input/mouse_input.cpp
@@ -940,7 +940,7 @@ namespace openloco::input
             default:
                 if (window->is_enabled(widgetIndex) && !window->is_disabled(widgetIndex))
                 {
-                    audio::play_sound(audio::sound_id::click_up, window->x + widget->mid_x());
+                    audio::play_sound(audio::sound_id::click_down, window->x + widget->mid_x());
 
                     // Set new cursor down widget
                     _pressedWidgetIndex = widgetIndex;


### PR DESCRIPTION
The click sound was implemented for both mouseup and mousedown events. This removes the mouseup variant.

It still sounds as though the click sound is clipped or cut off, but that's a separate issue.