### PR TITLE
Call tick() before ui::process_messages

### DIFF
--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -833,6 +833,11 @@ namespace openloco
         }
 #endif
 
+        // Call tick before ui::process_messages to ensure initialise is called
+        // otherwise window events can end up using an uninitialised window manager.
+        // This can be removed when initialise is moved out of tick().
+        tick();
+
         while (ui::process_messages())
         {
             if (addr<0x005252AC, uint32_t>() != 0)


### PR DESCRIPTION
Ensure WindowManager::init() is called before ui::process_messages(), otherwise any initial window events may call resize which then attempts to use the Window Manager.