### PR TITLE
Fix: Cargo rating is calculated incorrectly in some edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix: [#296] Correctly show challenge progression in save previews
 - Fix: [#297] Menu click sound not played.
 - Fix: [#303] Play title music preference is not saved.
+- Fix: [#340] Cargo rating is calculated incorrectly in some edge cases.
 
 19.03 (2019-03-01)
 ------------------------------------------------------------------------

--- a/src/openloco/station.cpp
+++ b/src/openloco/station.cpp
@@ -192,6 +192,7 @@ namespace openloco
         return atLeastOneGoodRating;
     }
 
+    // 0x004927F6
     int32_t station::calculate_cargo_rating(const station_cargo_stats& cargo) const
     {
         int32_t rating = 0;
@@ -237,9 +238,9 @@ namespace openloco
             }
         }
 
-        if (flags != (station_flags::flag_7 | station_flags::flag_8) && is_player_company(owner))
+        if ((flags & (station_flags::flag_7 | station_flags::flag_8)) == 0 && !is_player_company(owner))
         {
-            rating += 120;
+            rating = 120;
         }
 
         int32_t unk3 = std::min<uint8_t>(cargo.var_36, 250);


### PR DESCRIPTION
Work on the station list window has uncovered a bug in the cargo rating computations.