### PR TITLE
Clean-ups of file browser and platform files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: [#297] Menu click sound not played.
 - Fix: [#303] Play title music preference is not saved.
 - Fix: [#340] Cargo rating is calculated incorrectly in some edge cases.
+- Fix: Strings were not wrapping properly in the file browser window.
 
 19.03 (2019-03-01)
 ------------------------------------------------------------------------

--- a/src/openloco/graphics/gfx.cpp
+++ b/src/openloco/graphics/gfx.cpp
@@ -525,15 +525,17 @@ namespace openloco::gfx
 
     // 0x00495224
     // al: colour
+    // bp: width
     // bx: string id
     // cx: x
     // dx: y
     // esi: args
     // edi: dpi
-    void draw_string_495224(
+    int16_t draw_string_495224(
         drawpixelinfo_t& dpi,
         int16_t x,
         int16_t y,
+        int16_t width,
         uint8_t colour,
         string_id stringId,
         const void* args)
@@ -541,11 +543,14 @@ namespace openloco::gfx
         registers regs;
         regs.al = colour;
         regs.bx = stringId;
+        regs.bp = width;
         regs.cx = x;
         regs.dx = y;
         regs.esi = (int32_t)args;
         regs.edi = (int32_t)&dpi;
         call(0x00495224, regs);
+
+        return regs.dx;
     }
 
     // 0x00494B3F

--- a/src/openloco/graphics/gfx.h
+++ b/src/openloco/graphics/gfx.h
@@ -138,10 +138,11 @@ namespace openloco::gfx
 
     gfx::point_t draw_string(drawpixelinfo_t* context, int16_t x, int16_t y, uint8_t colour, void* str);
 
-    void draw_string_495224(
+    int16_t draw_string_495224(
         drawpixelinfo_t& dpi,
         int16_t x,
         int16_t y,
+        int16_t width,
         uint8_t colour,
         string_id stringId,
         const void* args = nullptr);

--- a/src/openloco/graphics/image_ids.h
+++ b/src/openloco/graphics/image_ids.h
@@ -9,6 +9,7 @@ namespace openloco::image_ids
     constexpr uint32_t text_palette = 2169;
 
     constexpr uint32_t icon_folder = 2311;
+
     constexpr uint32_t close_button = 2321;
 
     constexpr uint32_t music_controls_stop = 2383;

--- a/src/openloco/graphics/image_ids.h
+++ b/src/openloco/graphics/image_ids.h
@@ -8,6 +8,7 @@ namespace openloco::image_ids
 {
     constexpr uint32_t text_palette = 2169;
 
+    constexpr uint32_t icon_parent_folder = 2310;
     constexpr uint32_t icon_folder = 2311;
 
     constexpr uint32_t close_button = 2321;

--- a/src/openloco/localisation/string_ids.h
+++ b/src/openloco/localisation/string_ids.h
@@ -652,7 +652,7 @@ namespace openloco::string_ids
     constexpr string_id window_browse_input_caret = 2003;
     constexpr string_id window_browse_filename = 2004;
     constexpr string_id window_browse_folder = 2005;
-
+    constexpr string_id window_browse_parent_folder_tooltip = 2006;
     constexpr string_id window_browse_company = 2007;
     constexpr string_id window_browse_date = 2008;
     constexpr string_id window_browse_challenge_progress = 2009;

--- a/src/openloco/openloco.cpp
+++ b/src/openloco/openloco.cpp
@@ -671,6 +671,9 @@ namespace openloco
         addr<0x010E7D64, uint32_t>() = 0xD900BF;
     }
 
+    static loco_global<int8_t, 0x0050C197> _50C197;
+    static loco_global<string_id, 0x0050C198> _50C198;
+
     // 0x0046ABCB
     static void tick_logic()
     {
@@ -697,16 +700,16 @@ namespace openloco
         call(0x00444387);
 
         addr<0x009C871C, uint8_t>() = addr<0x00F25374, uint8_t>();
-        if (addr<0x0050C197, uint8_t>() != 0)
+        if (_50C197 != 0)
         {
             auto title = string_ids::error_unable_to_load_saved_game;
-            auto message = addr<0x0050C198, string_id>();
-            if (addr<0x0050C197, uint8_t>() == 0xFE)
+            auto message = _50C198;
+            if (_50C197 == -2)
             {
-                title = addr<0x0050C198, string_id>();
+                title = _50C198;
                 message = string_ids::null;
             }
-            addr<0x0050C197, uint8_t>() = 0;
+            _50C197 = 0;
             ui::windows::show_error(title, message);
         }
     }

--- a/src/openloco/platform/platform.h
+++ b/src/openloco/platform/platform.h
@@ -15,7 +15,7 @@ namespace openloco::platform
     fs::path get_user_directory();
     std::string prompt_directory(const std::string& title);
     fs::path GetCurrentExecutablePath();
-    std::vector<fs::path> get_drives();
+    std::vector<fs::path> getDrives();
 #if defined(__APPLE__) && defined(__MACH__)
     fs::path GetBundlePath();
 #endif

--- a/src/openloco/platform/platform.macos.mm
+++ b/src/openloco/platform/platform.macos.mm
@@ -1,4 +1,3 @@
-
 #if defined(__APPLE__) && defined(__MACH__)
 
 #include "platform.h"
@@ -7,66 +6,68 @@
 
 #import <Cocoa/Cocoa.h>
 
-fs::path openloco::platform::get_user_directory()
+namespace openloco::platform
 {
-    @autoreleasepool
+    fs::path get_user_directory()
     {
-        NSFileManager * filemanager = [NSFileManager defaultManager];
-        NSURL *url = [[filemanager URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask] lastObject];
-        url = [url URLByAppendingPathComponent:@"OpenLoco"];
-        return url.path.UTF8String;
-    }
-}
-
-std::string openloco::platform::prompt_directory(const std::string &title)
-{
-
-    @autoreleasepool
-    {
-        NSOpenPanel *panel = [NSOpenPanel openPanel];
-        panel.canChooseFiles = false;
-        panel.canChooseDirectories = true;
-        panel.allowsMultipleSelection = false;
-        if ([panel runModal] == NSModalResponseOK)
+        @autoreleasepool
         {
-            NSString *selectedPath = panel.URL.path;
-            const char *path = selectedPath.UTF8String;
-            return path;
-        } else {
-            return "";
+            NSFileManager* filemanager = [NSFileManager defaultManager];
+            NSURL* url = [[filemanager URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask] lastObject];
+            url = [url URLByAppendingPathComponent:@"OpenLoco"];
+            return url.path.UTF8String;
         }
     }
-}
 
-fs::path openloco::platform::GetCurrentExecutablePath()
-{
-    char exePath[PATH_MAX];
-    uint32_t size = PATH_MAX;
-    int result = _NSGetExecutablePath(exePath, &size);
-    if (result == 0)
+    std::string prompt_directory(const std::string &title)
     {
-        return exePath;
-    }
-    else
-    {
-        return fs::path();
-    }
-}
-
-fs::path openloco::platform::GetBundlePath()
-{
-    @autoreleasepool
-    {
-        NSBundle * bundle = [NSBundle mainBundle];
-        if (bundle)
+        @autoreleasepool
         {
-            auto resources = bundle.resourcePath.UTF8String;
-            if (fs::exists(resources))
+            NSOpenPanel* panel = [NSOpenPanel openPanel];
+            panel.canChooseFiles = false;
+            panel.canChooseDirectories = true;
+            panel.allowsMultipleSelection = false;
+            if ([panel runModal] == NSModalResponseOK)
             {
-                return resources;
+                NSString* selectedPath = panel.URL.path;
+                const char* path = selectedPath.UTF8String;
+                return path;
+            } else {
+                return "";
             }
         }
-        return fs::path();
+    }
+
+    fs::path GetCurrentExecutablePath()
+    {
+        char exePath[PATH_MAX];
+        uint32_t size = PATH_MAX;
+        int result = _NSGetExecutablePath(exePath, &size);
+        if (result == 0)
+        {
+            return exePath;
+        }
+        else
+        {
+            return fs::path();
+        }
+    }
+
+    fs::path GetBundlePath()
+    {
+        @autoreleasepool
+        {
+            NSBundle* bundle = [NSBundle mainBundle];
+            if (bundle)
+            {
+                auto resources = bundle.resourcePath.UTF8String;
+                if (fs::exists(resources))
+                {
+                    return resources;
+                }
+            }
+            return fs::path();
+        }
     }
 }
 

--- a/src/openloco/platform/platform.posix.cpp
+++ b/src/openloco/platform/platform.posix.cpp
@@ -28,7 +28,7 @@ uint32_t openloco::platform::get_time()
     return spec.tv_nsec / 1000000;
 }
 
-std::vector<fs::path> openloco::platform::get_drives()
+std::vector<fs::path> openloco::platform::getDrives()
 {
     return {};
 }

--- a/src/openloco/platform/platform.posix.cpp
+++ b/src/openloco/platform/platform.posix.cpp
@@ -21,91 +21,94 @@ int main(int argc, const char** argv)
     return 0;
 }
 
-uint32_t openloco::platform::get_time()
+namespace openloco::platform
 {
-    struct timespec spec;
-    clock_gettime(CLOCK_REALTIME, &spec);
-    return spec.tv_nsec / 1000000;
-}
+    uint32_t get_time()
+    {
+        struct timespec spec;
+        clock_gettime(CLOCK_REALTIME, &spec);
+        return spec.tv_nsec / 1000000;
+    }
 
-std::vector<fs::path> openloco::platform::getDrives()
-{
-    return {};
-}
+    std::vector<fs::path> getDrives()
+    {
+        return {};
+    }
 
 #if !(defined(__APPLE__) && defined(__MACH__))
-static std::string GetEnvironmentVariable(const std::string& name)
-{
-    auto result = getenv(name.c_str());
-    return result == nullptr ? std::string() : result;
-}
-
-static fs::path get_home_directory()
-{
-    auto pw = getpwuid(getuid());
-    if (pw != nullptr)
+    static std::string GetEnvironmentVariable(const std::string& name)
     {
-        return pw->pw_dir;
+        auto result = getenv(name.c_str());
+        return result == nullptr ? std::string() : result;
     }
-    else
-    {
-        return GetEnvironmentVariable("HOME");
-    }
-}
 
-fs::path openloco::platform::get_user_directory()
-{
-    auto path = fs::path(GetEnvironmentVariable("XDG_CONFIG_HOME"));
-    if (path.empty())
+    static fs::path get_home_directory()
     {
-        path = get_home_directory();
-        if (path.empty())
+        auto pw = getpwuid(getuid());
+        if (pw != nullptr)
         {
-            path = "/";
+            return pw->pw_dir;
         }
         else
         {
-            path = path / fs::path(".config");
+            return GetEnvironmentVariable("HOME");
         }
     }
-    return path / fs::path("OpenLoco");
-}
+
+    fs::path get_user_directory()
+    {
+        auto path = fs::path(GetEnvironmentVariable("XDG_CONFIG_HOME"));
+        if (path.empty())
+        {
+            path = get_home_directory();
+            if (path.empty())
+            {
+                path = "/";
+            }
+            else
+            {
+                path = path / fs::path(".config");
+            }
+        }
+        return path / fs::path("OpenLoco");
+    }
 #endif
 
 #if !(defined(__APPLE__) && defined(__MACH__))
-fs::path openloco::platform::GetCurrentExecutablePath()
-{
-    char exePath[PATH_MAX] = { 0 };
+    fs::path GetCurrentExecutablePath()
+    {
+        char exePath[PATH_MAX] = { 0 };
 #ifdef __linux__
-    auto bytesRead = readlink("/proc/self/exe", exePath, sizeof(exePath));
-    if (bytesRead == -1)
-    {
-        console::error("failed to read /proc/self/exe");
-    }
+        auto bytesRead = readlink("/proc/self/exe", exePath, sizeof(exePath));
+        if (bytesRead == -1)
+        {
+            console::error("failed to read /proc/self/exe");
+        }
 #elif defined(__FreeBSD__)
-    const int32_t mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
-    auto exeLen = sizeof(exePath);
-    if (sysctl(mib, 4, exePath, &exeLen, nullptr, 0) == -1)
-    {
-        console::error("failed to get process path");
-    }
+        const int32_t mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+        auto exeLen = sizeof(exePath);
+        if (sysctl(mib, 4, exePath, &exeLen, nullptr, 0) == -1)
+        {
+            console::error("failed to get process path");
+        }
 #elif defined(__OpenBSD__)
-    // There is no way to get the path name of a running executable.
-    // If you are not using the port or package, you may have to change this line!
-    strlcpy(exePath, "/usr/local/bin/", sizeof(exePath));
+        // There is no way to get the path name of a running executable.
+        // If you are not using the port or package, you may have to change this line!
+        strlcpy(exePath, "/usr/local/bin/", sizeof(exePath));
 #else
 #error "Platform does not support full path exe retrieval"
-#endif
-    return exePath;
-}
+#endif // __linux__
+        return exePath;
+    }
 
-std::string openloco::platform::prompt_directory(const std::string& title)
-{
-    std::string input;
-    std::cout << "Type your Locomotion path: ";
-    std::cin >> input;
-    return input;
+    std::string prompt_directory(const std::string& title)
+    {
+        std::string input;
+        std::cout << "Type your Locomotion path: ";
+        std::cin >> input;
+        return input;
+    }
+#endif // !(defined(__APPLE__) && defined(__MACH__))
 }
-#endif
 
 #endif

--- a/src/openloco/platform/platform.windows.cpp
+++ b/src/openloco/platform/platform.windows.cpp
@@ -100,7 +100,7 @@ namespace openloco::platform
         return WIN32_GetModuleFileNameW(nullptr);
     }
 
-    std::vector<fs::path> get_drives()
+    std::vector<fs::path> getDrives()
     {
         char drive[4] = { 'A', ':', '\0' };
         std::vector<fs::path> drives;

--- a/src/openloco/window.cpp
+++ b/src/openloco/window.cpp
@@ -817,20 +817,18 @@ namespace openloco::ui
 
     ui::window* window::call_on_resize()
     {
-        auto handler = event_handlers->on_resize;
-        if (handler != nullptr)
+        if (event_handlers->on_resize == nullptr)
+            return this;
+
+        if (is_interop_event(event_handlers->on_resize))
         {
-            if (is_interop_event(handler))
-            {
-                registers regs;
-                regs.esi = (int32_t)this;
-                call((uint32_t)handler, regs);
-            }
-            else
-            {
-                handler(this);
-            }
+            registers regs;
+            regs.esi = (int32_t)this;
+            call((uint32_t)event_handlers->on_resize, regs);
+            return (window*)regs.esi;
         }
+
+        event_handlers->on_resize(this);
         return this;
     }
 

--- a/src/openloco/windows/promptbrowsewnd.cpp
+++ b/src/openloco/windows/promptbrowsewnd.cpp
@@ -390,19 +390,18 @@ namespace openloco::ui::prompt_browse
         }
         y += 207;
 
+        uint16_t maxWidth = window.width - window.widgets[7].right;
+
         // Company
         set_common_args_stringptr(saveInfo.company);
-        gfx::draw_string_495224(dpi, x, y, 0, string_ids::window_browse_company, _commonFormatArgs);
-        y += 10;
+        y = gfx::draw_string_495224(dpi, x, y, maxWidth, colour::black, string_ids::window_browse_company, _commonFormatArgs);
 
         // Owner
         set_common_args_stringptr(saveInfo.owner);
-        gfx::draw_string_495224(dpi, x, y, 0, string_ids::owner_label, _commonFormatArgs);
-        y += 10;
+        y = gfx::draw_string_495224(dpi, x, y, maxWidth, colour::black, string_ids::owner_label, _commonFormatArgs);
 
         // Date
-        gfx::draw_string_495224(dpi, x, y, 0, string_ids::window_browse_date, &saveInfo.date);
-        y += 10;
+        y = gfx::draw_string_495224(dpi, x, y, maxWidth, colour::black, string_ids::window_browse_date, &saveInfo.date);
 
         // Challenge progress
         auto flags = saveInfo.challenge_flags;
@@ -419,7 +418,7 @@ namespace openloco::ui::prompt_browse
                     progress = saveInfo.challenge_progress;
                 }
             }
-            gfx::draw_string_495224(dpi, x, y, 0, stringId, &progress);
+            gfx::draw_string_495224(dpi, x, y, maxWidth, colour::black, stringId, &progress);
         }
     }
 

--- a/src/openloco/windows/promptbrowsewnd.cpp
+++ b/src/openloco/windows/promptbrowsewnd.cpp
@@ -109,6 +109,18 @@ namespace openloco::ui::prompt_browse
         scrollview,
     };
 
+    static widget_t widgets[] = {
+        make_widget({ 0, 0 }, { 500, 380 }, widget_type::frame, 0),
+        make_widget({ 1, 1 }, { 498, 13 }, widget_type::caption_25, 0, string_ids::buffer_2039),
+        make_widget({ 485, 2 }, { 13, 13 }, widget_type::wt_9, 0, image_ids::close_button, string_ids::tooltip_close_window),
+        make_widget({ 0, 15 }, { 500, 365 }, widget_type::panel, 1),
+        make_widget({ 473, 18 }, { 24, 24 }, widget_type::wt_9, 1, image_ids::icon_parent_folder, string_ids::window_browse_parent_folder_tooltip),
+        make_widget({ 88, 348 }, { 408, 14 }, widget_type::wt_17, 1),
+        make_widget({ 426, 364 }, { 70, 12 }, widget_type::wt_11, 1, string_ids::label_button_ok),
+        make_widget({ 3, 45 }, { 494, 323 }, widget_type::scrollview, 1, vertical),
+        widget_end(),
+    };
+
     static window_event_list _events;
     static loco_global<uint8_t, 0x009D9D63> _type;
     static loco_global<uint8_t, 0x009DA284> _fileType;
@@ -202,7 +214,7 @@ namespace openloco::ui::prompt_browse
 
         if (window != nullptr)
         {
-            window->widgets = (widget_t*)0x0050AD58;
+            window->widgets = widgets;
             window->enabled_widgets = (1 << widx::close_button) | (1 << widx::parent_button) | (1 << widx::ok_button);
             window->init_scroll_widgets();
 
@@ -300,11 +312,60 @@ namespace openloco::ui::prompt_browse
     }
 
     // 0x00445C8F
-    static void prepare_draw(ui::window* window)
+    static void prepare_draw(ui::window* self)
     {
+        // TODO: replace with a fixed length!
+        char* buffer = (char*)stringmgr::get_string(string_ids::buffer_2039);
+        strcpy(buffer, _title);
+
+        self->widgets[widx::frame].right = self->width - 1;
+        self->widgets[widx::frame].bottom = self->height - 1;
+
+        self->widgets[widx::panel].right = self->width - 1;
+        self->widgets[widx::panel].bottom = self->height - 1;
+
+        self->widgets[widx::caption].right = self->width - 2;
+
+        self->widgets[widx::close_button].left = self->width - 15;
+        self->widgets[widx::close_button].right = self->width - 3;
+
+        if (*_type == (uint8_t)browse_file_type::unk_2)
+        {
+            self->widgets[widx::ok_button].top = self->height - 16;
+            self->widgets[widx::ok_button].bottom = self->height - 5;
+
+            self->widgets[widx::text_filename].right = self->width - 6;
+            self->widgets[widx::text_filename].top = self->height - 32;
+            self->widgets[widx::text_filename].bottom = self->height - 19;
+
+            self->widgets[widx::text_filename].bottom = self->height - 35;
+
+            self->widgets[widx::ok_button].type = widget_type::wt_11;
+            self->widgets[widx::text_filename].type = widget_type::wt_17;
+        }
+        else
+        {
+            self->widgets[widx::text_filename].bottom = self->height - 4;
+
+            self->widgets[widx::ok_button].type = widget_type::none;
+            self->widgets[widx::text_filename].type = widget_type::none;
+        }
+
+        self->widgets[widx::scrollview].right = self->width - 261;
+        if (*_fileType != (uint8_t)browse_file_type::saved_game)
+            self->widgets[widx::scrollview].right += 122;
+
+        self->widgets[widx::text_filename].left = self->width - 86;
+        self->widgets[widx::text_filename].right = self->width - 16;
+
+        self->widgets[widx::parent_button].left = self->width - 26;
+        self->widgets[widx::parent_button].right = self->width - 3;
+
+        // Resume the original prepare_draw routine beyond the widget repositioning.
         registers regs;
-        regs.esi = (int32_t)window;
-        call(0x00445C8F, regs);
+        regs.edi = (int32_t)buffer;
+        regs.esi = (int32_t)self;
+        call(0x00445D91, regs);
     }
 
     static void set_common_args_stringptr(const char* buffer)

--- a/src/openloco/windows/promptbrowsewnd.cpp
+++ b/src/openloco/windows/promptbrowsewnd.cpp
@@ -452,7 +452,7 @@ namespace openloco::ui::prompt_browse
             auto imageId = image_ids::random_map_watermark | (window.colours[1] << 19) | 0x20000000;
             gfx::draw_image(&dpi, x, y, imageId);
             gfx::point_t origin = { (int16_t)(x + 64), (int16_t)(y + 60) };
-            gfx::draw_string_centred_wrapped(&dpi, &origin, 128, 0, string_ids::randomly_generated_landscape, nullptr);
+            gfx::draw_string_centred_wrapped(&dpi, &origin, 128, 0, string_ids::randomly_generated_landscape);
         }
     }
 
@@ -492,14 +492,12 @@ namespace openloco::ui::prompt_browse
     // 0x00446314
     static void draw_scroll(ui::window* window, gfx::drawpixelinfo_t* dpi, uint32_t scrollIndex)
     {
-        loco_global<uint8_t[256], 0x001136BA4> byte_1136BA4;
         loco_global<char[16], 0x0112C826> _commonFormatArgs;
 
         static std::string _nameBuffer;
 
         // Background
-        auto paletteId = byte_1136BA4[window->colours[1] * 8];
-        gfx::clear_single(*dpi, paletteId);
+        gfx::clear_single(*dpi, colour::get_shade(window->colours[1], 4));
 
         // Directories / files
         auto y = 0;
@@ -587,7 +585,7 @@ namespace openloco::ui::prompt_browse
         _newFiles.clear();
         if (_directory[0] == '\0')
         {
-            auto drives = platform::get_drives();
+            auto drives = platform::getDrives();
             for (auto& drive : drives)
             {
 #ifdef _OPENLOCO_USE_BOOST_FS_

--- a/src/openloco/windows/stationwnd.cpp
+++ b/src/openloco/windows/stationwnd.cpp
@@ -39,8 +39,7 @@ namespace openloco::ui::windows::station
     // 0x0048ED2F
     void tab_2_scroll_paint(window& w, gfx::drawpixelinfo_t& dpi)
     {
-        auto paletteId = byte_1136BA4[w.colours[1] * 8];
-        gfx::clear_single(dpi, paletteId);
+        gfx::clear_single(dpi, colour::get_shade(w.colours[1], 4));
 
         const auto station = stationmgr::get(w.number);
         int16_t y = 0;

--- a/src/openloco/windows/toolbar_top.cpp
+++ b/src/openloco/windows/toolbar_top.cpp
@@ -130,7 +130,7 @@ namespace openloco::ui::windows::toolbar_top
     {
         auto main = WindowManager::getMainWindow();
         if (main == nullptr)
-            window->set_disabled_widgets_and_invalidate(1 << 2 | 1 << 3);
+            window->set_disabled_widgets_and_invalidate(widx::zoom_menu | widx::rotate_menu);
         else
             window->set_disabled_widgets_and_invalidate(0);
     }

--- a/src/openloco/windows/townwnd.cpp
+++ b/src/openloco/windows/townwnd.cpp
@@ -13,7 +13,7 @@ namespace openloco::ui::windows
 #ifdef _DISABLE_TOWN_RENAME_
         if (is_editor_mode())
         {
-            w->enabled_widgets &= ~2;
+            w->enabled_widgets &= ~(1 << 1);
         }
 #endif
     }


### PR DESCRIPTION
Minor clean-ups of file browser and platform files that I didn't want to clog another PR with.

The second commit is mostly whitespace: I've moved the functions into a dedicated `namespace` rather than repeating it for every function.