### PR TITLE
Fix #342: Text cursor does not advance correctly.

### DIFF
--- a/src/openloco/input.h
+++ b/src/openloco/input.h
@@ -4,7 +4,7 @@
 
 namespace openloco::input
 {
-    enum class mouse_button
+    enum class mouse_button : uint16_t
     {
         released,
         left_pressed,


### PR DESCRIPTION
Caused by `mouse_button` being 32-bits rather than 16-bits. Therefore, an assignment to `_lastKnownButtonState` (`0x001136FA0`) would also overwrite `_textInputCaret` (`0x01136FA2`). See 6a73f0b2abd840e68e8a1dfae52667fc8b495acf for the offending lines.