### PR TITLE
Fix #351: Game crashes when opening terraform window

### DIFF
--- a/src/openloco/window.h
+++ b/src/openloco/window.h
@@ -380,7 +380,7 @@ namespace openloco::ui
         uint16_t row_count;                                // 0x83A
         uint16_t var_83C;
         uint16_t var_83E;
-        int16_t row_hover; // 0x840
+        int16_t row_hover = -1; // 0x840
         uint8_t pad_842[0x844 - 0x842];
         uint16_t sort_mode; // 0x844;
         uint16_t var_846 = 0;


### PR DESCRIPTION
The game sometimes crashed when opening the terraform window. This happened due to the row_hover value not being properly initialised, thereby relying on a previous window having it set to a valid value.

As this bug was not present in the last release, no changelog entry is required.