### PR TITLE
Fix #350: Map window opens with wrong dimensions

### DIFF
--- a/src/openloco/window.cpp
+++ b/src/openloco/window.cpp
@@ -30,6 +30,10 @@ namespace openloco::ui
         , y(position.y)
         , width(size.width)
         , height(size.height)
+        , min_width(size.width)
+        , max_width(size.width)
+        , min_height(size.height)
+        , max_height(size.height)
     {
     }
 

--- a/src/openloco/window.h
+++ b/src/openloco/window.h
@@ -369,10 +369,10 @@ namespace openloco::ui
         int16_t y;                                         // 0x32
         uint16_t width;                                    // 0x34
         uint16_t height;                                   // 0x36
-        uint16_t min_width;                                // 0x38
-        uint16_t max_width;                                // 0x3a
-        uint16_t min_height;                               // 0x3c
-        uint16_t max_height;                               // 0x3e
+        uint16_t min_width = 0;                            // 0x38
+        uint16_t max_width = 0;                            // 0x3A
+        uint16_t min_height = 0;                           // 0x3C
+        uint16_t max_height = 0;                           // 0x3E
         window_number number = 0;                          // 0x40
         uint32_t flags;                                    // 0x42
         scroll_area_t scroll_areas[2];                     // 0x46

--- a/src/openloco/window.h
+++ b/src/openloco/window.h
@@ -369,10 +369,10 @@ namespace openloco::ui
         int16_t y;                                         // 0x32
         uint16_t width;                                    // 0x34
         uint16_t height;                                   // 0x36
-        uint16_t min_width = 0;                            // 0x38
-        uint16_t max_width = 0;                            // 0x3A
-        uint16_t min_height = 0;                           // 0x3C
-        uint16_t max_height = 0;                           // 0x3E
+        uint16_t min_width;                                // 0x38
+        uint16_t max_width;                                // 0x3a
+        uint16_t min_height;                               // 0x3c
+        uint16_t max_height;                               // 0x3e
         window_number number = 0;                          // 0x40
         uint32_t flags;                                    // 0x42
         scroll_area_t scroll_areas[2];                     // 0x46


### PR DESCRIPTION
The window struct had no default values for its min/max width and height, and the window isn't setting all of these values correctly, leaving the memory in question uninitialised.

While the affected property is only min_height, I'd rather be cautious and zero-initialise the other attributes, too.