### PR TITLE
Use Homebrew-provided GCC6 instead of Boost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,20 +51,19 @@ matrix:
           name: macOS 10.13 Clang (Xcode 9.3)
           osx_image: xcode9.3 # macOS 10.13
           language: cpp
-          before_install:
-            - export HOMEBREW_NO_AUTO_UPDATE=1
+          addons:
+            homebrew:
+              packages:
+                - gcc6
           install:
-            - brew uninstall --ignore-dependencies boost
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*; fi
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/tags/*:refs/tags/*; fi
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git fetch --tags; fi
           script:
             - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.0/openloco.dependencies.macos.1.1.0.zip -o dependencies.zip
             - unzip -q dependencies.zip -d vcpkg/
-            - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.1/macos-x86-static-boost-1.68.0.zip -o boost.zip
-            - unzip -q boost.zip -d boost/
             - mkdir build && cd build
-            - cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx "-DBOOST_ROOT=($pwd)/../boost"
+            - cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx
             - make -j2
             - zip -r openloco-macos.zip openloco.app
             - curl --progress-bar --upload-file openloco-macos.zip https://transfer.sh/openloco-macos.zip; echo;
@@ -72,20 +71,19 @@ matrix:
           name: macOS 10.12 Clang (Xcode 9.2)
           osx_image: xcode9.2 # macOS 10.12 (lacks std::byte)
           language: cpp
-          before_install:
-            - export HOMEBREW_NO_AUTO_UPDATE=1
+          addons:
+            homebrew:
+              packages:
+                - gcc6
           install:
-            - brew uninstall --ignore-dependencies boost
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*; fi
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/tags/*:refs/tags/*; fi
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git fetch --tags; fi
           script:
             - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.0/openloco.dependencies.macos.1.1.0.zip -o dependencies.zip
             - unzip -q dependencies.zip -d vcpkg/
-            - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.1/macos-x86-static-boost-1.68.0.zip -o boost.zip
-            - unzip -q boost.zip -d boost/
             - mkdir build && cd build
-            - cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx "-DBOOST_ROOT=($pwd)/../boost"
+            - cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx
             - make -j2
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ matrix:
             - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.0/openloco.dependencies.macos.1.1.0.zip -o dependencies.zip
             - unzip -q dependencies.zip -d vcpkg/
             - mkdir build && cd build
-            - cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx
+            - CXX=g++-6 cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx
             - make -j2
             - zip -r openloco-macos.zip openloco.app
             - curl --progress-bar --upload-file openloco-macos.zip https://transfer.sh/openloco-macos.zip; echo;
@@ -87,7 +87,7 @@ matrix:
             - curl -L https://github.com/OpenLoco/Dependencies/releases/download/v1.1.0/openloco.dependencies.macos.1.1.0.zip -o dependencies.zip
             - unzip -q dependencies.zip -d vcpkg/
             - mkdir build && cd build
-            - cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx
+            - CXX=g++-6 cmake .. "-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-osx
             - make -j2
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ matrix:
             homebrew:
               packages:
                 - gcc6
+              update: true
           install:
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*; fi
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/tags/*:refs/tags/*; fi
@@ -75,6 +76,7 @@ matrix:
             homebrew:
               packages:
                 - gcc6
+              update: true
           install:
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*; fi
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/tags/*:refs/tags/*; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ matrix:
               packages:
                 - gcc6
               update: true
+          before_install: []
           install:
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*; fi
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/tags/*:refs/tags/*; fi
@@ -77,6 +78,7 @@ matrix:
               packages:
                 - gcc6
               update: true
+          before_install: []
           install:
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*; fi
             - if [[ $TRAVIS_JOB_NAME != "clang-format" ]]; then git config remote.origin.fetch +refs/tags/*:refs/tags/*; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 INCLUDE(FindPkgConfig)
 
 set(USE_BOOST_FS_DEFAULT OFF)
-if(APPLE OR MINGW)
+if(MINGW)
 	set(USE_BOOST_FS_DEFAULT ON)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,12 @@ endif()
 
 INCLUDE(FindPkgConfig)
 
-option(USE_BOOST_FILESYSTEM "Use Boost filesystem instead of C++17" OFF)
+set(USE_BOOST_FS_DEFAULT OFF)
+if(APPLE OR MINGW)
+	set(USE_BOOST_FS_DEFAULT ON)
+endif()
+
+option(USE_BOOST_FILESYSTEM "Use Boost filesystem instead of C++17" ${USE_BOOST_FS_DEFAULT})
 option(STRICT "Build with warnings as errors" YES)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,12 +18,7 @@ endif()
 
 INCLUDE(FindPkgConfig)
 
-set(USE_BOOST_FS_DEFAULT OFF)
-if(APPLE OR MINGW)
-	set(USE_BOOST_FS_DEFAULT ON)
-endif()
-
-option(USE_BOOST_FILESYSTEM "Use Boost filesystem instead of C++17" ${USE_BOOST_FS_DEFAULT})
+option(USE_BOOST_FILESYSTEM "Use Boost filesystem instead of C++17" OFF)
 option(STRICT "Build with warnings as errors" YES)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")


### PR DESCRIPTION
`vcpkg` has switched to Homebrew-provided GCC6 to get support for C++ Filesystem. I figured we might be able to do the same.

For what it's worth:

> Trying to build vcpkg on macOS:
> ```
> CMake Error at CMakeLists.txt:20 (message):
>   Building the vcpkg tool requires support for the C++ Filesystem TS.
> 
>   Apple clang versions 10.01 and below do not have support for it.
> 
>   Please install gcc6 or newer from homebrew (brew install gcc6).
> 
>   If you would like to try anyway, pass --allowAppleClang to bootstrap.sh.
> ```