### PR TITLE
Make keypad enter work the same as normal enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix: [#303] Play title music preference is not saved.
 - Fix: [#340] Cargo rating is calculated incorrectly in some edge cases.
 - Fix: Strings were not wrapping properly in the file browser window.
+- Change: [#380] Make keypad enter work the same as normal enter.
 
 19.03 (2019-03-01)
 ------------------------------------------------------------------------

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -745,6 +745,11 @@ namespace openloco::ui
                     }
 #endif
 
+                    // Map keypad enter to normal enter
+                    if (keycode == SDLK_KP_ENTER) {
+                        keycode = SDLK_RETURN;
+                    }
+
                     auto locokey = convert_sdl_keycode_to_windows(keycode);
                     if (locokey != 0)
                     {

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -746,7 +746,8 @@ namespace openloco::ui
 #endif
 
                     // Map keypad enter to normal enter
-                    if (keycode == SDLK_KP_ENTER) {
+                    if (keycode == SDLK_KP_ENTER)
+                    {
                         keycode = SDLK_RETURN;
                     }
 


### PR DESCRIPTION
Simple change to allow using the keypad enter as normal enter which currently does nothing.