### PR TITLE
Use C++17 for Visual Studio

### DIFF
--- a/openloco.common.props
+++ b/openloco.common.props
@@ -55,7 +55,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_USE_MATH_DEFINES;SDL_MAIN_HANDLED;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/utf-8 /std:c++latest /permissive-</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /std:c++17 /permissive-</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>imm32.lib;version.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Fixes building on VS2019.