### PR TITLE
Introduce FormatArguments wrapper class

### DIFF
--- a/src/openloco/localisation/FormatArguments.hpp
+++ b/src/openloco/localisation/FormatArguments.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "../interop/interop.hpp"
+
+using namespace openloco::interop;
+
+namespace openloco
+{
+
+    class FormatArguments
+    {
+    private:
+        void* _buffer;
+        void* _bufferStart;
+
+    public:
+        FormatArguments(void* buffer)
+        {
+            _bufferStart = buffer;
+            _buffer = _bufferStart;
+        }
+
+        FormatArguments()
+            : FormatArguments(&addr<0x112C826, void*>())
+        {
+        }
+
+        template<typename T>
+        void push(T arg)
+        {
+            *(T*)_buffer = arg;
+            _buffer = (void*)((uint8_t*)_buffer + sizeof(T));
+        }
+
+        const void* operator&()
+        {
+            return _bufferStart;
+        }
+    };
+
+}

--- a/src/openloco/localisation/languagefiles.cpp
+++ b/src/openloco/localisation/languagefiles.cpp
@@ -108,7 +108,7 @@ namespace openloco::localisation
                 {
                     if (commands.size() == 1)
                     {
-                        *out = (unsigned char)(123 + 8);
+                        *out = (char)control_codes::stringid_args;
                         out++;
                     }
                     else

--- a/src/openloco/types.hpp
+++ b/src/openloco/types.hpp
@@ -48,6 +48,8 @@ namespace openloco
         constexpr int16_t null = (int16_t)0x8000u;
     }
 
+    class FormatArguments;
+
     enum class ZoomLevel : uint8_t
     {
         full = 0,

--- a/src/openloco/window.cpp
+++ b/src/openloco/window.cpp
@@ -4,6 +4,7 @@
 #include "graphics/colours.h"
 #include "input.h"
 #include "interop/interop.hpp"
+#include "localisation/FormatArguments.hpp"
 #include "map/tile.h"
 #include "map/tilemgr.h"
 #include "things/thingmgr.h"
@@ -995,7 +996,8 @@ namespace openloco::ui
             return regs.ax != (int16_t)string_ids::null;
         }
 
-        event_handlers->tooltip(this, widget_index);
+        auto args = FormatArguments();
+        event_handlers->tooltip(args, this, widget_index);
         return true;
     }
 

--- a/src/openloco/window.h
+++ b/src/openloco/window.h
@@ -225,7 +225,7 @@ namespace openloco::ui
                 void (*text_input)(window*, widget_index, char*);
                 void (*viewport_rotate)(window*);
                 uint32_t event_22;
-                void (*tooltip)(window*, widget_index);
+                void (*tooltip)(FormatArguments& args, window*, widget_index);
                 ui::cursor_id (*cursor)(window*, int16_t, int16_t, int16_t, ui::cursor_id);
                 uint32_t on_move;
                 void (*prepare_draw)(window*);

--- a/src/openloco/windows/KeyboardShortcuts.cpp
+++ b/src/openloco/windows/KeyboardShortcuts.cpp
@@ -3,6 +3,7 @@
 #include "../graphics/image_ids.h"
 #include "../input/ShortcutManager.h"
 #include "../interop/interop.hpp"
+#include "../localisation/FormatArguments.hpp"
 #include "../localisation/string_ids.h"
 #include "../objects/interface_skin_object.h"
 #include "../objects/objectmgr.h"
@@ -46,7 +47,7 @@ namespace openloco::ui::KeyboardShortcuts
     static void draw_scroll(ui::window* self, gfx::drawpixelinfo_t* dpi, uint32_t scrollIndex);
     static void on_mouse_up(window* self, widget_index widgetIndex);
     static void loc_4BE832(window* self);
-    static void tooltip(window*, widget_index);
+    static void tooltip(FormatArguments& args, window*, widget_index);
     static void get_scroll_size(ui::window* self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);
     static void on_scroll_mouse_over(ui::window* self, int16_t x, int16_t y, uint8_t scroll_index);
     static void on_scroll_mouse_down(ui::window* self, int16_t x, int16_t y, uint8_t scroll_index);
@@ -163,10 +164,9 @@ namespace openloco::ui::KeyboardShortcuts
     }
 
     // 0x004BE844
-    static void tooltip(window*, widget_index)
+    static void tooltip(FormatArguments& args, window*, widget_index)
     {
-        loco_global<string_id, 0x112C826> common_format_args;
-        *common_format_args = string_ids::tooltip_scroll_list;
+        args.push(string_ids::tooltip_scroll_list);
     }
 
     // 0x004BE84E

--- a/src/openloco/windows/LandscapeGeneration.cpp
+++ b/src/openloco/windows/LandscapeGeneration.cpp
@@ -3,6 +3,7 @@
 #include "../graphics/image_ids.h"
 #include "../input.h"
 #include "../interop/interop.hpp"
+#include "../localisation/FormatArguments.hpp"
 #include "../localisation/string_ids.h"
 #include "../objects/interface_skin_object.h"
 #include "../objects/land_object.h"
@@ -634,9 +635,9 @@ namespace openloco::ui::windows::LandscapeGeneration
         }
 
         // 0x0043E2A2
-        static void tooltip(ui::window* window, widget_index widgetIndex)
+        static void tooltip(FormatArguments& args, ui::window* window, widget_index widgetIndex)
         {
-            commonFormatArgs[0] = string_ids::tooltip_scroll_list;
+            args.push(string_ids::tooltip_scroll_list);
         }
 
         // 0x0043E3D9

--- a/src/openloco/windows/TimePanel.cpp
+++ b/src/openloco/windows/TimePanel.cpp
@@ -62,7 +62,7 @@ namespace openloco::ui::TimePanel
     static void text_input(window* w, widget_index widgetIndex, char* str);
     static void on_dropdown(window* w, widget_index widgetIndex, int16_t item_index);
     static ui::cursor_id on_cursor(window* w, int16_t widgetIdx, int16_t xPos, int16_t yPos, ui::cursor_id fallback);
-    static void tooltip(ui::window* window, widget_index widgetIndex);
+    static void tooltip(FormatArguments& args, ui::window* window, widget_index widgetIndex);
     static void text_input(window* w, widget_index widgetIndex, char* str);
     static void on_update(window* w);
 
@@ -317,7 +317,7 @@ namespace openloco::ui::TimePanel
     }
 
     // 0x00439955
-    static void tooltip(ui::window* window, widget_index widgetIndex)
+    static void tooltip(FormatArguments& args, ui::window* window, widget_index widgetIndex)
     {
         switch (widgetIndex)
         {

--- a/src/openloco/windows/about_music.cpp
+++ b/src/openloco/windows/about_music.cpp
@@ -2,6 +2,7 @@
 #include "../graphics/gfx.h"
 #include "../graphics/image_ids.h"
 #include "../interop/interop.hpp"
+#include "../localisation/FormatArguments.hpp"
 #include "../localisation/string_ids.h"
 #include "../objects/interface_skin_object.h"
 #include "../objects/objectmgr.h"
@@ -41,7 +42,7 @@ namespace openloco::ui::about_music
 
     static void on_mouse_up(ui::window* window, widget_index widgetIndex);
     static void get_scroll_size(ui::window* window, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);
-    static void tooltip(ui::window* window, widget_index widgetIndex);
+    static void tooltip(FormatArguments& args, ui::window* window, widget_index widgetIndex);
     static void draw(ui::window* window, gfx::drawpixelinfo_t* dpi);
     static void draw_scroll(ui::window* window, gfx::drawpixelinfo_t* dpi, uint32_t scrollIndex);
 
@@ -90,10 +91,9 @@ namespace openloco::ui::about_music
     }
 
     // 0x0043BFC0
-    static void tooltip(ui::window* window, widget_index widgetIndex)
+    static void tooltip(FormatArguments& args, ui::window* window, widget_index widgetIndex)
     {
-        loco_global<string_id, 0x112C826> common_format_args;
-        *common_format_args = string_ids::tooltip_scroll_credits_list;
+        args.push(string_ids::tooltip_scroll_credits_list);
     }
 
     // 0x0043B8B8

--- a/src/openloco/windows/music_selection.cpp
+++ b/src/openloco/windows/music_selection.cpp
@@ -3,6 +3,7 @@
 #include "../graphics/colours.h"
 #include "../graphics/image_ids.h"
 #include "../interop/interop.hpp"
+#include "../localisation/FormatArguments.hpp"
 #include "../localisation/string_ids.h"
 #include "../objects/interface_skin_object.h"
 #include "../objects/objectmgr.h"
@@ -44,7 +45,7 @@ namespace openloco::ui::windows::music_selection
     static void on_scroll_mouse_down(ui::window* window, int16_t x, int16_t y, uint8_t scroll_index);
     static void on_scroll_mouse_over(ui::window* window, int16_t x, int16_t y, uint8_t scroll_index);
     static void on_update(window* window);
-    static void tooltip(ui::window* window, widget_index widgetIndex);
+    static void tooltip(FormatArguments& args, ui::window* window, widget_index widgetIndex);
 
     static void init_events()
     {
@@ -196,9 +197,8 @@ namespace openloco::ui::windows::music_selection
     }
 
     // 0x004C1762
-    static void tooltip(ui::window* window, widget_index widgetIndex)
+    static void tooltip(FormatArguments& args, ui::window* window, widget_index widgetIndex)
     {
-        loco_global<string_id, 0x112C826> common_format_args;
-        *common_format_args = string_ids::tooltip_scroll_list;
+        args.push(string_ids::tooltip_scroll_list);
     }
 }

--- a/src/openloco/windows/promptbrowsewnd.cpp
+++ b/src/openloco/windows/promptbrowsewnd.cpp
@@ -4,6 +4,7 @@
 #include "../graphics/image_ids.h"
 #include "../input.h"
 #include "../interop/interop.hpp"
+#include "../localisation/FormatArguments.hpp"
 #include "../localisation/string_ids.h"
 #include "../openloco.h"
 #include "../platform/platform.h"
@@ -114,7 +115,7 @@ namespace openloco::ui::prompt_browse
     static void on_mouse_up(ui::window* window, widget_index widgetIndex);
     static void on_update(ui::window* window);
     static void get_scroll_size(ui::window* window, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);
-    static void tooltip(ui::window* window, widget_index widgetIndex);
+    static void tooltip(FormatArguments& args, ui::window* window, widget_index widgetIndex);
     static void prepare_draw(window* window);
     static void draw(ui::window* window, gfx::drawpixelinfo_t* dpi);
     static void draw_save_preview(ui::window& window, gfx::drawpixelinfo_t& dpi, int32_t x, int32_t y, int32_t width, int32_t height, const s5::SaveDetails& saveInfo);
@@ -275,9 +276,9 @@ namespace openloco::ui::prompt_browse
     }
 
     // 0x004467D7
-    static void tooltip(ui::window* window, widget_index widgetIndex)
+    static void tooltip(FormatArguments& args, ui::window* window, widget_index widgetIndex)
     {
-        addr<0x0112C826, string_id>() = string_ids::tooltip_scroll_list;
+        args.push(string_ids::tooltip_scroll_list);
     }
 
     // 0x00445C8F

--- a/src/openloco/windows/station_list.cpp
+++ b/src/openloco/windows/station_list.cpp
@@ -4,6 +4,7 @@
 #include "../graphics/image_ids.h"
 #include "../input.h"
 #include "../interop/interop.hpp"
+#include "../localisation/FormatArguments.hpp"
 #include "../localisation/string_ids.h"
 #include "../objects/cargo_object.h"
 #include "../objects/competitor_object.h"
@@ -105,7 +106,7 @@ namespace openloco::ui::windows::station_list
     static void on_scroll_mouse_over(ui::window* window, int16_t x, int16_t y, uint8_t scroll_index);
     static void on_update(window* window);
     static void prepare_draw(ui::window* window);
-    static void tooltip(ui::window* window, widget_index widgetIndex);
+    static void tooltip(FormatArguments& args, ui::window* window, widget_index widgetIndex);
 
     static void init_events()
     {
@@ -749,8 +750,8 @@ namespace openloco::ui::windows::station_list
     }
 
     // 0x00491841
-    static void tooltip(ui::window* window, widget_index widgetIndex)
+    static void tooltip(FormatArguments& args, ui::window* window, widget_index widgetIndex)
     {
-        *_common_format_args = string_ids::tooltip_scroll_station_list;
+        args.push(string_ids::tooltip_scroll_station_list);
     }
 }


### PR DESCRIPTION
This introduces a basic `FormatArguments` wrapper class, which I cherry-picked from a stale branch.

I'd like to start using this more, to prevent seeing `commonFormatArgs` declared everywhere. Pretty basic in its current state, but this should be a good base to easily expand on later.