### PR TITLE
Fix #264: Corrected size of Options/Miscellaneous window

### DIFF
--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -1820,7 +1820,7 @@ namespace openloco::ui::options
 
     namespace misc
     {
-        static const gfx::ui_size_t _window_size = { 420, 102 };
+        static const gfx::ui_size_t _window_size = { 420, 124 };
 
         namespace widx
         {


### PR DESCRIPTION
Extended the height of the Options window Miscellaneous tab so it wouldn't cut off the last line.