### PR TITLE
Disable window scale factor buttons when not applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: [#388] Re-center Options window on scale factor change.
 - Fix: [#396] Preferred owner name is not saved.
 - Fix: [#423] Date in challenge tooltip is incorrect.
+- Change: [#420] Disable window scale factor buttons when not applicable.
 
 20.03 (2020-03-23)
 ------------------------------------------------------------------------

--- a/src/openloco/graphics/gfx.h
+++ b/src/openloco/graphics/gfx.h
@@ -126,10 +126,6 @@ namespace openloco::gfx
         }
     };
 
-    const float scaleFactorMin = 1.0f;
-    const float scaleFactorMax = 4.0f;
-    const float scaleFactorStep = 1.0f;
-
     drawpixelinfo_t& screen_dpi();
 
     void load_g1();

--- a/src/openloco/graphics/gfx.h
+++ b/src/openloco/graphics/gfx.h
@@ -126,6 +126,10 @@ namespace openloco::gfx
         }
     };
 
+	const float scaleFactorMin = 1.0f;
+	const float scaleFactorMax = 4.0f;
+	const float scaleFactorStep = 1.0f;
+
     drawpixelinfo_t& screen_dpi();
 
     void load_g1();

--- a/src/openloco/graphics/gfx.h
+++ b/src/openloco/graphics/gfx.h
@@ -126,9 +126,9 @@ namespace openloco::gfx
         }
     };
 
-	const float scaleFactorMin = 1.0f;
-	const float scaleFactorMax = 4.0f;
-	const float scaleFactorStep = 1.0f;
+    const float scaleFactorMin = 1.0f;
+    const float scaleFactorMax = 4.0f;
+    const float scaleFactorStep = 1.0f;
 
     drawpixelinfo_t& screen_dpi();
 

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -1072,4 +1072,16 @@ namespace openloco::ui
 
         WindowManager::callEvent9OnAllWindows();
     }
+    void adjust_window_scale(float adjust_by)
+    {
+        auto& config = config::get_new();
+        float newScaleFactor = std::clamp(config.scale_factor + adjust_by, ScaleFactor::min, ScaleFactor::max);
+        if (config.scale_factor == newScaleFactor)
+            return;
+        config.scale_factor = newScaleFactor;
+
+        openloco::config::write();
+        gfx::invalidate_screen();
+        ui::trigger_resize();
+    }
 }

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -1072,6 +1072,7 @@ namespace openloco::ui
 
         WindowManager::callEvent9OnAllWindows();
     }
+
     void adjust_window_scale(float adjust_by)
     {
         auto& config = config::get_new();

--- a/src/openloco/ui.h
+++ b/src/openloco/ui.h
@@ -28,6 +28,13 @@ namespace openloco::ui
         int32_t height;
     };
 
+	namespace ScaleFactor
+	{
+		const float min = 1.0f;
+		const float max = 4.0f;
+		const float step = 1.0f;
+	};
+
 #ifdef _WIN32
     void* hwnd();
 #endif
@@ -59,6 +66,7 @@ namespace openloco::ui
 #endif
     void handleInput();
     void minimalHandleInput();
+    void adjust_window_scale(float adjust_by);
 
     namespace viewport_interaction
     {

--- a/src/openloco/ui.h
+++ b/src/openloco/ui.h
@@ -28,12 +28,12 @@ namespace openloco::ui
         int32_t height;
     };
 
-	namespace ScaleFactor
-	{
-		const float min = 1.0f;
-		const float max = 4.0f;
-		const float step = 1.0f;
-	};
+    namespace ScaleFactor
+    {
+        const float min = 1.0f;
+        const float max = 4.0f;
+        const float step = 1.0f;
+    };
 
 #ifdef _WIN32
     void* hwnd();

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -455,21 +455,7 @@ namespace openloco::ui::options
 
         static void display_scale_mouse_down(window* w, widget_index wi, float adjust_by)
         {
-            auto& config = config::get_new();
-            float newScaleFactor = std::clamp(config.scale_factor + adjust_by, openloco::gfx::scaleFactorMin, openloco::gfx::scaleFactorMax);
-            if (config.scale_factor == newScaleFactor)
-                return;
-            config.scale_factor = newScaleFactor;
-            w->disabled_widgets &= ~(1 << widx::display_scale_down_btn);
-            w->disabled_widgets &= ~(1 << widx::display_scale_up_btn);
-            if (newScaleFactor <= openloco::gfx::scaleFactorMin)
-                w->disabled_widgets |= (1 << widx::display_scale_down_btn);
-            if (newScaleFactor >= openloco::gfx::scaleFactorMax)
-                w->disabled_widgets |= (1 << widx::display_scale_up_btn);
-
-            openloco::config::write();
-            gfx::invalidate_screen();
-            ui::trigger_resize();
+            openloco::ui::adjust_window_scale(adjust_by);
         }
 
         // 0x004BFBB7
@@ -493,10 +479,10 @@ namespace openloco::ui::options
                     station_names_scale_mouse_down(w, wi);
                     break;
                 case widx::display_scale_down_btn:
-                    display_scale_mouse_down(w, wi, -openloco::gfx::scaleFactorStep);
+                    display_scale_mouse_down(w, wi, -openloco::ui::ScaleFactor::step);
                     break;
                 case widx::display_scale_up_btn:
-                    display_scale_mouse_down(w, wi, openloco::gfx::scaleFactorStep);
+                    display_scale_mouse_down(w, wi, openloco::ui::ScaleFactor::step);
                     break;
             }
         }
@@ -594,10 +580,15 @@ namespace openloco::ui::options
                 w->activated_widgets |= (1 << widx::gridlines_on_landscape);
             }
 
-            if (config::get_new().scale_factor <= openloco::gfx::scaleFactorMin)
+            if (config::get_new().scale_factor <= openloco::ui::ScaleFactor::min)
                 w->disabled_widgets |= (1 << widx::display_scale_down_btn);
-            if (config::get_new().scale_factor >= openloco::gfx::scaleFactorMax)
+            else
+                w->disabled_widgets &= ~(1 << widx::display_scale_down_btn);
+
+            if (config::get_new().scale_factor >= openloco::ui::ScaleFactor::max)
                 w->disabled_widgets |= (1 << widx::display_scale_up_btn);
+            else
+                w->disabled_widgets &= ~(1 << widx::display_scale_up_btn);
 
             sub_4C13BE(w);
         }

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -456,11 +456,18 @@ namespace openloco::ui::options
         static void display_scale_mouse_down(window* w, widget_index wi, float adjust_by)
         {
             auto& config = config::get_new();
-            float old_config_scale_factor = config.scale_factor;
-            config.scale_factor = std::clamp(config.scale_factor + adjust_by, 1.0f, 4.0f);
-            if (old_config_scale_factor == config.scale_factor)
+            float newScaleFactor = std::clamp(config.scale_factor + adjust_by, openloco::gfx::scaleFactorMin, openloco::gfx::scaleFactorMax);
+            if (config.scale_factor == newScaleFactor)
                 return;
-
+            config.scale_factor = newScaleFactor;
+            
+            w->disabled_widgets &= ~(1 << widx::display_scale_down_btn);
+            w->disabled_widgets &= ~(1 << widx::display_scale_up_btn);
+            if (newScaleFactor <= openloco::gfx::scaleFactorMin)
+                w->disabled_widgets |= (1 << widx::display_scale_down_btn);
+            if (newScaleFactor >= openloco::gfx::scaleFactorMax)
+                w->disabled_widgets |= (1 << widx::display_scale_up_btn);
+            
             openloco::config::write();
             gfx::invalidate_screen();
             ui::trigger_resize();
@@ -487,10 +494,10 @@ namespace openloco::ui::options
                     station_names_scale_mouse_down(w, wi);
                     break;
                 case widx::display_scale_down_btn:
-                    display_scale_mouse_down(w, wi, -1.0f);
+                    display_scale_mouse_down(w, wi, -openloco::gfx::scaleFactorStep);
                     break;
                 case widx::display_scale_up_btn:
-                    display_scale_mouse_down(w, wi, 1.0f);
+                    display_scale_mouse_down(w, wi, openloco::gfx::scaleFactorStep);
                     break;
             }
         }
@@ -587,6 +594,11 @@ namespace openloco::ui::options
             {
                 w->activated_widgets |= (1 << widx::gridlines_on_landscape);
             }
+
+            if (config::get_new().scale_factor <= openloco::gfx::scaleFactorMin)
+                w->disabled_widgets |= (1 << widx::display_scale_down_btn);
+            if (config::get_new().scale_factor >= openloco::gfx::scaleFactorMax)
+                w->disabled_widgets |= (1 << widx::display_scale_up_btn);
 
             sub_4C13BE(w);
         }

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -456,6 +456,7 @@ namespace openloco::ui::options
         static void display_scale_mouse_down(window* w, widget_index wi, float adjust_by)
         {
             openloco::ui::adjust_window_scale(adjust_by);
+            w->moveToCentre();
         }
 
         // 0x004BFBB7

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -456,7 +456,9 @@ namespace openloco::ui::options
         static void display_scale_mouse_down(window* w, widget_index wi, float adjust_by)
         {
             auto& config = config::get_new();
+            float old_config_scale_factor = config.scale_factor;
             config.scale_factor = std::clamp(config.scale_factor + adjust_by, 1.0f, 4.0f);
+            if (old_config_scale_factor == config.scale_factor) return;
 
             openloco::config::write();
             gfx::invalidate_screen();

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -458,7 +458,8 @@ namespace openloco::ui::options
             auto& config = config::get_new();
             float old_config_scale_factor = config.scale_factor;
             config.scale_factor = std::clamp(config.scale_factor + adjust_by, 1.0f, 4.0f);
-            if (old_config_scale_factor == config.scale_factor) return;
+            if (old_config_scale_factor == config.scale_factor)
+                return;
 
             openloco::config::write();
             gfx::invalidate_screen();

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -460,14 +460,13 @@ namespace openloco::ui::options
             if (config.scale_factor == newScaleFactor)
                 return;
             config.scale_factor = newScaleFactor;
-            
             w->disabled_widgets &= ~(1 << widx::display_scale_down_btn);
             w->disabled_widgets &= ~(1 << widx::display_scale_up_btn);
             if (newScaleFactor <= openloco::gfx::scaleFactorMin)
                 w->disabled_widgets |= (1 << widx::display_scale_down_btn);
             if (newScaleFactor >= openloco::gfx::scaleFactorMax)
                 w->disabled_widgets |= (1 << widx::display_scale_up_btn);
-            
+
             openloco::config::write();
             gfx::invalidate_screen();
             ui::trigger_resize();


### PR DESCRIPTION
Implemented a check when the Plus or Minus button is pressed on the Options window to change the Scale Factor to make sure that the new scale factor is actually different to the current one.
If the new scale factor has not changed (ie. it's outside the expected range) we cancel the function instead of refreshing the Screen/UI and causing a purple flash.