### PR TITLE
Fix OpenLoco#425: Fullscreen Resolution Change doesn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: [#388] Re-center Options window on scale factor change.
 - Fix: [#396] Preferred owner name is not saved.
 - Fix: [#423] Date in challenge tooltip is incorrect.
+- Fix: [#425] Changing resolution in fullscreen mode doesn't work.
 - Change: [#420] Disable window scale factor buttons when not applicable.
 
 20.03 (2020-03-23)

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -899,6 +899,14 @@ namespace openloco::ui
             auto& cfg = config::get_new();
             cfg.display.mode = mode;
             config::write_new_config();
+
+            config::resolution_t* dimensions;
+            if (mode == config::screen_mode::window)
+                dimensions = &cfg.display.window_resolution;
+            else
+                dimensions = &cfg.display.fullscreen_resolution;
+
+            resize(dimensions->width, dimensions->height);
         }
     }
 

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -776,6 +776,23 @@ namespace openloco::ui
         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, title.c_str(), message.c_str(), window);
     }
 
+    bool updateSDLResolution()
+    {
+        SDL_DisplayMode mode;
+        SDL_GetWindowDisplayMode(window, &mode);
+
+        auto& cfg = config::get();
+        mode.h = cfg.resolution_height;
+        mode.w = cfg.resolution_width;
+
+        if (SDL_SetWindowDisplayMode(window, &mode) != 0)
+            return false;
+
+        gfx::invalidate_screen();
+        resize(cfg.resolution_width, cfg.resolution_height);
+        return true;
+    }
+
     void updateFullscreenResolutions()
     {
         // Query number of display modes

--- a/src/openloco/ui.h
+++ b/src/openloco/ui.h
@@ -58,6 +58,7 @@ namespace openloco::ui
     void render();
     bool process_messages();
     void show_message_box(const std::string& title, const std::string& message);
+    bool updateSDLResolution();
     void updateFullscreenResolutions();
     std::vector<Resolution> getFullscreenResolutions();
     Resolution getClosestResolution(int32_t inWidth, int32_t inHeight);

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -449,6 +449,8 @@ namespace openloco::ui::options
 
             openloco::config::write();
             WindowManager::invalidateWidget(w->type, w->number, widx::display_resolution);
+            openloco::ui::updateSDLResolution();
+            w->moveToCentre();
         }
 
 #pragma mark -

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -406,6 +406,7 @@ namespace openloco::ui::options
 #if !(defined(__APPLE__) && defined(__MACH__))
             ui::set_screen_mode(new_mode);
             screen_mode_toggle_enabled(w);
+            w->moveToCentre();
 #endif
         }
 


### PR DESCRIPTION
Fix for issue #425 
Allows full screen resolution changes to take affect immediately instead of requiring the game to be restarted.

Waiting to see if PR https://github.com/OpenLoco/OpenLoco/pull/421 is merged so I can use the `window->moveToCentre()` function to re-center the Options window after the resolution change takes affect.