### PR TITLE
Fix Issue #429, plus implemented simple SDL Window display functions

### DIFF
--- a/src/openloco/config.h
+++ b/src/openloco/config.h
@@ -91,6 +91,11 @@ namespace openloco::config
     {
         int32_t width{};
         int32_t height{};
+
+        bool isPositive() const
+        {
+            return width > 0 && height > 0;
+        }
     };
 
     struct display_config

--- a/src/openloco/config.h
+++ b/src/openloco/config.h
@@ -102,7 +102,7 @@ namespace openloco::config
     {
         screen_mode mode;
         int32_t index{};
-        resolution_t window_resolution;
+        resolution_t window_resolution = { 800, 600 };
         resolution_t fullscreen_resolution;
     };
 

--- a/src/openloco/config.h
+++ b/src/openloco/config.h
@@ -49,8 +49,8 @@ namespace openloco::config
     struct config_t
     {
         uint32_t flags;                             // 0x50AEB4, 0x00
-        uint16_t resolution_width;                  // 0x50AEB8, 0x04
-        uint16_t resolution_height;                 // 0x50AEBA, 0x06
+        int16_t resolution_width;                   // 0x50AEB8, 0x04
+        int16_t resolution_height;                  // 0x50AEBA, 0x06
         uint16_t backup_resolution_width;           // 0x50AEBC, 0x08
         uint16_t backup_resolution_height;          // 0x50AEBE, 0x10
         uint8_t countdown;                          // 0x50AEC0, 0x0C

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -774,21 +774,21 @@ namespace openloco::ui
         auto& config = config::get_new();
         switch (mode)
         {
-        case config::screen_mode::window:
-            if (config.display.window_resolution.width > 0 && config.display.window_resolution.height > 0)
-                outputResolution = &config.display.window_resolution;
-            else
-                outputResolution = &defaultResolution;
-            break;
-        case config::screen_mode::fullscreen:
-            if (config.display.fullscreen_resolution.width > 0 && config.display.fullscreen_resolution.height > 0)
-                outputResolution = &config.display.fullscreen_resolution;
-            break;
-        case config::screen_mode::fullscreen_borderless:
-            break;
-        default:
-            console::error("Unrecongised display mode");
-            break;
+            case config::screen_mode::window:
+                if (config.display.window_resolution.width > 0 && config.display.window_resolution.height > 0)
+                    outputResolution = &config.display.window_resolution;
+                else
+                    outputResolution = &defaultResolution;
+                break;
+            case config::screen_mode::fullscreen:
+                if (config.display.fullscreen_resolution.width > 0 && config.display.fullscreen_resolution.height > 0)
+                    outputResolution = &config.display.fullscreen_resolution;
+                break;
+            case config::screen_mode::fullscreen_borderless:
+                break;
+            default:
+                console::error("Unrecongised display mode");
+                break;
         }
 
         // If we have no resolution in config, or it's 0x0, use the current desktop resolution instead
@@ -796,7 +796,8 @@ namespace openloco::ui
         {
             config::resolution_t desktopResolution = getDesktopResolution(displayIndex);
             outputResolution = &desktopResolution;
-        } else if (!(outputResolution->width > 0 && outputResolution->height > 0))
+        }
+        else if (!(outputResolution->width > 0 && outputResolution->height > 0))
         {
             config::resolution_t desktopResolution = getDesktopResolution(displayIndex);
             outputResolution = &desktopResolution;

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -769,39 +769,18 @@ namespace openloco::ui
 
     static config::resolution_t getDisplayResolutionByMode(config::screen_mode mode)
     {
-        config::resolution_t defaultResolution = { 640, 480 };
-        config::resolution_t* outputResolution = &defaultResolution;
-
         auto& config = config::get_new();
-        switch (mode)
+        if (mode == config::screen_mode::window)
         {
-            case config::screen_mode::window:
-                if (config.display.window_resolution.isPositive())
-                    outputResolution = &config.display.window_resolution;
-                break;
-
-            case config::screen_mode::fullscreen:
-                if (config.display.fullscreen_resolution.isPositive())
-                    outputResolution = &config.display.fullscreen_resolution;
-                break;
-
-            case config::screen_mode::fullscreen_borderless:
-                break;
-
-            default:
-                console::error("Unrecongised display mode");
-                break;
+            if (config.display.window_resolution.isPositive())
+                return config.display.window_resolution;
+            else
+                return { 800, 600 };
         }
-
-        if (outputResolution != nullptr && outputResolution->isPositive())
-        {
-            return *outputResolution;
-        }
+        else if (mode == config::screen_mode::fullscreen && config.display.fullscreen_resolution.isPositive())
+            return config.display.fullscreen_resolution;
         else
-        {
-            // If we have no resolution in config, or it's 0x0, use the current desktop resolution instead
             return getDesktopResolution();
-        }
     }
 
     static config::resolution_t getDesktopResolution()

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -801,6 +801,13 @@ namespace openloco::ui
         else if (mode == config::screen_mode::fullscreen_borderless)
             flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 
+        // *HACK* Set window to non fullscreen before switching resolution.
+        // This fixes issues with high dpi and Windows scaling affecting the gui size.
+        SDL_SetWindowFullscreen(window, 0);
+
+        // Set the new dimensions of the screen.
+        SDL_SetWindowSize(window, newResolution.width, newResolution.height);
+
         // Set the window fullscreen mode.
         if (SDL_SetWindowFullscreen(window, flags) != 0)
         {
@@ -808,15 +815,6 @@ namespace openloco::ui
             return false;
         }
 
-        // Set the new dimensions of the screen, or just the window.
-        if (mode != config::screen_mode::window)
-        {
-            SDL_SetWindowSize(window, newResolution.width, newResolution.height);
-        }
-        else
-        {
-            SDL_SetWindowSize(window, newResolution.width, newResolution.height);
-        }
 
         // It appears we were successful in setting the screen mode, so let's up date the config.
         auto& config = config::get_new();

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -815,7 +815,6 @@ namespace openloco::ui
             return false;
         }
 
-
         // It appears we were successful in setting the screen mode, so let's up date the config.
         auto& config = config::get_new();
         config.display.mode = mode;

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -794,10 +794,6 @@ namespace openloco::ui
 
     bool setDisplayMode(config::screen_mode mode, config::resolution_t newResolution)
     {
-        SDL_DisplayMode displayMode;
-        int32_t displayIndex = SDL_GetWindowDisplayIndex(window);
-        SDL_GetDesktopDisplayMode(displayIndex, &displayMode);
-
         // First, set the appropriate screen mode flags.
         auto flags = 0;
         if (mode == config::screen_mode::fullscreen)
@@ -815,14 +811,7 @@ namespace openloco::ui
         // Set the new dimensions of the screen, or just the window.
         if (mode != config::screen_mode::window)
         {
-            displayMode.w = newResolution.width;
-            displayMode.h = newResolution.height;
-
-            if (SDL_SetWindowDisplayMode(window, &displayMode) != 0)
-            {
-                console::error("SDL_SetWindowDisplayMode failed: %s", SDL_GetError());
-                return false;
-            }
+            SDL_SetWindowSize(window, newResolution.width, newResolution.height);
         }
         else
         {

--- a/src/openloco/ui.h
+++ b/src/openloco/ui.h
@@ -78,13 +78,11 @@ namespace openloco::ui
     void render();
     bool process_messages();
     void show_message_box(const std::string& title, const std::string& message);
-    bool updateSDLResolution();
+    bool setDisplayMode(config::screen_mode mode, int16_t width, int16_t height);
+    bool setDisplayMode(config::screen_mode mode);
     void updateFullscreenResolutions();
     std::vector<Resolution> getFullscreenResolutions();
     Resolution getClosestResolution(int32_t inWidth, int32_t inHeight);
-#if true || !(defined(__APPLE__) && defined(__MACH__))
-    void set_screen_mode(config::screen_mode mode);
-#endif
     void handleInput();
     void minimalHandleInput();
     void adjust_window_scale(float adjust_by);

--- a/src/openloco/ui.h
+++ b/src/openloco/ui.h
@@ -8,6 +8,7 @@ namespace openloco::config
 {
     enum class screen_mode;
     struct display_config;
+    struct resolution_t;
 }
 
 namespace openloco::ui
@@ -78,7 +79,7 @@ namespace openloco::ui
     void render();
     bool process_messages();
     void show_message_box(const std::string& title, const std::string& message);
-    bool setDisplayMode(config::screen_mode mode, int16_t width, int16_t height);
+    bool setDisplayMode(config::screen_mode mode, config::resolution_t newResolution);
     bool setDisplayMode(config::screen_mode mode);
     void updateFullscreenResolutions();
     std::vector<Resolution> getFullscreenResolutions();

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -404,7 +404,7 @@ namespace openloco::ui::options
                 return;
 
 #if !(defined(__APPLE__) && defined(__MACH__))
-            openloco::ui::setDisplayMode(new_mode);
+            ui::setDisplayMode(new_mode);
 #endif
         }
 
@@ -433,7 +433,7 @@ namespace openloco::ui::options
             if (index == -1)
                 return;
             std::vector<Resolution> resolutions = getFullscreenResolutions();
-            openloco::ui::setDisplayMode(config::screen_mode::fullscreen, resolutions[index].width, resolutions[index].height);
+            ui::setDisplayMode(config::screen_mode::fullscreen, { resolutions[index].width, resolutions[index].height });
         }
 
 #pragma mark -

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -2146,12 +2146,6 @@ namespace openloco::ui::options
         controls::init_events();
         misc::init_events();
 
-        // Update config fullscreen resolution if not set
-        auto& cfg = config::get();
-        auto& cfg_new = config::get_new();
-        if (!(cfg_new.display.fullscreen_resolution.width > 0 && cfg_new.display.fullscreen_resolution.height > 0 && cfg.resolution_width > 0 && cfg.resolution_height > 0))
-            updateFullscreenResolutions();
-
         // 0x004BF833 (create_options_window)
         window = WindowManager::createWindowCentred(
             WindowType::options,

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -404,9 +404,7 @@ namespace openloco::ui::options
                 return;
 
 #if !(defined(__APPLE__) && defined(__MACH__))
-            ui::set_screen_mode(new_mode);
-            screen_mode_toggle_enabled(w);
-            w->moveToCentre();
+            openloco::ui::setDisplayMode(new_mode);
 #endif
         }
 
@@ -420,11 +418,11 @@ namespace openloco::ui::options
             widget_t dropdown = w->widgets[widx::display_resolution];
             dropdown::show_text_2(w->x + dropdown.left, w->y + dropdown.top, dropdown.width(), dropdown.height(), w->colours[1], resolutions.size(), 0x80);
 
-            auto& cfg = config::get();
+            auto& cfg = config::get_new();
             for (size_t i = 0; i < resolutions.size(); i++)
             {
                 dropdown::add(i, string_ids::dropdown_stringid, { string_ids::display_resolution_dropdown_format, (uint16_t)resolutions[i].width, (uint16_t)resolutions[i].height });
-                if (cfg.resolution_width == resolutions[i].width && cfg.resolution_height == resolutions[i].height)
+                if (cfg.display.fullscreen_resolution.width == resolutions[i].width && cfg.display.fullscreen_resolution.height == resolutions[i].height)
                     dropdown::set_item_selected((int16_t)i);
             }
         }
@@ -434,24 +432,8 @@ namespace openloco::ui::options
         {
             if (index == -1)
                 return;
-
-            auto& config = config::get_new();
-            auto current_res = config.display.fullscreen_resolution;
-
             std::vector<Resolution> resolutions = getFullscreenResolutions();
-            if (current_res.width == resolutions[index].width && current_res.height == resolutions[index].height)
-                return;
-
-            config.display.fullscreen_resolution = { resolutions[index].width, resolutions[index].height };
-
-            auto& old_config = config::get();
-            old_config.resolution_width = resolutions[index].width;
-            old_config.resolution_height = resolutions[index].height;
-
-            openloco::config::write();
-            WindowManager::invalidateWidget(w->type, w->number, widx::display_resolution);
-            openloco::ui::updateSDLResolution();
-            w->moveToCentre();
+            openloco::ui::setDisplayMode(config::screen_mode::fullscreen, resolutions[index].width, resolutions[index].height);
         }
 
 #pragma mark -
@@ -459,7 +441,6 @@ namespace openloco::ui::options
         static void display_scale_mouse_down(window* w, widget_index wi, float adjust_by)
         {
             openloco::ui::adjust_window_scale(adjust_by);
-            w->moveToCentre();
         }
 
         // 0x004BFBB7
@@ -556,8 +537,9 @@ namespace openloco::ui::options
 
             FormatArguments args = {};
             args.skip(0x10);
-            args.push<uint16_t>(config::get().resolution_width);
-            args.push<uint16_t>(config::get().resolution_height);
+            auto& resolution = config::get_new().display.fullscreen_resolution;
+            args.push<uint16_t>(resolution.width);
+            args.push<uint16_t>(resolution.height);
 
             if (config::get().construction_marker)
                 w->widgets[widx::construction_marker].text = string_ids::translucent;
@@ -595,6 +577,8 @@ namespace openloco::ui::options
                 w->disabled_widgets |= (1 << widx::display_scale_up_btn);
             else
                 w->disabled_widgets &= ~(1 << widx::display_scale_up_btn);
+
+            screen_mode_toggle_enabled(w);
 
             sub_4C13BE(w);
         }
@@ -2159,6 +2143,12 @@ namespace openloco::ui::options
         regional::init_events();
         controls::init_events();
         misc::init_events();
+
+        // Update config fullscreen resolution if not set
+        auto& cfg = config::get();
+        auto& cfg_new = config::get_new();
+        if (!(cfg_new.display.fullscreen_resolution.width > 0 && cfg_new.display.fullscreen_resolution.height > 0 && cfg.resolution_width > 0 && cfg.resolution_height > 0))
+            updateFullscreenResolutions();
 
         // 0x004BF833 (create_options_window)
         window = WindowManager::createWindowCentred(

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -578,7 +578,9 @@ namespace openloco::ui::options
             else
                 w->disabled_widgets &= ~(1 << widx::display_scale_up_btn);
 
+#if !(defined(__APPLE__) && defined(__MACH__))
             screen_mode_toggle_enabled(w);
+#endif
 
             sub_4C13BE(w);
         }


### PR DESCRIPTION
Fix Issue #429 , plus implement simple SDL Window display functions.

Implements a brand new function in the `openloco::ui` namespace.
Function name: `setDisplayMode(config::screen_mode mode, int16_t width, int16_t height)`
Function name: `setDisplayMode(config::screen_mode mode)`

This function can be called to change the main program window display type and size.
If you don't specify a width/height, it will use the size last saved to the config, and if that's not there it will fallback to the desktop resolution, or 640x480 for windowed.

Have tested very thoroughly with clear config, and existing config, switching between all different display types and sizes.

I have adjusted the code in the Options Window to use this new function to set display type when the user chooses from either the Screen Type, or Display Resolution dropdowns.
This function is also used when ALT+ENTER is pressed to switch between Windowed and Borderless Fullscreen mode.

Finally, as an added bonus I've made it that the Options window is always moved to the center of the screen no matter how you change the window size (in the options, alt enter, or resizing the window manually.)