### PR TITLE
Fix #430: Null characters added to end of Locomotion path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: [#396] Preferred owner name is not saved.
 - Fix: [#423] Date in challenge tooltip is incorrect.
 - Fix: [#425] Changing resolution in fullscreen mode doesn't work.
+- Fix: [#430] Null-chars added when manually specifying Locomotion directory, preventing launch.
 - Change: [#420] Disable window scale factor buttons when not applicable.
 
 20.03 (2020-03-23)

--- a/src/openloco/platform/platform.windows.cpp
+++ b/src/openloco/platform/platform.windows.cpp
@@ -45,6 +45,7 @@ namespace openloco::platform
             }
             pszPath.resize(pszPath.size() * 2);
         }
+        pszPath.erase(std::find(pszPath.begin(), pszPath.end(), '\0'), pszPath.end());
         return pszPath;
     }
 

--- a/src/openloco/platform/platform.windows.cpp
+++ b/src/openloco/platform/platform.windows.cpp
@@ -45,7 +45,9 @@ namespace openloco::platform
             }
             pszPath.resize(pszPath.size() * 2);
         }
-        pszPath.erase(std::find(pszPath.begin(), pszPath.end(), '\0'), pszPath.end());
+        auto nullBytePos = pszPath.find(L'\0');
+        if (nullBytePos != std::string::npos)
+            pszPath.resize(nullBytePos);
         return pszPath;
     }
 

--- a/src/openloco/platform/platform.windows.cpp
+++ b/src/openloco/platform/platform.windows.cpp
@@ -45,9 +45,11 @@ namespace openloco::platform
             }
             pszPath.resize(pszPath.size() * 2);
         }
+
         auto nullBytePos = pszPath.find(L'\0');
-        if (nullBytePos != std::string::npos)
+        if (nullBytePos != std::wstring::npos)
             pszPath.resize(nullBytePos);
+
         return pszPath;
     }
 


### PR DESCRIPTION
Fix for issue #430 
Removed null characters that are appended to end of the path returned by the Browse dialog in Windows.