### PR TITLE
Issue #77: Add "Exit OpenLoco" to game menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 20.03+ (???)
 ------------------------------------------------------------------------
+- Feature: [#77] Add "Exit OpenLoco" to the main menu.
 - Fix: [#264] Option 'Export plug-in objects with saved games' is partially cut off.
 - Fix: [#388] Re-center Options window on scale factor change.
 - Fix: [#396] Preferred owner name is not saved.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2191,3 +2191,5 @@ strings:
   2136: "{COLOUR WINDOW_2}Zoom to cursor position"
   2137: "{SMALLFONT}{COLOUR BLACK}When enabled, zooming in will centre around the cursor, as opposed to the screen centre."
   2138: "{COLOUR WINDOW_2}Play title screen music"
+  2139: "Quit to menu"
+  2140: "Exit OpenLoco"

--- a/src/openloco/localisation/string_ids.h
+++ b/src/openloco/localisation/string_ids.h
@@ -906,4 +906,7 @@ namespace openloco::string_ids
     constexpr string_id zoom_to_cursor_tip = 2137;
 
     constexpr string_id play_title_music = 2138;
+
+    constexpr string_id menu_quit_to_menu = 2139;
+    constexpr string_id menu_exit_openloco = 2140;
 }

--- a/src/openloco/windows/toolbar_top.cpp
+++ b/src/openloco/windows/toolbar_top.cpp
@@ -120,8 +120,9 @@ namespace openloco::ui::windows::toolbar_top::game
         dropdown::add(4, string_ids::options);
         dropdown::add(5, string_ids::menu_screenshot);
         dropdown::add(6, 0);
-        dropdown::add(7, string_ids::menu_quit_game);
-        dropdown::show_below(window, widgetIndex, 8);
+        dropdown::add(7, string_ids::menu_quit_to_menu);
+        dropdown::add(8, string_ids::menu_exit_openloco);
+        dropdown::show_below(window, widgetIndex, 9);
         dropdown::set_highlighted_item(1);
     }
 
@@ -161,6 +162,11 @@ namespace openloco::ui::windows::toolbar_top::game
             case 7:
                 // Return to title screen
                 game_commands::do_21(0, 1);
+                break;
+
+            case 8:
+                // Exit to desktop
+                game_commands::do_21(0, 2);
                 break;
         }
     }

--- a/src/openloco/windows/toolbar_top_alt.cpp
+++ b/src/openloco/windows/toolbar_top_alt.cpp
@@ -113,8 +113,9 @@ namespace openloco::ui::windows::toolbar_top::editor
         dropdown::add(4, string_ids::options);
         dropdown::add(5, string_ids::menu_screenshot);
         dropdown::add(6, 0);
-        dropdown::add(7, string_ids::menu_quit_scenario_editor);
-        dropdown::show_below(window, widgetIndex, 8);
+        dropdown::add(7, string_ids::menu_quit_to_menu);
+        dropdown::add(8, string_ids::menu_exit_openloco);
+        dropdown::show_below(window, widgetIndex, 9);
         dropdown::set_highlighted_item(1);
     }
 
@@ -154,6 +155,11 @@ namespace openloco::ui::windows::toolbar_top::editor
             case 7:
                 // Return to title screen
                 game_commands::do_21(0, 1);
+                break;
+
+            case 8:
+                // Exit to desktop
+                game_commands::do_21(0, 2);
                 break;
         }
     }


### PR DESCRIPTION
Issue #77 : Add "Exit OpenLoco" to game menu

- Adds "Exit OpenLoco" to the in-game Load/Save menu.
- Changes existing "Quit Game" menu item to "Quit to menu"
- Changes existing "Quit Scenario Editor" menu item to "Quit to menu"

This is all matched to what OpenRCT2 says.