### PR TITLE
Fix #467: Incorrect scrolling thumbs on auto resize windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#77] Add "Exit OpenLoco" to the main menu.
 - Fix: [#264] Option 'Export plug-in objects with saved games' is partially cut off.
+- Fix: [#359] Widgets tied to tools could get stuck in pressed state.
 - Fix: [#388] Re-center Options window on scale factor change.
 - Fix: [#396] Preferred owner name is not saved.
 - Fix: [#412] Game crashes after a while on Great Britain & Ireland 1930.
@@ -10,7 +11,7 @@
 - Fix: [#428] Show an error when a vehicle can't be built due to invalid properties. (Original bug.)
 - Fix: [#430] Null-chars added when manually specifying Locomotion directory, preventing launch.
 - Fix: [#440] Final segment in town population graphs could show no population.
-- Fix: [#359] Widgets tied to tools could get stuck in pressed state.
+- Fix: [#467] Incorrect scrolling thumbs when leaving the bottom of an auto resizing window.
 - Change: [#420] Disable window scale factor buttons when not applicable.
 
 20.03 (2020-03-23)

--- a/src/openloco/window.cpp
+++ b/src/openloco/window.cpp
@@ -216,8 +216,6 @@ namespace openloco::ui
     // 0x004C6456
     void window::viewports_update_position()
     {
-        this->call_on_resize();
-
         for (int i = 0; i < 2; i++)
         {
             viewport* viewport = this->viewports[i];
@@ -227,6 +225,7 @@ namespace openloco::ui
             {
                 continue;
             }
+            this->call_on_resize();
 
             int16_t centreX, centreY;
 


### PR DESCRIPTION
This tiny change represents a good many hours of bug finding.