### PR TITLE
Rename three misnamed string ids

### DIFF
--- a/src/openloco/localisation/string_ids.h
+++ b/src/openloco/localisation/string_ids.h
@@ -210,12 +210,12 @@ namespace openloco::string_ids
     constexpr string_id dropdown_without_checkmark = 443;
     constexpr string_id dropdown_with_checkmark = 444;
 
-    constexpr string_id outlined_wcolour2_stringid2 = 450;
+    constexpr string_id outlined_wcolour2_stringid = 450;
 
     constexpr string_id red_stringid = 454;
-    constexpr string_id white_stringid2 = 455;
+    constexpr string_id black_stringid = 455;
 
-    constexpr string_id wcolour2_stringid2 = 457;
+    constexpr string_id wcolour2_stringid = 457;
 
     constexpr string_id audio_device_none = 479;
     constexpr string_id stringptr = 480;

--- a/src/openloco/windows/CompanyWindow.cpp
+++ b/src/openloco/windows/CompanyWindow.cpp
@@ -228,7 +228,7 @@ namespace openloco::ui::windows::CompanyWindow
                     &origin,
                     widget.right - widget.left,
                     colour::black,
-                    string_ids::white_stringid2,
+                    string_ids::black_stringid,
                     &args);
             }
 
@@ -250,7 +250,7 @@ namespace openloco::ui::windows::CompanyWindow
                     self->y + widget.top - 1,
                     widget.right - widget.left,
                     colour::black,
-                    string_ids::white_stringid2,
+                    string_ids::black_stringid,
                     &args);
             }
 
@@ -1658,7 +1658,7 @@ namespace openloco::ui::windows::CompanyWindow
                     self->x + 5,
                     y - 1,
                     colour::black,
-                    string_ids::wcolour2_stringid2,
+                    string_ids::wcolour2_stringid,
                     &args);
 
                 y += 10;
@@ -1746,10 +1746,10 @@ namespace openloco::ui::windows::CompanyWindow
             args.push(string_ids::uint16_raw);
             args.push(columnYear);
 
-            string_id format = string_ids::wcolour2_stringid2;
+            string_id format = string_ids::wcolour2_stringid;
             if (columnYear != currentYear)
             {
-                format = string_ids::white_stringid2;
+                format = string_ids::black_stringid;
             }
 
             gfx::draw_string_underline(
@@ -1770,7 +1770,7 @@ namespace openloco::ui::windows::CompanyWindow
                 currency48_t expenditures = company.expenditures[columnIndex][j];
                 sum += expenditures;
 
-                string_id mainFormat = string_ids::white_stringid2;
+                string_id mainFormat = string_ids::black_stringid;
                 string_id currFormat = string_ids::plus_currency48;
                 if (expenditures < 0)
                 {
@@ -1802,7 +1802,7 @@ namespace openloco::ui::windows::CompanyWindow
         {
             FormatArguments args{};
 
-            auto mainFormat = string_ids::white_stringid2;
+            auto mainFormat = string_ids::black_stringid;
             auto sumFormat = string_ids::plus_currency48;
             if (sum < 0)
             {
@@ -2117,7 +2117,7 @@ namespace openloco::ui::windows::CompanyWindow
                     self->x + 10,
                     y,
                     colour::black,
-                    string_ids::white_stringid2,
+                    string_ids::black_stringid,
                     &args);
 
                 numPrinted++;

--- a/src/openloco/windows/IndustryWindow.cpp
+++ b/src/openloco/windows/IndustryWindow.cpp
@@ -147,7 +147,7 @@ namespace openloco::ui::windows::industry
             auto x = self->x + widget->left - 1;
             auto y = self->y + widget->top - 1;
             auto width = widget->width();
-            gfx::draw_string_494BBF(*dpi, x, y, width, colour::black, string_ids::white_stringid2, &args);
+            gfx::draw_string_494BBF(*dpi, x, y, width, colour::black, string_ids::black_stringid, &args);
         }
 
         // 0x00455C86
@@ -484,7 +484,7 @@ namespace openloco::ui::windows::industry
                         }
                         args.push<uint32_t>(industry->required_cargo_quantity[cargoNumber]);
 
-                        origin.y = gfx::draw_string_495224(*dpi, origin.x, origin.y, 290, colour::black, string_ids::white_stringid2, &args);
+                        origin.y = gfx::draw_string_495224(*dpi, origin.x, origin.y, 290, colour::black, string_ids::black_stringid, &args);
                     }
                     cargoNumber++;
                 }

--- a/src/openloco/windows/KeyboardShortcuts.cpp
+++ b/src/openloco/windows/KeyboardShortcuts.cpp
@@ -108,11 +108,11 @@ namespace openloco::ui::KeyboardShortcuts
         auto yPos = 0;
         for (auto i = 0; i < self->row_count; i++)
         {
-            string_id format = string_ids::white_stringid2;
+            string_id format = string_ids::black_stringid;
             if (i == self->row_hover)
             {
                 gfx::draw_rect(dpi, 0, yPos, 800, rowHeight, 0x2000030);
-                format = string_ids::wcolour2_stringid2;
+                format = string_ids::wcolour2_stringid;
             }
 
             _commonFormatArgs[1] = ShortcutManager::getName(static_cast<Shortcut>(i));

--- a/src/openloco/windows/LandscapeGeneration.cpp
+++ b/src/openloco/windows/LandscapeGeneration.cpp
@@ -431,7 +431,7 @@ namespace openloco::ui::windows::LandscapeGeneration
 
                 // Draw land description.
                 commonFormatArgs[0] = landObject->name;
-                gfx::draw_string_494BBF(*dpi, 24, yPos + 5, 121, colour::black, string_ids::wcolour2_stringid2, &*commonFormatArgs);
+                gfx::draw_string_494BBF(*dpi, 24, yPos + 5, 121, colour::black, string_ids::wcolour2_stringid, &*commonFormatArgs);
 
                 // Draw rectangle.
                 gfx::fill_rect_inset(dpi, 150, yPos + 5, 340, yPos + 16, window->colours[1], 0b110000);
@@ -439,7 +439,7 @@ namespace openloco::ui::windows::LandscapeGeneration
                 // Draw current distribution setting.
                 const string_id distributionId = landDistributionLabelIds[s5::getOptions().landDistributionPatterns[i]];
                 commonFormatArgs[0] = distributionId;
-                gfx::draw_string_494BBF(*dpi, 151, yPos + 5, 177, colour::black, string_ids::white_stringid2, &*commonFormatArgs);
+                gfx::draw_string_494BBF(*dpi, 151, yPos + 5, 177, colour::black, string_ids::black_stringid, &*commonFormatArgs);
 
                 // Draw rectangle (knob).
                 const uint8_t flags = window->row_hover == i ? 0b110000 : 0;

--- a/src/openloco/windows/LandscapeGenerationConfirm.cpp
+++ b/src/openloco/windows/LandscapeGenerationConfirm.cpp
@@ -44,7 +44,7 @@ namespace openloco::ui::windows::LandscapeGenerationConfirm
         *commonFormatArgs = prompt;
 
         auto origin = gfx::point_t(window->x + (window->width / 2), window->y + 41);
-        gfx::draw_string_centred_wrapped(dpi, &origin, window->width, colour::black, string_ids::wcolour2_stringid2, (const char*)&*commonFormatArgs);
+        gfx::draw_string_centred_wrapped(dpi, &origin, window->width, colour::black, string_ids::wcolour2_stringid, (const char*)&*commonFormatArgs);
     }
 
     // 0x004C18E4

--- a/src/openloco/windows/ScenarioOptions.cpp
+++ b/src/openloco/windows/ScenarioOptions.cpp
@@ -1037,7 +1037,7 @@ namespace openloco::ui::windows::ScenarioOptions
                     commonFormatArgs[0] = stex->details;
 
                 auto& target = window->widgets[widx::change_details_btn];
-                gfx::draw_string_495224(*dpi, window->x + 16, window->y + 12 + target.top, target.left - 26, colour::black, string_ids::white_stringid2, &*commonFormatArgs);
+                gfx::draw_string_495224(*dpi, window->x + 16, window->y + 12 + target.top, target.left - 26, colour::black, string_ids::black_stringid, &*commonFormatArgs);
             }
         }
 

--- a/src/openloco/windows/build_vehicle.cpp
+++ b/src/openloco/windows/build_vehicle.cpp
@@ -1182,11 +1182,11 @@ namespace openloco::ui::build_vehicle
                             continue;
                         }
 
-                        auto colouredString = string_ids::white_stringid2;
+                        auto colouredString = string_ids::black_stringid;
                         if (window->row_hover == vehicleType)
                         {
                             gfx::fill_rect(dpi, 0, y, window->width, y + window->row_height - 1, 0x2000030);
-                            colouredString = string_ids::wcolour2_stringid2;
+                            colouredString = string_ids::wcolour2_stringid;
                         }
 
                         int16_t half = (window->row_height - 22) / 2;
@@ -1234,7 +1234,7 @@ namespace openloco::ui::build_vehicle
                 *buffer++ = '\0';
                 FormatArguments args{};
                 args.push(string_ids::buffer_1250);
-                gfx::draw_string_centred_clipped(*dpi, 89, 52, 177, 0x20, string_ids::wcolour2_stringid2, &args);
+                gfx::draw_string_centred_clipped(*dpi, 89, 52, 177, 0x20, string_ids::wcolour2_stringid, &args);
                 break;
             }
         }

--- a/src/openloco/windows/industry_list.cpp
+++ b/src/openloco/windows/industry_list.cpp
@@ -140,7 +140,7 @@ namespace openloco::ui::windows::industry_list
                 args.push(string_ids::status_num_industries_plural);
             args.push(self->var_83C);
 
-            gfx::draw_string_494B3F(*dpi, xPos, yPos, colour::black, string_ids::white_stringid2, &args);
+            gfx::draw_string_494B3F(*dpi, xPos, yPos, colour::black, string_ids::black_stringid, &args);
         }
 
         // 0x00457EC4
@@ -393,13 +393,13 @@ namespace openloco::ui::windows::industry_list
                     continue;
                 }
 
-                string_id text_colour_id = string_ids::white_stringid2;
+                string_id text_colour_id = string_ids::black_stringid;
 
                 // Highlight selection.
                 if (industryId == self->row_hover)
                 {
                     gfx::draw_rect(dpi, 0, yPos, self->width, rowHeight, 0x2000030);
-                    text_colour_id = string_ids::wcolour2_stringid2;
+                    text_colour_id = string_ids::wcolour2_stringid;
                 }
 
                 if (industryId == 0xFFFF)
@@ -663,7 +663,7 @@ namespace openloco::ui::windows::industry_list
             auto yPos = self->y + self->height - 13;
             auto width = self->width - 19 - widthOffset;
 
-            gfx::draw_string_494BBF(*dpi, xPos, yPos, width, colour::black, string_ids::white_stringid2, &industryObj->name);
+            gfx::draw_string_494BBF(*dpi, xPos, yPos, width, colour::black, string_ids::black_stringid, &industryObj->name);
         }
 
         // 0x0045843A

--- a/src/openloco/windows/music_selection.cpp
+++ b/src/openloco/windows/music_selection.cpp
@@ -107,13 +107,13 @@ namespace openloco::ui::windows::music_selection
         uint16_t y = 0;
         for (uint16_t i = 0; i < window->row_count; i++)
         {
-            string_id text_colour_id = string_ids::white_stringid2;
+            string_id text_colour_id = string_ids::black_stringid;
 
             // Draw hovered track
             if (i == window->row_hover)
             {
                 gfx::draw_rect(dpi, 0, y, 800, rowHeight, 0x2000030);
-                text_colour_id = string_ids::wcolour2_stringid2;
+                text_colour_id = string_ids::wcolour2_stringid;
             }
 
             // Draw checkbox.
@@ -121,7 +121,7 @@ namespace openloco::ui::windows::music_selection
 
             // Draw checkmark if track is enabled.
             if (config.enabled_music[i])
-                gfx::draw_string_494B3F(*dpi, 2, y, window->colours[1], string_ids::wcolour2_stringid2, (void*)&string_ids::checkmark);
+                gfx::draw_string_494B3F(*dpi, 2, y, window->colours[1], string_ids::wcolour2_stringid, (void*)&string_ids::checkmark);
 
             // Draw track name.
             string_id music_title_id = audio::getMusicInfo(i)->title_id;

--- a/src/openloco/windows/promptbrowsewnd.cpp
+++ b/src/openloco/windows/promptbrowsewnd.cpp
@@ -376,7 +376,7 @@ namespace openloco::ui::prompt_browse
                     y,
                     width,
                     0,
-                    string_ids::wcolour2_stringid2,
+                    string_ids::wcolour2_stringid,
                     _commonFormatArgs);
                 y += 12;
 
@@ -512,7 +512,7 @@ namespace openloco::ui::prompt_browse
         // Draw text box text
         gfx::point_t origin = { 0, 1 };
         set_common_args_stringptr(text);
-        gfx::draw_string_494B3F(dpi, &origin, 0, string_ids::white_stringid2, _commonFormatArgs);
+        gfx::draw_string_494B3F(dpi, &origin, 0, string_ids::black_stringid, _commonFormatArgs);
 
         if (showCaret)
         {
@@ -528,7 +528,7 @@ namespace openloco::ui::prompt_browse
                 gbuffer = std::string_view(text, caret);
                 set_common_args_stringptr(gbuffer.c_str());
                 origin = { 0, 1 };
-                gfx::draw_string_494B3F(dpi, &origin, 0, string_ids::white_stringid2, _commonFormatArgs);
+                gfx::draw_string_494B3F(dpi, &origin, 0, string_ids::black_stringid, _commonFormatArgs);
 
                 // Draw vertical caret
                 gfx::draw_rect(&dpi, origin.x, origin.y, 1, 9, byte_1136C99[window->colours[1] * 8]);
@@ -556,11 +556,11 @@ namespace openloco::ui::prompt_browse
                 auto file = _files[i];
 
                 // Draw the row highlight
-                auto stringId = string_ids::white_stringid2;
+                auto stringId = string_ids::black_stringid;
                 if (i == window->var_85A)
                 {
                     gfx::draw_rect(dpi, 0, y, window->width, lineHeight, 0x2000000 | 48);
-                    stringId = string_ids::wcolour2_stringid2;
+                    stringId = string_ids::wcolour2_stringid;
                 }
 
                 // Draw the folder icon

--- a/src/openloco/windows/station_list.cpp
+++ b/src/openloco/windows/station_list.cpp
@@ -486,13 +486,13 @@ namespace openloco::ui::windows::station_list
                 continue;
             }
 
-            string_id text_colour_id = string_ids::white_stringid2;
+            string_id text_colour_id = string_ids::black_stringid;
 
             // Highlight selection.
             if (stationId == window->row_hover)
             {
                 gfx::draw_rect(dpi, 0, yPos, window->width, rowHeight, 0x2000030);
-                text_colour_id = string_ids::wcolour2_stringid2;
+                text_colour_id = string_ids::wcolour2_stringid;
             }
 
             auto station = stationmgr::get(stationId);
@@ -598,7 +598,7 @@ namespace openloco::ui::windows::station_list
 
         // Draw number of stations.
         auto origin = gfx::point_t(window->x + 4, window->y + window->height - 12);
-        gfx::draw_string_494B3F(*dpi, &origin, colour::black, string_ids::white_stringid2, &*_common_format_args);
+        gfx::draw_string_494B3F(*dpi, &origin, colour::black, string_ids::black_stringid, &*_common_format_args);
     }
 
     // 0x004917BB

--- a/src/openloco/windows/stationwnd.cpp
+++ b/src/openloco/windows/stationwnd.cpp
@@ -128,7 +128,7 @@ namespace openloco::ui::windows::station
             const auto x = self->x + widget.left - 1;
             const auto y = self->y + widget.top - 1;
             const auto width = widget.width() - 1;
-            gfx::draw_string_494BBF(*dpi, x, y, width, colour::black, string_ids::white_stringid2, &args);
+            gfx::draw_string_494BBF(*dpi, x, y, width, colour::black, string_ids::black_stringid, &args);
         }
 
         // 0x0048E4D4
@@ -543,7 +543,7 @@ namespace openloco::ui::windows::station
             {
                 auto args = FormatArguments();
                 args.push(string_ids::nothing_waiting);
-                gfx::draw_string_494B3F(*dpi, 1, 0, colour::black, string_ids::white_stringid2, &args);
+                gfx::draw_string_494B3F(*dpi, 1, 0, colour::black, string_ids::black_stringid, &args);
             }
         }
 
@@ -681,7 +681,7 @@ namespace openloco::ui::windows::station
                 }
 
                 auto cargoObj = objectmgr::get<cargo_object>(cargoId);
-                gfx::draw_string_494BBF(*dpi, 1, y, 98, 0, string_ids::wcolour2_stringid2, &cargoObj->name);
+                gfx::draw_string_494BBF(*dpi, 1, y, 98, 0, string_ids::wcolour2_stringid, &cargoObj->name);
 
                 auto rating = cargo.rating;
                 auto colour = colour::moss_green;

--- a/src/openloco/windows/textinputwnd.cpp
+++ b/src/openloco/windows/textinputwnd.cpp
@@ -253,7 +253,7 @@ namespace openloco::ui::textinput
         memcpy(&_commonFormatArgs[2], _formatArgs + 8, 8);
 
         gfx::point_t position = { (int16_t)(window->x + window->width / 2), (int16_t)(window->y + 30) };
-        gfx::draw_string_centred_wrapped(context, &position, window->width - 8, 0, string_ids::wcolour2_stringid2, &_commonFormatArgs[0]);
+        gfx::draw_string_centred_wrapped(context, &position, window->width - 8, 0, string_ids::wcolour2_stringid, &_commonFormatArgs[0]);
 
         auto widget = &_widgets[widx::input];
         gfx::drawpixelinfo_t* clipped = nullptr;
@@ -268,7 +268,7 @@ namespace openloco::ui::textinput
         *((string_id*)(&_commonFormatArgs[0])) = string_ids::buffer_2039;
 
         position = { _xOffset, 1 };
-        gfx::draw_string_494B3F(*clipped, &position, 0, string_ids::white_stringid2, _commonFormatArgs);
+        gfx::draw_string_494B3F(*clipped, &position, 0, string_ids::black_stringid, _commonFormatArgs);
 
         if ((_cursorFrame % 32) >= 16)
         {
@@ -280,7 +280,7 @@ namespace openloco::ui::textinput
 
         *((string_id*)(&_commonFormatArgs[0])) = string_ids::buffer_2039;
         position = { _xOffset, 1 };
-        gfx::draw_string_494B3F(*clipped, &position, 0, string_ids::white_stringid2, _commonFormatArgs);
+        gfx::draw_string_494B3F(*clipped, &position, 0, string_ids::black_stringid, _commonFormatArgs);
         gfx::fill_rect(clipped, position.x, position.y, position.x, position.y + 9, colour::get_shade(window->colours[1], 9));
     }
 

--- a/src/openloco/windows/title_options.cpp
+++ b/src/openloco/windows/title_options.cpp
@@ -64,7 +64,7 @@ namespace openloco::ui::title_options
         int16_t y = window->y + window->widgets[widx::options_button].top + 2;
         gfx::point_t origin = { x, y };
 
-        gfx::draw_string_centred_wrapped(dpi, &origin, window->width, colour::white, string_ids::outlined_wcolour2_stringid2, (const char*)&string_ids::options);
+        gfx::draw_string_centred_wrapped(dpi, &origin, window->width, colour::white, string_ids::outlined_wcolour2_stringid, (const char*)&string_ids::options);
     }
 
     static void on_mouse_up(window* window, widget_index widgetIndex)


### PR DESCRIPTION
At the core of this PR is the following diff:

```diff
-    constexpr string_id outlined_wcolour2_stringid2 = 450;
+    constexpr string_id outlined_wcolour2_stringid = 450;

-    constexpr string_id white_stringid2 = 455;
+    constexpr string_id black_stringid = 455;

-    constexpr string_id wcolour2_stringid2 = 457;
+    constexpr string_id wcolour2_stringid = 457;
```

When the original dump for the en-GB strings was made, certain assumptions were made with the OpenRCT2 format codes in mind. Implementing the string formatting functions revealed some of these were incorrect.

These incorrect string names have been bothering me for a while. Hopefully there aren't any conflicts with outstanding PRs at this time.