### PR TITLE
Refactor industry::update

### DIFF
--- a/src/openloco/industry.cpp
+++ b/src/openloco/industry.cpp
@@ -119,69 +119,82 @@ namespace openloco
         if (!(flags & industry_flags::flag_01) && under_construction == 0xFF)
         {
             // Run tile loop for 100 iterations
-            auto obj = object();
             for (int i = 0; i < 100; i++)
             {
-                const auto& surface = tilemgr::get(tile_loop.current()).surface();
-                if (surface != nullptr)
-                {
-                    if (surface->data()[0] & 0x80)
-                    {
-                        if (surface->industry_id() == id())
-                        {
-                            uint8_t bl = surface->data()[6] >> 5;
-                            if (bl == 0 || bl != obj->var_EA)
-                            {
-                                var_DB++;
-                                if ((!(obj->flags & industry_object_flags::flag_29) && (surface->data()[4] & 0xE0) == 0) || find_5(surface))
-                                {
-                                    var_DD++;
-                                }
-                            }
-                        }
-                    }
-                }
+                sub_45329B(tile_loop.current());
                 if (tile_loop.next() == map_pos())
                 {
-                    int16_t tmp_a = var_DB / 16;
-                    int16_t tmp_b = std::max(0, var_DD - tmp_a);
-                    int16_t tmp_c = var_DB - tmp_b;
-                    int16_t tmp_d = std::min(tmp_c / 25, 255);
-                    if (tmp_d < obj->var_EB)
-                    {
-                        var_DF = tmp_d / obj->var_EB;
-                    }
-                    else
-                    {
-                        var_DF = 255;
-                    }
-
-                    var_DB = 0;
-                    var_DD = 0;
-                    if (var_DF < 224)
-                    {
-                        if (produced_cargo_quantity[0] / 8 <= produced_cargo_max[0] || produced_cargo_quantity[1] / 8 <= produced_cargo_max[1])
-                        {
-                            if (prng.rand_bool())
-                            {
-                                map::map_pos randTile{ static_cast<coord_t>(x + (prng.rand_next(-15, 16) * 32)), static_cast<coord_t>(y + (prng.rand_next(-15, 16) * 32)) };
-                                uint8_t bl = obj->var_ED;
-                                uint8_t bh = obj->var_EE;
-                                if (obj->var_EF != 0xFF && prng.rand_bool())
-                                {
-                                    bl = obj->var_EF;
-                                    bh = obj->var_F0;
-                                }
-                                uint8_t dl = prng.rand_next(7) * 32;
-                                sub_454A43(randTile, bl, bh, dl);
-                            }
-                        }
-                    }
+                    sub_453354();
                     break;
                 }
             }
         }
     }
+
+    // 0x0045329B
+    void industry::sub_45329B(const map_pos& pos)
+    {
+        const auto& surface = tilemgr::get(pos).surface();
+        if (surface != nullptr)
+        {
+            if (surface->has_high_type_flag())
+            {
+                if (surface->industry_id() == id())
+                {
+                    uint8_t bl = surface->var_6_SLR5();
+                    auto obj = object();
+                    if (bl == 0 || bl != obj->var_EA)
+                    {
+                        var_DB++;
+                        if ((!(obj->flags & industry_object_flags::flag_28) && surface->var_4_E0() == 0) || find_5(surface))
+                        {
+                            var_DD++;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    void industry::sub_453354()
+    {
+        auto obj = object();
+        int16_t tmp_a = var_DB / 16;
+        int16_t tmp_b = std::max(0, var_DD - tmp_a);
+        int16_t tmp_c = var_DB - tmp_b;
+        int16_t tmp_d = std::min(tmp_c / 25, 255);
+        if (tmp_d < obj->var_EB)
+        {
+            var_DF = tmp_d / obj->var_EB;
+        }
+        else
+        {
+            var_DF = 255;
+        }
+
+        var_DB = 0;
+        var_DD = 0;
+        if (var_DF < 224)
+        {
+            if (produced_cargo_quantity[0] / 8 <= produced_cargo_max[0] || produced_cargo_quantity[1] / 8 <= produced_cargo_max[1])
+            {
+                if (prng.rand_bool())
+                {
+                    map::map_pos randTile{ static_cast<coord_t>(x + (prng.rand_next(-15, 16) * 32)), static_cast<coord_t>(y + (prng.rand_next(-15, 16) * 32)) };
+                    uint8_t bl = obj->var_ED;
+                    uint8_t bh = obj->var_EE;
+                    if (obj->var_EF != 0xFF && prng.rand_bool())
+                    {
+                        bl = obj->var_EF;
+                        bh = obj->var_F0;
+                    }
+                    uint8_t dl = prng.rand_next(7) * 32;
+                    sub_454A43(randTile, bl, bh, dl);
+                }
+            }
+        }
+    }
+
     void industry::sub_454A43(map_pos pos, uint8_t bl, uint8_t bh, uint8_t dl)
     {
         registers regs;

--- a/src/openloco/industry.h
+++ b/src/openloco/industry.h
@@ -65,6 +65,8 @@ namespace openloco
         void getStatusString(const char* buffer);
 
         void update();
+        void sub_45329B(const map_pos& pos);
+        void sub_453354();
         void sub_454A43(map_pos pos, uint8_t bl, uint8_t bh, uint8_t dl);
     };
 #pragma pack(pop)

--- a/src/openloco/industrymgr.cpp
+++ b/src/openloco/industrymgr.cpp
@@ -38,8 +38,6 @@ namespace openloco::industrymgr
                 }
             }
         }
-
-        call(0x00453234);
     }
 
     // 0x0045383B

--- a/src/openloco/map/tile.h
+++ b/src/openloco/map/tile.h
@@ -109,6 +109,7 @@ namespace openloco::map
         uint8_t base_z() const { return _base_z; }
         uint8_t clear_z() const { return _clear_z; }
 
+        bool has_high_type_flag() const { return _type & 0x80; }
         bool is_flag_4() const { return _flags & element_flags::flag_4; }
         void set_flag_6() { _flags |= element_flags::flag_6; }
         bool is_last() const;
@@ -175,8 +176,10 @@ namespace openloco::map
         bool is_slope_dbl_height() const { return _slope & surface_slope::double_height; }
         uint8_t slope_corners() const { return _slope & 0x0F; }
         uint8_t slope() const { return _slope & 0x1F; }
+        uint8_t var_4_E0() const { return _slope & 0xE0; }
         uint8_t water() const { return _water & 0x1F; }
         uint8_t terrain() const { return _terrain & 0x1F; }
+        uint8_t var_6_SLR5() const { return _terrain >> 5; }
         uint8_t industry_id() const { return _industry; }
         void createWave(int16_t x, int16_t y, int animationIndex);
     };

--- a/src/openloco/objects/industry_object.h
+++ b/src/openloco/objects/industry_object.h
@@ -9,7 +9,7 @@ namespace openloco
         constexpr uint32_t built_on_water = 1 << 8;
         constexpr uint32_t can_be_founded_by_user = 1 << 16;
         constexpr uint32_t requires_all_cargo = 1 << 17;
-        constexpr uint32_t flag_29 = 1 << 28;
+        constexpr uint32_t flag_28 = 1 << 28;
     }
 #pragma pack(push, 1)
     struct industry_object


### PR DESCRIPTION
* Fix industrymgr::update being called twice in a tick.
* Move some of the surface tile element operations to property methods.
* Extract code into smaller functions.