### PR TITLE
Fix #409. Incorrect refund cost when deleting signals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: [#359] Widgets tied to tools could get stuck in pressed state.
 - Fix: [#388] Re-center Options window on scale factor change.
 - Fix: [#396] Preferred owner name is not saved.
+- Fix: [#409] Incorrect refund cost when deleting signals.
 - Fix: [#412] Game crashes after a while on Great Britain & Ireland 1930.
 - Fix: [#423] Date in challenge tooltip is incorrect.
 - Fix: [#425] Changing resolution in fullscreen mode doesn't work.

--- a/src/openloco/GameCommands.cpp
+++ b/src/openloco/GameCommands.cpp
@@ -115,7 +115,7 @@ namespace openloco::game_commands
         int32_t ebx = fnRegs1.ebx;
         _gameCommandFlags = flagsBackup;
 
-        if (ebx != 0x80000000)
+        if (ebx != static_cast<int32_t>(0x80000000))
         {
             if (is_editor_mode())
                 ebx = 0;
@@ -134,7 +134,7 @@ namespace openloco::game_commands
             }
         }
 
-        if (ebx == 0x80000000)
+        if (ebx == static_cast<int32_t>(0x80000000))
         {
             if (flags & GameCommandFlag::apply)
             {
@@ -159,7 +159,7 @@ namespace openloco::game_commands
         int32_t ebx2 = fnRegs2.ebx;
         _gameCommandFlags = flagsBackup2;
 
-        if (ebx2 == 0x80000000)
+        if (ebx2 == static_cast<int32_t>(0x80000000))
         {
             return loc_4314EA();
         }

--- a/src/openloco/GameCommands.cpp
+++ b/src/openloco/GameCommands.cpp
@@ -112,7 +112,7 @@ namespace openloco::game_commands
         registers fnRegs1 = regs;
         fnRegs1.bl &= ~GameCommandFlag::apply;
         call(addr, fnRegs1);
-        uint32_t ebx = fnRegs1.ebx;
+        int32_t ebx = fnRegs1.ebx;
         _gameCommandFlags = flagsBackup;
 
         if (ebx != 0x80000000)
@@ -156,7 +156,7 @@ namespace openloco::game_commands
         uint16_t flagsBackup2 = _gameCommandFlags;
         registers fnRegs2 = regs;
         call(addr, fnRegs2);
-        uint32_t ebx2 = fnRegs2.ebx;
+        int32_t ebx2 = fnRegs2.ebx;
         _gameCommandFlags = flagsBackup2;
 
         if (ebx2 == 0x80000000)

--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -784,6 +784,9 @@ void openloco::interop::register_hooks()
             return 0;
         });
 
+    /* This can be removed after implementing signal place and remove game commands.
+     * It fixes an original bug with those two game commands.
+     */
     register_hook(
         0x004A2AD7,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
@@ -794,6 +797,7 @@ void openloco::interop::register_hooks()
 
             // Set ebp register to a nice large non-negative number.
             // This fixes exorbitant prices for signals on Linux and macOS.
+            // Value must be greater than the cost for placing a signal.
             regs.ebp = 0xC0FFEE;
             return 0;
         });

--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -785,6 +785,20 @@ void openloco::interop::register_hooks()
         });
 
     register_hook(
+        0x004A2AD7,
+        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            addr<0x001135F88, uint16_t>() = 0;
+            regs.esi = 0x004A2AF0;
+            regs.edi = 0x004A2CE7;
+            call(0x004A2E46, regs);
+
+            // Set ebp register to a nice large non-negative number.
+            // This fixes exorbitant prices for signals on Linux and macOS.
+            regs.ebp = 0xC0FFEE;
+            return 0;
+        });
+
+    register_hook(
         0x004CA4DF,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             registers backup = regs;


### PR DESCRIPTION
Fix #409. Incorrect refund cost when deleting signals.

The cost had incorrectly been marked as unsigned which caused a comparison to fail. It looks like there is an original bug that caused signal deletion to return a pointer to the stack instead of the cost which due to the incorrect cost check caused a very large number to be taken as the cost.