### PR TITLE
Change phrasing for environment::get_path error

### DIFF
--- a/src/openloco/environment.cpp
+++ b/src/openloco/environment.cpp
@@ -153,15 +153,14 @@ namespace openloco::environment
             auto similarResult = find_similar_file(result);
             if (similarResult.empty())
             {
-                std::cerr << "File not found: " << result << std::endl;
+                std::cerr << "Warning: file " << result << " could not be not found" << std::endl;
             }
             else
             {
                 result = similarResult;
             }
 #else
-
-            std::cerr << "File not found: " << result << std::endl;
+            std::cerr << "Warning: file " << result << " could not be not found" << std::endl;
 #endif
         }
         return result;


### PR DESCRIPTION
When launching for the first time, `game.cfg` is saved at the first opportunity. However, until then, reading this config file will fail with a console warning. There was some confusion in #299 as to whether this was cause for failing to load the game. Perhaps rephrasing the warning would solve this.

The following message on master:
> File not found: "/home/aaron/.config/OpenLoco/game.cfg"

Is changed by this PR to read:
> Warning: file "/home/aaron/.config/OpenLoco/game.cfg" could not be not found