### PR TITLE
Clean up game commands

### DIFF
--- a/src/openloco/game_commands.h
+++ b/src/openloco/game_commands.h
@@ -43,6 +43,19 @@ namespace openloco::game_commands
         do_command(9, regs);
     }
 
+    // Change Station name
+    inline void do_11(uint16_t cx, uint16_t ax, uint32_t edx, uint32_t ebp, uint32_t edi)
+    {
+        registers regs;
+        regs.bl = GameCommandFlag::apply;
+        regs.cx = cx;   // station number or 0
+        regs.ax = ax;   // [ 0, 1, 2]
+        regs.edx = edx; // part of name buffer
+        regs.ebp = ebp; // part of name buffer
+        regs.edi = edi; // part of name buffer
+        do_command(11, regs);
+    }
+
     // Change company colour scheme
     inline void do_19(int8_t isPrimary, int8_t value, int8_t colourType, int8_t setColourMode, uint8_t companyId)
     {
@@ -64,19 +77,6 @@ namespace openloco::game_commands
         }
 
         do_command(19, regs);
-    }
-
-    //Change Station name
-    inline void do_11(uint16_t cx, uint16_t ax, uint32_t edx, uint32_t ebp, uint32_t edi)
-    {
-        registers regs;
-        regs.bl = GameCommandFlag::apply;
-        regs.cx = cx;   // station number or 0
-        regs.ax = ax;   // [ 0, 1, 2]
-        regs.edx = edx; // part of name buffer
-        regs.ebp = ebp; // part of name buffer
-        regs.edi = edi; // part of name buffer
-        do_command(11, regs);
     }
 
     inline void do_20()
@@ -133,6 +133,22 @@ namespace openloco::game_commands
         do_command(46, regs);
     }
 
+    inline bool do_48(uint8_t bl, uint8_t industryId)
+    {
+        registers regs;
+        regs.bl = bl; // [ 1 = remove industry]
+        regs.dx = industryId;
+        return do_command(48, regs) != GameCommandFlag::failure;
+    }
+
+    inline bool do_50(uint8_t bl, uint8_t townId)
+    {
+        registers regs;
+        regs.bl = bl; // [ 1 = remove town]
+        regs.edi = townId;
+        return do_command(50, regs) != GameCommandFlag::failure;
+    }
+
     inline void do_55(uint8_t bl, uint16_t ax, uint16_t cx, uint16_t di)
     {
         registers regs;
@@ -158,7 +174,6 @@ namespace openloco::game_commands
 
     inline void do_71(int32_t ax, char* string)
     {
-
         registers regs;
         regs.bl = GameCommandFlag::apply;
         regs.ax = ax;
@@ -167,35 +182,6 @@ namespace openloco::game_commands
         memcpy(&regs.ebp, &string[8], 4);
         memcpy(&regs.edi, &string[12], 4);
         do_command(71, regs);
-    }
-
-    //Rename Industry
-    inline void do_79(uint16_t cx, uint16_t ax, uint32_t edx, uint32_t ebp, uint32_t edi)
-    {
-        registers regs;
-        regs.bl = GameCommandFlag::apply;
-        regs.cx = cx;   // industry number or 0
-        regs.ax = ax;   // [ 0, 1, 2]
-        regs.edx = edx; // part of name buffer
-        regs.ebp = ebp; // part of name buffer
-        regs.edi = edi; // part of name buffer
-        do_command(79, regs);
-    }
-
-    inline bool do_48(uint8_t bl, uint8_t industryId)
-    {
-        registers regs;
-        regs.bl = bl; // [ 1 = remove industry]
-        regs.dx = industryId;
-        return do_command(48, regs) != GameCommandFlag::failure;
-    }
-
-    inline bool do_50(uint8_t bl, uint8_t townId)
-    {
-        registers regs;
-        regs.bl = bl; // [ 1 = remove town]
-        regs.edi = townId;
-        return do_command(50, regs) != GameCommandFlag::failure;
     }
 
     inline void do_73(thing_id_t id)
@@ -214,5 +200,18 @@ namespace openloco::game_commands
         regs.ax = position.x;
         regs.cx = position.y;
         do_command(73, regs);
+    }
+
+    // Rename Industry
+    inline void do_79(uint16_t cx, uint16_t ax, uint32_t edx, uint32_t ebp, uint32_t edi)
+    {
+        registers regs;
+        regs.bl = GameCommandFlag::apply;
+        regs.cx = cx;   // industry number or 0
+        regs.ax = ax;   // [ 0, 1, 2]
+        regs.edx = edx; // part of name buffer
+        regs.ebp = ebp; // part of name buffer
+        regs.edi = edi; // part of name buffer
+        do_command(79, regs);
     }
 }

--- a/src/openloco/game_commands.h
+++ b/src/openloco/game_commands.h
@@ -79,6 +79,7 @@ namespace openloco::game_commands
         do_command(19, regs);
     }
 
+    // Pause game
     inline void do_20()
     {
         registers regs;
@@ -86,6 +87,7 @@ namespace openloco::game_commands
         do_command(20, regs);
     }
 
+    // Load/save/quit game
     inline void do_21(uint8_t dl, uint8_t di)
     {
         registers regs;
@@ -96,10 +98,10 @@ namespace openloco::game_commands
     }
 
     // Change company name
-    inline bool do_30(uint8_t bl, uint16_t cx, uint16_t ax, uint32_t edx, uint32_t ebp, uint32_t edi)
+    inline bool do_30(uint16_t cx, uint16_t ax, uint32_t edx, uint32_t ebp, uint32_t edi)
     {
         registers regs;
-        regs.bl = bl;   // [ 1 ]
+        regs.bl = GameCommandFlag::apply;
         regs.cx = cx;   // company id
         regs.ax = ax;   // [ 0, 1, 2]
         regs.edx = edx; // part of name buffer
@@ -109,10 +111,10 @@ namespace openloco::game_commands
     }
 
     // Change company owner name
-    inline bool do_31(uint8_t bl, uint16_t cx, uint16_t ax, uint32_t edx, uint32_t ebp, uint32_t edi)
+    inline bool do_31(uint16_t cx, uint16_t ax, uint32_t edx, uint32_t ebp, uint32_t edi)
     {
         registers regs;
-        regs.bl = bl;   // [ 1 ]
+        regs.bl = GameCommandFlag::apply;
         regs.cx = cx;   // company id
         regs.ax = ax;   // [ 0, 1, 2]
         regs.edx = edx; // part of name buffer
@@ -121,10 +123,11 @@ namespace openloco::game_commands
         return do_command(31, regs) != GameCommandFlag::failure;
     }
 
-    inline void do_46(uint8_t bl, uint16_t cx, uint16_t ax, uint32_t edx, uint32_t ebp, uint32_t edi)
+    // Rename town
+    inline void do_46(uint16_t cx, uint16_t ax, uint32_t edx, uint32_t ebp, uint32_t edi)
     {
         registers regs;
-        regs.bl = bl;   // [ 1 ]
+        regs.bl = GameCommandFlag::apply;
         regs.cx = cx;   // town number or 0
         regs.ax = ax;   // [ 0, 1, 2]
         regs.edx = edx; // part of name buffer
@@ -133,18 +136,20 @@ namespace openloco::game_commands
         do_command(46, regs);
     }
 
-    inline bool do_48(uint8_t bl, uint8_t industryId)
+    // Remove industry
+    inline bool do_48(uint8_t industryId)
     {
         registers regs;
-        regs.bl = bl; // [ 1 = remove industry]
+        regs.bl = GameCommandFlag::apply;
         regs.dx = industryId;
         return do_command(48, regs) != GameCommandFlag::failure;
     }
 
-    inline bool do_50(uint8_t bl, uint8_t townId)
+    // Remove town
+    inline bool do_50(uint8_t townId)
     {
         registers regs;
-        regs.bl = bl; // [ 1 = remove town]
+        regs.bl = GameCommandFlag::apply;
         regs.edi = townId;
         return do_command(50, regs) != GameCommandFlag::failure;
     }
@@ -152,7 +157,7 @@ namespace openloco::game_commands
     inline void do_55(uint8_t bl, uint16_t ax, uint16_t cx, uint16_t di)
     {
         registers regs;
-        regs.bl = bl; //
+        regs.bl = bl; // flags
         regs.cx = cx; // x?
         regs.ax = ax; // y?
         regs.di = di; // z?

--- a/src/openloco/game_commands.h
+++ b/src/openloco/game_commands.h
@@ -9,16 +9,17 @@ using namespace openloco::interop;
 
 namespace openloco::game_commands
 {
-    enum GameCommandFlag : uint32_t
+    enum GameCommandFlag : uint8_t
     {
-        apply = 1 << 0,     // 0x01
-        flag_2 = 1 << 2,    // 0x04
-        flag_3 = 1 << 3,    // 0x08
-        flag_4 = 1 << 4,    // 0x10
-        flag_5 = 1 << 5,    // 0x20
-        flag_6 = 1 << 6,    // 0x40
-        failure = 1U << 31, // 0x80000000
+        apply = 1 << 0,  // 0x01
+        flag_2 = 1 << 2, // 0x04
+        flag_3 = 1 << 3, // 0x08
+        flag_4 = 1 << 4, // 0x10
+        flag_5 = 1 << 5, // 0x20
+        flag_6 = 1 << 6, // 0x40
     };
+
+    constexpr uint32_t FAILURE = 0x80000000;
 
     void registerHooks();
     uint32_t do_command(int esi, const registers& registers);
@@ -31,7 +32,7 @@ namespace openloco::game_commands
         regs.di = vehicle_id;
         regs.edx = vehicle_type;
 
-        return do_command(5, regs) != GameCommandFlag::failure;
+        return do_command(5, regs) != FAILURE;
     }
 
     // Change loan
@@ -107,7 +108,7 @@ namespace openloco::game_commands
         regs.edx = edx; // part of name buffer
         regs.ebp = ebp; // part of name buffer
         regs.edi = edi; // part of name buffer
-        return do_command(30, regs) != GameCommandFlag::failure;
+        return do_command(30, regs) != FAILURE;
     }
 
     // Change company owner name
@@ -120,7 +121,7 @@ namespace openloco::game_commands
         regs.edx = edx; // part of name buffer
         regs.ebp = ebp; // part of name buffer
         regs.edi = edi; // part of name buffer
-        return do_command(31, regs) != GameCommandFlag::failure;
+        return do_command(31, regs) != FAILURE;
     }
 
     // Rename town
@@ -142,7 +143,7 @@ namespace openloco::game_commands
         registers regs;
         regs.bl = GameCommandFlag::apply;
         regs.dx = industryId;
-        return do_command(48, regs) != GameCommandFlag::failure;
+        return do_command(48, regs) != FAILURE;
     }
 
     // Remove town
@@ -151,7 +152,7 @@ namespace openloco::game_commands
         registers regs;
         regs.bl = GameCommandFlag::apply;
         regs.edi = townId;
-        return do_command(50, regs) != GameCommandFlag::failure;
+        return do_command(50, regs) != FAILURE;
     }
 
     // Build company headquarters
@@ -176,7 +177,7 @@ namespace openloco::game_commands
         regs.edx = *objPtr++;
         regs.edi = *objPtr;
         regs.bh = company;
-        return do_command(65, regs) != GameCommandFlag::failure;
+        return do_command(65, regs) != FAILURE;
     }
 
     // Send chat message

--- a/src/openloco/game_commands.h
+++ b/src/openloco/game_commands.h
@@ -43,7 +43,7 @@ namespace openloco::game_commands
         do_command(9, regs);
     }
 
-    // Change Station name
+    // Change station name
     inline void do_11(uint16_t cx, uint16_t ax, uint32_t edx, uint32_t ebp, uint32_t edi)
     {
         registers regs;
@@ -154,6 +154,7 @@ namespace openloco::game_commands
         return do_command(50, regs) != GameCommandFlag::failure;
     }
 
+    // Build company headquarters
     inline void do_55(uint8_t bl, uint16_t ax, uint16_t cx, uint16_t di)
     {
         registers regs;
@@ -164,6 +165,7 @@ namespace openloco::game_commands
         do_command(55, regs);
     }
 
+    // Change company face
     inline bool do_65(const objectmgr::header& object, uint8_t company)
     {
         auto objPtr = reinterpret_cast<const int32_t*>(&object);
@@ -177,6 +179,7 @@ namespace openloco::game_commands
         return do_command(65, regs) != GameCommandFlag::failure;
     }
 
+    // Send chat message
     inline void do_71(int32_t ax, char* string)
     {
         registers regs;
@@ -189,6 +192,7 @@ namespace openloco::game_commands
         do_command(71, regs);
     }
 
+    // Update owner status
     inline void do_73(thing_id_t id)
     {
         registers regs;
@@ -198,6 +202,7 @@ namespace openloco::game_commands
         do_command(73, regs);
     }
 
+    // Update owner status
     inline void do_73(map::map_pos position)
     {
         registers regs;
@@ -207,7 +212,7 @@ namespace openloco::game_commands
         do_command(73, regs);
     }
 
-    // Rename Industry
+    // Rename industry
     inline void do_79(uint16_t cx, uint16_t ax, uint32_t edx, uint32_t ebp, uint32_t edi)
     {
         registers regs;

--- a/src/openloco/game_commands.h
+++ b/src/openloco/game_commands.h
@@ -9,27 +9,29 @@ using namespace openloco::interop;
 
 namespace openloco::game_commands
 {
-    enum GameCommandFlag
+    enum GameCommandFlag : uint32_t
     {
-        apply = 1 << 0,  // 0x01
-        flag_2 = 1 << 2, // 0x04
-        flag_3 = 1 << 3, // 0x08
-        flag_4 = 1 << 4, // 0x10
-        flag_5 = 1 << 5, // 0x20
-        flag_6 = 1 << 6, // 0x40
+        apply = 1 << 0,     // 0x01
+        flag_2 = 1 << 2,    // 0x04
+        flag_3 = 1 << 3,    // 0x08
+        flag_4 = 1 << 4,    // 0x10
+        flag_5 = 1 << 5,    // 0x20
+        flag_6 = 1 << 6,    // 0x40
+        failure = 1U << 31, // 0x80000000
     };
 
     void registerHooks();
     uint32_t do_command(int esi, const registers& registers);
 
+    // Build vehicle
     inline bool do_5(uint16_t vehicle_type, uint16_t vehicle_id = 0xFFFF)
     {
         registers regs;
         regs.bl = GameCommandFlag::apply;
         regs.di = vehicle_id;
         regs.edx = vehicle_type;
-        do_command(5, regs);
-        return (uint32_t)regs.ebx != 0x80000000;
+
+        return do_command(5, regs) != GameCommandFlag::failure;
     }
 
     // Change loan
@@ -103,9 +105,7 @@ namespace openloco::game_commands
         regs.edx = edx; // part of name buffer
         regs.ebp = ebp; // part of name buffer
         regs.edi = edi; // part of name buffer
-        do_command(30, regs);
-
-        return (regs.eax & (1 << 31)) != 0;
+        return do_command(30, regs) != GameCommandFlag::failure;
     }
 
     // Change company owner name
@@ -118,9 +118,7 @@ namespace openloco::game_commands
         regs.edx = edx; // part of name buffer
         regs.ebp = ebp; // part of name buffer
         regs.edi = edi; // part of name buffer
-        do_command(31, regs);
-
-        return (regs.eax & (1 << 31)) != 0;
+        return do_command(31, regs) != GameCommandFlag::failure;
     }
 
     inline void do_46(uint8_t bl, uint16_t cx, uint16_t ax, uint32_t edx, uint32_t ebp, uint32_t edi)
@@ -155,9 +153,7 @@ namespace openloco::game_commands
         regs.edx = *objPtr++;
         regs.edi = *objPtr;
         regs.bh = company;
-        do_command(65, regs);
-
-        return (uint32_t)regs.ebx != 0x80000000;
+        return do_command(65, regs) != GameCommandFlag::failure;
     }
 
     inline void do_71(int32_t ax, char* string)
@@ -191,8 +187,7 @@ namespace openloco::game_commands
         registers regs;
         regs.bl = bl; // [ 1 = remove industry]
         regs.dx = industryId;
-        do_command(48, regs);
-        return (uint32_t)regs.ebx != 0x80000000;
+        return do_command(48, regs) != GameCommandFlag::failure;
     }
 
     inline bool do_50(uint8_t bl, uint8_t townId)
@@ -200,8 +195,7 @@ namespace openloco::game_commands
         registers regs;
         regs.bl = bl; // [ 1 = remove town]
         regs.edi = townId;
-        do_command(50, regs);
-        return (uint32_t)regs.ebx != 0x80000000;
+        return do_command(50, regs) != GameCommandFlag::failure;
     }
 
     inline void do_73(thing_id_t id)

--- a/src/openloco/windows/CompanyWindow.cpp
+++ b/src/openloco/windows/CompanyWindow.cpp
@@ -342,9 +342,9 @@ namespace openloco::ui::windows::CompanyWindow
             bool success = false;
             {
                 uint32_t* buffer = (uint32_t*)input;
-                game_commands::do_31(1, self->number, 1, buffer[0], buffer[1], buffer[2]);
-                game_commands::do_31(1, 0, 2, buffer[3], buffer[4], buffer[5]);
-                success = game_commands::do_31(1, 0, 0, buffer[6], buffer[7], buffer[8]);
+                game_commands::do_31(self->number, 1, buffer[0], buffer[1], buffer[2]);
+                game_commands::do_31(0, 2, buffer[3], buffer[4], buffer[5]);
+                success = game_commands::do_31(0, 0, buffer[6], buffer[7], buffer[8]);
             }
 
             // No need to propate the name if it could not be set.
@@ -2521,9 +2521,9 @@ namespace openloco::ui::windows::CompanyWindow
             gGameCommandErrorTitle = string_ids::cannot_rename_this_company;
 
             uint32_t* buffer = (uint32_t*)input;
-            game_commands::do_30(1, self->number, 1, buffer[0], buffer[1], buffer[2]);
-            game_commands::do_30(1, 0, 2, buffer[3], buffer[4], buffer[5]);
-            game_commands::do_30(1, 0, 0, buffer[6], buffer[7], buffer[8]);
+            game_commands::do_30(self->number, 1, buffer[0], buffer[1], buffer[2]);
+            game_commands::do_30(0, 2, buffer[3], buffer[4], buffer[5]);
+            game_commands::do_30(0, 0, buffer[6], buffer[7], buffer[8]);
         }
 
         static void drawCompanySelect(const window* const self, gfx::drawpixelinfo_t* const dpi)

--- a/src/openloco/windows/IndustryWindow.cpp
+++ b/src/openloco/windows/IndustryWindow.cpp
@@ -184,7 +184,7 @@ namespace openloco::ui::windows::industry
                 // 0x00455E59
                 case widx::demolish_industry:
                 {
-                    bool success = game_commands::do_48(GameCommandFlag::apply, self->number);
+                    bool success = game_commands::do_48(self->number);
                     if (!success)
                         break;
 

--- a/src/openloco/windows/townwnd.cpp
+++ b/src/openloco/windows/townwnd.cpp
@@ -220,7 +220,7 @@ namespace openloco::ui::windows::town
                 {
                     loco_global<string_id, 0x009C68E8> gameErrorString;
                     gameErrorString = string_ids::cant_remove_town;
-                    bool success = game_commands::do_50(GameCommandFlag::apply, self->number);
+                    bool success = game_commands::do_50(self->number);
                     if (!success)
                         break;
 
@@ -672,9 +672,9 @@ namespace openloco::ui::windows::town
             addr<0x009C68E8, string_id>() = string_ids::error_cant_rename_town;
 
             uint32_t* buffer = (uint32_t*)input;
-            game_commands::do_46(1, self->number, 1, buffer[0], buffer[1], buffer[2]);
-            game_commands::do_46(1, 0, 2, buffer[3], buffer[4], buffer[5]);
-            game_commands::do_46(1, 0, 0, buffer[6], buffer[7], buffer[8]);
+            game_commands::do_46(self->number, 1, buffer[0], buffer[1], buffer[2]);
+            game_commands::do_46(0, 2, buffer[3], buffer[4], buffer[5]);
+            game_commands::do_46(0, 0, buffer[6], buffer[7], buffer[8]);
         }
 
         static void update(window* self)


### PR DESCRIPTION
*Game commands: check do_command's return value instead of ebx.*

Errors weren't handled properly because do_command does not update regs.ebx, but instead returns its value.

*Reorder command functions to be in numerical order.*

The file should really be in numerical order at all times. Probably happened due to PRs being merged in-between each other.

*Remove bl parameter when only used as GameCommandFlag::apply.*

In some cases, the bl register is used to pass flags. Otherwise, it's just GameCommandFlag::apply. I believe we can omit it as a parameter in such (most) cases.