### PR TITLE
Fix #498: Zero-initialise current_secondary_tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix: [#487] Checkbox behaviour reversed for industry opening/closing in landscape generation options.
 - Fix: [#488] Repeated clicking may lead to a negative loan.
 - Fix: [#494] Farms not producing grain for stations in Mountain Mayhem scenario.
+- Fix: [#498] Clicking newly invented vehicle in news throws out of range exception.
 
 20.05 (2020-05-24)
 ------------------------------------------------------------------------

--- a/src/openloco/window.h
+++ b/src/openloco/window.h
@@ -362,7 +362,7 @@ namespace openloco::ui
         uint8_t pad_85E[0x870 - 0x85E];
         uint16_t current_tab = 0;                   // 0x870
         uint16_t frame_no = 0;                      // 0x872
-        uint16_t current_secondary_tab;             // 0x874
+        uint16_t current_secondary_tab = 0;         // 0x874
         viewport_config viewport_configurations[2]; // 0x876
         WindowType type;                            // 0x882
         uint8_t pad_883[1];

--- a/src/openloco/windows/build_vehicle.cpp
+++ b/src/openloco/windows/build_vehicle.cpp
@@ -384,8 +384,9 @@ namespace openloco::ui::build_vehicle
             0x4C1AF7,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 registers backup = regs;
-                open(regs.eax, regs.eax);
+                auto window = open(regs.eax, regs.eax);
                 regs = backup;
+                regs.esi = (int32_t)window;
                 return 0;
             });
     }


### PR DESCRIPTION
`window::current_secondary_tab` was not initialised to zero when constructing or opening the window — only when clicking a primary tab.