### PR TITLE
Construction: holdable build and remove buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 20.05.1+ (???)
 ------------------------------------------------------------------------
+- Feature: Holding the construction window's build or remove button will keep repeating the action.
 - Fix: [#485] Incorrect position of exhaust smoke on vehicles.
+- Removed: Click (while holding shift) track / road construction will place 10 pieces in a row.
 
 20.05.1 (2020-05-30)
 ------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 20.05.1+ (???)
 ------------------------------------------------------------------------
-- Feature: Holding the construction window's build or remove button will keep repeating the action.
+- Feature: [#523] Holding the construction window's build or remove button will keep repeating the action.
+- Fix: [#158] Pressing shift to build underground tracks automatically builds ten track pieces.
 - Fix: [#485] Incorrect position of exhaust smoke on vehicles.
-- Removed: Click (while holding shift) track / road construction will place 10 pieces in a row.
+- Removed: Clicking track / road construction while holding shift will place 10 pieces in a row.
 
 20.05.1 (2020-05-30)
 ------------------------------------------------------------------------
@@ -45,6 +46,7 @@
 19.03 (2019-03-01)
 ------------------------------------------------------------------------
 - Feature: [#163] Remove terraforming limits outside of scenario editor.
+- Feature: [#178] Allow zooming to cursor position instead of viewport centre.
 - Feature: [#192] The option window now includes OpenLoco-specific settings.
 - Feature: [#203] Support multiple languages by loading text strings from YAML files.
 - Feature: [#212] Add fullscreen support.
@@ -65,7 +67,7 @@
 - Feature: Towns can now always be renamed (As seen in OpenTTD).
 - Feature: Vehicle breakdowns can now be disabled (As seen in OpenTTD).
 - Feature: Playable in a resizable window.
-- Feature: Click (while holding shift) track / road construction will place 10 pieces in a row.
+- Feature: Clicking track / road construction while holding shift will place 10 pieces in a row.
 - Change: [#79] Store `game.cfg`, `plugin.dat` and `scores.dat` in:
   - Windows: `%APPDATA%\OpenLoco`
   - Linux: `~/.config/openloco`

--- a/src/openloco/windows/construction/Common.cpp
+++ b/src/openloco/windows/construction/Common.cpp
@@ -436,6 +436,7 @@ namespace openloco::ui::windows::construction
             self->event_handlers = tabInfo.events;
             self->activated_widgets = 0;
             self->widgets = tabInfo.widgets;
+            self->holdable_widgets = 0;
 
             setDisabledWidgets(self);
 
@@ -1191,7 +1192,8 @@ namespace openloco::ui::windows::construction
 
             _mapSelectedTiles[posId].x = -1;
             map_invalidate_map_selection_tiles();
-            window->holdable_widgets = 0;
+            window->holdable_widgets = (1 << construction::widx::construct) | (1 << construction::widx::remove);
+
             auto trackType = _trackType & ~(1 << 7);
             auto roadObj = objectmgr::get<road_object>(trackType);
 
@@ -1385,7 +1387,7 @@ namespace openloco::ui::windows::construction
 
             _mapSelectedTiles[posId].x = -1;
             map_invalidate_map_selection_tiles();
-            window->holdable_widgets = 0;
+            window->holdable_widgets = (1 << construction::widx::construct) | (1 << construction::widx::remove);
 
             auto trackObj = objectmgr::get<track_object>(_trackType);
 

--- a/src/openloco/windows/construction/ConstructionTab.cpp
+++ b/src/openloco/windows/construction/ConstructionTab.cpp
@@ -16,6 +16,8 @@ using namespace openloco::map::tilemgr;
 
 namespace openloco::ui::windows::construction::construction
 {
+    static loco_global<uint16_t, 0x00523376> _clickRepeatTicks;
+
     widget_t widgets[] = {
         commonWidgets(138, 276, string_ids::stringid_2),
         make_widget({ 3, 45 }, { 22, 24 }, widget_type::wt_9, 1, image_ids::construction_left_hand_curve_very_small, string_ids::tooltip_left_hand_curve_very_small),
@@ -67,17 +69,6 @@ namespace openloco::ui::windows::construction::construction
     // 0x0049D3F6
     static void on_mouse_up(window* self, widget_index widgetIndex)
     {
-        // Allow shift key to repeat the action multiple times
-        // This is useful for building very long tracks.
-        int multiplier = 1;
-        if (input::has_key_modifier(input::key_modifier::shift))
-        {
-            multiplier = 10;
-        }
-
-        registers regs;
-        regs.edx = widgetIndex;
-        regs.esi = (int32_t)self;
         switch (widgetIndex)
         {
             case common::widx::close_button:
@@ -92,17 +83,11 @@ namespace openloco::ui::windows::construction::construction
                 break;
 
             case widx::construct:
-                for (int i = 0; i < multiplier; i++)
-                {
-                    constructTrack(self, widgetIndex);
-                }
+                constructTrack(self, widgetIndex);
                 break;
 
             case widx::remove:
-                for (int i = 0; i < multiplier; i++)
-                {
-                    removeTrack(self, widgetIndex);
-                }
+                removeTrack(self, widgetIndex);
                 break;
 
             case widx::rotate_90:
@@ -481,6 +466,20 @@ namespace openloco::ui::windows::construction::construction
             case widx::bridge_dropdown:
             {
                 bridgeDropdown(self);
+                break;
+            }
+
+            case widx::construct:
+            {
+                if (*_clickRepeatTicks >= 40)
+                    constructTrack(self, widgetIndex);
+                break;
+            }
+
+            case widx::remove:
+            {
+                if (*_clickRepeatTicks >= 40)
+                    removeTrack(self, widgetIndex);
                 break;
             }
         }


### PR DESCRIPTION
Thanks to @Svelbeard's painstaking efforts in #493, the construction window has been fully implemented. This allows us to change its behaviour in a more fine-grained manner than before.

This PR changes the construction window's build and remove buttons such that their actions are now repeatable. In v18.02, we added behaviour where holding shift while clicking would repeat the action 10 times. This PR removes this behaviour, as it interfered with placing tracks underground.

The new 'holdable' behaviour has a threshold of 40 ticks, meaning it is delayed by one second before it takes effect. I believe this makes it work in an intuitive way.