### PR TITLE
Fix tree industries not updating properly

### DIFF
--- a/src/openloco/industry.cpp
+++ b/src/openloco/industry.cpp
@@ -51,13 +51,13 @@ namespace openloco
         return produceCargoState;
     }
 
-    static bool find_5(surface_element* surface)
+    static bool find_tree(surface_element* surface)
     {
         auto element = surface;
         while (!element->is_last())
         {
             element++;
-            if (element->type() == element_type::industry)
+            if (element->type() == element_type::tree)
             {
                 return true;
             }
@@ -146,7 +146,7 @@ namespace openloco
                     if (bl == 0 || bl != obj->var_EA)
                     {
                         var_DB++;
-                        if ((!(obj->flags & industry_object_flags::flag_28) && surface->var_4_E0() != 0) || find_5(surface))
+                        if ((!(obj->flags & industry_object_flags::flag_28) && surface->var_4_E0() != 0) || find_tree(surface))
                         {
                             var_DD++;
                         }


### PR DESCRIPTION
Following up on #494, we received reports of tree-related industries in the game not updating properly.

Investigation revealed `industry::find_5` to be checking for industries (0x20) present. The original routine instead checks for trees (0x14) at address 0x45330C. The function name `find_5` corresponds with the `element_type` offset for trees as well.

Considering 0x14 is 20 in decimal, I am assuming the mistake was originally introduced in a refactor. The [last diff](https://github.com/OpenLoco/OpenLoco/commit/5caff164cec0938d9193df7737ff1ca312c78e39#diff-389abedf2f6cc4cfc020640a089aa355R35) changed `unk_8` into `industry`, so it must have been in for a longer time.