### PR TITLE
Fix industry production not starting up under some conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Feature: [#523] Holding the construction window's build or remove button will keep repeating the action.
 - Fix: [#158] Pressing shift to build underground tracks automatically builds ten track pieces.
 - Fix: [#485] Incorrect position of exhaust smoke on vehicles.
+- Fix: [#529] Tree-related industries are not updating properly.
+- Fix: [#530] Industry production not starting up under some conditions.
 - Removed: Clicking track / road construction while holding shift will place 10 pieces in a row.
 
 20.05.1 (2020-05-30)

--- a/src/openloco/industry.cpp
+++ b/src/openloco/industry.cpp
@@ -165,7 +165,7 @@ namespace openloco
         int16_t tmp_d = std::min(tmp_c / 25, 255);
         if (tmp_d < obj->var_EB)
         {
-            var_DF = tmp_d / obj->var_EB;
+            var_DF = ((tmp_d << 8) / obj->var_EB) & 0xFF;
         }
         else
         {

--- a/src/openloco/industry.cpp
+++ b/src/openloco/industry.cpp
@@ -170,7 +170,7 @@ namespace openloco
         auto obj = object();
         if (tmp_d < obj->var_EB)
         {
-            var_DF = ((tmp_d << 8) / obj->var_EB) & 0xFF;
+            var_DF = ((tmp_d * 256) / obj->var_EB) & 0xFF;
         }
         else
         {

--- a/src/openloco/industry.cpp
+++ b/src/openloco/industry.cpp
@@ -122,6 +122,8 @@ namespace openloco
             for (int i = 0; i < 100; i++)
             {
                 sub_45329B(tile_loop.current());
+
+                // loc_453318
                 if (tile_loop.next() == map_pos())
                 {
                     sub_453354();
@@ -145,6 +147,7 @@ namespace openloco
                     auto obj = object();
                     if (bl == 0 || bl != obj->var_EA)
                     {
+                        // loc_4532E5
                         var_DB++;
                         if ((!(obj->flags & industry_object_flags::flag_28) && surface->var_4_E0() != 0) || find_tree(surface))
                         {
@@ -158,20 +161,24 @@ namespace openloco
 
     void industry::sub_453354()
     {
-        auto obj = object();
+        // 0x00453366
         int16_t tmp_a = var_DB / 16;
         int16_t tmp_b = std::max(0, var_DD - tmp_a);
         int16_t tmp_c = var_DB - tmp_b;
         int16_t tmp_d = std::min(tmp_c / 25, 255);
+
+        auto obj = object();
         if (tmp_d < obj->var_EB)
         {
             var_DF = ((tmp_d << 8) / obj->var_EB) & 0xFF;
         }
         else
         {
+            // 0x0045335F; moved here.
             var_DF = 255;
         }
 
+        // 0x004533B2
         var_DB = 0;
         var_DD = 0;
         if (var_DF < 224)


### PR DESCRIPTION
In addition to #496 and #529, we found another bug in the industry update implementation. This one is likely the cause for the livestock farms not producing anything.

This bug went unnoticed for a long time. Until #472 was merged, the original update routine was still called at the end of `industry::update`, masking the bug.

The PR is split into two commits: the first contains the bugfix, the second some address annotations for posterity.