### PR TITLE
Fix #531: Game crash after creating vehicles

### DIFF
--- a/src/openloco/things/vehicle.h
+++ b/src/openloco/things/vehicle.h
@@ -198,7 +198,7 @@ namespace openloco
         int16_t tile_y;      // 0x32
         uint8_t tile_base_z; // 0x34
         uint8_t track_type;  // 0x35 field same in all vehicles
-        uint16_t var_36;     // 0x36 field same in all vehicles
+        uint16_t var_36;     // 0x36 field same in all vehicles orderId * max_num_routing_steps
         uint8_t var_38;
         uint8_t pad_39;         // 0x39
         thing_id_t next_car_id; // 0x3A


### PR DESCRIPTION
Fix #531: Game crash after creating vehicles

2 mistakes made in implementation. Incorrect dimensions of the vehicle order table and incorrect value for the vehicle order. This caused memory corruption and could cause a variety of different crashes

I'm not 100% sure it will fix the source of #531 as for one it will have corrupted the saves and for two I can't get the save to load as I've not got the objects.