### PR TITLE
Fix #538. Prevent crashes when trying to access bad directories

### DIFF
--- a/src/openloco/windows/promptbrowsewnd.cpp
+++ b/src/openloco/windows/promptbrowsewnd.cpp
@@ -644,8 +644,8 @@ namespace openloco::ui::prompt_browse
                 {
                     for (auto& f : fs::directory_iterator(directory))
                     {
-                        auto isDirectory = f.is_directory();
-                        if (!isDirectory)
+                        bool isDirectory = f.is_directory();
+                        if (f.is_regular_file())
                         {
                             auto extension = f.path().extension().u8string();
                             if (!utility::iequals(extension, filterExtension))
@@ -653,7 +653,10 @@ namespace openloco::ui::prompt_browse
                                 continue;
                             }
                         }
-
+                        else if (!isDirectory) // Only list directories or normal files
+                        {
+                            continue;
+                        }
                         auto name = f.path().stem().u8string();
                         _newFiles.emplace_back(name, isDirectory);
                     }

--- a/src/openloco/windows/promptbrowsewnd.cpp
+++ b/src/openloco/windows/promptbrowsewnd.cpp
@@ -1,4 +1,5 @@
 #include "../audio/audio.h"
+#include "../console.h"
 #include "../core/FileSystem.hpp"
 #include "../graphics/colours.h"
 #include "../graphics/image_ids.h"
@@ -639,20 +640,27 @@ namespace openloco::ui::prompt_browse
             auto directory = fs::path((char*)_directory);
             if (fs::is_directory(directory))
             {
-                for (auto& f : fs::directory_iterator(directory))
+                try
                 {
-                    bool isDirectory = fs::is_directory(f);
-                    if (!isDirectory)
+                    for (auto& f : fs::directory_iterator(directory))
                     {
-                        auto extension = f.path().extension().u8string();
-                        if (!utility::iequals(extension, filterExtension))
+                        auto isDirectory = f.is_directory();
+                        if (!isDirectory)
                         {
-                            continue;
+                            auto extension = f.path().extension().u8string();
+                            if (!utility::iequals(extension, filterExtension))
+                            {
+                                continue;
+                            }
                         }
-                    }
 
-                    auto name = f.path().stem().u8string();
-                    _newFiles.emplace_back(name, isDirectory);
+                        auto name = f.path().stem().u8string();
+                        _newFiles.emplace_back(name, isDirectory);
+                    }
+                }
+                catch (const fs::filesystem_error& err)
+                {
+                    console::error("Invalid directory or file: %s", err.what());
                 }
             }
         }


### PR DESCRIPTION
Fix #538. Prevent crashes when trying to access bad directories

It also prevents a crash when trying to check if a file is a directory.