### PR TITLE
Fix #543: Tutorial does not resize correctly if maximised or scaled

### DIFF
--- a/src/openloco/tutorial.cpp
+++ b/src/openloco/tutorial.cpp
@@ -105,9 +105,10 @@ namespace openloco::tutorial
             }
 
             // Ensure that we're in windowed mode, using dimensions 1024x768.
-            if (config.display.mode != config::screen_mode::window || config.display.window_resolution != tutorialResolution)
+            auto currentResolution = ui::getResolution();
+            if (config.display.mode != config::screen_mode::window || currentResolution != newResolution)
             {
-                if (!ui::setDisplayMode(config::screen_mode::window, tutorialResolution))
+                if (!ui::setDisplayMode(config::screen_mode::window, newResolution))
                     return;
             }
 

--- a/src/openloco/ui.cpp
+++ b/src/openloco/ui.cpp
@@ -782,6 +782,11 @@ namespace openloco::ui
             return getDesktopResolution();
     }
 
+    config::resolution_t getResolution()
+    {
+        return { ui::width(), ui::height() };
+    }
+
     config::resolution_t getDesktopResolution()
     {
         int32_t displayIndex = SDL_GetWindowDisplayIndex(window);
@@ -805,6 +810,13 @@ namespace openloco::ui
         SDL_SetWindowFullscreen(window, 0);
 
         // Set the new dimensions of the screen.
+        if (mode == config::screen_mode::window)
+        {
+            auto desktopResolution = getDesktopResolution();
+            auto x = (desktopResolution.width - newResolution.width) / 2;
+            auto y = (desktopResolution.height - newResolution.height) / 2;
+            SDL_SetWindowPosition(window, x, y);
+        }
         SDL_SetWindowSize(window, newResolution.width, newResolution.height);
 
         // Set the window fullscreen mode.

--- a/src/openloco/ui.h
+++ b/src/openloco/ui.h
@@ -79,6 +79,7 @@ namespace openloco::ui
     void render();
     bool process_messages();
     void show_message_box(const std::string& title, const std::string& message);
+    config::resolution_t getResolution();
     config::resolution_t getDesktopResolution();
     bool setDisplayMode(config::screen_mode mode, config::resolution_t newResolution);
     bool setDisplayMode(config::screen_mode mode);


### PR DESCRIPTION
- Use current resolution rather than config resolution for check.
- Set window position to centre of desktop if resized to ensure it doesn't go off the edge of the desktop.