### PR TITLE
Fix sounds. Refactor to split up object sounds

### DIFF
--- a/src/openloco/audio/vehicle_channel.cpp
+++ b/src/openloco/audio/vehicle_channel.cpp
@@ -7,12 +7,12 @@ using namespace openloco;
 using namespace openloco::audio;
 using namespace openloco::interop;
 
-static std::tuple<sound_id, channel_attributes> sub_48A590(const vehicle* v)
+static std::tuple<Sound, channel_attributes> sub_48A590(const vehicle* v)
 {
     registers regs;
     regs.esi = (int32_t)v;
     call(0x0048A590, regs);
-    return std::make_tuple<sound_id, channel_attributes>((sound_id)regs.eax, { regs.ecx, regs.edx, regs.ebx });
+    return std::make_tuple<Sound, channel_attributes>({ regs.ax }, { regs.ecx, regs.edx, regs.ebx });
 }
 
 vehicle_channel::vehicle_channel(channel&& c)

--- a/src/openloco/audio/vehicle_channel.h
+++ b/src/openloco/audio/vehicle_channel.h
@@ -18,7 +18,7 @@ namespace openloco::audio
     private:
         channel _channel;
         thing_id_t _vehicle_id = thing_id::null;
-        sound_id _sound_id{};
+        Sound _sound_id{};
         channel_attributes _attributes;
 
     public:

--- a/src/openloco/interop/hooks.cpp
+++ b/src/openloco/interop/hooks.cpp
@@ -598,13 +598,13 @@ static void register_audio_hooks()
     register_hook(
         0x00489CB5,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-            audio::play_sound((audio::sound_id)regs.eax, { regs.cx, regs.dx, regs.bp }, regs.ebx);
+            audio::play_sound({ regs.ax }, { regs.cx, regs.dx, regs.bp }, regs.ebx);
             return 0;
         });
     register_hook(
         0x00489F1B,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-            audio::play_sound((audio::sound_id)regs.eax, { regs.cx, regs.dx, regs.bp }, regs.edi, regs.ebx);
+            audio::play_sound({ regs.ax }, { regs.cx, regs.dx, regs.bp }, regs.edi, regs.ebx);
             return 0;
         });
 }

--- a/src/openloco/things/CreateVehicle.cpp
+++ b/src/openloco/things/CreateVehicle.cpp
@@ -630,7 +630,7 @@ namespace openloco::things::vehicle
         newVeh2->var_56 = 0;
         newVeh2->var_5A = 0;
         newVeh2->var_5B = 0;
-        newVeh2->soundId = audio::sound_id::null;
+        newVeh2->soundId = audio::sound::null;
         newVeh2->var_48 = -1;
         newVeh2->var_48 = 0;
         newVeh2->var_4A = 0;
@@ -665,7 +665,7 @@ namespace openloco::things::vehicle
         newTail->var_15 = 0;
         newTail->var_38 = 0;
 
-        newTail->soundId = audio::sound_id::null;
+        newTail->soundId = audio::sound::null;
         newTail->var_48 = -1;
         newTail->var_4A = 0;
         lastVeh->next_car_id = newTail->id;

--- a/src/openloco/things/vehicle.cpp
+++ b/src/openloco/things/vehicle.cpp
@@ -1122,7 +1122,7 @@ void openloco::vehicle_body::steam_puffs_animation_update(uint8_t num, int32_t v
 
     if (itemFound)
     {
-        auto soundId = static_cast<audio::sound_id>(steam_obj->var_1F[var_55 + (steam_obj->sound_effect >> 1)]);
+        auto soundId = static_cast<audio::sound_t>(steam_obj->var_1F[var_55 + (steam_obj->sound_effect >> 1)]);
 
         if (veh_2->var_56 > 983040)
             return;
@@ -1136,7 +1136,7 @@ void openloco::vehicle_body::steam_puffs_animation_update(uint8_t num, int32_t v
             volume -= 1500;
         }
 
-        audio::play_sound(audio::make_object_sound_id(soundId), loc, volume, 22050);
+        audio::play_sound(soundId, loc, volume, 22050);
     }
     else
     {
@@ -1145,8 +1145,8 @@ void openloco::vehicle_body::steam_puffs_animation_update(uint8_t num, int32_t v
         {
             soundModifier = 0;
         }
-        auto underSoundId = static_cast<audio::sound_id>(steam_obj->var_1F[soundModifier + var_55]);
-        auto soundId = static_cast<audio::sound_id>(steam_obj->var_1F[var_55]);
+        auto underSoundId = static_cast<audio::sound_t>(steam_obj->var_1F[soundModifier + var_55]);
+        auto soundId = static_cast<audio::sound_t>(steam_obj->var_1F[var_55]);
 
         if (veh_2->var_56 > 983040)
             return;
@@ -1166,7 +1166,7 @@ void openloco::vehicle_body::steam_puffs_animation_update(uint8_t num, int32_t v
             volume = -400;
         }
 
-        audio::play_sound(audio::make_object_sound_id(soundId), loc, volume, 22050);
+        audio::play_sound(soundId, loc, volume, 22050);
     }
 }
 

--- a/src/openloco/things/vehicle.h
+++ b/src/openloco/things/vehicle.h
@@ -165,7 +165,7 @@ namespace openloco
     struct vehicle_26 : vehicle_base
     {
         uint8_t pad_20[0x44 - 0x20];
-        uint8_t sound_id; // 0x44
+        audio::sound_t sound_id; // 0x44
         uint8_t pad_45[0x4A - 0x45];
         uint16_t var_4A;                       // sound-related flag(s)
         ui::window_number sound_window_number; // 0x4C
@@ -289,7 +289,7 @@ namespace openloco
         uint8_t pad_3C[0x42 - 0x3C]; // 0x3C
         TransportMode mode;          // 0x42 field same in all vehicles
         uint8_t pad_43;
-        audio::sound_id soundId; // 0x44 common with tail
+        audio::sound_t soundId; // 0x44 common with tail
         uint8_t pad_45[0x48 - 0x45];
         int16_t var_48;
         uint16_t var_4A;                       // sound-related flag(s) common with tail
@@ -441,7 +441,7 @@ namespace openloco
         uint8_t pad_3C[0x42 - 0x3C]; // 0x3C
         TransportMode mode;          // 0x42 field same in all vehicles
         uint8_t pad_43;
-        audio::sound_id soundId; // 0x44
+        audio::sound_t soundId; // 0x44
         uint8_t pad_45[0x48 - 0x45];
         int16_t var_48;
         uint16_t var_4A;                       // sound-related flag(s) common with veh_2


### PR DESCRIPTION
Due to object sounds and non object sounds both being used in functions it was easy to get the two confused. This splits them up sound_t is an object sound reference and sound_id is a non object sound reference