### PR TITLE
Fix #491: Station/city names disappear on save.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fix: [#158] Pressing shift to build underground tracks automatically builds ten track pieces.
 - Fix: [#397] Opening a tutorial crashes the game.
 - Fix: [#485] Incorrect position of exhaust smoke on vehicles.
-- Fix: [#491] Station/City names disappear on saving.
+- Fix: [#491] Station/city name labels are hidden from viewport when saving.
 - Fix: [#529] Tree-related industries are not updating properly.
 - Fix: [#530] Industry production not starting up under some conditions.
 - Removed: Clicking track / road construction while holding shift will place 10 pieces in a row.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: [#158] Pressing shift to build underground tracks automatically builds ten track pieces.
 - Fix: [#397] Opening a tutorial crashes the game.
 - Fix: [#485] Incorrect position of exhaust smoke on vehicles.
+- Fix: [#491] Station/City names disappear on saving.
 - Fix: [#529] Tree-related industries are not updating properly.
 - Fix: [#530] Industry production not starting up under some conditions.
 - Removed: Clicking track / road construction while holding shift will place 10 pieces in a row.

--- a/src/openloco/viewportmgr.h
+++ b/src/openloco/viewportmgr.h
@@ -14,8 +14,8 @@ namespace openloco::ui::viewportmgr
     void init();
     void registerHooks();
     void collectGarbage();
-    void create(window* window, int viewportIndex, gfx::point_t origin, gfx::ui_size_t size, ZoomLevel zoom, thing_id_t thing_id);
-    void create(window* window, int viewportIndex, gfx::point_t origin, gfx::ui_size_t size, ZoomLevel zoom, map::map_pos3 tile);
+    viewport* create(window* window, int viewportIndex, gfx::point_t origin, gfx::ui_size_t size, ZoomLevel zoom, thing_id_t thing_id);
+    viewport* create(window* window, int viewportIndex, gfx::point_t origin, gfx::ui_size_t size, ZoomLevel zoom, map::map_pos3 tile);
     void invalidate(station* station);
     void invalidate(Thing* t, ZoomLevel zoom);
     void invalidate(map::map_pos pos, coord_t zMin, coord_t zMax, ZoomLevel zoom = ZoomLevel::eighth, int radius = 32);


### PR DESCRIPTION
Mistake made in viewport create function meant that an un-implemented function would not get a pointer to the newly created viewport but a pointer to the main windows viewport. When it set the flags for the new viewport it instead set the flags for the main viewport. Fixed by passing back the viewport to the correct register.