### PR TITLE
Resize title exit button based on language

### DIFF
--- a/src/openloco/windows/title_exit.cpp
+++ b/src/openloco/windows/title_exit.cpp
@@ -30,11 +30,13 @@ namespace openloco::ui::windows
     static window_event_list _events;
 
     static void on_mouse_up(window* window, widget_index widgetIndex);
+    static void prepare_draw(ui::window* self);
     static void draw(ui::window* window, gfx::drawpixelinfo_t* dpi);
 
     window* open_title_exit()
     {
         _events.on_mouse_up = on_mouse_up;
+        _events.prepare_draw = prepare_draw;
         _events.draw = draw;
 
         auto window = openloco::ui::WindowManager::createWindow(
@@ -53,6 +55,14 @@ namespace openloco::ui::windows
         window->colours[1] = colour::translucent(colour::saturated_green);
 
         return window;
+    }
+
+    static void prepare_draw(ui::window* self)
+    {
+        auto exitString = stringmgr::get_string(string_ids::title_exit_game);
+        self->width = gfx::get_string_width_new_lined(exitString) + 10;
+        self->x = ui::width() - self->width;
+        self->widgets[widx::exit_button].right = self->width;
     }
 
     // 0x00439236


### PR DESCRIPTION
The 'exit' button on the title screen is not resized to accommodate the language that is being used. This leads to awkward string wrapping when the string is longer, for instance with Dutch:

![Screenshot_20200721_112448](https://user-images.githubusercontent.com/604665/88037144-d3cf1500-cb44-11ea-9daa-4d5342b3166e.png)

This PR adds a resize step to the `prepare_draw` event, so the button is the right size, regardless of the language used:

![Screenshot_20200721_112411](https://user-images.githubusercontent.com/604665/88037143-d3367e80-cb44-11ea-9fbb-f584aa4a9e27.png)