### PR TITLE
Fix #558: Station catchment area not invalidating map properly

### DIFF
--- a/src/openloco/map/tile.h
+++ b/src/openloco/map/tile.h
@@ -16,7 +16,9 @@ namespace openloco::map
     constexpr coord_t tile_size = 32;
     constexpr coord_t map_rows = 384;
     constexpr coord_t map_columns = 384;
-    constexpr coord_t map_size = map_columns * tile_size;
+    constexpr coord_t map_height = map_rows * tile_size;
+    constexpr coord_t map_width = map_columns * tile_size;
+    constexpr int32_t map_size = map_columns * map_rows;
 
     constexpr coord_t tile_floor(coord_t coord)
     {

--- a/src/openloco/map/tile_loop.hpp
+++ b/src/openloco/map/tile_loop.hpp
@@ -15,11 +15,11 @@ namespace openloco::map
         map_pos next()
         {
             _pos.x += tile_size;
-            if (_pos.x >= map_size - 1)
+            if (_pos.x >= map_width - 1)
             {
                 _pos.x = 0;
                 _pos.y += tile_size;
-                if (_pos.y >= map_size - 1)
+                if (_pos.y >= map_height - 1)
                 {
                     _pos.y = 0;
                 }

--- a/src/openloco/windows/stationwnd.cpp
+++ b/src/openloco/windows/stationwnd.cpp
@@ -745,20 +745,6 @@ namespace openloco::ui::windows::station
             }
             tileLoop.next();
         }
-
-        //uint32_t posId = 0;
-
-        //for (int16_t y = 0; y < 0x3000; y += 32)
-        //{
-        //    for (int16_t x = 0; x < 0x3000; x += 32)
-        //    {
-        //        if (_byte_F00484[posId] & (1 << 0))
-        //        {
-        //            tilemgr::map_invalidate_tile_full({ x, y });
-        //        }
-        //        posId++;
-        //    }
-        //}
     }
 
     // 0x00491D70

--- a/src/openloco/windows/stationwnd.cpp
+++ b/src/openloco/windows/stationwnd.cpp
@@ -736,11 +736,12 @@ namespace openloco::ui::windows::station
     static void sub_491BC6()
     {
         tile_loop tileLoop;
+
         for (uint32_t posId = 0; posId < 0x24000; posId++)
         {
             if (_byte_F00484[posId] & (1 << 0))
             {
-                tilemgr::map_invalidate_tile_full({ tileLoop.current() });
+                tilemgr::map_invalidate_tile_full(tileLoop.current());
             }
             tileLoop.next();
         }

--- a/src/openloco/windows/stationwnd.cpp
+++ b/src/openloco/windows/stationwnd.cpp
@@ -24,7 +24,7 @@ using namespace openloco::map;
 
 namespace openloco::ui::windows::station
 {
-    static loco_global<uint8_t[0x24000], 0x00F00484> _byte_F00484;
+    static loco_global<uint8_t[map_size], 0x00F00484> _byte_F00484;
     static loco_global<uint16_t, 0x00F24484> _mapSelectionFlags;
     static loco_global<uint16_t, 0x00112C786> _lastSelectedStation;
 
@@ -737,7 +737,7 @@ namespace openloco::ui::windows::station
     {
         tile_loop tileLoop;
 
-        for (uint32_t posId = 0; posId < 0x24000; posId++)
+        for (uint32_t posId = 0; posId < map_size; posId++)
         {
             if (_byte_F00484[posId] & (1 << 0))
             {
@@ -920,10 +920,12 @@ namespace openloco::ui::windows::station
         static void switchTab(window* self, widget_index widgetIndex)
         {
             if (widgetIndex != widx::tab_cargo)
+            {
                 if (self->number == _lastSelectedStation)
                 {
                     showStationCatchment(station_id::null);
                 }
+            }
 
             if (input::is_tool_active(self->type, self->number))
                 input::cancel_tool();

--- a/src/openloco/windows/stationwnd.cpp
+++ b/src/openloco/windows/stationwnd.cpp
@@ -735,19 +735,29 @@ namespace openloco::ui::windows::station
     // 0x00491BC6
     static void sub_491BC6()
     {
-        uint32_t posId = 0;
-
-        for (int16_t y = 0; y < 0x3000; y += 32)
+        tile_loop tileLoop;
+        for (uint32_t posId = 0; posId < 0x24000; posId++)
         {
-            for (int16_t x = 0; x < 0x3000; x += 32)
+            if (_byte_F00484[posId] & (1 << 0))
             {
-                if (_byte_F00484[posId] & (1 << 0))
-                {
-                    tilemgr::map_invalidate_tile_full({ x, y });
-                }
-                posId++;
+                tilemgr::map_invalidate_tile_full({ tileLoop.current() });
             }
+            tileLoop.next();
         }
+
+        //uint32_t posId = 0;
+
+        //for (int16_t y = 0; y < 0x3000; y += 32)
+        //{
+        //    for (int16_t x = 0; x < 0x3000; x += 32)
+        //    {
+        //        if (_byte_F00484[posId] & (1 << 0))
+        //        {
+        //            tilemgr::map_invalidate_tile_full({ x, y });
+        //        }
+        //        posId++;
+        //    }
+        //}
     }
 
     // 0x00491D70


### PR DESCRIPTION
`_byte_F00484` was incorrectly defined as  a `uint16_t[0x24000]`  causing the `map_invalidate_tile_full` to never be called.

`events.on_close` was missing for cargo tab.

`switchTabs` was only resetting station catchment area when the window was switched to the cargo tab not from the cargo tab.
