### PR TITLE
Optionally disable AI companies entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+20.07+ (in development)
+------------------------------------------------------------------------
+- Feature: [#569] Option/cheat to disable AI companies entirely.
+
 20.07 (2020-07-26)
 ------------------------------------------------------------------------
 - Feature: [#523] Holding the construction window's build or remove button will keep repeating the action.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2193,3 +2193,5 @@ strings:
   2138: "{COLOUR WINDOW_2}Play title screen music"
   2139: "Quit to menu"
   2140: "Exit OpenLoco"
+  2141: "{COLOUR WINDOW_2}Disable AI companies"
+  2142: "{SMALLFONT}{COLOUR BLACK}This disables AI from 'thinking', rendering them ineffective.{NEWLINE}In new games, this also prevents new AI companies from forming."

--- a/src/openloco/companymgr.cpp
+++ b/src/openloco/companymgr.cpp
@@ -1,4 +1,5 @@
 #include "companymgr.h"
+#include "config.h"
 #include "game_commands.h"
 #include "interop/interop.hpp"
 #include "localisation/FormatArguments.hpp"
@@ -70,7 +71,7 @@ namespace openloco::companymgr
     // 0x00430319
     void update()
     {
-        if (!is_editor_mode())
+        if (!is_editor_mode() && !config::get_new().company_ai_disabled)
         {
             company_id_t id = scenario_ticks() & 0x0F;
             auto company = get(id);

--- a/src/openloco/companymgr.cpp
+++ b/src/openloco/companymgr.cpp
@@ -71,7 +71,7 @@ namespace openloco::companymgr
     // 0x00430319
     void update()
     {
-        if (!is_editor_mode() && !config::get_new().company_ai_disabled)
+        if (!is_editor_mode() && !config::get_new().companyAIDisabled)
         {
             company_id_t id = scenario_ticks() & 0x0F;
             auto company = get(id);

--- a/src/openloco/config.cpp
+++ b/src/openloco/config.cpp
@@ -81,8 +81,8 @@ namespace openloco::config
             _new_config.language = config["language"].as<std::string>();
         if (config["breakdowns_disabled"])
             _new_config.breakdowns_disabled = config["breakdowns_disabled"].as<bool>();
-        if (config["company_ai_disabled"])
-            _new_config.company_ai_disabled = config["company_ai_disabled"].as<bool>();
+        if (config["companyAIDisabled"])
+            _new_config.companyAIDisabled = config["companyAIDisabled"].as<bool>();
         if (config["scale_factor"])
             _new_config.scale_factor = config["scale_factor"].as<float>();
         if (config["zoom_to_cursor"])
@@ -140,7 +140,7 @@ namespace openloco::config
         node["loco_install_path"] = _new_config.loco_install_path;
         node["language"] = _new_config.language;
         node["breakdowns_disabled"] = _new_config.breakdowns_disabled;
-        node["company_ai_disabled"] = _new_config.company_ai_disabled;
+        node["companyAIDisabled"] = _new_config.companyAIDisabled;
         node["scale_factor"] = _new_config.scale_factor;
         node["zoom_to_cursor"] = _new_config.zoom_to_cursor;
 

--- a/src/openloco/config.cpp
+++ b/src/openloco/config.cpp
@@ -81,6 +81,8 @@ namespace openloco::config
             _new_config.language = config["language"].as<std::string>();
         if (config["breakdowns_disabled"])
             _new_config.breakdowns_disabled = config["breakdowns_disabled"].as<bool>();
+        if (config["company_ai_disabled"])
+            _new_config.company_ai_disabled = config["company_ai_disabled"].as<bool>();
         if (config["scale_factor"])
             _new_config.scale_factor = config["scale_factor"].as<float>();
         if (config["zoom_to_cursor"])
@@ -138,6 +140,7 @@ namespace openloco::config
         node["loco_install_path"] = _new_config.loco_install_path;
         node["language"] = _new_config.language;
         node["breakdowns_disabled"] = _new_config.breakdowns_disabled;
+        node["company_ai_disabled"] = _new_config.company_ai_disabled;
         node["scale_factor"] = _new_config.scale_factor;
         node["zoom_to_cursor"] = _new_config.zoom_to_cursor;
 

--- a/src/openloco/config.h
+++ b/src/openloco/config.h
@@ -150,7 +150,7 @@ namespace openloco::config
         std::string loco_install_path;
         std::string language = "en-GB";
         bool breakdowns_disabled = false;
-        bool company_ai_disabled = false;
+        bool companyAIDisabled = false;
         float scale_factor = 1.0f;
         bool zoom_to_cursor = true;
     };

--- a/src/openloco/config.h
+++ b/src/openloco/config.h
@@ -150,6 +150,7 @@ namespace openloco::config
         std::string loco_install_path;
         std::string language = "en-GB";
         bool breakdowns_disabled = false;
+        bool company_ai_disabled = false;
         float scale_factor = 1.0f;
         bool zoom_to_cursor = true;
     };

--- a/src/openloco/localisation/string_ids.h
+++ b/src/openloco/localisation/string_ids.h
@@ -1317,6 +1317,6 @@ namespace openloco::string_ids
     constexpr string_id menu_quit_to_menu = 2139;
     constexpr string_id menu_exit_openloco = 2140;
 
-    constexpr string_id disable_ai_companies = 2141;
-    constexpr string_id disable_ai_companies_tip = 2142;
+    constexpr string_id disableAICompanies = 2141;
+    constexpr string_id disableAICompanies_tip = 2142;
 }

--- a/src/openloco/localisation/string_ids.h
+++ b/src/openloco/localisation/string_ids.h
@@ -1316,4 +1316,7 @@ namespace openloco::string_ids
 
     constexpr string_id menu_quit_to_menu = 2139;
     constexpr string_id menu_exit_openloco = 2140;
+
+    constexpr string_id disable_ai_companies = 2141;
+    constexpr string_id disable_ai_companies_tip = 2142;
 }

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -1847,27 +1847,29 @@ namespace openloco::ui::options
 
     namespace misc
     {
-        static const gfx::ui_size_t _window_size = { 420, 124 };
+        static const gfx::ui_size_t _window_size = { 420, 139 };
 
         namespace widx
         {
             enum
             {
                 disable_vehicle_breakdowns = 10,
+                disable_ai_companies,
                 use_preferred_owner_name,
                 change_btn,
                 export_plugin_objects,
             };
         }
 
-        static constexpr uint64_t enabledWidgets = common::enabledWidgets | (1 << misc::widx::disable_vehicle_breakdowns) | (1 << misc::widx::use_preferred_owner_name) | (1 << misc::widx::change_btn) | (1 << misc::widx::export_plugin_objects);
+        static constexpr uint64_t enabledWidgets = common::enabledWidgets | (1 << misc::widx::disable_vehicle_breakdowns) | (1 << widx::disable_ai_companies) | (1 << misc::widx::use_preferred_owner_name) | (1 << misc::widx::change_btn) | (1 << misc::widx::export_plugin_objects);
 
         static widget_t _widgets[] = {
             common_options_widgets(_window_size, string_ids::options_title_miscellaneous),
             make_widget({ 10, 49 }, { 400, 12 }, widget_type::checkbox, 1, string_ids::disable_vehicle_breakdowns, string_ids::null),
-            make_widget({ 10, 64 }, { 400, 12 }, widget_type::checkbox, 1, string_ids::use_preferred_owner_name, string_ids::use_preferred_owner_name_tip),
-            make_widget({ 335, 79 }, { 75, 12 }, widget_type::wt_11, 1, string_ids::change),
-            make_widget({ 10, 94 }, { 400, 12 }, widget_type::checkbox, 1, string_ids::export_plugin_objects, string_ids::export_plugin_objects_tip),
+            make_widget({ 10, 64 }, { 400, 12 }, widget_type::checkbox, 1, string_ids::disable_ai_companies, string_ids::disable_ai_companies_tip),
+            make_widget({ 10, 79 }, { 400, 12 }, widget_type::checkbox, 1, string_ids::use_preferred_owner_name, string_ids::use_preferred_owner_name_tip),
+            make_widget({ 335, 94 }, { 75, 12 }, widget_type::wt_11, 1, string_ids::change),
+            make_widget({ 10, 109 }, { 400, 12 }, widget_type::checkbox, 1, string_ids::export_plugin_objects, string_ids::export_plugin_objects_tip),
             widget_end(),
         };
 
@@ -1879,6 +1881,7 @@ namespace openloco::ui::options
         static void set_preferred_name(window* w, char* str);
         static void use_preferred_owner_name_mouse_up(window* w);
         static void disable_vehicle_breakdowns_mouse_up(window* w);
+        static void disable_ai_companies_mouse_up(window* w);
         static void export_plugin_objects_mouse_up(window* w);
 
         // 0x004C11B7
@@ -1902,6 +1905,11 @@ namespace openloco::ui::options
                 w->activated_widgets |= (1 << widx::disable_vehicle_breakdowns);
             else
                 w->activated_widgets &= ~(1 << widx::disable_vehicle_breakdowns);
+
+            if (config::get_new().company_ai_disabled)
+                w->activated_widgets |= (1 << widx::disable_ai_companies);
+            else
+                w->activated_widgets &= ~(1 << widx::disable_ai_companies);
 
             w->activated_widgets &= ~(1 << widx::export_plugin_objects);
             if (config::get().flags & config::flags::export_objects_with_saves)
@@ -1962,6 +1970,10 @@ namespace openloco::ui::options
 
                 case widx::disable_vehicle_breakdowns:
                     disable_vehicle_breakdowns_mouse_up(w);
+                    break;
+
+                case widx::disable_ai_companies:
+                    disable_ai_companies_mouse_up(w);
                     break;
 
                 case widx::export_plugin_objects:
@@ -2045,6 +2057,14 @@ namespace openloco::ui::options
         {
             auto& cfg = openloco::config::get_new();
             cfg.breakdowns_disabled = !cfg.breakdowns_disabled;
+            config::write();
+            w->invalidate();
+        }
+
+        static void disable_ai_companies_mouse_up(window* w)
+        {
+            auto& cfg = openloco::config::get_new();
+            cfg.company_ai_disabled = !cfg.company_ai_disabled;
             config::write();
             w->invalidate();
         }

--- a/src/openloco/windows/options.cpp
+++ b/src/openloco/windows/options.cpp
@@ -1854,19 +1854,19 @@ namespace openloco::ui::options
             enum
             {
                 disable_vehicle_breakdowns = 10,
-                disable_ai_companies,
+                disableAICompanies,
                 use_preferred_owner_name,
                 change_btn,
                 export_plugin_objects,
             };
         }
 
-        static constexpr uint64_t enabledWidgets = common::enabledWidgets | (1 << misc::widx::disable_vehicle_breakdowns) | (1 << widx::disable_ai_companies) | (1 << misc::widx::use_preferred_owner_name) | (1 << misc::widx::change_btn) | (1 << misc::widx::export_plugin_objects);
+        static constexpr uint64_t enabledWidgets = common::enabledWidgets | (1 << misc::widx::disable_vehicle_breakdowns) | (1 << widx::disableAICompanies) | (1 << misc::widx::use_preferred_owner_name) | (1 << misc::widx::change_btn) | (1 << misc::widx::export_plugin_objects);
 
         static widget_t _widgets[] = {
             common_options_widgets(_window_size, string_ids::options_title_miscellaneous),
             make_widget({ 10, 49 }, { 400, 12 }, widget_type::checkbox, 1, string_ids::disable_vehicle_breakdowns, string_ids::null),
-            make_widget({ 10, 64 }, { 400, 12 }, widget_type::checkbox, 1, string_ids::disable_ai_companies, string_ids::disable_ai_companies_tip),
+            make_widget({ 10, 64 }, { 400, 12 }, widget_type::checkbox, 1, string_ids::disableAICompanies, string_ids::disableAICompanies_tip),
             make_widget({ 10, 79 }, { 400, 12 }, widget_type::checkbox, 1, string_ids::use_preferred_owner_name, string_ids::use_preferred_owner_name_tip),
             make_widget({ 335, 94 }, { 75, 12 }, widget_type::wt_11, 1, string_ids::change),
             make_widget({ 10, 109 }, { 400, 12 }, widget_type::checkbox, 1, string_ids::export_plugin_objects, string_ids::export_plugin_objects_tip),
@@ -1881,7 +1881,7 @@ namespace openloco::ui::options
         static void set_preferred_name(window* w, char* str);
         static void use_preferred_owner_name_mouse_up(window* w);
         static void disable_vehicle_breakdowns_mouse_up(window* w);
-        static void disable_ai_companies_mouse_up(window* w);
+        static void disableAICompaniesMouseUp(window* w);
         static void export_plugin_objects_mouse_up(window* w);
 
         // 0x004C11B7
@@ -1906,10 +1906,10 @@ namespace openloco::ui::options
             else
                 w->activated_widgets &= ~(1 << widx::disable_vehicle_breakdowns);
 
-            if (config::get_new().company_ai_disabled)
-                w->activated_widgets |= (1 << widx::disable_ai_companies);
+            if (config::get_new().companyAIDisabled)
+                w->activated_widgets |= (1 << widx::disableAICompanies);
             else
-                w->activated_widgets &= ~(1 << widx::disable_ai_companies);
+                w->activated_widgets &= ~(1 << widx::disableAICompanies);
 
             w->activated_widgets &= ~(1 << widx::export_plugin_objects);
             if (config::get().flags & config::flags::export_objects_with_saves)
@@ -1972,8 +1972,8 @@ namespace openloco::ui::options
                     disable_vehicle_breakdowns_mouse_up(w);
                     break;
 
-                case widx::disable_ai_companies:
-                    disable_ai_companies_mouse_up(w);
+                case widx::disableAICompanies:
+                    disableAICompaniesMouseUp(w);
                     break;
 
                 case widx::export_plugin_objects:
@@ -2061,10 +2061,10 @@ namespace openloco::ui::options
             w->invalidate();
         }
 
-        static void disable_ai_companies_mouse_up(window* w)
+        static void disableAICompaniesMouseUp(window* w)
         {
             auto& cfg = openloco::config::get_new();
-            cfg.company_ai_disabled = !cfg.company_ai_disabled;
+            cfg.companyAIDisabled = !cfg.companyAIDisabled;
             config::write();
             w->invalidate();
         }


### PR DESCRIPTION
The current, vanilla implementation of AI companies is not very good. Their railroads swirl across the landscape, potentially ruining any elegant lines the player may have created. This PR introduces an option to disable them entirely.

Much like the option to disable vehicle breakdowns, as-is, this is very much a cheat. Ultimately, I would like to see this checkbox replaced with a dropdown to select which AI to use.

![Screenshot](https://user-images.githubusercontent.com/604665/89121699-56e75800-d4c1-11ea-9e12-65d813180539.png)