### PR TITLE
Refactor scroll

### DIFF
--- a/src/openloco/input/mouse_input.cpp
+++ b/src/openloco/input/mouse_input.cpp
@@ -40,7 +40,7 @@ namespace openloco::input
 
     static void viewport_drag_begin(window* w);
 
-    static void scroll_begin(int16_t x, int16_t y, ui::window* window, ui::widget_t* widget, int8_t widgetIndex);
+    static void scrollLeft(int16_t x, int16_t y, ui::window* window, ui::widget_t* widget, int8_t widgetIndex);
 
     static void scroll_drag_begin(int16_t x, int16_t y, window* pWindow, widget_index index);
 
@@ -1562,7 +1562,7 @@ namespace openloco::input
                 _pressedWindowNumber = window->number;
                 _tooltipCursorX = x;
                 _tooltipCursorY = y;
-                scroll_begin(x, y, window, widget, widgetIndex);
+                scrollLeft(x, y, window, widget, widgetIndex);
                 break;
 
             default:
@@ -1722,7 +1722,7 @@ namespace openloco::input
 #pragma mark - Scroll bars
 
     // 0x004C8689
-    void scroll_begin(int16_t x, int16_t y, ui::window* w, ui::widget_t* widget, int8_t widgetIndex)
+    void scrollLeft(int16_t x, int16_t y, ui::window* w, ui::widget_t* widget, int8_t widgetIndex)
     {
         ui::scrollview::scroll_part scrollArea;
         int16_t outX, outY;
@@ -1746,50 +1746,50 @@ namespace openloco::input
                 // 0x004C894F
                 w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::HSCROLLBAR_LEFT_PRESSED;
                 w->scroll_areas[scrollAreaIndex].h_left = std::max(w->scroll_areas[scrollAreaIndex].h_left - SCROLLBAR_BUTTON_CLICK_STEP, 0);
-                scrollview::update_thumbs(w, _pressedWidgetIndex);
-                WindowManager::invalidateWidget(_pressedWindowType, _pressedWindowNumber, _pressedWidgetIndex);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
                 break;
             }
             case ui::scrollview::scroll_part::hscrollbar_button_right:
             {
                 // 0x004C89AE
                 w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::HSCROLLBAR_RIGHT_PRESSED;
-                int16_t widgetWidth = w->widgets[_pressedWidgetIndex].width() - 2;
+                int16_t widgetWidth = w->widgets[widgetIndex].width() - 2;
                 if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::VSCROLLBAR_VISIBLE) != 0)
                 {
                     widgetWidth -= SCROLLBAR_WIDTH + 1;
                 }
                 int16_t widgetContentWidth = std::max(w->scroll_areas[scrollAreaIndex].h_right - widgetWidth, 0);
                 w->scroll_areas[scrollAreaIndex].h_left = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].h_left + SCROLLBAR_BUTTON_CLICK_STEP, widgetContentWidth);
-                scrollview::update_thumbs(w, _pressedWidgetIndex);
-                WindowManager::invalidateWidget(_pressedWindowType, _pressedWindowNumber, _pressedWidgetIndex);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
                 break;
             }
             case ui::scrollview::scroll_part::hscrollbar_track_left:
             {
                 // 0x004C8A36
-                int16_t widgetWidth = w->widgets[_pressedWidgetIndex].width() - 2;
+                int16_t widgetWidth = w->widgets[widgetIndex].width() - 2;
                 if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::VSCROLLBAR_VISIBLE) != 0)
                 {
                     widgetWidth -= SCROLLBAR_WIDTH + 1;
                 }
                 w->scroll_areas[scrollAreaIndex].h_left = std::max(w->scroll_areas[scrollAreaIndex].h_left - widgetWidth, 0);
-                scrollview::update_thumbs(w, _pressedWidgetIndex);
-                WindowManager::invalidateWidget(_pressedWindowType, _pressedWindowNumber, _pressedWidgetIndex);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
                 break;
             }
             case ui::scrollview::scroll_part::hscrollbar_track_right:
             {
                 // 0x004C8AA6
-                int16_t widgetWidth = w->widgets[_pressedWidgetIndex].width() - 2;
+                int16_t widgetWidth = w->widgets[widgetIndex].width() - 2;
                 if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::VSCROLLBAR_VISIBLE) != 0)
                 {
                     widgetWidth -= SCROLLBAR_WIDTH + 1;
                 }
                 int16_t widgetContentWidth = std::max(w->scroll_areas[scrollAreaIndex].h_right - widgetWidth, 0);
                 w->scroll_areas[scrollAreaIndex].h_left = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].h_left + widgetWidth, widgetContentWidth);
-                scrollview::update_thumbs(w, _pressedWidgetIndex);
-                WindowManager::invalidateWidget(_pressedWindowType, _pressedWindowNumber, _pressedWidgetIndex);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
                 break;
             }
 
@@ -1798,50 +1798,50 @@ namespace openloco::input
                 // 0x004C8B26
                 w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::VSCROLLBAR_UP_PRESSED;
                 w->scroll_areas[scrollAreaIndex].v_top = std::max(w->scroll_areas[scrollAreaIndex].v_top - SCROLLBAR_BUTTON_CLICK_STEP, 0);
-                scrollview::update_thumbs(w, _pressedWidgetIndex);
-                WindowManager::invalidateWidget(_pressedWindowType, _pressedWindowNumber, _pressedWidgetIndex);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
                 break;
             }
             case ui::scrollview::scroll_part::vscrollbar_button_bottom:
             {
                 // 0x004C8B85
                 w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::VSCROLLBAR_DOWN_PRESSED;
-                int16_t widgetHeight = w->widgets[_pressedWidgetIndex].height() - 2;
+                int16_t widgetHeight = w->widgets[widgetIndex].height() - 2;
                 if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::HSCROLLBAR_VISIBLE) != 0)
                 {
                     widgetHeight -= SCROLLBAR_WIDTH + 1;
                 }
                 int16_t widgetContentHeight = std::max(w->scroll_areas[scrollAreaIndex].v_bottom - widgetHeight, 0);
                 w->scroll_areas[scrollAreaIndex].v_top = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].v_top + SCROLLBAR_BUTTON_CLICK_STEP, widgetContentHeight);
-                scrollview::update_thumbs(w, _pressedWidgetIndex);
-                WindowManager::invalidateWidget(_pressedWindowType, _pressedWindowNumber, _pressedWidgetIndex);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
                 break;
             }
             case ui::scrollview::scroll_part::vscrollbar_track_top:
             {
                 // 0x004C8C0D
-                int16_t widgetHeight = w->widgets[_pressedWidgetIndex].height() - 2;
+                int16_t widgetHeight = w->widgets[widgetIndex].height() - 2;
                 if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::HSCROLLBAR_VISIBLE) != 0)
                 {
                     widgetHeight -= SCROLLBAR_WIDTH + 1;
                 }
                 w->scroll_areas[scrollAreaIndex].v_top = std::max(w->scroll_areas[scrollAreaIndex].v_top - widgetHeight, 0);
-                scrollview::update_thumbs(w, _pressedWidgetIndex);
-                WindowManager::invalidateWidget(_pressedWindowType, _pressedWindowNumber, _pressedWidgetIndex);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
                 break;
             }
             case ui::scrollview::scroll_part::vscrollbar_track_bottom:
             {
                 // 0x004C8C7D
-                int16_t widgetHeight = w->widgets[_pressedWidgetIndex].height() - 2;
+                int16_t widgetHeight = w->widgets[widgetIndex].height() - 2;
                 if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::HSCROLLBAR_VISIBLE) != 0)
                 {
                     widgetHeight -= SCROLLBAR_WIDTH + 1;
                 }
                 int16_t widgetContentHeight = std::max(w->scroll_areas[scrollAreaIndex].v_bottom - widgetHeight, 0);
                 w->scroll_areas[scrollAreaIndex].v_top = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].v_top + widgetHeight, widgetContentHeight);
-                scrollview::update_thumbs(w, _pressedWidgetIndex);
-                WindowManager::invalidateWidget(_pressedWindowType, _pressedWindowNumber, _pressedWidgetIndex);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
                 break;
             }
 

--- a/src/openloco/input/mouse_input.cpp
+++ b/src/openloco/input/mouse_input.cpp
@@ -1557,7 +1557,7 @@ namespace openloco::input
                 _pressedWindowNumber = window->number;
                 _tooltipCursorX = x;
                 _tooltipCursorY = y;
-                ui::scrollview::scrollLeft(x, y, window, widget, widgetIndex);
+                ui::scrollview::scrollLeftBegin(x, y, window, widget, widgetIndex);
                 break;
 
             default:

--- a/src/openloco/ui/scrollview.cpp
+++ b/src/openloco/ui/scrollview.cpp
@@ -7,6 +7,8 @@ using namespace openloco::interop;
 
 namespace openloco::ui::scrollview
 {
+    static loco_global<uint16_t, 0x00523396> _currentScrollArea;
+    static loco_global<uint32_t, 0x00523398> _currentScrollOffset;
 
     // 0x004C8EF0
     void get_part(
@@ -42,5 +44,153 @@ namespace openloco::ui::scrollview
         regs.ebx = window->get_scroll_data_index(widgetIndex) * sizeof(scroll_area_t);
         regs.edi = (uintptr_t)&window->widgets[widgetIndex];
         call(0x4CA1ED, regs);
+    }
+
+    // 0x004C8689
+    void scrollLeft(const int16_t x, const int16_t y, ui::window* const w, ui::widget_t* const widget, const int8_t widgetIndex)
+    {
+        ui::scrollview::scroll_part scrollArea;
+        int16_t outX, outY;
+        int32_t scrollAreaOffset;
+
+        ui::scrollview::get_part(w, widget, x, y, &outX, &outY, &scrollArea, &scrollAreaOffset);
+
+        _currentScrollArea = (uint16_t)scrollArea;
+        _currentScrollOffset = scrollAreaOffset;
+        int16_t scrollAreaIndex = scrollAreaOffset / sizeof(ui::scroll_area_t);
+
+        // Not implemented for any window
+        // window->call_22()
+        switch (scrollArea)
+        {
+            case ui::scrollview::scroll_part::view:
+                w->call_scroll_mouse_down(outX, outY, scrollAreaIndex);
+                break;
+            case ui::scrollview::scroll_part::hscrollbar_button_left:
+            {
+                // 0x004C894F
+                w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::HSCROLLBAR_LEFT_PRESSED;
+                w->scroll_areas[scrollAreaIndex].h_left = std::max(w->scroll_areas[scrollAreaIndex].h_left - SCROLLBAR_BUTTON_CLICK_STEP, 0);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                break;
+            }
+            case ui::scrollview::scroll_part::hscrollbar_button_right:
+            {
+                // 0x004C89AE
+                w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::HSCROLLBAR_RIGHT_PRESSED;
+                int16_t widgetWidth = w->widgets[widgetIndex].width() - 2;
+                if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::VSCROLLBAR_VISIBLE) != 0)
+                {
+                    widgetWidth -= SCROLLBAR_WIDTH + 1;
+                }
+                int16_t widgetContentWidth = std::max(w->scroll_areas[scrollAreaIndex].h_right - widgetWidth, 0);
+                w->scroll_areas[scrollAreaIndex].h_left = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].h_left + SCROLLBAR_BUTTON_CLICK_STEP, widgetContentWidth);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                break;
+            }
+            case ui::scrollview::scroll_part::hscrollbar_track_left:
+            {
+                // 0x004C8A36
+                int16_t widgetWidth = w->widgets[widgetIndex].width() - 2;
+                if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::VSCROLLBAR_VISIBLE) != 0)
+                {
+                    widgetWidth -= SCROLLBAR_WIDTH + 1;
+                }
+                w->scroll_areas[scrollAreaIndex].h_left = std::max(w->scroll_areas[scrollAreaIndex].h_left - widgetWidth, 0);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                break;
+            }
+            case ui::scrollview::scroll_part::hscrollbar_track_right:
+            {
+                // 0x004C8AA6
+                int16_t widgetWidth = w->widgets[widgetIndex].width() - 2;
+                if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::VSCROLLBAR_VISIBLE) != 0)
+                {
+                    widgetWidth -= SCROLLBAR_WIDTH + 1;
+                }
+                int16_t widgetContentWidth = std::max(w->scroll_areas[scrollAreaIndex].h_right - widgetWidth, 0);
+                w->scroll_areas[scrollAreaIndex].h_left = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].h_left + widgetWidth, widgetContentWidth);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                break;
+            }
+
+            case ui::scrollview::scroll_part::vscrollbar_button_top:
+            {
+                // 0x004C8B26
+                w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::VSCROLLBAR_UP_PRESSED;
+                w->scroll_areas[scrollAreaIndex].v_top = std::max(w->scroll_areas[scrollAreaIndex].v_top - SCROLLBAR_BUTTON_CLICK_STEP, 0);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                break;
+            }
+            case ui::scrollview::scroll_part::vscrollbar_button_bottom:
+            {
+                // 0x004C8B85
+                w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::VSCROLLBAR_DOWN_PRESSED;
+                int16_t widgetHeight = w->widgets[widgetIndex].height() - 2;
+                if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::HSCROLLBAR_VISIBLE) != 0)
+                {
+                    widgetHeight -= SCROLLBAR_WIDTH + 1;
+                }
+                int16_t widgetContentHeight = std::max(w->scroll_areas[scrollAreaIndex].v_bottom - widgetHeight, 0);
+                w->scroll_areas[scrollAreaIndex].v_top = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].v_top + SCROLLBAR_BUTTON_CLICK_STEP, widgetContentHeight);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                break;
+            }
+            case ui::scrollview::scroll_part::vscrollbar_track_top:
+            {
+                // 0x004C8C0D
+                int16_t widgetHeight = w->widgets[widgetIndex].height() - 2;
+                if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::HSCROLLBAR_VISIBLE) != 0)
+                {
+                    widgetHeight -= SCROLLBAR_WIDTH + 1;
+                }
+                w->scroll_areas[scrollAreaIndex].v_top = std::max(w->scroll_areas[scrollAreaIndex].v_top - widgetHeight, 0);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                break;
+            }
+            case ui::scrollview::scroll_part::vscrollbar_track_bottom:
+            {
+                // 0x004C8C7D
+                int16_t widgetHeight = w->widgets[widgetIndex].height() - 2;
+                if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::HSCROLLBAR_VISIBLE) != 0)
+                {
+                    widgetHeight -= SCROLLBAR_WIDTH + 1;
+                }
+                int16_t widgetContentHeight = std::max(w->scroll_areas[scrollAreaIndex].v_bottom - widgetHeight, 0);
+                w->scroll_areas[scrollAreaIndex].v_top = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].v_top + widgetHeight, widgetContentHeight);
+                scrollview::update_thumbs(w, widgetIndex);
+                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                break;
+            }
+
+            default:
+                break;
+        }
+    }
+
+    // Based on 0x004C8689
+    void scrollModalRight(const int16_t x, const int16_t y, ui::window* const w, ui::widget_t* const widget, const int8_t widgetIndex)
+    {
+        ui::scrollview::scroll_part scrollArea;
+        int16_t outX, outY;
+        int32_t scrollAreaOffset;
+
+        ui::scrollview::get_part(w, widget, x, y, &outX, &outY, &scrollArea, &scrollAreaOffset);
+
+        _currentScrollArea = (uint16_t)scrollArea;
+        _currentScrollOffset = scrollAreaOffset;
+        int16_t scrollAreaIndex = scrollAreaOffset / sizeof(ui::scroll_area_t);
+
+        if (scrollArea == ui::scrollview::scroll_part::view)
+        {
+            w->call_scroll_mouse_down(outX, outY, scrollAreaIndex);
+        }
     }
 }

--- a/src/openloco/ui/scrollview.cpp
+++ b/src/openloco/ui/scrollview.cpp
@@ -8,6 +8,7 @@ using namespace openloco::interop;
 namespace openloco::ui::scrollview
 {
     static loco_global<uint16_t, 0x00523396> _currentScrollArea;
+    // TODO: Convert to a scrollIndex when all scroll functions implemented
     static loco_global<uint32_t, 0x00523398> _currentScrollOffset;
 
     // 0x004C8EF0
@@ -46,8 +47,110 @@ namespace openloco::ui::scrollview
         call(0x4CA1ED, regs);
     }
 
+    // 0x004C894F
+    static void hButtonLeft(ui::window* const w, const int16_t scrollAreaIndex, const widget_index widgetIndex)
+    {
+        w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::HSCROLLBAR_LEFT_PRESSED;
+        w->scroll_areas[scrollAreaIndex].h_left = std::max(w->scroll_areas[scrollAreaIndex].h_left - SCROLLBAR_BUTTON_CLICK_STEP, 0);
+        scrollview::update_thumbs(w, widgetIndex);
+        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+    }
+
+    // 0x004C89AE
+    static void hButtonRight(ui::window* const w, const int16_t scrollAreaIndex, const widget_index widgetIndex)
+    {
+        w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::HSCROLLBAR_RIGHT_PRESSED;
+        int16_t widgetWidth = w->widgets[widgetIndex].width() - 2;
+        if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::VSCROLLBAR_VISIBLE) != 0)
+        {
+            widgetWidth -= SCROLLBAR_WIDTH + 1;
+        }
+        int16_t widgetContentWidth = std::max(w->scroll_areas[scrollAreaIndex].h_right - widgetWidth, 0);
+        w->scroll_areas[scrollAreaIndex].h_left = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].h_left + SCROLLBAR_BUTTON_CLICK_STEP, widgetContentWidth);
+        scrollview::update_thumbs(w, widgetIndex);
+        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+    }
+
+    // 0x004C8A36
+    static void hTrackLeft(ui::window* const w, const int16_t scrollAreaIndex, const widget_index widgetIndex)
+    {
+        int16_t widgetWidth = w->widgets[widgetIndex].width() - 2;
+        if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::VSCROLLBAR_VISIBLE) != 0)
+        {
+            widgetWidth -= SCROLLBAR_WIDTH + 1;
+        }
+        w->scroll_areas[scrollAreaIndex].h_left = std::max(w->scroll_areas[scrollAreaIndex].h_left - widgetWidth, 0);
+        scrollview::update_thumbs(w, widgetIndex);
+        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+    }
+
+    // 0x004C8AA6
+    static void hTrackRight(ui::window* const w, const int16_t scrollAreaIndex, const widget_index widgetIndex)
+    {
+        int16_t widgetWidth = w->widgets[widgetIndex].width() - 2;
+        if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::VSCROLLBAR_VISIBLE) != 0)
+        {
+            widgetWidth -= SCROLLBAR_WIDTH + 1;
+        }
+        int16_t widgetContentWidth = std::max(w->scroll_areas[scrollAreaIndex].h_right - widgetWidth, 0);
+        w->scroll_areas[scrollAreaIndex].h_left = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].h_left + widgetWidth, widgetContentWidth);
+        scrollview::update_thumbs(w, widgetIndex);
+        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+    }
+
+    // 0x004C8B26
+    static void vButtonTop(ui::window* const w, const int16_t scrollAreaIndex, const widget_index widgetIndex)
+    {
+        w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::VSCROLLBAR_UP_PRESSED;
+        w->scroll_areas[scrollAreaIndex].v_top = std::max(w->scroll_areas[scrollAreaIndex].v_top - SCROLLBAR_BUTTON_CLICK_STEP, 0);
+        scrollview::update_thumbs(w, widgetIndex);
+        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+    }
+
+    // 0x004C8B85
+    static void vButtonBottom(ui::window* const w, const int16_t scrollAreaIndex, const widget_index widgetIndex)
+    {
+        w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::VSCROLLBAR_DOWN_PRESSED;
+        int16_t widgetHeight = w->widgets[widgetIndex].height() - 2;
+        if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::HSCROLLBAR_VISIBLE) != 0)
+        {
+            widgetHeight -= SCROLLBAR_WIDTH + 1;
+        }
+        int16_t widgetContentHeight = std::max(w->scroll_areas[scrollAreaIndex].v_bottom - widgetHeight, 0);
+        w->scroll_areas[scrollAreaIndex].v_top = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].v_top + SCROLLBAR_BUTTON_CLICK_STEP, widgetContentHeight);
+        scrollview::update_thumbs(w, widgetIndex);
+        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+    }
+
+    // 0x004C8C0D
+    static void vTrackTop(ui::window* const w, const int16_t scrollAreaIndex, const widget_index widgetIndex)
+    {
+        int16_t widgetHeight = w->widgets[widgetIndex].height() - 2;
+        if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::HSCROLLBAR_VISIBLE) != 0)
+        {
+            widgetHeight -= SCROLLBAR_WIDTH + 1;
+        }
+        w->scroll_areas[scrollAreaIndex].v_top = std::max(w->scroll_areas[scrollAreaIndex].v_top - widgetHeight, 0);
+        scrollview::update_thumbs(w, widgetIndex);
+        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+    }
+
+    // 0x004C8C7D
+    static void vTrackBottom(ui::window* const w, const int16_t scrollAreaIndex, const widget_index widgetIndex)
+    {
+        int16_t widgetHeight = w->widgets[widgetIndex].height() - 2;
+        if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::HSCROLLBAR_VISIBLE) != 0)
+        {
+            widgetHeight -= SCROLLBAR_WIDTH + 1;
+        }
+        int16_t widgetContentHeight = std::max(w->scroll_areas[scrollAreaIndex].v_bottom - widgetHeight, 0);
+        w->scroll_areas[scrollAreaIndex].v_top = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].v_top + widgetHeight, widgetContentHeight);
+        scrollview::update_thumbs(w, widgetIndex);
+        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+    }
+
     // 0x004C8689
-    void scrollLeft(const int16_t x, const int16_t y, ui::window* const w, ui::widget_t* const widget, const int8_t widgetIndex)
+    void scrollLeftBegin(const int16_t x, const int16_t y, ui::window* const w, ui::widget_t* const widget, const widget_index widgetIndex)
     {
         ui::scrollview::scroll_part scrollArea;
         int16_t outX, outY;
@@ -67,116 +170,36 @@ namespace openloco::ui::scrollview
                 w->call_scroll_mouse_down(outX, outY, scrollAreaIndex);
                 break;
             case ui::scrollview::scroll_part::hscrollbar_button_left:
-            {
-                // 0x004C894F
-                w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::HSCROLLBAR_LEFT_PRESSED;
-                w->scroll_areas[scrollAreaIndex].h_left = std::max(w->scroll_areas[scrollAreaIndex].h_left - SCROLLBAR_BUTTON_CLICK_STEP, 0);
-                scrollview::update_thumbs(w, widgetIndex);
-                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                hButtonLeft(w, scrollAreaIndex, widgetIndex);
                 break;
-            }
             case ui::scrollview::scroll_part::hscrollbar_button_right:
-            {
-                // 0x004C89AE
-                w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::HSCROLLBAR_RIGHT_PRESSED;
-                int16_t widgetWidth = w->widgets[widgetIndex].width() - 2;
-                if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::VSCROLLBAR_VISIBLE) != 0)
-                {
-                    widgetWidth -= SCROLLBAR_WIDTH + 1;
-                }
-                int16_t widgetContentWidth = std::max(w->scroll_areas[scrollAreaIndex].h_right - widgetWidth, 0);
-                w->scroll_areas[scrollAreaIndex].h_left = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].h_left + SCROLLBAR_BUTTON_CLICK_STEP, widgetContentWidth);
-                scrollview::update_thumbs(w, widgetIndex);
-                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                hButtonRight(w, scrollAreaIndex, widgetIndex);
                 break;
-            }
             case ui::scrollview::scroll_part::hscrollbar_track_left:
-            {
-                // 0x004C8A36
-                int16_t widgetWidth = w->widgets[widgetIndex].width() - 2;
-                if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::VSCROLLBAR_VISIBLE) != 0)
-                {
-                    widgetWidth -= SCROLLBAR_WIDTH + 1;
-                }
-                w->scroll_areas[scrollAreaIndex].h_left = std::max(w->scroll_areas[scrollAreaIndex].h_left - widgetWidth, 0);
-                scrollview::update_thumbs(w, widgetIndex);
-                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                hTrackLeft(w, scrollAreaIndex, widgetIndex);
                 break;
-            }
             case ui::scrollview::scroll_part::hscrollbar_track_right:
-            {
-                // 0x004C8AA6
-                int16_t widgetWidth = w->widgets[widgetIndex].width() - 2;
-                if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::VSCROLLBAR_VISIBLE) != 0)
-                {
-                    widgetWidth -= SCROLLBAR_WIDTH + 1;
-                }
-                int16_t widgetContentWidth = std::max(w->scroll_areas[scrollAreaIndex].h_right - widgetWidth, 0);
-                w->scroll_areas[scrollAreaIndex].h_left = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].h_left + widgetWidth, widgetContentWidth);
-                scrollview::update_thumbs(w, widgetIndex);
-                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                hTrackRight(w, scrollAreaIndex, widgetIndex);
                 break;
-            }
-
             case ui::scrollview::scroll_part::vscrollbar_button_top:
-            {
-                // 0x004C8B26
-                w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::VSCROLLBAR_UP_PRESSED;
-                w->scroll_areas[scrollAreaIndex].v_top = std::max(w->scroll_areas[scrollAreaIndex].v_top - SCROLLBAR_BUTTON_CLICK_STEP, 0);
-                scrollview::update_thumbs(w, widgetIndex);
-                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                vButtonTop(w, scrollAreaIndex, widgetIndex);
                 break;
-            }
             case ui::scrollview::scroll_part::vscrollbar_button_bottom:
-            {
-                // 0x004C8B85
-                w->scroll_areas[scrollAreaIndex].flags |= scroll_flags::VSCROLLBAR_DOWN_PRESSED;
-                int16_t widgetHeight = w->widgets[widgetIndex].height() - 2;
-                if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::HSCROLLBAR_VISIBLE) != 0)
-                {
-                    widgetHeight -= SCROLLBAR_WIDTH + 1;
-                }
-                int16_t widgetContentHeight = std::max(w->scroll_areas[scrollAreaIndex].v_bottom - widgetHeight, 0);
-                w->scroll_areas[scrollAreaIndex].v_top = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].v_top + SCROLLBAR_BUTTON_CLICK_STEP, widgetContentHeight);
-                scrollview::update_thumbs(w, widgetIndex);
-                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                vButtonBottom(w, scrollAreaIndex, widgetIndex);
                 break;
-            }
             case ui::scrollview::scroll_part::vscrollbar_track_top:
-            {
-                // 0x004C8C0D
-                int16_t widgetHeight = w->widgets[widgetIndex].height() - 2;
-                if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::HSCROLLBAR_VISIBLE) != 0)
-                {
-                    widgetHeight -= SCROLLBAR_WIDTH + 1;
-                }
-                w->scroll_areas[scrollAreaIndex].v_top = std::max(w->scroll_areas[scrollAreaIndex].v_top - widgetHeight, 0);
-                scrollview::update_thumbs(w, widgetIndex);
-                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                vTrackTop(w, scrollAreaIndex, widgetIndex);
                 break;
-            }
             case ui::scrollview::scroll_part::vscrollbar_track_bottom:
-            {
-                // 0x004C8C7D
-                int16_t widgetHeight = w->widgets[widgetIndex].height() - 2;
-                if ((w->scroll_areas[scrollAreaIndex].flags & scroll_flags::HSCROLLBAR_VISIBLE) != 0)
-                {
-                    widgetHeight -= SCROLLBAR_WIDTH + 1;
-                }
-                int16_t widgetContentHeight = std::max(w->scroll_areas[scrollAreaIndex].v_bottom - widgetHeight, 0);
-                w->scroll_areas[scrollAreaIndex].v_top = std::min<int16_t>(w->scroll_areas[scrollAreaIndex].v_top + widgetHeight, widgetContentHeight);
-                scrollview::update_thumbs(w, widgetIndex);
-                WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+                vTrackBottom(w, scrollAreaIndex, widgetIndex);
                 break;
-            }
-
             default:
                 break;
         }
     }
 
     // Based on 0x004C8689
-    void scrollModalRight(const int16_t x, const int16_t y, ui::window* const w, ui::widget_t* const widget, const int8_t widgetIndex)
+    void scrollModalRight(const int16_t x, const int16_t y, ui::window* const w, ui::widget_t* const widget, const widget_index widgetIndex)
     {
         ui::scrollview::scroll_part scrollArea;
         int16_t outX, outY;

--- a/src/openloco/ui/scrollview.h
+++ b/src/openloco/ui/scrollview.h
@@ -46,4 +46,6 @@ namespace openloco::ui::scrollview
         scroll_part* output_scroll_area,
         int32_t* scroll_id);
     void update_thumbs(window* window, widget_index widgetIndex);
+    void scrollLeft(const int16_t x, const int16_t y, ui::window* const w, ui::widget_t* const widget, const int8_t widgetIndex);
+    void scrollModalRight(const int16_t x, const int16_t y, ui::window* const w, ui::widget_t* const widget, const int8_t widgetIndex);
 }

--- a/src/openloco/ui/scrollview.h
+++ b/src/openloco/ui/scrollview.h
@@ -46,6 +46,6 @@ namespace openloco::ui::scrollview
         scroll_part* output_scroll_area,
         int32_t* scroll_id);
     void update_thumbs(window* window, widget_index widgetIndex);
-    void scrollLeft(const int16_t x, const int16_t y, ui::window* const w, ui::widget_t* const widget, const int8_t widgetIndex);
-    void scrollModalRight(const int16_t x, const int16_t y, ui::window* const w, ui::widget_t* const widget, const int8_t widgetIndex);
+    void scrollLeftBegin(const int16_t x, const int16_t y, ui::window* const w, ui::widget_t* const widget, const widget_index widgetIndex);
+    void scrollModalRight(const int16_t x, const int16_t y, ui::window* const w, ui::widget_t* const widget, const widget_index widgetIndex);
 }


### PR DESCRIPTION
This moves the scroll_begin function to the scroll view file and also gets it ready for slotting in the scroll left and right functions.

I also split up the modal right function as it didn't make sense to call the main scroll begin function. This fixes a bug in the ui where the modal scroll button would get stuck on.

In addition there were a bunch of pointless gets of the window ptr when we already had the window ptr those have been removed. View each individual commit if you want something easier to follow for these changes. 