### PR TITLE
Fix right click map scroll

### DIFF
--- a/src/openloco/ui/WindowManager.cpp
+++ b/src/openloco/ui/WindowManager.cpp
@@ -1491,7 +1491,7 @@ namespace openloco::ui::WindowManager
                 return;
 
             auto main = WindowManager::getMainWindow();
-            if (main != nullptr)
+            if (main != nullptr && wheel != 0)
             {
                 if (wheel > 0)
                 {


### PR DESCRIPTION
Due to a mistake in implementation the right click mouse scroll would always reset the view back to centre.

For some reason I couldn't seem to reproduce this on all of the releases but it is definitely an issue. 