### PR TITLE
Vehicle Superclass V2

### DIFF
--- a/src/openloco/things/CreateVehicle.cpp
+++ b/src/openloco/things/CreateVehicle.cpp
@@ -436,7 +436,7 @@ namespace openloco::things::vehicle
         Vehicle train(head);
         // lastVeh will point to the vehicle component prior to the tail (head, unk_1, unk_2 *here*, tail) or (... bogie, bogie, body *here*, tail)
         openloco::vehicle* lastVeh = nullptr;
-        if (std::distance(train.cars.begin(), train.cars.end()) > 0)
+        if (!train.cars.empty())
         {
             for (auto& car : train.cars)
             {
@@ -914,7 +914,7 @@ namespace openloco::things::vehicle
                 vehicle_head* veh0backup = _backupVeh0;
                 // If it has an existing body
                 Vehicle bkupTrain(veh0backup);
-                if (std::distance(bkupTrain.cars.begin(), bkupTrain.cars.end()) > 0)
+                if (!bkupTrain.cars.empty())
                 {
                     placeDownVehicle(_backupVeh0, _backupX, _backupY, _backupZ, _backup2C, _backup2E);
                 }

--- a/src/openloco/things/CreateVehicle.cpp
+++ b/src/openloco/things/CreateVehicle.cpp
@@ -436,9 +436,15 @@ namespace openloco::things::vehicle
         Vehicle train(head);
         // lastVeh will point to the vehicle component prior to the tail (head, unk_1, unk_2 *here*, tail) or (... bogie, bogie, body *here*, tail)
         openloco::vehicle* lastVeh = nullptr;
-        if (train.cars.size() > 0)
+        if (std::distance(train.cars.begin(), train.cars.end()) > 0)
         {
-            lastVeh = reinterpret_cast<openloco::vehicle*>(train.cars.back().carComponents.back().body);
+            for (auto& car : train.cars)
+            {
+                for (auto& carComponent : car)
+                {
+                    lastVeh = reinterpret_cast<openloco::vehicle*>(carComponent.body);
+                }
+            }
         }
         else
         {
@@ -908,7 +914,7 @@ namespace openloco::things::vehicle
                 vehicle_head* veh0backup = _backupVeh0;
                 // If it has an existing body
                 Vehicle bkupTrain(veh0backup);
-                if (bkupTrain.cars.size() > 0)
+                if (std::distance(bkupTrain.cars.begin(), bkupTrain.cars.end()) > 0)
                 {
                     placeDownVehicle(_backupVeh0, _backupX, _backupY, _backupZ, _backup2C, _backup2E);
                 }

--- a/src/openloco/things/vehicle.cpp
+++ b/src/openloco/things/vehicle.cpp
@@ -1631,7 +1631,7 @@ bool vehicle_head::isVehicleTypeCompatible(const uint16_t vehicleTypeId) // TODO
     if (newObject->mode == TransportMode::air || newObject->mode == TransportMode::water)
     {
         things::vehicle::Vehicle train(this);
-        if (std::distance(train.cars.begin(), train.cars.end()) != 0)
+        if (!train.cars.empty())
         {
             gGameCommandErrorText = string_ids::incompatible_vehicle;
             return false;

--- a/src/openloco/things/vehicle.h
+++ b/src/openloco/things/vehicle.h
@@ -503,7 +503,7 @@ namespace openloco
                         return *this;
                     }
                     CarComponent next{ nextVehicleComponent };
-                    if (next.body->type == VehicleThingType::body_start)
+                    if (next.body == nullptr || next.body->type == VehicleThingType::body_start)
                     {
                         nextVehicleComponent = nullptr;
                         return *this;
@@ -588,6 +588,10 @@ namespace openloco
                         while (nextVehicleComponent->type != VehicleThingType::tail)
                         {
                             Car next{ nextVehicleComponent };
+                            if (next.body == nullptr)
+                            {
+                                break;
+                            }
                             if (next.body->type == VehicleThingType::body_start)
                             {
                                 current = next;

--- a/src/openloco/things/vehicle.h
+++ b/src/openloco/things/vehicle.h
@@ -570,7 +570,7 @@ namespace openloco
                 public:
                     constexpr CarIter(const Car* carComponent)
                     {
-                        if (carComponent == nullptr)
+                        if (carComponent == nullptr || carComponent->body == nullptr)
                         {
                             nextVehicleComponent = nullptr;
                             return;
@@ -633,6 +633,24 @@ namespace openloco
                 CarIter end() const
                 {
                     return CarIter(nullptr);
+                }
+
+                std::size_t size() const
+                {
+                    if (firstCar.body == nullptr)
+                    {
+                        return 0;
+                    }
+                    return std::distance(begin(), end());
+                }
+
+                bool empty() const
+                {
+                    if (firstCar.body == nullptr)
+                    {
+                        return true;
+                    }
+                    return false;
                 }
 
                 Cars(Car&& _firstCar)

--- a/src/openloco/things/vehicle.h
+++ b/src/openloco/things/vehicle.h
@@ -480,7 +480,7 @@ namespace openloco
                 openloco::vehicle* nextVehicleComponent = nullptr;
 
             public:
-                constexpr CarComponentIter(const CarComponent* carComponent)
+                CarComponentIter(const CarComponent* carComponent)
                 {
                     if (carComponent == nullptr)
                     {
@@ -491,7 +491,7 @@ namespace openloco
                     nextVehicleComponent = reinterpret_cast<openloco::vehicle*>(current.body)->nextVehicleComponent();
                 }
 
-                constexpr CarComponentIter& operator++()
+                CarComponentIter& operator++()
                 {
                     if (nextVehicleComponent == nullptr)
                     {
@@ -512,18 +512,18 @@ namespace openloco
                     return *this;
                 }
 
-                constexpr CarComponentIter operator++(int)
+                CarComponentIter operator++(int)
                 {
                     CarComponentIter retval = *this;
                     ++(*this);
                     return retval;
                 }
 
-                constexpr bool operator==(CarComponentIter other) const
+                bool operator==(CarComponentIter other) const
                 {
                     return nextVehicleComponent == other.nextVehicleComponent;
                 }
-                constexpr bool operator!=(CarComponentIter other) const
+                bool operator!=(CarComponentIter other) const
                 {
                     return !(*this == other);
                 }
@@ -568,7 +568,7 @@ namespace openloco
                     openloco::vehicle* nextVehicleComponent = nullptr;
 
                 public:
-                    constexpr CarIter(const Car* carComponent)
+                    CarIter(const Car* carComponent)
                     {
                         if (carComponent == nullptr || carComponent->body == nullptr)
                         {
@@ -579,7 +579,7 @@ namespace openloco
                         nextVehicleComponent = reinterpret_cast<openloco::vehicle*>(current.body)->nextVehicleComponent();
                     }
 
-                    constexpr CarIter& operator++()
+                    CarIter& operator++()
                     {
                         if (nextVehicleComponent == nullptr)
                         {
@@ -598,18 +598,18 @@ namespace openloco
                         return *this;
                     }
 
-                    constexpr CarIter operator++(int)
+                    CarIter operator++(int)
                     {
                         CarIter retval = *this;
                         ++(*this);
                         return retval;
                     }
 
-                    constexpr bool operator==(CarIter other) const
+                    bool operator==(CarIter other) const
                     {
                         return nextVehicleComponent == other.nextVehicleComponent;
                     }
-                    constexpr bool operator!=(CarIter other) const
+                    bool operator!=(CarIter other) const
                     {
                         return !(*this == other);
                     }

--- a/src/openloco/windows/CompanyWindow.cpp
+++ b/src/openloco/windows/CompanyWindow.cpp
@@ -547,7 +547,7 @@ namespace openloco::ui::windows::CompanyWindow
 
                 int8_t rotation = static_cast<int8_t>(self->viewports[0]->getRotation());
                 SavedView view(
-                    train.cars[0].carComponents[0].body->id,
+                    train.cars.firstCar.body->id,
                     0xC000,
                     ZoomLevel::full,
                     rotation,

--- a/src/openloco/windows/News/News.cpp
+++ b/src/openloco/windows/News/News.cpp
@@ -233,9 +233,9 @@ namespace openloco::ui::NewsWindow
 
                     view.thingId = train.veh2->id;
 
-                    if (train.cars.size() > 0)
+                    if (std::distance(train.cars.begin(), train.cars.end()) > 0)
                     {
-                        view.thingId = train.cars[0].carComponents[0].body->id;
+                        view.thingId = train.cars.firstCar.body->id;
                     }
 
                     view.flags = (1 << 15);

--- a/src/openloco/windows/News/News.cpp
+++ b/src/openloco/windows/News/News.cpp
@@ -233,7 +233,7 @@ namespace openloco::ui::NewsWindow
 
                     view.thingId = train.veh2->id;
 
-                    if (std::distance(train.cars.begin(), train.cars.end()) > 0)
+                    if (!train.cars.empty())
                     {
                         view.thingId = train.cars.firstCar.body->id;
                     }

--- a/src/openloco/windows/map.cpp
+++ b/src/openloco/windows/map.cpp
@@ -1143,7 +1143,7 @@ namespace openloco::ui::windows::map
 
         if (widgetIndex == widx::tabOwnership || widgetIndex == widx::tabVehicles)
         {
-            uint8_t index = car.carComponents[0].front->owner;
+            uint8_t index = car.front->owner;
             colour = colour::get_shade(_companyColours[index], 7);
 
             if (widgetIndex == widx::tabVehicles)
@@ -1200,11 +1200,11 @@ namespace openloco::ui::windows::map
             if (train.head->x == location::null)
                 continue;
 
-            for (auto car : train.cars)
+            for (auto& car : train.cars)
             {
                 auto colour = getVehicleColour(widgetIndex, train, car);
 
-                for (auto carComponent : car.carComponents)
+                for (auto& carComponent : car)
                 {
                     drawVehicleOnMap(dpi, carComponent.front, colour);
                     drawVehicleOnMap(dpi, carComponent.back, colour);


### PR DESCRIPTION
Okay so the Vehicle Superclass is super inefficient memory allocation wise and its causing noticable slowdowns already and its not even used in that many locations. I've therefore redesigned it so that it no longer allocates any memory. This means the vectors have been removed. Instead begin and end iterators have been made available. 

Previously to iterate over every car it was:
```
things::vehicle::Vehicle train(trainHeadId);
for (auto& car : train.cars)
{
   // do stuff with car
}
```
This has not changed at all and still works.

Previously to iterate over every carComponent it was:
```
for (auto& carComponent : car.carComponents)
{
   // do stuff with carComponent
}
```
This has now changed to:
```
for (auto& carComponent : car)
{
   // do stuff with carComponent
}
```
This change was made as majority of the time the first carComponent is what you want so therefore car has become the first carComponent.

Previously
```
car.carComponents[0].front
```
Now
```
car.front
```

Previously
```
train.cars[0]
```
Now
```
train.cars.firstCar
```
Hmm should this actually be accessible by `train.firstCar`?

I've added helper functions (`size()` and `empty()`) to the cars container as well so no need to change those calls. `empty()` is very cheap to call where as `size()` needs to walk the whole length of the train.