### PR TITLE
Fix #585: Properly initialise small hook memory

### DIFF
--- a/src/openloco/interop/hook.cpp
+++ b/src/openloco/interop/hook.cpp
@@ -220,7 +220,7 @@ namespace openloco::interop
         {
             size_t size = 20 * 500;
 #ifdef _WIN32
-            _hookTableAddress = VirtualAllocEx(GetCurrentProcess(), NULL, size, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+            _smallHooks = VirtualAllocEx(GetCurrentProcess(), NULL, size, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 #else
             _smallHooks = mmap(NULL, size, PROT_EXEC | PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
             if (_smallHooks == MAP_FAILED)
@@ -228,8 +228,8 @@ namespace openloco::interop
                 perror("mmap");
                 exit(1);
             }
-            _offset = static_cast<uint8_t*>(_smallHooks);
 #endif // _WIN32
+            _offset = static_cast<uint8_t*>(_smallHooks);
         }
 
         int i = 0;


### PR DESCRIPTION
This is my attempt at fixing #585, although I'm not certain this is what's really expected or running into some other bug. With this code in place #585 (null dereference) no longer happens and is instead replaced with stack overflow:
```
OpenLoco, v20.07-32 (a4e4392 on master, DEBUG)
0024:fixme:win:RegisterTouchWindow (0x10058 00000003): stub
0024:fixme:imm:ImmReleaseContext (00010058, 0169C8C8): stub
0024:fixme:msctf:ThreadMgr_ActivateEx Unimplemented flags 0x4
0024:fixme:imm:ImeSetCompositionString PROBLEM: This only sets the wine level string
0024:fixme:imm:ImeSetCompositionString Reading string unimplemented
0024:fixme:imm:NotifyIME NI_CLOSECANDIDATE
00c4:fixme:avrt:AvSetMmThreadCharacteristicsW (L"Pro Audio",020EFEE8): stub
CreateRectRgn(0, 0, 1, 1)
Create progress bar
SendMessage(PBM_SETRANGE, 256)
SendMessage(PBM_SETSTEP, 1)
SendMessage(PBM_SETPOS, 30)
OpenMutexA(0x1f0001, 0, Locomotion_GSKMUTEX)
CreateMutexA(0x0, 0, Locomotion_GSKMUTEX)
SendMessage(PBM_SETPOS, 40)
Destroy progress bar
Missing hook: 0x4d70bc
[…snip…]
Missing hook: 0x4d70bc
Missing hook: 0x0024:err:virtual:virtual_setup_exception stack overflow 844 bytes in thread 0024 addr 0xf7b3e174 stack 0x220cb4 (0x220000-0x221000-0x320000)
```