### PR TITLE
Fix crash in vehicle update head caused by CreateVehicle

### DIFF
--- a/src/OpenLoco/Things/CreateVehicle.cpp
+++ b/src/OpenLoco/Things/CreateVehicle.cpp
@@ -571,6 +571,8 @@ namespace OpenLoco::Things::Vehicle
         newHead->var_22 = static_cast<uint8_t>(vehicleType) + 4;
         newHead->var_44 = 0; // Reset to null value so ignored in next function
         newHead->var_44 = createUniqueTypeNumber(vehicleType);
+        newHead->var_52 = 0;
+        newHead->var_5C = 0;
         newHead->var_5D = 0;
         newHead->var_54 = -1;
         newHead->var_5F = 0;

--- a/src/OpenLoco/Things/Vehicle.h
+++ b/src/OpenLoco/Things/Vehicle.h
@@ -212,7 +212,8 @@ namespace OpenLoco
         int16_t var_54;
         uint8_t pad_56[0x4];
         uint8_t pad_5A;
-        uint8_t pad_5B[0x5D - 0x5B];
+        uint8_t pad_5B;
+        uint8_t var_5C;
         uint8_t var_5D;
         VehicleType vehicleType; // 0x5E
         uint8_t var_5F;          // 0x5F


### PR DESCRIPTION
Missed setting two variables to 0 which caused a jump into unexpected code when used as part of an indirect call