### PR TITLE
Fix #660. Missing += rowHeight caused drawing to perform incorrectly

### DIFF
--- a/src/OpenLoco/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/Windows/ScenarioSelect.cpp
@@ -341,7 +341,10 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
                 continue;
 
             if (y + rowHeight < dpi->y || y > dpi->y + dpi->height)
+            {
+                y += rowHeight;
                 continue;
+            }
 
             // Highlight selected item
             auto formatStringId = StringIds::black_stringid;


### PR DESCRIPTION
Fix #660. Missing += rowHeight caused drawing to perform incorrectly

This bit of code is meant to reduce the amount of drawing taking place. Without the += rowHeight the code would do its skipping of drawing but then when it was meant to draw it would be at the wrong y coordinate. This would cause a flickering when items behind the window caused redraws of parts of the screen.