### PR TITLE
Fix #588. Crash when changing default audio device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#569] Option/cheat to disable AI companies entirely.
 - Fix: [#573] Crash caused by opening Road construction window.
+- Fix: [#588] Crash caused by changing default audio device.
 - Fix: [#595] Implementation mistake in CreateVehicle could lead to crashes.
 - Fix: [#635] Land tool not working properly, due to tool drag events not passing on coordinates.
 - Fix: [#648] Fix crash in vehicle update head caused by CreateVehicle.


### PR DESCRIPTION
Due to SDL not allowing population of the available devices until the audio system is loaded the audio tries to set the device to a nullptr. Instead we load the default audio device and then immediately close it. This allows SDL to load correctly