### PR TITLE
Address regressions in PromptBrowse window

### DIFF
--- a/src/OpenLoco/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/Windows/PromptBrowseWindow.cpp
@@ -854,7 +854,7 @@ namespace OpenLoco::Ui::PromptBrowse
             {
                 // Copy directory and filename to buffer.
                 char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
-                strncpy(&buffer_2039[0], path.u8string().c_str(), 512);
+                strncpy(&buffer_2039[0], &_text_input_buffer[0], 512);
 
                 FormatArguments args{};
                 args.push(StringIds::buffer_2039);
@@ -900,7 +900,7 @@ namespace OpenLoco::Ui::PromptBrowse
 
         // Copy directory and filename to buffer.
         char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
-        strncpy(&buffer_2039[0], path.u8string().c_str(), 512);
+        strncpy(&buffer_2039[0], entry.get_name().data(), 512);
 
         FormatArguments args{};
         args.push(StringIds::buffer_2039);

--- a/src/OpenLoco/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/Windows/PromptBrowseWindow.cpp
@@ -859,6 +859,9 @@ namespace OpenLoco::Ui::PromptBrowse
                 FormatArguments args{};
                 args.push(StringIds::buffer_2039);
 
+                // Copy window title into title buffer for ok/cancel window.
+                strncpy(&_stringFormatBuffer[0], _title, 256);
+
                 // Formatted string into description buffer for ok/cancel window.
                 loco_global<char[512], 0x0112CE04> descriptionBuffer;
                 StringManager::formatString(&descriptionBuffer[0], StringIds::replace_existing_file_prompt, &args);
@@ -904,6 +907,9 @@ namespace OpenLoco::Ui::PromptBrowse
 
         FormatArguments args{};
         args.push(StringIds::buffer_2039);
+
+        // Copy window title into title buffer for ok/cancel window.
+        strncpy(&_stringFormatBuffer[0], _title, 256);
 
         // Formatted string into description buffer for ok/cancel window.
         loco_global<char[512], 0x0112CE04> descriptionBuffer;


### PR DESCRIPTION
Addresses two minor regressions from #666:
* We were showing the full path in confirmation windows, rather than just the filename.
* The browse window caption wasn't copied into the confirmation window.