### PR TITLE
Reorg thing so that base has access to more

### DIFF
--- a/src/OpenLoco/Audio/VehicleChannel.cpp
+++ b/src/OpenLoco/Audio/VehicleChannel.cpp
@@ -65,7 +65,7 @@ void vehicle_channel::update()
     if (!isFree())
     {
         auto v = ThingManager::get<vehicle>(_vehicle_id);
-        if (v != nullptr && v->base_type == thing_base_type::vehicle && (v->vType == VehicleThingType::vehicle_2 || v->vType == VehicleThingType::tail) && (v->var_4A & 1))
+        if (v != nullptr && v->base_type == thing_base_type::vehicle && (v->getVehicleType() == VehicleThingType::vehicle_2 || v->getVehicleType() == VehicleThingType::tail) && (v->var_4A & 1))
         {
             auto [sid, sa] = sub_48A590(v);
             if (_sound_id == sid)

--- a/src/OpenLoco/Audio/VehicleChannel.cpp
+++ b/src/OpenLoco/Audio/VehicleChannel.cpp
@@ -65,7 +65,7 @@ void vehicle_channel::update()
     if (!isFree())
     {
         auto v = ThingManager::get<vehicle>(_vehicle_id);
-        if (v != nullptr && v->base_type == thing_base_type::vehicle && (v->type == VehicleThingType::vehicle_2 || v->type == VehicleThingType::tail) && (v->var_4A & 1))
+        if (v != nullptr && v->base_type == thing_base_type::vehicle && (v->vType == VehicleThingType::vehicle_2 || v->vType == VehicleThingType::tail) && (v->var_4A & 1))
         {
             auto [sid, sa] = sub_48A590(v);
             if (_sound_id == sid)

--- a/src/OpenLoco/Audio/VehicleChannel.cpp
+++ b/src/OpenLoco/Audio/VehicleChannel.cpp
@@ -65,7 +65,7 @@ void vehicle_channel::update()
     if (!isFree())
     {
         auto v = ThingManager::get<vehicle>(_vehicle_id);
-        if (v != nullptr && v->base_type == thing_base_type::vehicle && (v->getVehicleType() == VehicleThingType::vehicle_2 || v->getVehicleType() == VehicleThingType::tail) && (v->var_4A & 1))
+        if (v != nullptr && v->base_type == thing_base_type::vehicle && (v->getSubType() == VehicleThingType::vehicle_2 || v->getSubType() == VehicleThingType::tail) && (v->var_4A & 1))
         {
             auto [sid, sa] = sub_48A590(v);
             if (_sound_id == sid)

--- a/src/OpenLoco/Input/MouseInput.cpp
+++ b/src/OpenLoco/Input/MouseInput.cpp
@@ -516,7 +516,7 @@ namespace OpenLoco::Input
                     {
                         case InteractionItem::thing:
                         {
-                            auto _thing = reinterpret_cast<Thing*>(interaction.object);
+                            auto _thing = reinterpret_cast<thing_base*>(interaction.object);
                             auto veh = _thing->asVehicle();
                             if (veh != nullptr)
                             {
@@ -742,7 +742,7 @@ namespace OpenLoco::Input
                         {
                             case InteractionItem::thing:
                             {
-                                auto _thing = reinterpret_cast<Thing*>(item2.object);
+                                auto _thing = reinterpret_cast<thing_base*>(item2.object);
                                 auto veh = _thing->asVehicle();
                                 if (veh != nullptr)
                                 {

--- a/src/OpenLoco/Things/CreateVehicle.cpp
+++ b/src/OpenLoco/Things/CreateVehicle.cpp
@@ -187,7 +187,7 @@ namespace OpenLoco::Things::Vehicle
     {
         auto* const base = createVehicleThing();
         base->base_type = thing_base_type::vehicle;
-        base->vType = T::vehicleThingType;
+        base->setVehicleType(T::vehicleThingType);
         return reinterpret_cast<T*>(base);
     }
 
@@ -333,7 +333,7 @@ namespace OpenLoco::Things::Vehicle
     {
         auto newBody = createVehicleThing<vehicle_body>();
         // TODO: move this into the create function somehow
-        newBody->vType = bodyNumber == 0 ? VehicleThingType::body_start : VehicleThingType::body_continued;
+        newBody->setVehicleType(bodyNumber == 0 ? VehicleThingType::body_start : VehicleThingType::body_continued);
         newBody->owner = _updating_company_id;
         newBody->head = head;
         newBody->body_index = bodyNumber;

--- a/src/OpenLoco/Things/CreateVehicle.cpp
+++ b/src/OpenLoco/Things/CreateVehicle.cpp
@@ -187,7 +187,7 @@ namespace OpenLoco::Things::Vehicle
     {
         auto* const base = createVehicleThing();
         base->base_type = thing_base_type::vehicle;
-        base->type = T::vehicleThingType;
+        base->vType = T::vehicleThingType;
         return reinterpret_cast<T*>(base);
     }
 
@@ -333,7 +333,7 @@ namespace OpenLoco::Things::Vehicle
     {
         auto newBody = createVehicleThing<vehicle_body>();
         // TODO: move this into the create function somehow
-        newBody->type = bodyNumber == 0 ? VehicleThingType::body_start : VehicleThingType::body_continued;
+        newBody->vType = bodyNumber == 0 ? VehicleThingType::body_start : VehicleThingType::body_continued;
         newBody->owner = _updating_company_id;
         newBody->head = head;
         newBody->body_index = bodyNumber;

--- a/src/OpenLoco/Things/CreateVehicle.cpp
+++ b/src/OpenLoco/Things/CreateVehicle.cpp
@@ -187,7 +187,7 @@ namespace OpenLoco::Things::Vehicle
     {
         auto* const base = createVehicleThing();
         base->base_type = thing_base_type::vehicle;
-        base->setVehicleType(T::vehicleThingType);
+        base->setSubType(T::vehicleThingType);
         return reinterpret_cast<T*>(base);
     }
 
@@ -333,7 +333,7 @@ namespace OpenLoco::Things::Vehicle
     {
         auto newBody = createVehicleThing<vehicle_body>();
         // TODO: move this into the create function somehow
-        newBody->setVehicleType(bodyNumber == 0 ? VehicleThingType::body_start : VehicleThingType::body_continued);
+        newBody->setSubType(bodyNumber == 0 ? VehicleThingType::body_start : VehicleThingType::body_continued);
         newBody->owner = _updating_company_id;
         newBody->head = head;
         newBody->body_index = bodyNumber;

--- a/src/OpenLoco/Things/Misc.cpp
+++ b/src/OpenLoco/Things/Misc.cpp
@@ -35,7 +35,7 @@ exhaust* OpenLoco::exhaust::create(loc16 loc, uint8_t type)
         _exhaust->var_14 = obj->var_05;
         _exhaust->var_09 = obj->var_06;
         _exhaust->var_15 = obj->var_07;
-        _exhaust->setMiscType(MiscThingType::exhaust);
+        _exhaust->setSubType(MiscThingType::exhaust);
         _exhaust->var_26 = 0;
         _exhaust->var_28 = 0;
         _exhaust->var_32 = 0;
@@ -56,7 +56,7 @@ smoke* OpenLoco::smoke::create(loc16 loc)
         t->var_15 = 34;
         t->base_type = thing_base_type::misc;
         t->moveTo(loc);
-        t->setMiscType(MiscThingType::smoke);
+        t->setSubType(MiscThingType::smoke);
         t->var_28 = 0;
     }
     return t;

--- a/src/OpenLoco/Things/Misc.cpp
+++ b/src/OpenLoco/Things/Misc.cpp
@@ -35,7 +35,7 @@ exhaust* OpenLoco::exhaust::create(loc16 loc, uint8_t type)
         _exhaust->var_14 = obj->var_05;
         _exhaust->var_09 = obj->var_06;
         _exhaust->var_15 = obj->var_07;
-        _exhaust->mType = MiscThingType::exhaust;
+        _exhaust->setMiscType(MiscThingType::exhaust);
         _exhaust->var_26 = 0;
         _exhaust->var_28 = 0;
         _exhaust->var_32 = 0;
@@ -56,7 +56,7 @@ smoke* OpenLoco::smoke::create(loc16 loc)
         t->var_15 = 34;
         t->base_type = thing_base_type::misc;
         t->moveTo(loc);
-        t->mType = MiscThingType::smoke;
+        t->setMiscType(MiscThingType::smoke);
         t->var_28 = 0;
     }
     return t;

--- a/src/OpenLoco/Things/Misc.cpp
+++ b/src/OpenLoco/Things/Misc.cpp
@@ -35,7 +35,7 @@ exhaust* OpenLoco::exhaust::create(loc16 loc, uint8_t type)
         _exhaust->var_14 = obj->var_05;
         _exhaust->var_09 = obj->var_06;
         _exhaust->var_15 = obj->var_07;
-        _exhaust->type = misc_thing_type::exhaust;
+        _exhaust->mType = MiscThingType::exhaust;
         _exhaust->var_26 = 0;
         _exhaust->var_28 = 0;
         _exhaust->var_32 = 0;
@@ -56,7 +56,7 @@ smoke* OpenLoco::smoke::create(loc16 loc)
         t->var_15 = 34;
         t->base_type = thing_base_type::misc;
         t->moveTo(loc);
-        t->type = misc_thing_type::smoke;
+        t->mType = MiscThingType::smoke;
         t->var_28 = 0;
     }
     return t;

--- a/src/OpenLoco/Things/Misc.h
+++ b/src/OpenLoco/Things/Misc.h
@@ -8,48 +8,28 @@ namespace OpenLoco
     struct smoke;
     struct exhaust;
 
-    enum class misc_thing_type : uint8_t
+    enum class MiscThingType : uint8_t
     {
         exhaust = 0,
         smoke = 8
     };
 
 #pragma pack(push, 1)
-    struct misc_thing : thing_base
+    struct MiscBase : thing_base
     {
-        misc_thing_type type;
-        uint8_t pad_02;
-        uint8_t pad_03;
-        thing_id_t next_thing_id; // 0x04
-        uint8_t pad_06[0x09 - 0x06];
-        uint8_t var_09;
-        thing_id_t id; // 0x0A
-        uint16_t var_0C;
-        int16_t x; // 0x0E
-        int16_t y; // 0x10
-        int16_t z; // 0x12
-        uint8_t var_14;
-        uint8_t var_15;
-        int16_t sprite_left;   // 0x16
-        int16_t sprite_top;    // 0x18
-        int16_t sprite_right;  // 0x1A
-        int16_t sprite_bottom; // 0x1C
-        uint8_t sprite_yaw;    // 0x1E
-        uint8_t sprite_pitch;  // 0x1F
-
     private:
-        template<typename TType, misc_thing_type TClass>
+        template<typename TType, MiscThingType TClass>
         TType* as() const
         {
-            return type == TClass ? (TType*)this : nullptr;
+            return mType == TClass ? (TType*)this : nullptr;
         }
 
     public:
-        smoke* as_smoke() const { return as<smoke, misc_thing_type::smoke>(); }
-        exhaust* as_exhaust() const { return as<exhaust, misc_thing_type::exhaust>(); }
+        smoke* as_smoke() const { return as<smoke, MiscThingType::smoke>(); }
+        exhaust* as_exhaust() const { return as<exhaust, MiscThingType::exhaust>(); }
     };
 
-    struct exhaust : misc_thing
+    struct exhaust : MiscBase
     {
         uint8_t pad_20[0x26 - 0x20];
         int16_t var_26;
@@ -66,7 +46,7 @@ namespace OpenLoco
         static exhaust* create(loc16 loc, uint8_t type);
     };
 
-    struct smoke : misc_thing
+    struct smoke : MiscBase
     {
         uint8_t pad_20[0x28 - 0x20];
         uint16_t var_28;

--- a/src/OpenLoco/Things/Misc.h
+++ b/src/OpenLoco/Things/Misc.h
@@ -21,10 +21,12 @@ namespace OpenLoco
         template<typename TType, MiscThingType TClass>
         TType* as() const
         {
-            return mType == TClass ? (TType*)this : nullptr;
+            return getMiscType() == TClass ? (TType*)this : nullptr;
         }
 
     public:
+        MiscThingType getMiscType() const { return MiscThingType(thing_base::getSubType()); }
+        void setMiscType(const MiscThingType newType) { thing_base::setSubType(static_cast<uint8_t>(newType)); }
         smoke* as_smoke() const { return as<smoke, MiscThingType::smoke>(); }
         exhaust* as_exhaust() const { return as<exhaust, MiscThingType::exhaust>(); }
     };

--- a/src/OpenLoco/Things/Misc.h
+++ b/src/OpenLoco/Things/Misc.h
@@ -21,12 +21,12 @@ namespace OpenLoco
         template<typename TType, MiscThingType TClass>
         TType* as() const
         {
-            return getMiscType() == TClass ? (TType*)this : nullptr;
+            return getSubType() == TClass ? (TType*)this : nullptr;
         }
 
     public:
-        MiscThingType getMiscType() const { return MiscThingType(thing_base::getSubType()); }
-        void setMiscType(const MiscThingType newType) { thing_base::setSubType(static_cast<uint8_t>(newType)); }
+        MiscThingType getSubType() const { return MiscThingType(thing_base::getSubType()); }
+        void setSubType(const MiscThingType newType) { thing_base::setSubType(static_cast<uint8_t>(newType)); }
         smoke* as_smoke() const { return as<smoke, MiscThingType::smoke>(); }
         exhaust* as_exhaust() const { return as<exhaust, MiscThingType::exhaust>(); }
     };

--- a/src/OpenLoco/Things/Thing.cpp
+++ b/src/OpenLoco/Things/Thing.cpp
@@ -22,5 +22,5 @@ void thing_base::moveTo(loc16 loc)
 // 0x004CBB01
 void OpenLoco::thing_base::invalidateSprite()
 {
-    Ui::ViewportManager::invalidate((Thing*)this, ZoomLevel::eighth);
+    Ui::ViewportManager::invalidate(this, ZoomLevel::eighth);
 }

--- a/src/OpenLoco/Things/Thing.h
+++ b/src/OpenLoco/Things/Thing.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     struct Thing;
     struct vehicle_base;
-    struct misc_thing;
+    struct MiscBase;
 
     namespace ThingId
     {
@@ -22,14 +22,16 @@ namespace OpenLoco
     };
 
     enum class VehicleThingType : uint8_t;
+    enum class MiscThingType : uint8_t;
+
 #pragma pack(push, 1)
     struct thing_base
     {
         thing_base_type base_type;
         union
         {
-            uint8_t mType;          // Misc Thing type (only valid for misc_thing things)
             VehicleThingType vType; // Vehicle Thing type (only valid for vehicle_base things)
+            MiscThingType mType;    // Misc Thing type (only valid for MiscBase things)
         };
         uint8_t pad_02;
         uint8_t pad_03;
@@ -67,7 +69,7 @@ namespace OpenLoco
 
     public:
         vehicle_base* asVehicle() const { return as<vehicle_base, thing_base_type::vehicle>(); }
-        misc_thing* asMisc() const { return as<misc_thing, thing_base_type::misc>(); }
+        MiscBase* asMisc() const { return as<MiscBase, thing_base_type::misc>(); }
     };
     static_assert(sizeof(Thing) == 0x80);
 #pragma pack(pop)

--- a/src/OpenLoco/Things/Thing.h
+++ b/src/OpenLoco/Things/Thing.h
@@ -6,7 +6,6 @@
 
 namespace OpenLoco
 {
-    struct Thing;
     struct vehicle_base;
     struct MiscBase;
 
@@ -54,6 +53,16 @@ namespace OpenLoco
 
         void moveTo(loc16 loc);
         void invalidateSprite();
+
+        vehicle_base* asVehicle() const { return asBase<vehicle_base, thing_base_type::vehicle>(); }
+        MiscBase* asMisc() const { return asBase<MiscBase, thing_base_type::misc>(); }
+
+    private:
+        template<typename TType, thing_base_type TClass>
+        TType* asBase() const
+        {
+            return base_type == TClass ? (TType*)this : nullptr;
+        }
     };
 
     // Max size of a thing. Use when needing to know thing size
@@ -61,15 +70,6 @@ namespace OpenLoco
     {
     private:
         uint8_t pad_20[0x80 - 0x20];
-        template<typename TType, thing_base_type TClass>
-        TType* as() const
-        {
-            return base_type == TClass ? (TType*)this : nullptr;
-        }
-
-    public:
-        vehicle_base* asVehicle() const { return as<vehicle_base, thing_base_type::vehicle>(); }
-        MiscBase* asMisc() const { return as<MiscBase, thing_base_type::misc>(); }
     };
     static_assert(sizeof(Thing) == 0x80);
 #pragma pack(pop)

--- a/src/OpenLoco/Things/Thing.h
+++ b/src/OpenLoco/Things/Thing.h
@@ -21,26 +21,22 @@ namespace OpenLoco
         misc
     };
 
+    enum class VehicleThingType : uint8_t;
 #pragma pack(push, 1)
     struct thing_base
     {
         thing_base_type base_type;
-
-        void moveTo(loc16 loc);
-        void invalidateSprite();
-    };
-
-    // Max size of a thing. Use when needing to know thing size
-    struct Thing : thing_base
-    {
-    public:
-        uint8_t type;
+        union
+        {
+            uint8_t mType;          // Misc Thing type (only valid for misc_thing things)
+            VehicleThingType vType; // Vehicle Thing type (only valid for vehicle_base things)
+        };
         uint8_t pad_02;
         uint8_t pad_03;
         thing_id_t next_thing_id; // 0x04
         uint8_t pad_06[0x09 - 0x06];
         uint8_t var_09;
-        uint8_t pad_0A[0x0C - 0x0A];
+        thing_id_t id;
         uint16_t var_0C;
         int16_t x; // 0x0E
         int16_t y; // 0x10
@@ -54,6 +50,13 @@ namespace OpenLoco
         uint8_t sprite_yaw;    // 0x1E
         uint8_t sprite_pitch;  // 0x1F
 
+        void moveTo(loc16 loc);
+        void invalidateSprite();
+    };
+
+    // Max size of a thing. Use when needing to know thing size
+    struct Thing : thing_base
+    {
     private:
         uint8_t pad_20[0x80 - 0x20];
         template<typename TType, thing_base_type TClass>

--- a/src/OpenLoco/Things/Thing.h
+++ b/src/OpenLoco/Things/Thing.h
@@ -20,18 +20,14 @@ namespace OpenLoco
         misc
     };
 
-    enum class VehicleThingType : uint8_t;
-    enum class MiscThingType : uint8_t;
-
 #pragma pack(push, 1)
     struct thing_base
     {
         thing_base_type base_type;
-        union
-        {
-            VehicleThingType vType; // Vehicle Thing type (only valid for vehicle_base things)
-            MiscThingType mType;    // Misc Thing type (only valid for MiscBase things)
-        };
+
+    private:
+        uint8_t type; // Use type specific getters/setters as this depends on base_type
+    public:
         uint8_t pad_02;
         uint8_t pad_03;
         thing_id_t next_thing_id; // 0x04
@@ -56,6 +52,10 @@ namespace OpenLoco
 
         vehicle_base* asVehicle() const { return asBase<vehicle_base, thing_base_type::vehicle>(); }
         MiscBase* asMisc() const { return asBase<MiscBase, thing_base_type::misc>(); }
+
+    protected:
+        uint8_t getSubType() const { return type; }
+        void setSubType(const uint8_t newType) { type = newType; }
 
     private:
         template<typename TType, thing_base_type TClass>

--- a/src/OpenLoco/Things/Vehicle.cpp
+++ b/src/OpenLoco/Things/Vehicle.cpp
@@ -109,7 +109,7 @@ bool vehicle::updateComponent()
     int32_t result = 0;
     registers regs;
     regs.esi = (int32_t)this;
-    switch (type)
+    switch (vType)
     {
         case VehicleThingType::head:
             result = asVehicleHead()->update();
@@ -1708,11 +1708,11 @@ namespace OpenLoco::Things::Vehicle
         component = component->nextVehicleComponent();
         veh2 = component->asVehicle2();
         component = component->nextVehicleComponent();
-        if (component->type != VehicleThingType::tail)
+        if (component->vType != VehicleThingType::tail)
         {
             cars = Cars{ Car{ component } };
         }
-        while (component->type != VehicleThingType::tail)
+        while (component->vType != VehicleThingType::tail)
         {
             component = component->nextVehicleComponent();
         }

--- a/src/OpenLoco/Things/Vehicle.cpp
+++ b/src/OpenLoco/Things/Vehicle.cpp
@@ -109,7 +109,7 @@ bool vehicle::updateComponent()
     int32_t result = 0;
     registers regs;
     regs.esi = (int32_t)this;
-    switch (getVehicleType())
+    switch (getSubType())
     {
         case VehicleThingType::head:
             result = asVehicleHead()->update();
@@ -1708,11 +1708,11 @@ namespace OpenLoco::Things::Vehicle
         component = component->nextVehicleComponent();
         veh2 = component->asVehicle2();
         component = component->nextVehicleComponent();
-        if (component->getVehicleType() != VehicleThingType::tail)
+        if (component->getSubType() != VehicleThingType::tail)
         {
             cars = Cars{ Car{ component } };
         }
-        while (component->getVehicleType() != VehicleThingType::tail)
+        while (component->getSubType() != VehicleThingType::tail)
         {
             component = component->nextVehicleComponent();
         }

--- a/src/OpenLoco/Things/Vehicle.cpp
+++ b/src/OpenLoco/Things/Vehicle.cpp
@@ -109,7 +109,7 @@ bool vehicle::updateComponent()
     int32_t result = 0;
     registers regs;
     regs.esi = (int32_t)this;
-    switch (vType)
+    switch (getVehicleType())
     {
         case VehicleThingType::head:
             result = asVehicleHead()->update();
@@ -1708,11 +1708,11 @@ namespace OpenLoco::Things::Vehicle
         component = component->nextVehicleComponent();
         veh2 = component->asVehicle2();
         component = component->nextVehicleComponent();
-        if (component->vType != VehicleThingType::tail)
+        if (component->getVehicleType() != VehicleThingType::tail)
         {
             cars = Cars{ Car{ component } };
         }
-        while (component->vType != VehicleThingType::tail)
+        while (component->getVehicleType() != VehicleThingType::tail)
         {
             component = component->nextVehicleComponent();
         }

--- a/src/OpenLoco/Things/Vehicle.h
+++ b/src/OpenLoco/Things/Vehicle.h
@@ -83,7 +83,7 @@ namespace OpenLoco
         TType* as() const
         {
             // This can not use reinterpret_cast due to being a const member without considerable more code
-            return getVehicleType() == TClass ? (TType*)this : nullptr;
+            return getSubType() == TClass ? (TType*)this : nullptr;
         }
 
         template<typename TType>
@@ -93,8 +93,8 @@ namespace OpenLoco
         }
 
     public:
-        VehicleThingType getVehicleType() const { return VehicleThingType(thing_base::getSubType()); }
-        void setVehicleType(const VehicleThingType newType) { thing_base::setSubType(static_cast<uint8_t>(newType)); }
+        VehicleThingType getSubType() const { return VehicleThingType(thing_base::getSubType()); }
+        void setSubType(const VehicleThingType newType) { thing_base::setSubType(static_cast<uint8_t>(newType)); }
         vehicle_head* asVehicleHead() const { return as<vehicle_head>(); }
         vehicle_1* asVehicle1() const { return as<vehicle_1>(); }
         vehicle_2* asVehicle2() const { return as<vehicle_2>(); }
@@ -516,13 +516,13 @@ namespace OpenLoco
                     {
                         return *this;
                     }
-                    if (nextVehicleComponent->getVehicleType() == VehicleThingType::tail)
+                    if (nextVehicleComponent->getSubType() == VehicleThingType::tail)
                     {
                         nextVehicleComponent = nullptr;
                         return *this;
                     }
                     CarComponent next{ nextVehicleComponent };
-                    if (next.body == nullptr || next.body->getVehicleType() == VehicleThingType::body_start)
+                    if (next.body == nullptr || next.body->getSubType() == VehicleThingType::body_start)
                     {
                         nextVehicleComponent = nullptr;
                         return *this;
@@ -604,14 +604,14 @@ namespace OpenLoco
                         {
                             return *this;
                         }
-                        while (nextVehicleComponent->getVehicleType() != VehicleThingType::tail)
+                        while (nextVehicleComponent->getSubType() != VehicleThingType::tail)
                         {
                             Car next{ nextVehicleComponent };
                             if (next.body == nullptr)
                             {
                                 break;
                             }
-                            if (next.body->getVehicleType() == VehicleThingType::body_start)
+                            if (next.body->getSubType() == VehicleThingType::body_start)
                             {
                                 current = next;
                                 return *this;

--- a/src/OpenLoco/Things/Vehicle.h
+++ b/src/OpenLoco/Things/Vehicle.h
@@ -83,7 +83,7 @@ namespace OpenLoco
         TType* as() const
         {
             // This can not use reinterpret_cast due to being a const member without considerable more code
-            return vType == TClass ? (TType*)this : nullptr;
+            return getVehicleType() == TClass ? (TType*)this : nullptr;
         }
 
         template<typename TType>
@@ -93,6 +93,8 @@ namespace OpenLoco
         }
 
     public:
+        VehicleThingType getVehicleType() const { return VehicleThingType(thing_base::getSubType()); }
+        void setVehicleType(const VehicleThingType newType) { thing_base::setSubType(static_cast<uint8_t>(newType)); }
         vehicle_head* asVehicleHead() const { return as<vehicle_head>(); }
         vehicle_1* asVehicle1() const { return as<vehicle_1>(); }
         vehicle_2* asVehicle2() const { return as<vehicle_2>(); }
@@ -514,13 +516,13 @@ namespace OpenLoco
                     {
                         return *this;
                     }
-                    if (nextVehicleComponent->vType == VehicleThingType::tail)
+                    if (nextVehicleComponent->getVehicleType() == VehicleThingType::tail)
                     {
                         nextVehicleComponent = nullptr;
                         return *this;
                     }
                     CarComponent next{ nextVehicleComponent };
-                    if (next.body == nullptr || next.body->vType == VehicleThingType::body_start)
+                    if (next.body == nullptr || next.body->getVehicleType() == VehicleThingType::body_start)
                     {
                         nextVehicleComponent = nullptr;
                         return *this;
@@ -602,14 +604,14 @@ namespace OpenLoco
                         {
                             return *this;
                         }
-                        while (nextVehicleComponent->vType != VehicleThingType::tail)
+                        while (nextVehicleComponent->getVehicleType() != VehicleThingType::tail)
                         {
                             Car next{ nextVehicleComponent };
                             if (next.body == nullptr)
                             {
                                 break;
                             }
-                            if (next.body->vType == VehicleThingType::body_start)
+                            if (next.body->getVehicleType() == VehicleThingType::body_start)
                             {
                                 current = next;
                                 return *this;

--- a/src/OpenLoco/Things/Vehicle.h
+++ b/src/OpenLoco/Things/Vehicle.h
@@ -78,32 +78,12 @@ namespace OpenLoco
 #pragma pack(push, 1)
     struct vehicle_base : thing_base
     {
-        VehicleThingType type;
-        uint8_t pad_02;
-        uint8_t pad_03;
-        thing_id_t next_thing_id; // 0x04
-        uint8_t pad_06[0x09 - 0x06];
-        uint8_t var_09;
-        thing_id_t id; // 0x0A
-        uint16_t var_0C;
-        int16_t x; // 0x0E
-        int16_t y; // 0x10
-        int16_t z; // 0x12
-        uint8_t var_14;
-        uint8_t var_15;
-        int16_t sprite_left;   // 0x16
-        int16_t sprite_top;    // 0x18
-        int16_t sprite_right;  // 0x1A
-        int16_t sprite_bottom; // 0x1C
-        uint8_t sprite_yaw;    // 0x1E
-        uint8_t sprite_pitch;  // 0x1F
-
     private:
         template<typename TType, VehicleThingType TClass>
         TType* as() const
         {
             // This can not use reinterpret_cast due to being a const member without considerable more code
-            return type == TClass ? (TType*)this : nullptr;
+            return vType == TClass ? (TType*)this : nullptr;
         }
 
         template<typename TType>
@@ -534,13 +514,13 @@ namespace OpenLoco
                     {
                         return *this;
                     }
-                    if (nextVehicleComponent->type == VehicleThingType::tail)
+                    if (nextVehicleComponent->vType == VehicleThingType::tail)
                     {
                         nextVehicleComponent = nullptr;
                         return *this;
                     }
                     CarComponent next{ nextVehicleComponent };
-                    if (next.body == nullptr || next.body->type == VehicleThingType::body_start)
+                    if (next.body == nullptr || next.body->vType == VehicleThingType::body_start)
                     {
                         nextVehicleComponent = nullptr;
                         return *this;
@@ -622,14 +602,14 @@ namespace OpenLoco
                         {
                             return *this;
                         }
-                        while (nextVehicleComponent->type != VehicleThingType::tail)
+                        while (nextVehicleComponent->vType != VehicleThingType::tail)
                         {
                             Car next{ nextVehicleComponent };
                             if (next.body == nullptr)
                             {
                                 break;
                             }
-                            if (next.body->type == VehicleThingType::body_start)
+                            if (next.body->vType == VehicleThingType::body_start)
                             {
                                 current = next;
                                 return *this;

--- a/src/OpenLoco/ViewportManager.cpp
+++ b/src/OpenLoco/ViewportManager.cpp
@@ -71,7 +71,7 @@ namespace OpenLoco::Ui::ViewportManager
 
         w->viewport_configurations[index].viewport_target_sprite = dx;
 
-        auto t = ThingManager::get<Thing>(dx);
+        auto t = ThingManager::get<thing_base>(dx);
 
         int16_t dest_x, dest_y;
         viewport->centre2dCoordinates(t->x, t->y, t->z, &dest_x, &dest_y);
@@ -299,7 +299,7 @@ namespace OpenLoco::Ui::ViewportManager
      * @param t @<esi>
      * @param zoom
      */
-    void invalidate(Thing* t, ZoomLevel zoom)
+    void invalidate(thing_base* t, ZoomLevel zoom)
     {
         if (t->sprite_left == Location::null)
             return;
@@ -369,25 +369,25 @@ namespace OpenLoco::Ui::ViewportManager
         registerHook(
             0x004CBB01,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                invalidate((Thing*)regs.esi, ZoomLevel::eighth);
+                invalidate((thing_base*)regs.esi, ZoomLevel::eighth);
                 return 0;
             });
         registerHook(
             0x004CBBD2,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                invalidate((Thing*)regs.esi, ZoomLevel::quarter);
+                invalidate((thing_base*)regs.esi, ZoomLevel::quarter);
                 return 0;
             });
         registerHook(
             0x004CBCAC,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                invalidate((Thing*)regs.esi, ZoomLevel::half);
+                invalidate((thing_base*)regs.esi, ZoomLevel::half);
                 return 0;
             });
         registerHook(
             0x004CBD86,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                invalidate((Thing*)regs.esi, ZoomLevel::full);
+                invalidate((thing_base*)regs.esi, ZoomLevel::full);
                 return 0;
             });
         registerHook(

--- a/src/OpenLoco/ViewportManager.h
+++ b/src/OpenLoco/ViewportManager.h
@@ -17,6 +17,6 @@ namespace OpenLoco::Ui::ViewportManager
     viewport* create(window* window, int viewportIndex, Gfx::point_t origin, Gfx::ui_size_t size, ZoomLevel zoom, thing_id_t thing_id);
     viewport* create(window* window, int viewportIndex, Gfx::point_t origin, Gfx::ui_size_t size, ZoomLevel zoom, Map::map_pos3 tile);
     void invalidate(station* station);
-    void invalidate(Thing* t, ZoomLevel zoom);
+    void invalidate(thing_base* t, ZoomLevel zoom);
     void invalidate(Map::map_pos pos, coord_t zMin, coord_t zMax, ZoomLevel zoom = ZoomLevel::eighth, int radius = 32);
 }

--- a/src/OpenLoco/Window.cpp
+++ b/src/OpenLoco/Window.cpp
@@ -306,7 +306,7 @@ namespace OpenLoco::Ui
 
             if (config->viewport_target_sprite != 0xFFFF)
             {
-                auto thing = ThingManager::get<Thing>(config->viewport_target_sprite);
+                auto thing = ThingManager::get<thing_base>(config->viewport_target_sprite);
 
                 int z = (tileElementHeight(thing->x, thing->y).landHeight) - 16;
                 bool underground = (thing->z < z);
@@ -609,7 +609,7 @@ namespace OpenLoco::Ui
         auto main = WindowManager::getMainWindow();
         if (saved_view.isThingView())
         {
-            auto thing = ThingManager::get<Thing>(saved_view.thingId);
+            auto thing = ThingManager::get<thing_base>(saved_view.thingId);
             main->viewportCentreOnTile({ thing->x, thing->y, thing->z });
         }
         else

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -516,7 +516,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 // loc_434170
                 auto thing = ThingManager::get<OpenLoco::vehicle_head>(company->observation_thing);
 
-                if (thing->base_type != thing_base_type::vehicle || thing->type != VehicleThingType::head || (thing->x == Location::null))
+                if (thing->base_type != thing_base_type::vehicle || thing->vType != VehicleThingType::head || (thing->x == Location::null))
                 {
                     invalidViewport(self);
                     return;

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -514,15 +514,21 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             else
             {
                 // loc_434170
-                auto thing = ThingManager::get<OpenLoco::vehicle_head>(company->observation_thing);
-
-                if (thing->base_type != thing_base_type::vehicle || thing->vType != VehicleThingType::head || (thing->x == Location::null))
+                auto thing = ThingManager::get<OpenLoco::thing_base>(company->observation_thing);
+                auto* vehicle = thing->asVehicle();
+                if (vehicle == nullptr)
+                {
+                    invalidViewport(self);
+                    return;
+                }
+                auto* head = vehicle->asVehicleHead();
+                if (head == nullptr || (head->x == Location::null))
                 {
                     invalidViewport(self);
                     return;
                 }
 
-                Things::Vehicle::Vehicle train(thing);
+                Things::Vehicle::Vehicle train(head);
 
                 int8_t rotation = static_cast<int8_t>(self->viewports[0]->getRotation());
                 SavedView view(

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -267,7 +267,7 @@ namespace OpenLoco::Ui::Vehicle
             {
                 targetThing = train.cars.firstCar.front->id;
                 // Always true so above is pointless
-                if (train.cars.firstCar.front->getVehicleType() == VehicleThingType::bogie)
+                if (train.cars.firstCar.front->getSubType() == VehicleThingType::bogie)
                 {
                     targetThing = train.cars.firstCar.body->id;
                 }

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -267,7 +267,7 @@ namespace OpenLoco::Ui::Vehicle
             {
                 targetThing = train.cars.firstCar.front->id;
                 // Always true so above is pointless
-                if (train.cars.firstCar.front->type == VehicleThingType::bogie)
+                if (train.cars.firstCar.front->vType == VehicleThingType::bogie)
                 {
                     targetThing = train.cars.firstCar.body->id;
                 }

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -267,7 +267,7 @@ namespace OpenLoco::Ui::Vehicle
             {
                 targetThing = train.cars.firstCar.front->id;
                 // Always true so above is pointless
-                if (train.cars.firstCar.front->vType == VehicleThingType::bogie)
+                if (train.cars.firstCar.front->getVehicleType() == VehicleThingType::bogie)
                 {
                     targetThing = train.cars.firstCar.body->id;
                 }


### PR DESCRIPTION
I was having issues with Entity paint setup functions without access to all of the fields this will expose. Originally I was hoping that this sort of arrangement wouldn't be required but oh well! This is how OpenRCT2 handles its entities.