### PR TITLE
Paintsetup 2: entityPaintSetup

### DIFF
--- a/src/OpenLoco/Config.h
+++ b/src/OpenLoco/Config.h
@@ -76,7 +76,7 @@ namespace OpenLoco::Config
         uint8_t pad_29;                               // 0x29
         keyboard_shortcut_t keyboard_shortcuts[35];   // 0x2A
         uint8_t edge_scrolling;                       // 0x70
-        uint8_t vehicles_min_scale;                   // 0x71
+        uint8_t vehicles_min_scale;                   // 0x50AF25, 0x71
         uint8_t var_72;                               // 0x50AF26, 0x72
         music_playlist_type music_playlist;           // 0x50AF27, 0x73
         uint16_t height_marker_offset;                // 0x50AF28, 0x74

--- a/src/OpenLoco/Paint/Paint.cpp
+++ b/src/OpenLoco/Paint/Paint.cpp
@@ -20,6 +20,12 @@ namespace OpenLoco::Paint
     static loco_global<uint32_t, 0x00E40110> _getMapCoordinatesFromPosFlags;
     PaintSession _session;
 
+    void PaintSession::setEntityPosition(const Map::map_pos& pos)
+    {
+        _spritePositionX = pos.x;
+        _spritePositionY = pos.y;
+    }
+
     void PaintSession::init(Gfx::drawpixelinfo_t& dpi, const uint16_t viewportFlags)
     {
         _dpi = &dpi;

--- a/src/OpenLoco/Paint/Paint.cpp
+++ b/src/OpenLoco/Paint/Paint.cpp
@@ -5,6 +5,7 @@
 #include "../TownManager.h"
 #include "../Ui.h"
 #include "../Ui/WindowManager.h"
+#include "PaintEntity.h"
 
 using namespace OpenLoco::Interop;
 using namespace OpenLoco::Ui::ViewportInteraction;
@@ -73,24 +74,6 @@ namespace OpenLoco::Paint
         regs.eax = loc.x;
         regs.ecx = loc.y;
         call(0x004617C6, regs);
-    }
-
-    // 0x0046FA88
-    static void paintEntities(PaintSession& session, const Map::map_pos& loc)
-    {
-        registers regs{};
-        regs.eax = loc.x;
-        regs.ecx = loc.y;
-        call(0x0046FA88, regs);
-    }
-
-    // 0x0046FB67
-    static void paintEntities2(PaintSession& session, const Map::map_pos& loc)
-    {
-        registers regs{};
-        regs.eax = loc.x;
-        regs.ecx = loc.y;
-        call(0x0046FB67, regs);
     }
 
     struct GenerationParameters

--- a/src/OpenLoco/Paint/Paint.h
+++ b/src/OpenLoco/Paint/Paint.h
@@ -119,6 +119,10 @@ namespace OpenLoco::Paint
         [[nodiscard]] Ui::ViewportInteraction::InteractionArg getStationNameInteractionInfo(const uint32_t flags);
         [[nodiscard]] Ui::ViewportInteraction::InteractionArg getTownNameInteractionInfo(const uint32_t flags);
         Gfx::drawpixelinfo_t* getContext() { return _dpi; }
+        uint8_t rotation() { return currentRotation; }
+        void setCurrentObject(void* object) { _currentObject = object; }
+        void setInteractionItem(const Ui::ViewportInteraction::InteractionItem item) { _type = item; }
+        void setEntityPosition(const Map::map_pos& pos);
 
     private:
         void generateTilesAndEntities(GenerationParameters&& p);
@@ -135,6 +139,7 @@ namespace OpenLoco::Paint
         inline static Interop::loco_global<coord_t, 0x00E3F096> _spritePositionY;
         inline static Interop::loco_global<PaintStruct*, 0x00E40120> _lastPS;
         inline static Interop::loco_global<Ui::ViewportInteraction::InteractionItem, 0x00E3F0AC> _type;
+        inline static Interop::loco_global<void*, 0x00E3F0B4> _currentObject;
         inline static Interop::loco_global<PaintStringStruct*, 0x00E40118> _paintStringHead;
         inline static Interop::loco_global<PaintStringStruct*, 0x00E4011C> _lastPaintString;
         inline static Interop::loco_global<Map::map_pos, 0x00E3F0B0> _mapPosition;

--- a/src/OpenLoco/Paint/Paint.h
+++ b/src/OpenLoco/Paint/Paint.h
@@ -119,9 +119,10 @@ namespace OpenLoco::Paint
         [[nodiscard]] Ui::ViewportInteraction::InteractionArg getStationNameInteractionInfo(const uint32_t flags);
         [[nodiscard]] Ui::ViewportInteraction::InteractionArg getTownNameInteractionInfo(const uint32_t flags);
         Gfx::drawpixelinfo_t* getContext() { return _dpi; }
-        uint8_t rotation() { return currentRotation; }
-        void setCurrentObject(void* object) { _currentObject = object; }
-        void setInteractionItem(const Ui::ViewportInteraction::InteractionItem item) { _type = item; }
+        uint8_t getRotation() { return currentRotation; }
+        // TileElement or Entity
+        void setCurrentItem(void* item) { _currentItem = item; }
+        void setItemType(const Ui::ViewportInteraction::InteractionItem type) { _itemType = type; }
         void setEntityPosition(const Map::map_pos& pos);
 
     private:
@@ -138,8 +139,8 @@ namespace OpenLoco::Paint
         inline static Interop::loco_global<coord_t, 0x00E3F090> _spritePositionX;
         inline static Interop::loco_global<coord_t, 0x00E3F096> _spritePositionY;
         inline static Interop::loco_global<PaintStruct*, 0x00E40120> _lastPS;
-        inline static Interop::loco_global<Ui::ViewportInteraction::InteractionItem, 0x00E3F0AC> _type;
-        inline static Interop::loco_global<void*, 0x00E3F0B4> _currentObject;
+        inline static Interop::loco_global<Ui::ViewportInteraction::InteractionItem, 0x00E3F0AC> _itemType;
+        inline static Interop::loco_global<void*, 0x00E3F0B4> _currentItem;
         inline static Interop::loco_global<PaintStringStruct*, 0x00E40118> _paintStringHead;
         inline static Interop::loco_global<PaintStringStruct*, 0x00E4011C> _lastPaintString;
         inline static Interop::loco_global<Map::map_pos, 0x00E3F0B0> _mapPosition;

--- a/src/OpenLoco/Paint/PaintEntity.cpp
+++ b/src/OpenLoco/Paint/PaintEntity.cpp
@@ -1,0 +1,28 @@
+#include "PaintEntity.h"
+#include "../Interop/Interop.hpp"
+#include "../Map/Tile.h"
+#include "Paint.h"
+
+using namespace OpenLoco::Interop;
+using namespace OpenLoco::Ui::ViewportInteraction;
+
+namespace OpenLoco::Paint
+{
+    // 0x0046FA88
+    void paintEntities(PaintSession& session, const Map::map_pos& loc)
+    {
+        registers regs{};
+        regs.eax = loc.x;
+        regs.ecx = loc.y;
+        call(0x0046FA88, regs);
+    }
+
+    // 0x0046FB67
+    void paintEntities2(PaintSession& session, const Map::map_pos& loc)
+    {
+        registers regs{};
+        regs.eax = loc.x;
+        regs.ecx = loc.y;
+        call(0x0046FB67, regs);
+    }
+}

--- a/src/OpenLoco/Paint/PaintEntity.cpp
+++ b/src/OpenLoco/Paint/PaintEntity.cpp
@@ -12,25 +12,25 @@ using namespace OpenLoco::Ui::ViewportInteraction;
 namespace OpenLoco::Paint
 {
     // 0x004B0CCE
-    void paintVehicleEntities(PaintSession& session, vehicle_base* base)
+    void paintVehicleEntity(PaintSession& session, vehicle_base* base)
     {
         registers regs{};
         regs.ax = base->x;
         regs.cx = base->y;
         regs.dl = base->z;
-        regs.ebx = (base->sprite_yaw + (session.rotation() << 4)) & 0x3F;
+        regs.ebx = (base->sprite_yaw + (session.getRotation() << 4)) & 0x3F;
         regs.esi = reinterpret_cast<int32_t>(base);
         call(0x004B0CCE, regs);
     }
 
     // 0x00440325
-    void paintMiscEntities(PaintSession& session, MiscBase* base)
+    void paintMiscEntity(PaintSession& session, MiscBase* base)
     {
         registers regs{};
         regs.ax = base->x;
         regs.cx = base->y;
         regs.dl = base->z;
-        regs.ebx = (base->sprite_yaw + (session.rotation() << 4)) & 0x3F;
+        regs.ebx = (base->sprite_yaw + (session.getRotation() << 4)) & 0x3F;
         regs.esi = reinterpret_cast<int32_t>(base);
         call(0x00440325, regs);
     }
@@ -52,11 +52,13 @@ namespace OpenLoco::Paint
         ThingManager::ThingTileList entities(loc);
         for (auto* entity : entities)
         {
+            // TODO: Create a rect from dpi dims
             auto left = dpi->x;
             auto top = dpi->y;
             auto right = left + dpi->width;
             auto bottom = top + dpi->height;
 
+            // TODO: Create a rect from sprite dims and use a contains function
             if (entity->sprite_top > bottom)
             {
                 continue;
@@ -73,16 +75,16 @@ namespace OpenLoco::Paint
             {
                 continue;
             }
-            session.setCurrentObject(entity);
+            session.setCurrentItem(entity);
             session.setEntityPosition({ entity->x, entity->y });
-            session.setInteractionItem(InteractionItem::thing);
+            session.setItemType(InteractionItem::thing);
             switch (entity->base_type)
             {
                 case thing_base_type::vehicle:
-                    paintVehicleEntities(session, entity->asVehicle());
+                    paintVehicleEntity(session, entity->asVehicle());
                     break;
                 case thing_base_type::misc:
-                    paintMiscEntities(session, entity->asMisc());
+                    paintMiscEntity(session, entity->asMisc());
                     break;
             }
         }

--- a/src/OpenLoco/Paint/PaintEntity.cpp
+++ b/src/OpenLoco/Paint/PaintEntity.cpp
@@ -1,6 +1,8 @@
 #include "PaintEntity.h"
+#include "../Config.h"
 #include "../Interop/Interop.hpp"
 #include "../Map/Tile.h"
+#include "../Things/ThingManager.h"
 #include "Paint.h"
 
 using namespace OpenLoco::Interop;
@@ -11,6 +13,16 @@ namespace OpenLoco::Paint
     // 0x0046FA88
     void paintEntities(PaintSession& session, const Map::map_pos& loc)
     {
+        if (Config::get().vehicles_min_scale < session.dpi()->zoom_level)
+        {
+            return;
+        }
+
+        if (loc.x >= 0x4000 || loc.y >= 0x4000)
+        {
+            return;
+        }
+
         registers regs{};
         regs.eax = loc.x;
         regs.ecx = loc.y;

--- a/src/OpenLoco/Paint/PaintEntity.h
+++ b/src/OpenLoco/Paint/PaintEntity.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "../Types.hpp"
+
+namespace OpenLoco::Map
+{
+    struct map_pos;
+}
+
+namespace OpenLoco::Paint
+{
+    struct PaintSession;
+    void paintEntities(PaintSession& session, const Map::map_pos& loc);
+    void paintEntities2(PaintSession& session, const Map::map_pos& loc);
+}

--- a/src/OpenLoco/openloco.vcxproj
+++ b/src/OpenLoco/openloco.vcxproj
@@ -81,6 +81,7 @@
     <ClCompile Include="Objects\WaterObject.cpp" />
     <ClCompile Include="OpenLoco.cpp" />
     <ClCompile Include="Paint\Paint.cpp" />
+    <ClCompile Include="Paint\PaintEntity.cpp" />
     <ClCompile Include="Platform\Platform.Posix.cpp" />
     <ClCompile Include="Platform\Platform.Windows.cpp" />
     <ClCompile Include="ProgressBar.cpp" />
@@ -249,6 +250,7 @@
     <ClInclude Include="Objects\WaterObject.h" />
     <ClInclude Include="OpenLoco.h" />
     <ClInclude Include="Paint\Paint.h" />
+    <ClInclude Include="Paint\PaintEntity.h" />
     <ClInclude Include="Platform\Platform.h" />
     <ClInclude Include="ProgressBar.h" />
     <ClInclude Include="S5\S5.h" />


### PR DESCRIPTION
Continues from #681 and #684
Implements entityPaintSetup very similar to its OpenRCT2 equivalent.