### PR TITLE
Paintsetup 4: spriteInteractWith

### DIFF
--- a/src/OpenLoco/Graphics/Gfx.cpp
+++ b/src/OpenLoco/Graphics/Gfx.cpp
@@ -127,8 +127,6 @@ namespace OpenLoco::Gfx
         std::memcpy(&_data[dstIndex], &src._data[srcIndex], copyLength);
     }
 
-
-
     std::optional<uint32_t> getPaletteG1Index(colour_t paletteId)
     {
         if (paletteId < std::size(_paletteToG1Offset))

--- a/src/OpenLoco/Graphics/Gfx.cpp
+++ b/src/OpenLoco/Graphics/Gfx.cpp
@@ -1094,12 +1094,12 @@ namespace OpenLoco::Gfx
 
     uint32_t recolour(uint32_t image, uint8_t colour)
     {
-        return (1 << 29) | (colour << 19) | image;
+        return ImageIdFlags::remap | (colour << 19) | image;
     }
 
     uint32_t recolourTranslucent(uint32_t image, uint8_t colour)
     {
-        return (1 << 30) | (colour << 19) | image;
+        return ImageIdFlags::translucent | (colour << 19) | image;
     }
 
     loco_global<uint8_t*, 0x0050B860> _50B860;

--- a/src/OpenLoco/Graphics/Gfx.cpp
+++ b/src/OpenLoco/Graphics/Gfx.cpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <numeric>
 
 using namespace OpenLoco::Interop;
 using namespace OpenLoco::Utility;
@@ -46,6 +47,7 @@ namespace OpenLoco::Gfx
     static loco_global<g1_element[g1_expected_count::disc + g1_count_temporary + g1_count_objects], 0x9E2424> _g1Elements;
 
     static std::unique_ptr<std::byte[]> _g1Buffer;
+    static loco_global<uint16_t[147], 0x050B8C8> _paletteToG1Offset;
 
     static loco_global<uint16_t, 0x112C824> _currentFontFlags;
     static loco_global<int16_t, 0x112C876> _currentFontSpriteBase;
@@ -67,6 +69,87 @@ namespace OpenLoco::Gfx
     drawpixelinfo_t& screenDpi()
     {
         return _screen_dpi;
+    }
+
+    const PaletteMap& PaletteMap::getDefault()
+    {
+        static bool initialised = false;
+        static uint8_t data[256];
+        static PaletteMap defaultMap(data);
+        if (!initialised)
+        {
+            std::iota(std::begin(data), std::end(data), 0);
+        }
+        return defaultMap;
+    }
+
+    uint8_t& PaletteMap::operator[](size_t index)
+    {
+        assert(index < _dataLength);
+
+        // Provide safety in release builds
+        if (index >= _dataLength)
+        {
+            static uint8_t dummy;
+            return dummy;
+        }
+
+        return _data[index];
+    }
+
+    uint8_t PaletteMap::operator[](size_t index) const
+    {
+        assert(index < _dataLength);
+
+        // Provide safety in release builds
+        if (index >= _dataLength)
+        {
+            return 0;
+        }
+
+        return _data[index];
+    }
+
+    uint8_t PaletteMap::blend(uint8_t src, uint8_t dst) const
+    {
+        // src = 0 would be transparent so there is no blend palette for that, hence (src - 1)
+        assert(src != 0 && (src - 1) < _numMaps);
+        assert(dst < _mapLength);
+        auto idx = ((src - 1) * 256) + dst;
+        return (*this)[idx];
+    }
+
+    void PaletteMap::copy(size_t dstIndex, const PaletteMap& src, size_t srcIndex, size_t length)
+    {
+        auto maxLength = std::min(_mapLength - srcIndex, _mapLength - dstIndex);
+        assert(length <= maxLength);
+        auto copyLength = std::min(length, maxLength);
+        std::memcpy(&_data[dstIndex], &src._data[srcIndex], copyLength);
+    }
+
+
+
+    std::optional<uint32_t> getPaletteG1Index(colour_t paletteId)
+    {
+        if (paletteId < std::size(_paletteToG1Offset))
+        {
+            return _paletteToG1Offset[paletteId];
+        }
+        return std::nullopt;
+    }
+
+    std::optional<PaletteMap> getPaletteMapForColour(colour_t paletteId)
+    {
+        auto g1Index = getPaletteG1Index(paletteId);
+        if (g1Index)
+        {
+            auto g1 = getG1Element(*g1Index);
+            if (g1 != nullptr)
+            {
+                return PaletteMap(g1->offset, g1->height, g1->width);
+            }
+        }
+        return std::nullopt;
     }
 
     static std::vector<g1_element> convertElements(const std::vector<g1_element32_t>& elements32)

--- a/src/OpenLoco/Graphics/Gfx.h
+++ b/src/OpenLoco/Graphics/Gfx.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../Core/Optional.hpp"
 #include "../OpenLoco.h"
 #include "../Types.hpp"
 #include "../Ui/Rect.h"
@@ -117,6 +118,7 @@ namespace OpenLoco::Gfx
 
         uint8_t& operator[](size_t index);
         uint8_t operator[](size_t index) const;
+        uint8_t* data() const { return _data; }
         uint8_t blend(uint8_t src, uint8_t dst) const;
         void copy(size_t dstIndex, const PaletteMap& src, size_t srcIndex, size_t length);
     };

--- a/src/OpenLoco/Graphics/Gfx.h
+++ b/src/OpenLoco/Graphics/Gfx.h
@@ -67,6 +67,12 @@ namespace OpenLoco::Gfx
     };
 
 #pragma pack(pop)
+    namespace ImageIdFlags
+    {
+        constexpr uint32_t remap = 1 << 29;
+        constexpr uint32_t translucent = 1 << 30;
+        constexpr uint32_t remap2 = 1 << 31;
+    }
 
     drawpixelinfo_t& screenDpi();
 

--- a/src/OpenLoco/Graphics/Gfx.h
+++ b/src/OpenLoco/Graphics/Gfx.h
@@ -6,6 +6,11 @@
 #include "Types.h"
 #include <cstdint>
 
+namespace OpenLoco
+{
+    using colour_t = uint8_t;
+}
+
 namespace OpenLoco::Gfx
 {
 #pragma pack(push, 1)
@@ -73,6 +78,51 @@ namespace OpenLoco::Gfx
         constexpr uint32_t translucent = 1 << 30;
         constexpr uint32_t remap2 = 1 << 31;
     }
+
+    /**
+     * Represents an 8-bit indexed map that maps from one palette index to another.
+     */
+    struct PaletteMap
+    {
+    private:
+        uint8_t* _data{};
+        uint32_t _dataLength{};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-private-field"
+        uint16_t _numMaps;
+#pragma clang diagnostic pop
+        uint16_t _mapLength;
+
+    public:
+        static const PaletteMap& getDefault();
+
+        PaletteMap() = default;
+
+        PaletteMap(uint8_t* data, uint16_t numMaps, uint16_t mapLength)
+            : _data(data)
+            , _dataLength(numMaps * mapLength)
+            , _numMaps(numMaps)
+            , _mapLength(mapLength)
+        {
+        }
+
+        template<std::size_t TSize>
+        PaletteMap(uint8_t (&map)[TSize])
+            : _data(map)
+            , _dataLength(static_cast<uint32_t>(std::size(map)))
+            , _numMaps(1)
+            , _mapLength(static_cast<uint16_t>(std::size(map)))
+        {
+        }
+
+        uint8_t& operator[](size_t index);
+        uint8_t operator[](size_t index) const;
+        uint8_t blend(uint8_t src, uint8_t dst) const;
+        void copy(size_t dstIndex, const PaletteMap& src, size_t srcIndex, size_t length);
+    };
+
+    std::optional<uint32_t> getPaletteG1Index(colour_t paletteId);
+    std::optional<PaletteMap> getPaletteMapForColour(colour_t paletteId);
 
     drawpixelinfo_t& screenDpi();
 

--- a/src/OpenLoco/Paint/Paint.cpp
+++ b/src/OpenLoco/Paint/Paint.cpp
@@ -450,7 +450,7 @@ namespace OpenLoco::Paint
 
             for (auto* attachedPS = ps->attachedPS; attachedPS != nullptr; attachedPS = attachedPS->next)
             {
-                if (isSpriteInteractedWith(getContext(), attachedPS->imageId, { (attachedPS->x + ps->x), (attachedPS->y + ps->y) }))
+                if (isSpriteInteractedWith(getContext(), attachedPS->imageId, { static_cast<int16_t>(attachedPS->x + ps->x), static_cast<int16_t>(attachedPS->y + ps->y) }))
                 {
                     if (isPSSpriteTypeInFilter(ps->type, flags))
                     {

--- a/src/OpenLoco/Paint/Paint.cpp
+++ b/src/OpenLoco/Paint/Paint.cpp
@@ -367,7 +367,7 @@ namespace OpenLoco::Paint
         static loco_global<uint32_t, 0x00E04324> _interactionFlags;
         _interactionResult = false;
         _interactionFlags = 0;
-        auto paletteMap = PaletteMap::GetDefault();
+        auto paletteMap = Gfx::PaletteMap::getDefault();
         imageId &= ~Gfx::ImageIdFlags::translucent;
         if (imageId & Gfx::ImageIdFlags::remap)
         {
@@ -377,7 +377,7 @@ namespace OpenLoco::Paint
             {
                 index &= 0x1F;
             }
-            if (auto pm = GetPaletteMapForColour(index))
+            if (auto pm = Gfx::getPaletteMapForColour(index))
             {
                 paletteMap = *pm;
             }

--- a/src/OpenLoco/Paint/Paint.cpp
+++ b/src/OpenLoco/Paint/Paint.cpp
@@ -13,12 +13,6 @@ using namespace OpenLoco::Ui::ViewportInteraction;
 
 namespace OpenLoco::Paint
 {
-    static loco_global<InteractionItem, 0x00E40104> _sessionInteractionInfoType;
-    static loco_global<uint8_t, 0x00E40105> _sessionInteractionInfoBh; // Unk var_29 of paintstruct
-    static loco_global<int16_t, 0x00E40108> _sessionInteractionInfoX;
-    static loco_global<int16_t, 0x00E4010A> _sessionInteractionInfoY;
-    static loco_global<uint32_t, 0x00E4010C> _sessionInteractionInfoValue; // tileElement or thing ptr
-    static loco_global<uint32_t, 0x00E40110> _getMapCoordinatesFromPosFlags;
     PaintSession _session;
 
     void PaintSession::setEntityPosition(const Map::map_pos& pos)
@@ -425,11 +419,6 @@ namespace OpenLoco::Paint
     [[nodiscard]] InteractionArg PaintSession::getNormalInteractionInfo(const uint32_t flags)
     {
         InteractionArg info{};
-        _sessionInteractionInfoX = 0;
-        _sessionInteractionInfoY = 0;
-        _sessionInteractionInfoValue = 0;
-        _sessionInteractionInfoType = InteractionItem::t_0;
-        _sessionInteractionInfoBh = 0;
 
         for (auto* ps = (*_paintHead)->basic.nextQuadrantPS; ps != nullptr; ps = ps->nextQuadrantPS)
         {
@@ -461,11 +450,6 @@ namespace OpenLoco::Paint
 
             ps = tempPS;
         }
-        _sessionInteractionInfoX = info.x;
-        _sessionInteractionInfoY = info.y;
-        _sessionInteractionInfoValue = info.value;
-        _sessionInteractionInfoType = info.type;
-        _sessionInteractionInfoBh = info.unkBh;
         return info;
     }
 
@@ -502,10 +486,6 @@ namespace OpenLoco::Paint
             interaction.type = InteractionItem::station;
             interaction.value = station.id();
         }
-
-        // This is for functions that have not been implemented yet
-        _sessionInteractionInfoType = interaction.type;
-        _sessionInteractionInfoValue = interaction.value;
         return interaction;
     }
 
@@ -537,10 +517,6 @@ namespace OpenLoco::Paint
             interaction.type = InteractionItem::town;
             interaction.value = town.id();
         }
-
-        // This is for functions that have not been implemented yet
-        _sessionInteractionInfoType = interaction.type;
-        _sessionInteractionInfoValue = interaction.value;
         return interaction;
     }
 }

--- a/src/OpenLoco/Paint/Paint.h
+++ b/src/OpenLoco/Paint/Paint.h
@@ -89,9 +89,9 @@ namespace OpenLoco::Paint
         int16_t y;                  // 0x16
         uint16_t quadrantIndex;     // 0x18
         uint8_t flags;
-        uint8_t quadrantFlags;           // 0x1B
-        AttachedPaintStruct* attachedPS; // 0x1C
-        PaintStruct* children;
+        uint8_t quadrantFlags;                         // 0x1B
+        AttachedPaintStruct* attachedPS;               // 0x1C
+        PaintStruct* children;                         // 0x20
         PaintStruct* nextQuadrantPS;                   // 0x24
         Ui::ViewportInteraction::InteractionItem type; // 0x28
         uint8_t var_29;

--- a/src/OpenLoco/Ui.h
+++ b/src/OpenLoco/Ui.h
@@ -11,6 +11,11 @@ namespace OpenLoco::Config
     struct resolution_t;
 }
 
+namespace OpenLoco::Paint
+{
+    struct PaintStruct;
+}
+
 namespace OpenLoco::Ui
 {
     struct viewport;
@@ -134,6 +139,14 @@ namespace OpenLoco::Ui
             };
             InteractionItem type;
             uint8_t unkBh;
+            InteractionArg() = default;
+            InteractionArg(const coord_t _x, const coord_t _y, uint32_t _value, InteractionItem _type, uint8_t _unkBh)
+                : x(_x)
+                , y(_y)
+                , value(_value)
+                , type(_type)
+                , unkBh(_unkBh){}
+            InteractionArg(const Paint::PaintStruct& ps);
         };
 
         InteractionArg getItemLeft(int16_t tempX, int16_t tempY);

--- a/src/OpenLoco/Ui.h
+++ b/src/OpenLoco/Ui.h
@@ -145,7 +145,9 @@ namespace OpenLoco::Ui
                 , y(_y)
                 , value(_value)
                 , type(_type)
-                , unkBh(_unkBh){}
+                , unkBh(_unkBh)
+            {
+            }
             InteractionArg(const Paint::PaintStruct& ps);
         };
 

--- a/src/OpenLoco/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/Ui/ViewportInteraction.cpp
@@ -13,6 +13,15 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::ViewportInteraction
 {
+    InteractionArg::InteractionArg(const Paint::PaintStruct& ps)
+        : x(ps.map_x)
+        , y(ps.map_y)
+        , object(ps.thing)
+        , type(ps.type)
+        , unkBh(ps.var_29)
+    {
+    }
+
     // 0x004CD658
     InteractionArg getItemLeft(int16_t tempX, int16_t tempY)
     {


### PR DESCRIPTION
Continues from #686: Implements getNormalInteractionInfo. Based off of OpenRCT2 equivalent.