### PR TITLE
Implement #39: Auto save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: [#151] Mouse moves out of window when looking around.
 - Fix: [#588] 'Cancel or Show Last Announcement' shortcut doesn't close announcements.
 - Fix: [#679] Crash when changing ground texture.
+- Change: [#690] Default saved game directory is now in OpenLoco user directory.
 
 20.10 (2020-10-25)
 ------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 20.10+ (in development)
 ------------------------------------------------------------------------
+- Feature: [#690] Automatically save the game at regular intervals.
 - Fix: [#151] Mouse moves out of window when looking around.
 - Fix: [#588] 'Cancel or Show Last Announcement' shortcut doesn't close announcements.
 - Fix: [#679] Crash when changing ground texture.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2195,3 +2195,8 @@ strings:
   2140: "Exit OpenLoco"
   2141: "{COLOUR WINDOW_2}Disable AI companies"
   2142: "{SMALLFONT}{COLOUR BLACK}This disables AI from 'thinking', rendering them ineffective.{NEWLINE}In new games, this also prevents new AI companies from forming."
+  2143: "{COLOUR WINDOW_2}Autosave amount:"
+  2144: "{COLOUR WINDOW_2}Autosave frequency:"
+  2145: "Never"
+  2146: "Every month"
+  2147: "Every {INT32} months"

--- a/src/OpenLoco/Config.cpp
+++ b/src/OpenLoco/Config.cpp
@@ -87,6 +87,10 @@ namespace OpenLoco::Config
             _new_config.scale_factor = config["scale_factor"].as<float>();
         if (config["zoom_to_cursor"])
             _new_config.zoom_to_cursor = config["zoom_to_cursor"].as<bool>();
+        if (config["autosave_frequency"])
+            _new_config.autosave_frequency = config["autosave_frequency"].as<int32_t>();
+        if (config["autosave_amount"])
+            _new_config.autosave_amount = config["autosave_amount"].as<int32_t>();
 
         return _new_config;
     }
@@ -143,6 +147,8 @@ namespace OpenLoco::Config
         node["companyAIDisabled"] = _new_config.companyAIDisabled;
         node["scale_factor"] = _new_config.scale_factor;
         node["zoom_to_cursor"] = _new_config.zoom_to_cursor;
+        node["autosave_frequency"] = _new_config.autosave_frequency;
+        node["autosave_amount"] = _new_config.autosave_amount;
 
         std::ofstream stream(configPath);
         if (stream.is_open())

--- a/src/OpenLoco/Config.cpp
+++ b/src/OpenLoco/Config.cpp
@@ -47,7 +47,7 @@ namespace OpenLoco::Config
 
     new_config& readNewConfig()
     {
-        auto configPath = Environment::getPath(Environment::path_id::openloco_yml);
+        auto configPath = Environment::getPathNoWarning(Environment::path_id::openloco_yml);
 
         if (!fs::exists(configPath))
             return _new_config;
@@ -97,20 +97,9 @@ namespace OpenLoco::Config
 
     void writeNewConfig()
     {
-        auto configPath = Environment::getPath(Environment::path_id::openloco_yml);
+        auto configPath = Environment::getPathNoWarning(Environment::path_id::openloco_yml);
         auto dir = configPath.parent_path();
-        if (!fs::is_directory(dir))
-        {
-            fs::create_directories(dir);
-            // clang-format off
-            fs::permissions(
-                dir,
-                fs::perms::owner_all |
-                fs::perms::group_read | fs::perms::group_exec |
-                fs::perms::others_read | fs::perms::others_exec
-            );
-            // clang-format on
-        }
+        Environment::autoCreateDirectory(dir);
 
         auto& node = _config_yaml;
 

--- a/src/OpenLoco/Config.h
+++ b/src/OpenLoco/Config.h
@@ -153,6 +153,8 @@ namespace OpenLoco::Config
         bool companyAIDisabled = false;
         float scale_factor = 1.0f;
         bool zoom_to_cursor = true;
+        int32_t autosave_frequency = 1;
+        int32_t autosave_amount = 12;
     };
 
 #pragma pack(pop)

--- a/src/OpenLoco/Environment.cpp
+++ b/src/OpenLoco/Environment.cpp
@@ -166,10 +166,42 @@ namespace OpenLoco::Environment
         return result;
     }
 
+    fs::path getPathNoWarning(path_id id)
+    {
+        auto basePath = getBasePath(id);
+        auto subPath = getSubPath(id);
+        auto result = (basePath / subPath).lexically_normal();
+        return result;
+    }
+
     template<typename T>
     static void setDirectory(T& buffer, fs::path path)
     {
         Utility::strcpy_safe(buffer, path.make_preferred().u8string().c_str());
+    }
+
+    void autoCreateDirectory(const fs::path& path)
+    {
+        try
+        {
+            if (!fs::is_directory(path))
+            {
+                auto path8 = path.u8string();
+                std::printf("Creating directory: %s\n", path8.c_str());
+                fs::create_directories(path);
+                // clang-format off
+                fs::permissions(
+                    path,
+                    fs::perms::owner_all |
+                    fs::perms::group_read | fs::perms::group_exec |
+                    fs::perms::others_read | fs::perms::others_exec);
+                // clang-format on
+            }
+        }
+        catch (const std::exception& e)
+        {
+            std::fprintf(stderr, "Unable to create directory: %s\n", e.what());
+        }
     }
 
     // 0x004412CE
@@ -177,8 +209,12 @@ namespace OpenLoco::Environment
     {
         auto basePath = resolveLocoInstallPath();
         setDirectory(_path_install, basePath);
-        setDirectory(_path_saves_single_player, getPath(path_id::save));
-        setDirectory(_path_saves_two_player, getPath(path_id::save));
+
+        auto saveDirectory = getPathNoWarning(path_id::save);
+        setDirectory(_path_saves_single_player, saveDirectory);
+        setDirectory(_path_saves_two_player, saveDirectory);
+        autoCreateDirectory(saveDirectory);
+
         setDirectory(_path_scenarios, basePath / "Scenarios/*.SC5");
         setDirectory(_path_landscapes, basePath / "Scenarios/Landscapes/*.SC5");
         setDirectory(_path_objects, basePath / "ObjData/*.DAT");

--- a/src/OpenLoco/Environment.cpp
+++ b/src/OpenLoco/Environment.cpp
@@ -146,7 +146,7 @@ namespace OpenLoco::Environment
     {
         auto basePath = getBasePath(id);
         auto subPath = getSubPath(id);
-        auto result = basePath / subPath;
+        auto result = (basePath / subPath).lexically_normal();
         if (!fs::exists(result))
         {
 #ifndef _WIN32
@@ -193,6 +193,7 @@ namespace OpenLoco::Environment
             case path_id::gamecfg:
             case path_id::scores:
             case path_id::openloco_yml:
+            case path_id::autosave:
                 return platform::getUserDirectory();
             case path_id::language_files:
 #if defined(__APPLE__) && defined(__MACH__)
@@ -258,6 +259,7 @@ namespace OpenLoco::Environment
             "Data/TUT800_3.DAT",
             "openloco.yml",
             "language",
+            "save/autosave",
         };
 
         size_t index = (size_t)id;

--- a/src/OpenLoco/Environment.cpp
+++ b/src/OpenLoco/Environment.cpp
@@ -177,8 +177,8 @@ namespace OpenLoco::Environment
     {
         auto basePath = resolveLocoInstallPath();
         setDirectory(_path_install, basePath);
-        setDirectory(_path_saves_single_player, basePath / "Single Player Saved Games/");
-        setDirectory(_path_saves_two_player, basePath / "Two Player Saved Games/");
+        setDirectory(_path_saves_single_player, getPath(path_id::save));
+        setDirectory(_path_saves_two_player, getPath(path_id::save));
         setDirectory(_path_scenarios, basePath / "Scenarios/*.SC5");
         setDirectory(_path_landscapes, basePath / "Scenarios/Landscapes/*.SC5");
         setDirectory(_path_objects, basePath / "ObjData/*.DAT");
@@ -193,6 +193,7 @@ namespace OpenLoco::Environment
             case path_id::gamecfg:
             case path_id::scores:
             case path_id::openloco_yml:
+            case path_id::save:
             case path_id::autosave:
                 return platform::getUserDirectory();
             case path_id::language_files:
@@ -259,6 +260,7 @@ namespace OpenLoco::Environment
             "Data/TUT800_3.DAT",
             "openloco.yml",
             "language",
+            "save",
             "save/autosave",
         };
 

--- a/src/OpenLoco/Environment.h
+++ b/src/OpenLoco/Environment.h
@@ -56,6 +56,7 @@ namespace OpenLoco::Environment
         tut800_3,
         openloco_yml,
         language_files,
+        save,
         autosave,
     };
 

--- a/src/OpenLoco/Environment.h
+++ b/src/OpenLoco/Environment.h
@@ -56,6 +56,7 @@ namespace OpenLoco::Environment
         tut800_3,
         openloco_yml,
         language_files,
+        autosave,
     };
 
     fs::path getPath(path_id id);

--- a/src/OpenLoco/Environment.h
+++ b/src/OpenLoco/Environment.h
@@ -60,6 +60,8 @@ namespace OpenLoco::Environment
         autosave,
     };
 
+    void autoCreateDirectory(const fs::path& path);
     fs::path getPath(path_id id);
+    fs::path getPathNoWarning(path_id id);
     void resolvePaths();
 }

--- a/src/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/Localisation/StringIds.h
@@ -1459,4 +1459,9 @@ namespace OpenLoco::StringIds
     constexpr string_id menu_exit_openloco = 2140;
     constexpr string_id disableAICompanies = 2141;
     constexpr string_id disableAICompanies_tip = 2142;
+    constexpr string_id autosave_amount = 2143;
+    constexpr string_id autosave_frequency = 2144;
+    constexpr string_id autosave_never = 2145;
+    constexpr string_id autosave_every_month = 2146;
+    constexpr string_id autosave_every_x_months = 2147;
 }

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -894,17 +894,7 @@ namespace OpenLoco
         try
         {
             auto autosaveDirectory = Environment::getPath(Environment::path_id::autosave);
-            if (!fs::is_directory(autosaveDirectory))
-            {
-                fs::create_directories(autosaveDirectory);
-                // clang-format off
-                fs::permissions(
-                    autosaveDirectory,
-                    fs::perms::owner_all |
-                    fs::perms::group_read | fs::perms::group_exec |
-                    fs::perms::others_read | fs::perms::others_exec);
-                // clang-format on
-            }
+            Environment::autoCreateDirectory(autosaveDirectory);
 
             auto autosaveFullPath = autosaveDirectory / filename;
 

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -843,7 +843,7 @@ namespace OpenLoco
                     {
                         auto& path = f.path();
                         auto filename = path.filename().u8string();
-                        if (Utility::startsWith(filename, "autosave_") && Utility::endsWith(filename, ".sv5", true))
+                        if (Utility::startsWith(filename, "autosave_") && Utility::endsWith(filename, S5::extensionSV5, true))
                         {
                             autosaveFiles.push_back(path);
                         }
@@ -880,7 +880,16 @@ namespace OpenLoco
         auto localTime = std::localtime(&time);
         char filename[64];
         snprintf(
-            filename, sizeof(filename), "autosave_%04u-%02u-%02u_%02u-%02u-%02u.SV5", localTime->tm_year + 1900, localTime->tm_mon + 1, localTime->tm_mday, localTime->tm_hour, localTime->tm_min, localTime->tm_sec);
+            filename,
+            sizeof(filename),
+            "autosave_%04u-%02u-%02u_%02u-%02u-%02u%s",
+            localTime->tm_year + 1900,
+            localTime->tm_mon + 1,
+            localTime->tm_mday,
+            localTime->tm_hour,
+            localTime->tm_min,
+            localTime->tm_sec,
+            S5::extensionSV5);
 
         try
         {

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -827,10 +827,6 @@ namespace OpenLoco
         _monthsSinceLastAutosave = 0;
     }
 
-    static void save_sv5(const fs::path& path)
-    {
-    }
-
     static void autosave()
     {
         // Format filename
@@ -859,7 +855,7 @@ namespace OpenLoco
 
             auto autosaveFullPath8 = autosaveFullPath.u8string();
             std::printf("Autosaving game to %s\n", autosaveFullPath8.c_str());
-            save_sv5(autosaveFullPath);
+            S5::save(autosaveFullPath, static_cast<S5::SaveFlags>(S5::SaveFlags::savedGame | S5::SaveFlags::noWindowClose));
         }
         catch (const std::exception& e)
         {

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -880,7 +880,7 @@ namespace OpenLoco
         auto localTime = std::localtime(&time);
         char filename[64];
         snprintf(
-            filename, sizeof(filename), "autosave_%04u-%02u-%02u_%02u-%02u-%02u.sv5", localTime->tm_year + 1900, localTime->tm_mon + 1, localTime->tm_mday, localTime->tm_hour, localTime->tm_min, localTime->tm_sec);
+            filename, sizeof(filename), "autosave_%04u-%02u-%02u_%02u-%02u-%02u.SV5", localTime->tm_year + 1900, localTime->tm_mon + 1, localTime->tm_mday, localTime->tm_hour, localTime->tm_min, localTime->tm_sec);
 
         try
         {

--- a/src/OpenLoco/S5/S5.cpp
+++ b/src/OpenLoco/S5/S5.cpp
@@ -8,6 +8,8 @@ namespace OpenLoco::S5
     static loco_global<Options, 0x009C8714> _activeOptions;
     static loco_global<Header, 0x009CCA34> _header;
     static loco_global<Options, 0x009CCA54> _previewOptions;
+    static loco_global<uint32_t, 0x009D1C9C> _saveFlags;
+    static loco_global<char[512], 0x0112CE04> _savePath;
 
     Options& getOptions()
     {
@@ -17,5 +19,35 @@ namespace OpenLoco::S5
     Options& getPreviewOptions()
     {
         return _previewOptions;
+    }
+
+    // 0x00441C26
+    bool save(const fs::path& path, SaveFlags flags)
+    {
+        // Copy UTF-8 path into filename buffer
+        auto path8 = path.u8string();
+        if (path8.size() >= std::size(_savePath))
+        {
+            std::fprintf(stderr, "Save path is too long: %s\n", path8.c_str());
+            return false;
+        }
+        std::strncpy(_savePath, path8.c_str(), std::size(_savePath));
+
+        if (flags & SaveFlags::noWindowClose)
+        {
+            // TODO: Remove ghost elements before saving to file
+
+            // Skip the close construction window call
+            // We have skipped the _saveFlags = eax instruction, so do this here
+            _saveFlags = flags;
+            return call(0x00441C3C) & (1 << 8);
+        }
+        else
+        {
+            // Normal entry
+            registers regs;
+            regs.eax = flags;
+            return call(0x00441C26, regs) & (1 << 8);
+        }
     }
 }

--- a/src/OpenLoco/S5/S5.h
+++ b/src/OpenLoco/S5/S5.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../Core/FileSystem.hpp"
 #include "../Objects/ObjectManager.h"
 #include <cstdint>
 
@@ -107,6 +108,22 @@ namespace OpenLoco::S5
 #pragma pack(pop)
     static_assert(sizeof(SaveDetails) == 0xC618);
 
+    enum SaveFlags : uint32_t
+    {
+        savedGame = 1 << 0,
+
+        /**
+         * Using flag 31 causes the saved games to not open, so this must
+         * have another meaning. For autosave we just want to prevent the
+         * construction windows from closing.
+         */
+        noWindowClose = 1u << 29,
+
+        flag30 = 1u << 30, // Does not reorganise map elements
+        flag31 = 1u << 31, // Does not close construction windows
+    };
+
     Options& getOptions();
     Options& getPreviewOptions();
+    bool save(const fs::path& path, SaveFlags flags);
 }

--- a/src/OpenLoco/S5/S5.h
+++ b/src/OpenLoco/S5/S5.h
@@ -123,6 +123,9 @@ namespace OpenLoco::S5
         flag31 = 1u << 31, // Does not close construction windows
     };
 
+    constexpr const char* extensionSC5 = ".SC5";
+    constexpr const char* extensionSV5 = ".SV5";
+
     Options& getOptions();
     Options& getPreviewOptions();
     bool save(const fs::path& path, SaveFlags flags);

--- a/src/OpenLoco/Utility/String.hpp
+++ b/src/OpenLoco/Utility/String.hpp
@@ -10,16 +10,6 @@ namespace OpenLoco::Utility
     std::string toUtf8(const std::wstring_view& src);
     std::wstring toUtf16(const std::string_view& src);
 
-    inline bool startsWith(std::string_view s, std::string_view value)
-    {
-        if (s.size() >= value.size())
-        {
-            auto substr = s.substr(0, value.size());
-            return substr == value;
-        }
-        return false;
-    }
-
     inline bool iequals(const std::string_view& a, const std::string_view& b)
     {
         if (a.size() != b.size())
@@ -34,6 +24,31 @@ namespace OpenLoco::Utility
             }
         }
         return true;
+    }
+
+    inline bool equals(const std::string_view& a, const std::string_view& b, bool ignoreCase = false)
+    {
+        return ignoreCase ? iequals(a, b) : a == b;
+    }
+
+    inline bool startsWith(std::string_view s, std::string_view value, bool ignoreCase = false)
+    {
+        if (s.size() >= value.size())
+        {
+            auto substr = s.substr(0, value.size());
+            return equals(substr, value, ignoreCase);
+        }
+        return false;
+    }
+
+    inline bool endsWith(std::string_view s, std::string_view value, bool ignoreCase = false)
+    {
+        if (s.size() >= value.size())
+        {
+            auto substr = s.substr(s.size() - value.size());
+            return equals(substr, value, ignoreCase);
+        }
+        return false;
     }
 
     inline size_t strlcpy(char* dest, const char* src, size_t size)

--- a/src/OpenLoco/Utility/String.hpp
+++ b/src/OpenLoco/Utility/String.hpp
@@ -10,6 +10,16 @@ namespace OpenLoco::Utility
     std::string toUtf8(const std::wstring_view& src);
     std::wstring toUtf16(const std::string_view& src);
 
+    inline bool startsWith(std::string_view s, std::string_view value)
+    {
+        if (s.size() >= value.size())
+        {
+            auto substr = s.substr(0, value.size());
+            return substr == value;
+        }
+        return false;
+    }
+
     inline bool iequals(const std::string_view& a, const std::string_view& b)
     {
         if (a.size() != b.size())

--- a/src/OpenLoco/Windows/Options.cpp
+++ b/src/OpenLoco/Windows/Options.cpp
@@ -1842,7 +1842,7 @@ namespace OpenLoco::Ui::Options
 
     namespace Misc
     {
-        static const Gfx::ui_size_t _window_size = { 420, 239 };
+        static const Gfx::ui_size_t _window_size = { 420, 159 };
 
         namespace Widx
         {
@@ -1870,9 +1870,9 @@ namespace OpenLoco::Ui::Options
             makeWidget({ 10, 79 }, { 400, 12 }, widget_type::checkbox, 1, StringIds::use_preferred_owner_name, StringIds::use_preferred_owner_name_tip),
             makeWidget({ 335, 94 }, { 75, 12 }, widget_type::wt_11, 1, StringIds::change),
             makeWidget({ 10, 109 }, { 400, 12 }, widget_type::checkbox, 1, StringIds::export_plugin_objects, StringIds::export_plugin_objects_tip),
-            makeWidget({ 235, 123 }, { 156, 12 }, widget_type::wt_18, 1, StringIds::empty),
-            makeWidget({ 379, 124 }, { 11, 10 }, widget_type::wt_11, 1, StringIds::dropdown),
-            makeStepperWidgets({ 235, 139 }, { 156, 12 }, widget_type::wt_17, 1, StringIds::empty),
+            makeWidget({ 250, 123 }, { 156, 12 }, widget_type::wt_18, 1, StringIds::empty),
+            makeWidget({ 394, 124 }, { 11, 10 }, widget_type::wt_11, 1, StringIds::dropdown),
+            makeStepperWidgets({ 250, 139 }, { 156, 12 }, widget_type::wt_17, 1, StringIds::empty),
             widgetEnd(),
         };
 

--- a/src/OpenLoco/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/Windows/PromptBrowseWindow.cpp
@@ -657,7 +657,7 @@ namespace OpenLoco::Ui::PromptBrowse
                     return path;
                 }
             }
-            return fs::path();
+            return str / fs::path();
         }
     }
 


### PR DESCRIPTION
Add two new configuration options to control frequency of autosaving and the number of autosaves to keep.
Autosaves are saved to `<user openloco directory>/save/autosave`.
The default saved game directory is now `<user openloco directory>/save`.

Last thing that needs doing is:
* [ ] Remove ghost elements when saving.