### PR TITLE
Fix orders related crashes and quirks

### DIFF
--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -2424,7 +2424,8 @@ namespace OpenLoco::Ui::Vehicle
             auto chosenOffset = head->sizeOfOrderTable - 1;
             if (self->var_842 != -1)
             {
-                chosenOffset = 1;
+                auto orderIndex = 0; // self->var_842 is in terms of order indexs (i.e. 1 per order)
+                chosenOffset = 0;    // chosenOffset will be (orderOffset - head->orderTableOffset)
                 auto orderOffset = head->orderTableOffset;
                 auto orderType = -1; // Just to do one loop in all cases TODO ?do while?
                 while (orderType != 0)
@@ -2435,11 +2436,12 @@ namespace OpenLoco::Ui::Vehicle
                         break;
                     }
                     orderOffset += dword_4FE070[orderType];
-                    if (chosenOffset == self->var_842)
+                    chosenOffset += dword_4FE070[orderType];
+                    orderIndex++;
+                    if (orderIndex == self->var_842)
                     {
                         break;
                     }
-                    chosenOffset++;
                 }
             }
             gGameCommandErrorTitle = StringIds::orders_cant_insert;


### PR DESCRIPTION
Mistake made in implementation caused orders to be inserted in the wrong locations in the order table. This could cause unknown side effects or a crash