### PR TITLE
Fix #151: Mouse moves out of window when looking around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 20.10+ (in development)
 ------------------------------------------------------------------------
+- Fix: [#151] Mouse moves out of window when looking around.
 - Fix: [#588] 'Cancel or Show Last Announcement' shortcut doesn't close announcements.
 
 20.10 (2020-10-25)

--- a/src/OpenLoco/Input.cpp
+++ b/src/OpenLoco/Input.cpp
@@ -74,4 +74,17 @@ namespace OpenLoco::Input
             Ui::showCursor();
         }
     }
+
+    Gfx::point_t getNextDragOffset()
+    {
+        int32_t currentX, currentY;
+        Ui::getCursorPos(currentX, currentY);
+
+        auto deltaX = currentX - _cursor_drag_start_x;
+        auto deltaY = currentY - _cursor_drag_start_y;
+
+        Ui::setCursorPos(_cursor_drag_start_x, _cursor_drag_start_y);
+
+        return { static_cast<int16_t>(deltaX), static_cast<int16_t>(deltaY) };
+    }
 }

--- a/src/OpenLoco/Input.h
+++ b/src/OpenLoco/Input.h
@@ -100,6 +100,7 @@ namespace OpenLoco::Input
     void moveMouse(int32_t x, int32_t y, int32_t relX, int32_t relY);
     void sub_407218();
     void sub_407231();
+    Gfx::point_t getNextDragOffset();
     void processMouseOver(int16_t x, int16_t y);
     void processKeyboardInput();
 

--- a/src/OpenLoco/Input/MouseInput.cpp
+++ b/src/OpenLoco/Input/MouseInput.cpp
@@ -724,11 +724,13 @@ namespace OpenLoco::Input
                     return;
                 }
 
-                if (x != 0 || y != 0)
+                auto dragOffset = getNextDragOffset();
+                if (dragOffset.x != 0 || dragOffset.y != 0)
                 {
                     _ticksSinceDragStart = 1000;
-                    window->viewport_configurations[0].saved_view_x += x << (vp->zoom + 1);
-                    window->viewport_configurations[0].saved_view_y += y << (vp->zoom + 1);
+
+                    window->viewport_configurations[0].saved_view_x += dragOffset.x << (vp->zoom + 1);
+                    window->viewport_configurations[0].saved_view_y += dragOffset.y << (vp->zoom + 1);
                 }
 
                 break;


### PR DESCRIPTION
This was driving up the wall.