### PR TITLE
Implement the sawyer encoder / decoder

### DIFF
--- a/src/OpenLoco/Core/Span.hpp
+++ b/src/OpenLoco/Core/Span.hpp
@@ -1,0 +1,7 @@
+/// @file
+/// This file enables access to std::span as `stdx` namespace
+
+#pragma once
+
+#define TCB_SPAN_NAMESPACE_NAME stdx
+#include "../../Thirdparty/span.hpp"

--- a/src/OpenLoco/S5/SawyerStream.cpp
+++ b/src/OpenLoco/S5/SawyerStream.cpp
@@ -1,0 +1,488 @@
+#include "SawyerStream.h"
+#include "../Utility/Numeric.hpp"
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+using namespace OpenLoco;
+using namespace OpenLoco::Utility;
+
+constexpr const char* exceptionInvalidRLE = "Invalid RLE run";
+constexpr const char* exceptionUnknownEncoding = "Unknown encoding";
+
+uint8_t* FastBuffer::alloc(size_t len)
+{
+#ifdef _WIN32
+    return reinterpret_cast<uint8_t*>(HeapAlloc(GetProcessHeap(), 0, len));
+#else
+    return reinterpret_cast<uint8_t*>(std::malloc(len));
+#endif
+}
+
+uint8_t* FastBuffer::realloc(uint8_t* ptr, size_t len)
+{
+#ifdef _WIN32
+    return reinterpret_cast<uint8_t*>(HeapReAlloc(GetProcessHeap(), 0, ptr, len));
+#else
+    return reinterpret_cast<uint8_t*>(std::realloc(ptr, len));
+#endif
+}
+
+void FastBuffer::free(uint8_t* ptr)
+{
+#ifdef _WIN32
+    HeapFree(GetProcessHeap(), 0, ptr);
+#else
+    std::free(ptr);
+#endif
+}
+
+FastBuffer::~FastBuffer()
+{
+    if (_data != nullptr)
+    {
+        free(_data);
+        _data = 0;
+        _len = 0;
+        _capacity = 0;
+    }
+}
+
+uint8_t* FastBuffer::data()
+{
+    return _data;
+}
+
+size_t FastBuffer::size() const
+{
+    return _len;
+}
+
+void FastBuffer::resize(size_t len)
+{
+    reserve(len);
+    _len = len;
+}
+
+void FastBuffer::reserve(size_t len)
+{
+    if (_capacity < len)
+    {
+        do
+        {
+            _capacity = std::max<size_t>(256, _capacity * 2);
+        } while (_capacity < len);
+        auto newData = _data == nullptr ? alloc(_capacity) : realloc(_data, _capacity);
+        if (newData == nullptr)
+        {
+            throw std::bad_alloc();
+        }
+        else
+        {
+            _data = reinterpret_cast<uint8_t*>(newData);
+        }
+    }
+}
+
+void FastBuffer::clear()
+{
+    _len = 0;
+}
+
+void FastBuffer::push_back(uint8_t value)
+{
+    reserve(_len + 1);
+    _data[_len++] = value;
+}
+
+void FastBuffer::push_back(uint8_t value, size_t len)
+{
+    reserve(_len + len);
+    std::memset(&_data[_len], value, len);
+    _len += len;
+}
+
+void FastBuffer::push_back(const uint8_t* src, size_t len)
+{
+    reserve(_len + len);
+    std::memcpy(&_data[_len], src, len);
+    _len += len;
+}
+
+stdx::span<uint8_t const> FastBuffer::getSpan() const
+{
+    return stdx::span<uint8_t const>(_data, _len);
+}
+
+SawyerStreamReader::SawyerStreamReader(const fs::path& path)
+{
+    _stream.exceptions(std::ifstream::failbit);
+    _stream.open(path, std::ios::in | std::ios::binary);
+}
+
+stdx::span<uint8_t const> SawyerStreamReader::readChunk()
+{
+    SawyerEncoding encoding;
+    read(&encoding, sizeof(encoding));
+
+    uint32_t length;
+    read(&length, sizeof(length));
+
+    _decodeBuffer.resize(length);
+    read(_decodeBuffer.data(), length);
+
+    return decode(encoding, _decodeBuffer.getSpan());
+}
+
+size_t SawyerStreamReader::readChunk(void* data, size_t maxDataLen)
+{
+    auto chunkData = readChunk();
+    std::memcpy(data, chunkData.data(), std::min(chunkData.size(), maxDataLen));
+    return chunkData.size();
+}
+
+void SawyerStreamReader::read(void* data, size_t dataLen)
+{
+    _stream.read(reinterpret_cast<char*>(data), dataLen);
+}
+
+bool SawyerStreamReader::validateChecksum()
+{
+    auto valid = false;
+    auto backupPos = _stream.tellg();
+
+    _stream.seekg(0, std::ios::end);
+    auto fileLength = static_cast<uint32_t>(_stream.tellg());
+    if (fileLength >= 4)
+    {
+        // Read checksum
+        uint32_t checksum;
+        _stream.seekg(fileLength - 4);
+        _stream.read(reinterpret_cast<char*>(&checksum), sizeof(checksum));
+
+        // Calculate checksum
+        uint32_t actualChecksum = 0;
+        _stream.seekg(0);
+        uint8_t buffer[2048];
+        for (uint32_t i = 0; i < fileLength - 4; i += sizeof(buffer))
+        {
+            auto readLength = std::min(sizeof(buffer), fileLength - 4 - i);
+            _stream.read(reinterpret_cast<char*>(buffer), readLength);
+            for (size_t j = 0; j < readLength; j++)
+            {
+                actualChecksum += buffer[j];
+            }
+        }
+
+        valid = checksum == actualChecksum;
+    }
+
+    // Restore position
+    _stream.seekg(backupPos);
+
+    return valid;
+}
+
+void SawyerStreamReader::close()
+{
+    _stream.close();
+}
+
+stdx::span<uint8_t const> SawyerStreamReader::decode(SawyerEncoding encoding, stdx::span<uint8_t const> data)
+{
+    switch (encoding)
+    {
+        case SawyerEncoding::uncompressed:
+            return data;
+        case SawyerEncoding::runLengthSingle:
+            _decodeBuffer2.clear();
+            _decodeBuffer2.reserve(data.size());
+            decodeRunLengthSingle(_decodeBuffer2, data);
+            return _decodeBuffer2.getSpan();
+        case SawyerEncoding::runLengthMulti:
+            _decodeBuffer2.clear();
+            _decodeBuffer2.reserve(data.size());
+            decodeRunLengthSingle(_decodeBuffer2, data);
+
+            _decodeBuffer.clear();
+            _decodeBuffer.reserve(_decodeBuffer2.size());
+            decodeRunLengthMulti(_decodeBuffer, _decodeBuffer2.getSpan());
+            return _decodeBuffer.getSpan();
+        case SawyerEncoding::rotate:
+            _decodeBuffer2.clear();
+            _decodeBuffer2.reserve(data.size());
+            decodeRotate(_decodeBuffer2, data);
+            return _decodeBuffer2.getSpan();
+        default:
+            throw std::runtime_error(exceptionUnknownEncoding);
+    }
+}
+
+void SawyerStreamReader::decodeRunLengthSingle(FastBuffer& buffer, stdx::span<uint8_t const> data)
+{
+    for (size_t i = 0; i < data.size(); i++)
+    {
+        uint8_t rleCodeByte = data[i];
+        if (rleCodeByte & 128)
+        {
+            i++;
+            if (i >= data.size())
+            {
+                throw std::runtime_error(exceptionInvalidRLE);
+            }
+
+            auto copyLen = static_cast<size_t>(257 - rleCodeByte);
+            auto copyByte = data[i];
+            buffer.push_back(copyByte, copyLen);
+        }
+        else
+        {
+            if (i + 1 >= data.size() || i + 1 + rleCodeByte + 1 > data.size())
+            {
+                throw std::runtime_error(exceptionInvalidRLE);
+            }
+
+            auto copyLen = static_cast<size_t>(rleCodeByte + 1);
+            buffer.push_back(&data[i + 1], copyLen);
+            i += rleCodeByte + 1;
+        }
+    }
+}
+
+void SawyerStreamReader::decodeRunLengthMulti(FastBuffer& buffer, stdx::span<uint8_t const> data)
+{
+    for (size_t i = 0; i < data.size(); i++)
+    {
+        if (data[i] == 0xFF)
+        {
+            i++;
+            if (i >= data.size())
+            {
+                throw std::runtime_error(exceptionInvalidRLE);
+            }
+            buffer.push_back(data[i]);
+        }
+        else
+        {
+            auto offset = static_cast<int32_t>(data[i] >> 3) - 32;
+            assert(offset < 0);
+            if (static_cast<size_t>(-offset) > buffer.size())
+            {
+                throw std::runtime_error(exceptionInvalidRLE);
+            }
+            auto copySrc = buffer.data() + buffer.size() + offset;
+            auto copyLen = static_cast<size_t>((data[i] & 7) + 1);
+
+            // Copy it to temp buffer first as we can't copy buffer to itself due to potential
+            // realloc in between reserve and push
+            uint8_t copyBuffer[32];
+            assert(copyLen <= sizeof(copyBuffer));
+            std::memcpy(copyBuffer, copySrc, copyLen);
+            buffer.push_back(copyBuffer, copyLen);
+        }
+    }
+}
+
+void SawyerStreamReader::decodeRotate(FastBuffer& buffer, stdx::span<uint8_t const> data)
+{
+    uint8_t code = 1;
+    for (size_t i = 0; i < data.size(); i++)
+    {
+        buffer.push_back(ror(data[i], code));
+        code = (code + 2) & 7;
+    }
+}
+
+SawyerStreamWriter::SawyerStreamWriter(const fs::path& path)
+{
+    _stream.exceptions(std::ifstream::failbit);
+    _stream.open(path, std::ios::out | std::ios::binary);
+}
+
+void SawyerStreamWriter::writeChunk(SawyerEncoding chunkType, const void* data, size_t dataLen)
+{
+    auto encodedData = encode(chunkType, stdx::span<uint8_t const>(reinterpret_cast<const uint8_t*>(data), dataLen));
+    write(&chunkType, sizeof(chunkType));
+    write(static_cast<uint32_t>(encodedData.size()));
+    write(encodedData.data(), encodedData.size());
+}
+
+void SawyerStreamWriter::write(const void* data, size_t dataLen)
+{
+    _stream.write(reinterpret_cast<const char*>(data), dataLen);
+    auto data8 = reinterpret_cast<const uint8_t*>(data);
+    for (size_t i = 0; i < dataLen; i++)
+    {
+        _checksum += data8[i];
+    }
+}
+
+void SawyerStreamWriter::writeChecksum()
+{
+    _stream.write(reinterpret_cast<const char*>(&_checksum), sizeof(_checksum));
+}
+
+void SawyerStreamWriter::close()
+{
+    _stream.close();
+}
+
+stdx::span<uint8_t const> SawyerStreamWriter::encode(SawyerEncoding encoding, stdx::span<uint8_t const> data)
+{
+    switch (encoding)
+    {
+        case SawyerEncoding::uncompressed:
+            return data;
+        case SawyerEncoding::runLengthSingle:
+            _encodeBuffer.clear();
+            _encodeBuffer.reserve(data.size());
+            encodeRunLengthSingle(_encodeBuffer, data);
+            return _encodeBuffer.getSpan();
+        case SawyerEncoding::runLengthMulti:
+            _encodeBuffer.clear();
+            _encodeBuffer.reserve(data.size());
+            encodeRunLengthMulti(_encodeBuffer, data);
+
+            _encodeBuffer2.clear();
+            _encodeBuffer2.reserve(_encodeBuffer.size());
+            encodeRunLengthSingle(_encodeBuffer2, _encodeBuffer.getSpan());
+            return _encodeBuffer2.getSpan();
+        case SawyerEncoding::rotate:
+            _encodeBuffer.clear();
+            _encodeBuffer.reserve(data.size());
+            encodeRotate(_encodeBuffer, data);
+            return _encodeBuffer.getSpan();
+        default:
+            throw std::runtime_error(exceptionUnknownEncoding);
+    }
+}
+
+void SawyerStreamWriter::encodeRunLengthSingle(FastBuffer& buffer, stdx::span<uint8_t const> data)
+{
+    auto src = data.data();
+    auto srcEnd = src + data.size();
+    auto srcNormStart = src;
+    uint8_t count = 0;
+
+    while (src < srcEnd - 1)
+    {
+        if ((count != 0 && src[0] == src[1]) || count > 125)
+        {
+            buffer.push_back(count - 1);
+            buffer.push_back(srcNormStart, count);
+            srcNormStart += count;
+            count = 0;
+        }
+        if (src[0] == src[1])
+        {
+            for (; count < 125 && src + count < srcEnd; count++)
+            {
+                if (src[0] != src[count])
+                {
+                    break;
+                }
+            }
+            buffer.push_back(257 - count);
+            buffer.push_back(src[0]);
+            src += count;
+            srcNormStart = src;
+            count = 0;
+        }
+        else
+        {
+            count++;
+            src++;
+        }
+    }
+    if (src == srcEnd - 1)
+    {
+        count++;
+    }
+    if (count != 0)
+    {
+        buffer.push_back(count - 1);
+        buffer.push_back(srcNormStart, count);
+    }
+}
+
+void SawyerStreamWriter::encodeRunLengthMulti(FastBuffer& buffer, stdx::span<uint8_t const> data)
+{
+    auto src = data.data();
+    auto srcLen = data.size();
+    if (srcLen == 0)
+        return;
+
+    // Need to emit at least one byte, otherwise there is nothing to repeat
+    buffer.push_back(255);
+    buffer.push_back(src[0]);
+
+    // Iterate through remainder of the source buffer
+    for (size_t i = 1; i < srcLen;)
+    {
+        size_t searchIndex = (i < 32) ? 0 : (i - 32);
+        size_t searchEnd = i - 1;
+
+        size_t bestRepeatIndex = 0;
+        size_t bestRepeatCount = 0;
+        for (size_t repeatIndex = searchIndex; repeatIndex <= searchEnd; repeatIndex++)
+        {
+            size_t repeatCount = 0;
+            size_t maxRepeatCount = std::min(std::min(static_cast<size_t>(7), searchEnd - repeatIndex), srcLen - i - 1);
+            // maxRepeatCount should not exceed srcLen
+            assert(repeatIndex + maxRepeatCount < srcLen);
+            assert(i + maxRepeatCount < srcLen);
+            for (size_t j = 0; j <= maxRepeatCount; j++)
+            {
+                if (src[repeatIndex + j] == src[i + j])
+                {
+                    repeatCount++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+            if (repeatCount > bestRepeatCount)
+            {
+                bestRepeatIndex = repeatIndex;
+                bestRepeatCount = repeatCount;
+
+                // Maximum repeat count is 8
+                if (repeatCount == 8)
+                    break;
+            }
+        }
+
+        if (bestRepeatCount == 0)
+        {
+            buffer.push_back(255);
+            buffer.push_back(src[i]);
+            i++;
+        }
+        else
+        {
+            buffer.push_back(static_cast<uint8_t>((bestRepeatCount - 1) | ((32 - (i - bestRepeatIndex)) << 3)));
+            i += bestRepeatCount;
+        }
+    }
+}
+
+void SawyerStreamWriter::encodeRotate(FastBuffer& buffer, stdx::span<uint8_t const> data)
+{
+    uint8_t code = 1;
+    for (size_t i = 0; i < data.size(); i++)
+    {
+        buffer.push_back(rol(data[i], code));
+        code = (code + 2) & 7;
+    }
+}

--- a/src/OpenLoco/S5/SawyerStream.cpp
+++ b/src/OpenLoco/S5/SawyerStream.cpp
@@ -311,7 +311,7 @@ SawyerStreamWriter::SawyerStreamWriter(const fs::path& path)
 
 void SawyerStreamWriter::writeChunk(SawyerEncoding chunkType, const void* data, size_t dataLen)
 {
-    auto encodedData = encode(chunkType, stdx::span<uint8_t const>(reinterpret_cast<const uint8_t*>(data), dataLen));
+    auto encodedData = encode(chunkType, stdx::span(reinterpret_cast<const uint8_t*>(data), dataLen));
     write(&chunkType, sizeof(chunkType));
     write(static_cast<uint32_t>(encodedData.size()));
     write(encodedData.data(), encodedData.size());

--- a/src/OpenLoco/S5/SawyerStream.h
+++ b/src/OpenLoco/S5/SawyerStream.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "../Core/FileSystem.hpp"
+#include "../Core/Span.hpp"
+#include <cstdint>
+#include <fstream>
+
+namespace OpenLoco
+{
+    enum class SawyerEncoding : uint8_t
+    {
+        uncompressed,
+        runLengthSingle,
+        runLengthMulti,
+        rotate,
+    };
+
+    /**
+     * Provides a more efficient implementation than std::vector for allocating and
+     * pushing bytes to a buffer.
+     * 
+     * In particular, for Windows, HeapAlloc is used for a direct memory block from the OS
+     * which is not initialised (even in debug builds). It vastly reduces the time needed
+     * to load / save S5 files in debug builds.
+     */
+    class FastBuffer
+    {
+    private:
+        uint8_t* _data{};
+        size_t _len{};
+        size_t _capacity{};
+
+        static uint8_t* alloc(size_t len);
+        static uint8_t* realloc(uint8_t* ptr, size_t len);
+        static void free(uint8_t* ptr);
+
+    public:
+        ~FastBuffer();
+
+        uint8_t* data();
+        size_t size() const;
+        void resize(size_t len);
+        void reserve(size_t len);
+        void clear();
+        void push_back(uint8_t value);
+        void push_back(uint8_t value, size_t len);
+        void push_back(const uint8_t* src, size_t len);
+        stdx::span<uint8_t const> getSpan() const;
+    };
+
+    class SawyerStreamReader
+    {
+    private:
+        std::ifstream _stream;
+        FastBuffer _decodeBuffer;
+        FastBuffer _decodeBuffer2;
+
+        stdx::span<uint8_t const> decode(SawyerEncoding encoding, stdx::span<uint8_t const> data);
+        static void decodeRunLengthSingle(FastBuffer& buffer, stdx::span<uint8_t const> data);
+        static void decodeRunLengthMulti(FastBuffer& buffer, stdx::span<uint8_t const> data);
+        static void decodeRotate(FastBuffer& buffer, stdx::span<uint8_t const> data);
+
+    public:
+        SawyerStreamReader(const fs::path& path);
+
+        stdx::span<uint8_t const> readChunk();
+        size_t readChunk(void* data, size_t maxDataLen);
+        void read(void* data, size_t dataLen);
+        bool validateChecksum();
+        void close();
+    };
+
+    class SawyerStreamWriter
+    {
+    private:
+        std::ofstream _stream;
+        uint32_t _checksum{};
+        FastBuffer _encodeBuffer;
+        FastBuffer _encodeBuffer2;
+
+        stdx::span<uint8_t const> encode(SawyerEncoding encoding, stdx::span<uint8_t const> data);
+        static void encodeRunLengthSingle(FastBuffer& buffer, stdx::span<uint8_t const> data);
+        static void encodeRunLengthMulti(FastBuffer& buffer, stdx::span<uint8_t const> data);
+        static void encodeRotate(FastBuffer& buffer, stdx::span<uint8_t const> data);
+
+    public:
+        SawyerStreamWriter(const fs::path& path);
+
+        void writeChunk(SawyerEncoding chunkType, const void* data, size_t dataLen);
+        void write(const void* data, size_t dataLen);
+        void writeChecksum();
+        void close();
+
+        template<typename T>
+        void writeChunk(SawyerEncoding chunkType, const T& data)
+        {
+            writeChunk(chunkType, &data, sizeof(T));
+        }
+
+        template<typename T>
+        void write(const T& data)
+        {
+            write(&data, sizeof(T));
+        }
+    };
+}

--- a/src/OpenLoco/Utility/Numeric.hpp
+++ b/src/OpenLoco/Utility/Numeric.hpp
@@ -2,7 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <limits.h>
+#include <limits>
 #include <type_traits>
 
 namespace OpenLoco::Utility
@@ -11,18 +11,20 @@ namespace OpenLoco::Utility
 
     int32_t bitScanReverse(uint32_t source);
 
-    template<typename T>
-    constexpr T rol(T val, size_t len)
+    template<typename _UIntType>
+    static constexpr _UIntType rol(_UIntType x, size_t shift)
     {
-        static_assert(std::is_unsigned<T>::value, "Rotate Left can only be used on unsigned types.");
-        return (val << len) | ((unsigned)val >> (-len & (sizeof(T) * CHAR_BIT - 1)));
+        static_assert(std::is_unsigned<_UIntType>::value, "result_type must be an unsigned integral type");
+        using limits = typename std::numeric_limits<_UIntType>;
+        return ((static_cast<_UIntType>(x) << shift) | (static_cast<_UIntType>(x) >> (limits::digits - shift)));
     }
 
-    template<typename T>
-    constexpr T ror(T val, size_t len)
+    template<typename _UIntType>
+    static constexpr _UIntType ror(_UIntType x, size_t shift)
     {
-        static_assert(std::is_unsigned<T>::value, "Rotate Right can only be used on unsigned types.");
-        return (val >> len) | ((unsigned)val << (sizeof(T) * CHAR_BIT - len));
+        static_assert(std::is_unsigned<_UIntType>::value, "result_type must be an unsigned integral type");
+        using limits = std::numeric_limits<_UIntType>;
+        return ((static_cast<_UIntType>(x) >> shift) | (static_cast<_UIntType>(x) << (limits::digits - shift)));
     }
 
     template<typename T>

--- a/src/OpenLoco/openloco.vcxproj
+++ b/src/OpenLoco/openloco.vcxproj
@@ -185,6 +185,7 @@
     <ClInclude Include="Console.h" />
     <ClInclude Include="Core\FileSystem.hpp" />
     <ClInclude Include="Core\Optional.hpp" />
+    <ClInclude Include="Core\Span.hpp" />
     <ClInclude Include="Date.h" />
     <ClInclude Include="Drawing\SoftwareDrawingEngine.h" />
     <ClInclude Include="Environment.h" />

--- a/src/OpenLoco/openloco.vcxproj
+++ b/src/OpenLoco/openloco.vcxproj
@@ -86,6 +86,7 @@
     <ClCompile Include="Platform\Platform.Windows.cpp" />
     <ClCompile Include="ProgressBar.cpp" />
     <ClCompile Include="S5\S5.cpp" />
+    <ClCompile Include="S5\SawyerStream.cpp" />
     <ClCompile Include="Scenario.cpp" />
     <ClCompile Include="ScenarioManager.cpp" />
     <ClCompile Include="Station.cpp" />
@@ -255,6 +256,7 @@
     <ClInclude Include="Platform\Platform.h" />
     <ClInclude Include="ProgressBar.h" />
     <ClInclude Include="S5\S5.h" />
+    <ClInclude Include="S5\SawyerStream.h" />
     <ClInclude Include="Scenario.h" />
     <ClInclude Include="ScenarioManager.h" />
     <ClInclude Include="Station.h" />

--- a/src/Thirdparty/span.hpp
+++ b/src/Thirdparty/span.hpp
@@ -1,0 +1,621 @@
+
+/*
+This is an implementation of C++20's std::span
+http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/n4820.pdf
+*/
+
+//          Copyright Tristan Brindle 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../../LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef TCB_SPAN_HPP_INCLUDED
+#define TCB_SPAN_HPP_INCLUDED
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#ifndef TCB_SPAN_NO_EXCEPTIONS
+// Attempt to discover whether we're being compiled with exception support
+#if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
+#define TCB_SPAN_NO_EXCEPTIONS
+#endif
+#endif
+
+#ifndef TCB_SPAN_NO_EXCEPTIONS
+#include <cstdio>
+#include <stdexcept>
+#endif
+
+// Various feature test macros
+
+#ifndef TCB_SPAN_NAMESPACE_NAME
+#define TCB_SPAN_NAMESPACE_NAME tcb
+#endif
+
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#define TCB_SPAN_HAVE_CPP17
+#endif
+
+#if __cplusplus >= 201402L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
+#define TCB_SPAN_HAVE_CPP14
+#endif
+
+namespace TCB_SPAN_NAMESPACE_NAME {
+
+// Establish default contract checking behavior
+#if !defined(TCB_SPAN_THROW_ON_CONTRACT_VIOLATION) &&                          \
+    !defined(TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION) &&                      \
+    !defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#if defined(NDEBUG) || !defined(TCB_SPAN_HAVE_CPP14)
+#define TCB_SPAN_NO_CONTRACT_CHECKING
+#else
+#define TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION
+#endif
+#endif
+
+#if defined(TCB_SPAN_THROW_ON_CONTRACT_VIOLATION)
+struct contract_violation_error : std::logic_error {
+    explicit contract_violation_error(const char* msg) : std::logic_error(msg)
+    {}
+};
+
+inline void contract_violation(const char* msg)
+{
+    throw contract_violation_error(msg);
+}
+
+#elif defined(TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION)
+[[noreturn]] inline void contract_violation(const char* /*unused*/)
+{
+    std::terminate();
+}
+#endif
+
+#if !defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#define TCB_SPAN_STRINGIFY(cond) #cond
+#define TCB_SPAN_EXPECT(cond)                                                  \
+    cond ? (void) 0 : contract_violation("Expected " TCB_SPAN_STRINGIFY(cond))
+#else
+#define TCB_SPAN_EXPECT(cond)
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_inline_variables)
+#define TCB_SPAN_INLINE_VAR inline
+#else
+#define TCB_SPAN_INLINE_VAR
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14) ||                                            \
+    (defined(__cpp_constexpr) && __cpp_constexpr >= 201304)
+#define TCB_SPAN_HAVE_CPP14_CONSTEXPR
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14_CONSTEXPR)
+#define TCB_SPAN_CONSTEXPR14 constexpr
+#else
+#define TCB_SPAN_CONSTEXPR14
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14_CONSTEXPR) &&                                  \
+    (!defined(_MSC_VER) || _MSC_VER > 1900)
+#define TCB_SPAN_CONSTEXPR_ASSIGN constexpr
+#else
+#define TCB_SPAN_CONSTEXPR_ASSIGN
+#endif
+
+#if defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#define TCB_SPAN_CONSTEXPR11 constexpr
+#else
+#define TCB_SPAN_CONSTEXPR11 TCB_SPAN_CONSTEXPR14
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_deduction_guides)
+#define TCB_SPAN_HAVE_DEDUCTION_GUIDES
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_byte)
+#define TCB_SPAN_HAVE_STD_BYTE
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_array_constexpr)
+#define TCB_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC
+#endif
+
+#if defined(TCB_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC)
+#define TCB_SPAN_ARRAY_CONSTEXPR constexpr
+#else
+#define TCB_SPAN_ARRAY_CONSTEXPR
+#endif
+
+#ifdef TCB_SPAN_HAVE_STD_BYTE
+using byte = std::byte;
+#else
+using byte = unsigned char;
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17)
+#define TCB_SPAN_NODISCARD [[nodiscard]]
+#else
+#define TCB_SPAN_NODISCARD
+#endif
+
+TCB_SPAN_INLINE_VAR constexpr std::size_t dynamic_extent = SIZE_MAX;
+
+template <typename ElementType, std::size_t Extent = dynamic_extent>
+class span;
+
+namespace detail {
+
+template <typename E, std::size_t S>
+struct span_storage {
+    constexpr span_storage() noexcept = default;
+
+    constexpr span_storage(E* p_ptr, std::size_t /*unused*/) noexcept
+       : ptr(p_ptr)
+    {}
+
+    E* ptr = nullptr;
+    static constexpr std::size_t size = S;
+};
+
+template <typename E>
+struct span_storage<E, dynamic_extent> {
+    constexpr span_storage() noexcept = default;
+
+    constexpr span_storage(E* p_ptr, std::size_t p_size) noexcept
+        : ptr(p_ptr), size(p_size)
+    {}
+
+    E* ptr = nullptr;
+    std::size_t size = 0;
+};
+
+// Reimplementation of C++17 std::size() and std::data()
+#if defined(TCB_SPAN_HAVE_CPP17) ||                                            \
+    defined(__cpp_lib_nonmember_container_access)
+using std::data;
+using std::size;
+#else
+template <class C>
+constexpr auto size(const C& c) -> decltype(c.size())
+{
+    return c.size();
+}
+
+template <class T, std::size_t N>
+constexpr std::size_t size(const T (&)[N]) noexcept
+{
+    return N;
+}
+
+template <class C>
+constexpr auto data(C& c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class C>
+constexpr auto data(const C& c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class T, std::size_t N>
+constexpr T* data(T (&array)[N]) noexcept
+{
+    return array;
+}
+
+template <class E>
+constexpr const E* data(std::initializer_list<E> il) noexcept
+{
+    return il.begin();
+}
+#endif // TCB_SPAN_HAVE_CPP17
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_void_t)
+using std::void_t;
+#else
+template <typename...>
+using void_t = void;
+#endif
+
+template <typename T>
+using uncvref_t =
+    typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+
+template <typename>
+struct is_span : std::false_type {};
+
+template <typename T, std::size_t S>
+struct is_span<span<T, S>> : std::true_type {};
+
+template <typename>
+struct is_std_array : std::false_type {};
+
+template <typename T, std::size_t N>
+struct is_std_array<std::array<T, N>> : std::true_type {};
+
+template <typename, typename = void>
+struct has_size_and_data : std::false_type {};
+
+template <typename T>
+struct has_size_and_data<T, void_t<decltype(detail::size(std::declval<T>())),
+                                   decltype(detail::data(std::declval<T>()))>>
+    : std::true_type {};
+
+template <typename C, typename U = uncvref_t<C>>
+struct is_container {
+    static constexpr bool value =
+        !is_span<U>::value && !is_std_array<U>::value &&
+        !std::is_array<U>::value && has_size_and_data<C>::value;
+};
+
+template <typename T>
+using remove_pointer_t = typename std::remove_pointer<T>::type;
+
+template <typename, typename, typename = void>
+struct is_container_element_type_compatible : std::false_type {};
+
+template <typename T, typename E>
+struct is_container_element_type_compatible<
+    T, E,
+    typename std::enable_if<
+        !std::is_same<typename std::remove_cv<decltype(
+                          detail::data(std::declval<T>()))>::type,
+                      void>::value>::type>
+    : std::is_convertible<
+          remove_pointer_t<decltype(detail::data(std::declval<T>()))> (*)[],
+          E (*)[]> {};
+
+template <typename, typename = size_t>
+struct is_complete : std::false_type {};
+
+template <typename T>
+struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
+
+} // namespace detail
+
+template <typename ElementType, std::size_t Extent>
+class span {
+    static_assert(std::is_object<ElementType>::value,
+                  "A span's ElementType must be an object type (not a "
+                  "reference type or void)");
+    static_assert(detail::is_complete<ElementType>::value,
+                  "A span's ElementType must be a complete type (not a forward "
+                  "declaration)");
+    static_assert(!std::is_abstract<ElementType>::value,
+                  "A span's ElementType cannot be an abstract class type");
+
+    using storage_type = detail::span_storage<ElementType, Extent>;
+
+public:
+    // constants and types
+    using element_type = ElementType;
+    using value_type = typename std::remove_cv<ElementType>::type;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = element_type*;
+    using const_pointer = const element_type*;
+    using reference = element_type&;
+    using const_reference = const element_type&;
+    using iterator = pointer;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+
+    static constexpr size_type extent = Extent;
+
+    // [span.cons], span constructors, copy, assignment, and destructor
+    template <
+        std::size_t E = Extent,
+        typename std::enable_if<(E == dynamic_extent || E <= 0), int>::type = 0>
+    constexpr span() noexcept
+    {}
+
+    TCB_SPAN_CONSTEXPR11 span(pointer ptr, size_type count)
+        : storage_(ptr, count)
+    {
+        TCB_SPAN_EXPECT(extent == dynamic_extent || count == extent);
+    }
+
+    TCB_SPAN_CONSTEXPR11 span(pointer first_elem, pointer last_elem)
+        : storage_(first_elem, last_elem - first_elem)
+    {
+        TCB_SPAN_EXPECT(extent == dynamic_extent ||
+                        last_elem - first_elem ==
+                            static_cast<std::ptrdiff_t>(extent));
+    }
+
+    template <std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          element_type (&)[N], ElementType>::value,
+                  int>::type = 0>
+    constexpr span(element_type (&arr)[N]) noexcept : storage_(arr, N)
+    {}
+
+    template <std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          std::array<value_type, N>&, ElementType>::value,
+                  int>::type = 0>
+    TCB_SPAN_ARRAY_CONSTEXPR span(std::array<value_type, N>& arr) noexcept
+        : storage_(arr.data(), N)
+    {}
+
+    template <std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          const std::array<value_type, N>&, ElementType>::value,
+                  int>::type = 0>
+    TCB_SPAN_ARRAY_CONSTEXPR span(const std::array<value_type, N>& arr) noexcept
+        : storage_(arr.data(), N)
+    {}
+
+    template <
+        typename Container, std::size_t E = Extent,
+        typename std::enable_if<
+            E == dynamic_extent && detail::is_container<Container>::value &&
+                detail::is_container_element_type_compatible<
+                    Container&, ElementType>::value,
+            int>::type = 0>
+    constexpr span(Container& cont)
+        : storage_(detail::data(cont), detail::size(cont))
+    {}
+
+    template <
+        typename Container, std::size_t E = Extent,
+        typename std::enable_if<
+            E == dynamic_extent && detail::is_container<Container>::value &&
+                detail::is_container_element_type_compatible<
+                    const Container&, ElementType>::value,
+            int>::type = 0>
+    constexpr span(const Container& cont)
+        : storage_(detail::data(cont), detail::size(cont))
+    {}
+
+    constexpr span(const span& other) noexcept = default;
+
+    template <typename OtherElementType, std::size_t OtherExtent,
+              typename std::enable_if<
+                  (Extent == OtherExtent || Extent == dynamic_extent) &&
+                      std::is_convertible<OtherElementType (*)[],
+                                          ElementType (*)[]>::value,
+                  int>::type = 0>
+    constexpr span(const span<OtherElementType, OtherExtent>& other) noexcept
+        : storage_(other.data(), other.size())
+    {}
+
+    ~span() noexcept = default;
+
+    TCB_SPAN_CONSTEXPR_ASSIGN span&
+    operator=(const span& other) noexcept = default;
+
+    // [span.sub], span subviews
+    template <std::size_t Count>
+    TCB_SPAN_CONSTEXPR11 span<element_type, Count> first() const
+    {
+        TCB_SPAN_EXPECT(Count <= size());
+        return {data(), Count};
+    }
+
+    template <std::size_t Count>
+    TCB_SPAN_CONSTEXPR11 span<element_type, Count> last() const
+    {
+        TCB_SPAN_EXPECT(Count <= size());
+        return {data() + (size() - Count), Count};
+    }
+
+    template <std::size_t Offset, std::size_t Count = dynamic_extent>
+    using subspan_return_t =
+        span<ElementType, Count != dynamic_extent
+                              ? Count
+                              : (Extent != dynamic_extent ? Extent - Offset
+                                                          : dynamic_extent)>;
+
+    template <std::size_t Offset, std::size_t Count = dynamic_extent>
+    TCB_SPAN_CONSTEXPR11 subspan_return_t<Offset, Count> subspan() const
+    {
+        TCB_SPAN_EXPECT(Offset <= size() &&
+                        (Count == dynamic_extent || Offset + Count <= size()));
+        return {data() + Offset,
+                Count != dynamic_extent ? Count : size() - Offset};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    first(size_type count) const
+    {
+        TCB_SPAN_EXPECT(count <= size());
+        return {data(), count};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    last(size_type count) const
+    {
+        TCB_SPAN_EXPECT(count <= size());
+        return {data() + (size() - count), count};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    subspan(size_type offset, size_type count = dynamic_extent) const
+    {
+        TCB_SPAN_EXPECT(offset <= size() &&
+                        (count == dynamic_extent || offset + count <= size()));
+        return {data() + offset,
+                count == dynamic_extent ? size() - offset : count};
+    }
+
+    // [span.obs], span observers
+    constexpr size_type size() const noexcept { return storage_.size; }
+
+    constexpr size_type size_bytes() const noexcept
+    {
+        return size() * sizeof(element_type);
+    }
+
+    TCB_SPAN_NODISCARD constexpr bool empty() const noexcept
+    {
+        return size() == 0;
+    }
+
+    // [span.elem], span element access
+    TCB_SPAN_CONSTEXPR11 reference operator[](size_type idx) const
+    {
+        TCB_SPAN_EXPECT(idx < size());
+        return *(data() + idx);
+    }
+
+    TCB_SPAN_CONSTEXPR11 reference front() const
+    {
+        TCB_SPAN_EXPECT(!empty());
+        return *data();
+    }
+
+    TCB_SPAN_CONSTEXPR11 reference back() const
+    {
+        TCB_SPAN_EXPECT(!empty());
+        return *(data() + (size() - 1));
+    }
+
+    constexpr pointer data() const noexcept { return storage_.ptr; }
+
+    // [span.iterators], span iterator support
+    constexpr iterator begin() const noexcept { return data(); }
+
+    constexpr iterator end() const noexcept { return data() + size(); }
+
+    TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rbegin() const noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rend() const noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+private:
+    storage_type storage_{};
+};
+
+#ifdef TCB_SPAN_HAVE_DEDUCTION_GUIDES
+
+/* Deduction Guides */
+template <class T, size_t N>
+span(T (&)[N])->span<T, N>;
+
+template <class T, size_t N>
+span(std::array<T, N>&)->span<T, N>;
+
+template <class T, size_t N>
+span(const std::array<T, N>&)->span<const T, N>;
+
+template <class Container>
+span(Container&)->span<typename Container::value_type>;
+
+template <class Container>
+span(const Container&)->span<const typename Container::value_type>;
+
+#endif // TCB_HAVE_DEDUCTION_GUIDES
+
+template <typename ElementType, std::size_t Extent>
+constexpr span<ElementType, Extent>
+make_span(span<ElementType, Extent> s) noexcept
+{
+    return s;
+}
+
+template <typename T, std::size_t N>
+constexpr span<T, N> make_span(T (&arr)[N]) noexcept
+{
+    return {arr};
+}
+
+template <typename T, std::size_t N>
+TCB_SPAN_ARRAY_CONSTEXPR span<T, N> make_span(std::array<T, N>& arr) noexcept
+{
+    return {arr};
+}
+
+template <typename T, std::size_t N>
+TCB_SPAN_ARRAY_CONSTEXPR span<const T, N>
+make_span(const std::array<T, N>& arr) noexcept
+{
+    return {arr};
+}
+
+template <typename Container>
+constexpr span<typename Container::value_type> make_span(Container& cont)
+{
+    return {cont};
+}
+
+template <typename Container>
+constexpr span<const typename Container::value_type>
+make_span(const Container& cont)
+{
+    return {cont};
+}
+
+template <typename ElementType, std::size_t Extent>
+span<const byte, ((Extent == dynamic_extent) ? dynamic_extent
+                                             : sizeof(ElementType) * Extent)>
+as_bytes(span<ElementType, Extent> s) noexcept
+{
+    return {reinterpret_cast<const byte*>(s.data()), s.size_bytes()};
+}
+
+template <
+    class ElementType, size_t Extent,
+    typename std::enable_if<!std::is_const<ElementType>::value, int>::type = 0>
+span<byte, ((Extent == dynamic_extent) ? dynamic_extent
+                                       : sizeof(ElementType) * Extent)>
+as_writable_bytes(span<ElementType, Extent> s) noexcept
+{
+    return {reinterpret_cast<byte*>(s.data()), s.size_bytes()};
+}
+
+template <std::size_t N, typename E, std::size_t S>
+constexpr auto get(span<E, S> s) -> decltype(s[N])
+{
+    return s[N];
+}
+
+} // namespace TCB_SPAN_NAMESPACE_NAME
+
+namespace std {
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmismatched-tags"
+#endif
+
+template <typename ElementType, size_t Extent>
+class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<ElementType, Extent>>
+    : public integral_constant<size_t, Extent> {};
+
+template <typename ElementType>
+class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<
+    ElementType, TCB_SPAN_NAMESPACE_NAME::dynamic_extent>>; // not defined
+
+template <size_t I, typename ElementType, size_t Extent>
+class tuple_element<I, TCB_SPAN_NAMESPACE_NAME::span<ElementType, Extent>> {
+public:
+    static_assert(Extent != TCB_SPAN_NAMESPACE_NAME::dynamic_extent &&
+                      I < Extent,
+                  "");
+    using type = ElementType;
+};
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+} // end namespace std
+
+#endif // TCB_SPAN_HPP_INCLUDED


### PR DESCRIPTION
* Add a polyfill for `std::span`. I have chosen `stdx::span` and we can replace it with `std::span` when we move to C++20.
* Add the SawyerEncoder and SawyerDecoder classes.

Pretty much code I wrote for OpenRCT2 refactored. All works correctly in the save and load branches I am working on.