### PR TITLE
Vehicle update2 Part 1b: Order functions

### DIFF
--- a/src/OpenLoco/Vehicles/Orders.h
+++ b/src/OpenLoco/Vehicles/Orders.h
@@ -50,22 +50,22 @@ namespace OpenLoco::Vehicles
         template<typename T>
         constexpr bool is() const { return getType() == T::TYPE; }
 
-        template<>
-        constexpr bool is<OrderStation>() const
-        {
-            if (is<OrderStopAt>())
-            {
-                return true;
-            }
-            return is<OrderRouteThrough>();
-        }
         template<typename T>
         T* as() { return is<T>() ? reinterpret_cast<T*>(this) : nullptr; }
         template<typename T>
         const T* as() const { return is<T>() ? reinterpret_cast<const T*>(this) : nullptr; }
     };
-
     static_assert(sizeof(Order) == 1, "Size of order must be 1 for pointer arithmatic to work in OrderTableView");
+
+    template<>
+    constexpr bool Order::is<OrderStation>() const
+    {
+        if (is<OrderStopAt>())
+        {
+            return true;
+        }
+        return is<OrderRouteThrough>();
+    }
 
     struct OrderEnd : Order
     {

--- a/src/OpenLoco/Vehicles/Orders.h
+++ b/src/OpenLoco/Vehicles/Orders.h
@@ -23,9 +23,6 @@ namespace OpenLoco::Vehicles
         constexpr uint8_t HasCargo = (1 << 2);
         constexpr uint8_t HasStation = (1 << 3);
     }
-    struct OrderStation;
-    struct OrderStopAt;
-    struct OrderRouteThrough;
 
 #pragma pack(push, 1)
     struct Order
@@ -56,16 +53,6 @@ namespace OpenLoco::Vehicles
         const T* as() const { return is<T>() ? reinterpret_cast<const T*>(this) : nullptr; }
     };
     static_assert(sizeof(Order) == 1, "Size of order must be 1 for pointer arithmatic to work in OrderTableView");
-
-    template<>
-    constexpr bool Order::is<OrderStation>() const
-    {
-        if (is<OrderStopAt>())
-        {
-            return true;
-        }
-        return is<OrderRouteThrough>();
-    }
 
     struct OrderEnd : Order
     {
@@ -108,6 +95,16 @@ namespace OpenLoco::Vehicles
             setStation(station);
         }
     };
+
+    template<>
+    constexpr bool Order::is<OrderStation>() const
+    {
+        if (is<OrderStopAt>())
+        {
+            return true;
+        }
+        return is<OrderRouteThrough>();
+    }
 
     struct OrderRouteWaypoint : Order
     {

--- a/src/OpenLoco/Vehicles/Orders.h
+++ b/src/OpenLoco/Vehicles/Orders.h
@@ -23,6 +23,10 @@ namespace OpenLoco::Vehicles
         constexpr uint8_t HasCargo = (1 << 2);
         constexpr uint8_t HasStation = (1 << 3);
     }
+    struct OrderStation;
+    struct OrderStopAt;
+    struct OrderRouteThrough;
+
 #pragma pack(push, 1)
     struct Order
     {
@@ -45,6 +49,16 @@ namespace OpenLoco::Vehicles
 
         template<typename T>
         constexpr bool is() const { return getType() == T::TYPE; }
+
+        template<>
+        constexpr bool is<OrderStation>() const
+        {
+            if (is<OrderStopAt>())
+            {
+                return true;
+            }
+            return is<OrderRouteThrough>();
+        }
         template<typename T>
         T* as() { return is<T>() ? reinterpret_cast<T*>(this) : nullptr; }
         template<typename T>

--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -9,7 +9,9 @@
 #include "../StationManager.h"
 #include "../Things/Misc.h"
 #include "../Things/ThingManager.h"
+#include "../Ui/WindowManager.h"
 #include "../ViewportManager.h"
+#include "Orders.h"
 #include "Vehicle.h"
 #include <cassert>
 
@@ -813,9 +815,30 @@ namespace OpenLoco::Vehicles
     // 0x004B9987
     void VehicleHead::checkIfAtOrderStation()
     {
-        registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
-        call(0x004B9987, regs);
+        OrderTableView orders(orderTableOffset);
+        auto curOrder = orders.atOffset(currentOrder);
+        auto* orderStation = curOrder->as<OrderStation>();
+        if (orderStation == nullptr)
+        {
+            return;
+        }
+
+        if (orderStation->getStation() != stationId)
+        {
+            return;
+        }
+
+        curOrder++;
+
+        if (curOrder->is<OrderEnd>())
+        {
+            currentOrder = 0;
+        }
+        else
+        {
+            currentOrder = curOrder->getOffset() - orderTableOffset;
+        }
+        Ui::WindowManager::sub_4B93A5(id);
     }
 
     // 0x004BACAF


### PR DESCRIPTION
Continuing from #738. 
See final commit I've introduced a different way of viewing orders. Could swap them all to use this version. It has a cycle in it as most uses of the orders expect it to roll over back to the start. i.e. 0 -> 1 -> 2 -> 0 (where 3 is the end).

Will rebase after #754 