### PR TITLE
Fix compilation on Arch Linux

### DIFF
--- a/src/OpenLoco/Platform/Platform.Posix.cpp
+++ b/src/OpenLoco/Platform/Platform.Posix.cpp
@@ -9,6 +9,7 @@
 #include <time.h>
 
 #ifdef __linux__
+#include <linux/limits.h>
 #include <sys/types.h>
 #include <unistd.h>
 #endif


### PR DESCRIPTION
Commit 963203743 (#711) changed `Numeric.hpp` to include `<limits>` instead of `<limits.h>`. This had the side-effect of not `PATH_MAX` no longer being defined on (Arch) Linux.

This PR addresses it by including the appropriate header in `Platform.Posix.cpp`.