### PR TITLE
Change OrderTableView to OrderRingView

### DIFF
--- a/src/OpenLoco/Vehicles/CloneVehicle.cpp
+++ b/src/OpenLoco/Vehicles/CloneVehicle.cpp
@@ -75,7 +75,7 @@ namespace OpenLoco::Vehicles
 
         // Copy orders
         std::vector<std::shared_ptr<Vehicles::Order>> clonedOrders;
-        for (auto& existingOrders : Vehicles::OrderTableView(existingTrain.head->orderTableOffset))
+        for (auto& existingOrders : Vehicles::OrderRingView(existingTrain.head->orderTableOffset))
         {
             clonedOrders.push_back(existingOrders.clone());
         }

--- a/src/OpenLoco/Windows/Map.cpp
+++ b/src/OpenLoco/Windows/Map.cpp
@@ -1090,7 +1090,7 @@ namespace OpenLoco::Ui::Windows::Map
 
         xy32 startPos = { Location::null, 0 };
         xy32 endPos = { Location::null, 0 };
-        for (auto& order : Vehicles::OrderTableView(train.head->orderTableOffset))
+        for (auto& order : Vehicles::OrderRingView(train.head->orderTableOffset))
         {
             if (order.hasFlag(Vehicles::OrderFlags::HasStation))
             {

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -2290,9 +2290,9 @@ namespace OpenLoco::Ui::Vehicle
             sub_470824(head);
         }
 
-        static Vehicles::OrderTableView getOrderTable(const Vehicles::VehicleHead* const head)
+        static Vehicles::OrderRingView getOrderTable(const Vehicles::VehicleHead* const head)
         {
-            return Vehicles::OrderTableView(head->orderTableOffset);
+            return Vehicles::OrderRingView(head->orderTableOffset);
         }
 
         // 0x004B4F6D
@@ -2508,7 +2508,7 @@ namespace OpenLoco::Ui::Vehicle
 
         // order : al (first 3 bits)
         // order argument : eax (3 - 32 bits), cx
-        // Note will move orders so do not use while iterating OrderTableView
+        // Note will move orders so do not use while iterating OrderRingView
         // 0x004B4ECB
         static void addNewOrder(window* const self, const Vehicles::Order& order)
         {
@@ -2750,7 +2750,7 @@ namespace OpenLoco::Ui::Vehicle
                     // Copy complete order list
                     Audio::playSound(Audio::sound_id::waypoint, { x, y, Input::getDragLastLocation().x }, Input::getDragLastLocation().x);
                     std::vector<std::shared_ptr<Vehicles::Order>> clonedOrders;
-                    for (auto& existingOrders : Vehicles::OrderTableView(head->orderTableOffset))
+                    for (auto& existingOrders : getOrderTable(head))
                     {
                         clonedOrders.push_back(existingOrders.clone());
                     }


### PR DESCRIPTION
After playing with the vehicle update code I feel this is definitely a better way to structure the orders. You now have a ring view of the orders. It will loop around until it sees the order you started with. This allows for much simpler code to increment an order (its now just ++). To look for the first order satisfying a condition (which is used quite often) is also simplified. Empty orders always have an end order and this version will correctly know how to handle that.

If you pass an invalid current order offset then it will not operate correctly. This is not expected to happen.

This version is a slight improvement over the one in #747 and #747's version will be replaced by this one. Also no longer need the `atOffset` function.