### PR TITLE
Fix #737: Use _mph literals instead of numeric constants

### DIFF
--- a/src/OpenLoco/Types.hpp
+++ b/src/OpenLoco/Types.hpp
@@ -151,9 +151,17 @@ namespace OpenLoco
             return (static_cast<uint32_t>(wholeNumber) << 16) | static_cast<uint16_t>((fraction << 16) / 100000);
         }
 
+        static_assert(0.0_mph == 0x0000);
+        static_assert(1.0_mph == 0x10000);
         static_assert(2.75_mph == 0x2C000);
         static_assert(4.0_mph == 0x40000);
+        static_assert(6.0_mph == 0x60000);
+        static_assert(9.0_mph == 0x90000);
+        static_assert(13.0_mph == 0xD0000);
         static_assert(14.0_mph == 0xE0000);
+        static_assert(15.0_mph == 0xF0000);
+        static_assert(25.0_mph == 0x190000);
+        static_assert(35.0_mph == 0x230000);
         static_assert(0.333333_mph == 0x5555);
     }
 }

--- a/src/OpenLoco/Types.hpp
+++ b/src/OpenLoco/Types.hpp
@@ -151,17 +151,9 @@ namespace OpenLoco
             return (static_cast<uint32_t>(wholeNumber) << 16) | static_cast<uint16_t>((fraction << 16) / 100000);
         }
 
-        static_assert(0.0_mph == 0x0000);
-        static_assert(1.0_mph == 0x10000);
         static_assert(2.75_mph == 0x2C000);
         static_assert(4.0_mph == 0x40000);
-        static_assert(6.0_mph == 0x60000);
-        static_assert(9.0_mph == 0x90000);
-        static_assert(13.0_mph == 0xD0000);
         static_assert(14.0_mph == 0xE0000);
-        static_assert(15.0_mph == 0xF0000);
-        static_assert(25.0_mph == 0x190000);
-        static_assert(35.0_mph == 0x230000);
         static_assert(0.333333_mph == 0x5555);
     }
 }

--- a/src/OpenLoco/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/Vehicles/CreateVehicle.cpp
@@ -11,6 +11,7 @@
 #include "../Objects/TrackObject.h"
 #include "../Objects/VehicleObject.h"
 #include "../Things/ThingManager.h"
+#include "../Types.hpp"
 #include "../Ui/WindowManager.h"
 #include "Vehicle.h"
 #include <numeric>
@@ -18,6 +19,7 @@
 
 using namespace OpenLoco::Interop;
 using namespace OpenLoco::GameCommands;
+using namespace OpenLoco::Literals;
 
 namespace OpenLoco::Vehicles
 {
@@ -134,7 +136,7 @@ namespace OpenLoco::Vehicles
                         gGameCommandErrorText = StringIds::vehicle_must_be_stopped;
                         return false;
                     }
-                    if (train.veh2->var_56 == 0)
+                    if (train.veh2->var_56 == 0.0_mph)
                     {
                         return true;
                     }
@@ -148,7 +150,7 @@ namespace OpenLoco::Vehicles
                     {
                         return true;
                     }
-                    if (train.veh2->var_56 == 0)
+                    if (train.veh2->var_56 == 0.0_mph)
                     {
                         return true;
                     }
@@ -633,7 +635,7 @@ namespace OpenLoco::Vehicles
         newVeh2->var_15 = 0;
         newVeh2->var_38 = 0;
 
-        newVeh2->var_56 = 0;
+        newVeh2->var_56 = 0.0_mph;
         newVeh2->var_5A = 0;
         newVeh2->var_5B = 0;
         newVeh2->soundId = SoundObjectId::null;

--- a/src/OpenLoco/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/Vehicles/VehicleBody.cpp
@@ -179,7 +179,7 @@ namespace OpenLoco::Vehicles
             Vehicle2* veh3 = vehicleUpdate_2;
             al = var_46;
             int8_t ah = 0;
-            if (veh3->var_56 < 0x230000)
+            if (veh3->var_56 < 35.0_mph)
             {
                 ah = 0;
             }
@@ -899,7 +899,7 @@ namespace OpenLoco::Vehicles
             soundCode = true;
         }
         bool tickCalc = true;
-        if (veh_2->var_5A != 0 && veh_2->var_56 >= 65536)
+        if (veh_2->var_5A != 0 && veh_2->var_56 >= 1.0_mph)
         {
             tickCalc = false;
         }
@@ -1002,7 +1002,7 @@ namespace OpenLoco::Vehicles
         {
             auto soundId = static_cast<sound_object_id_t>(steam_obj->var_1F[var_55 + (steam_obj->sound_effect >> 1)]);
 
-            if (veh_2->var_56 > 983040)
+            if (veh_2->var_56 > 15.0_mph)
                 return;
 
             int32_t volume = 0 - (veh_2->var_56 >> 9);
@@ -1026,7 +1026,7 @@ namespace OpenLoco::Vehicles
             auto underSoundId = static_cast<sound_object_id_t>(steam_obj->var_1F[soundModifier + var_55]);
             auto soundId = static_cast<sound_object_id_t>(steam_obj->var_1F[var_55]);
 
-            if (veh_2->var_56 > 983040)
+            if (veh_2->var_56 > 15.0_mph)
                 return;
 
             int32_t volume = 0 - (veh_2->var_56 >> 9);
@@ -1062,7 +1062,7 @@ namespace OpenLoco::Vehicles
 
         if (headVeh->vehicleType == VehicleType::ship)
         {
-            if (veh_2->var_56 == 0)
+            if (veh_2->var_56 == 0.0_mph)
                 return;
 
             if (var_38 & Flags38::isReversed)
@@ -1360,17 +1360,17 @@ namespace OpenLoco::Vehicles
         if (veh_2->var_5A == 0)
             return;
 
-        if (veh_2->var_56 < 393216)
+        if (veh_2->var_56 < 6.0_mph)
             return;
 
         auto frequency = 32;
-        if (veh_2->var_56 >= 589824)
+        if (veh_2->var_56 >= 9.0_mph)
         {
             frequency = 16;
-            if (veh_2->var_56 >= 851968)
+            if (veh_2->var_56 >= 13.0_mph)
             {
                 frequency = 8;
-                if (veh_2->var_56 >= 1638400)
+                if (veh_2->var_56 >= 25.0_mph)
                 {
                     frequency = 4;
                 }


### PR DESCRIPTION
Replace numeric constants using literals with _mph defined in Types.hpp
All numeric constants are added to static_assert to check the validity of conversion.