### PR TITLE
Feature: allow main viewport to follow an entity

### DIFF
--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2206,3 +2206,5 @@ strings:
   2151: "Modify vehicle"
   2152: "Clone vehicle"
   2153: "Can't clone vehicle..."
+  2154: "Locate vehicle on main view"
+  2155: "Follow vehicle on main view"

--- a/src/OpenLoco/Input/MouseInput.cpp
+++ b/src/OpenLoco/Input/MouseInput.cpp
@@ -732,8 +732,15 @@ namespace OpenLoco::Input
                 {
                     _ticksSinceDragStart = 1000;
 
-                    window->viewport_configurations[0].saved_view_x += dragOffset.x << (vp->zoom + 1);
-                    window->viewport_configurations[0].saved_view_y += dragOffset.y << (vp->zoom + 1);
+                    if (!window->viewportIsFocusedOnEntity())
+                    {
+                        window->viewport_configurations[0].saved_view_x += dragOffset.x << (vp->zoom + 1);
+                        window->viewport_configurations[0].saved_view_y += dragOffset.y << (vp->zoom + 1);
+                    }
+                    else
+                    {
+                        window->viewportUnfocusFromEntity();
+                    }
                 }
 
                 break;

--- a/src/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/Localisation/StringIds.h
@@ -1482,4 +1482,6 @@ namespace OpenLoco::StringIds
     constexpr string_id dropdown_modify_vehicle = 2151;
     constexpr string_id dropdown_clone_vehicle = 2152;
     constexpr string_id cant_clone_vehicle = 2153;
+    constexpr string_id dropdown_viewport_move = 2154;
+    constexpr string_id dropdown_viewport_focus = 2155;
 }

--- a/src/OpenLoco/Window.cpp
+++ b/src/OpenLoco/Window.cpp
@@ -605,8 +605,12 @@ namespace OpenLoco::Ui
         if (viewports[0] == nullptr || saved_view.isEmpty())
             return;
 
-        // Centre viewport on tile/thing.
         auto main = WindowManager::getMainWindow();
+
+        // Unfocus the viewport.
+        main->viewport_configurations[0].viewport_target_sprite = ThingId::null;
+
+        // Centre viewport on tile/thing.
         if (saved_view.isThingView())
         {
             auto thing = ThingManager::get<thing_base>(saved_view.thingId);

--- a/src/OpenLoco/Window.cpp
+++ b/src/OpenLoco/Window.cpp
@@ -640,6 +640,35 @@ namespace OpenLoco::Ui
         vc->saved_view_y = dest_y + rebased_y + (offset_y / (1 << v->zoom));
     }
 
+    void window::viewportFocusOnEntity(uint16_t targetEntity)
+    {
+        if (viewports[0] == nullptr || saved_view.isEmpty())
+            return;
+
+        viewport_configurations[0].viewport_target_sprite = targetEntity;
+    }
+
+    bool window::viewportIsFocusedOnEntity() const
+    {
+        if (viewports[0] == nullptr || saved_view.isEmpty())
+            return false;
+
+        return viewport_configurations[0].viewport_target_sprite != ThingId::null;
+    }
+
+    void window::viewportUnfocusFromEntity()
+    {
+        if (viewports[0] == nullptr || saved_view.isEmpty())
+            return;
+
+        if (viewport_configurations[0].viewport_target_sprite == ThingId::null)
+            return;
+
+        auto thing = ThingManager::get<thing_base>(viewport_configurations[0].viewport_target_sprite);
+        viewport_configurations[0].viewport_target_sprite = ThingId::null;
+        viewportCentreOnTile({ thing->x, thing->y, thing->z });
+    }
+
     void window::viewportZoomSet(int8_t zoomLevel, bool toCursor)
     {
         viewport* v = this->viewports[0];

--- a/src/OpenLoco/Window.h
+++ b/src/OpenLoco/Window.h
@@ -465,6 +465,9 @@ namespace OpenLoco::Ui
         void moveWindowToLocation(viewport_pos pos);
         void viewportCentreOnTile(const Map::map_pos3& loc);
         void viewportCentreTileAroundCursor(int16_t map_x, int16_t map_y, int16_t offset_x, int16_t offset_y);
+        void viewportFocusOnEntity(uint16_t targetEntity);
+        bool viewportIsFocusedOnEntity() const;
+        void viewportUnfocusFromEntity();
         void viewportZoomSet(int8_t zoomLevel, bool toCursor);
         void viewportZoomIn(bool toCursor);
         void viewportZoomOut(bool toCursor);

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -431,8 +431,19 @@ namespace OpenLoco::Ui::Vehicle
                     GameCommands::do_4(self->number);
                     break;
                 case widx::centreViewport:
-                    self->viewportCentreMain();
+                {
+                    // self->viewportCentreMain();
+
+                    auto vehHead = Common::getVehicle(self);
+                    Vehicles::Vehicle train(vehHead);
+                    thing_id_t targetThing = train.veh2->id;
+
+                    // Centre viewport on tile/thing.
+                    auto main = WindowManager::getMainWindow();
+                    main->viewportFocusOnEntity(targetThing);
+
                     break;
+                }
             }
         }
 

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -402,6 +402,25 @@ namespace OpenLoco::Ui::Vehicle
             GameCommands::do_3(self->number, Common::getVehicle(self));
         }
 
+        static void onCentreViewportControl(window* const self)
+        {
+            Dropdown::add(0, StringIds::dropdown_stringid, StringIds::dropdown_viewport_move);
+            Dropdown::add(1, StringIds::dropdown_stringid, StringIds::dropdown_viewport_focus);
+
+            widget_t* widget = &self->widgets[widx::centreViewport];
+            Dropdown::showText(
+                self->x + widget->left,
+                self->y + widget->top,
+                widget->width(),
+                widget->height(),
+                self->colours[1],
+                2,
+                0);
+
+            Dropdown::setItemSelected(0);
+            Dropdown::setHighlightedItem(0);
+        }
+
         // 0x004B24D1
         static void onMouseUp(window* const self, const widget_index widgetIndex)
         {
@@ -430,20 +449,6 @@ namespace OpenLoco::Ui::Vehicle
                     gGameCommandErrorTitle = StringIds::cant_pass_signal_at_danger;
                     GameCommands::do_4(self->number);
                     break;
-                case widx::centreViewport:
-                {
-                    // self->viewportCentreMain();
-
-                    auto vehHead = Common::getVehicle(self);
-                    Vehicles::Vehicle train(vehHead);
-                    thing_id_t targetThing = train.veh2->id;
-
-                    // Centre viewport on tile/thing.
-                    auto main = WindowManager::getMainWindow();
-                    main->viewportFocusOnEntity(targetThing);
-
-                    break;
-                }
             }
         }
 
@@ -578,17 +583,15 @@ namespace OpenLoco::Ui::Vehicle
                 case widx::speedControl:
                     onSpeedControl(self);
                     break;
+                case widx::centreViewport:
+                    onCentreViewportControl(self);
+                    break;
             }
         }
 
         // 0x004B253A
-        static void onDropdown(window* const self, const widget_index widgetIndex, const int16_t itemIndex)
+        static void onStopStartDropdown(window* const self, const int16_t itemIndex)
         {
-            if (widgetIndex != widx::stopStart)
-            {
-                return;
-            }
-
             auto item = itemIndex == -1 ? Dropdown::getHighlightedItem() : itemIndex;
             if (item == -1 || item > 2)
             {
@@ -608,6 +611,41 @@ namespace OpenLoco::Ui::Vehicle
             args.push(head->var_22);
             args.push(head->var_44);
             GameCommands::do12(head->id, mode);
+        }
+
+        static void onCentreViewportDropdown(window* const self, const int16_t itemIndex)
+        {
+            if (itemIndex <= 0)
+            {
+                // Centre main window on vehicle, without locking.
+                self->viewportCentreMain();
+            }
+
+            // Focus main viewport on vehicle
+            if (itemIndex == 1)
+            {
+                auto vehHead = Common::getVehicle(self);
+                Vehicles::Vehicle train(vehHead);
+                thing_id_t targetThing = train.veh2->id;
+
+                // Focus viewport on vehicle, with locking.
+                auto main = WindowManager::getMainWindow();
+                main->viewportFocusOnEntity(targetThing);
+            }
+        }
+
+        // 0x004B253A
+        static void onDropdown(window* const self, const widget_index widgetIndex, const int16_t itemIndex)
+        {
+            switch (widgetIndex)
+            {
+                case widx::stopStart:
+                    onStopStartDropdown(self, itemIndex);
+                    break;
+                case widx::centreViewport:
+                    onCentreViewportDropdown(self, itemIndex);
+                    break;
+            }
         }
 
         // 0x004B2545


### PR DESCRIPTION
The vehicle window has long since had a button to centre the main viewport on the vehicle it represents. However, it may be nice to _follow_ a vehicle for a longer period of time. This PR makes that possible.

The centre viewport button has been changed into a dropdown, with two items. The first and default item is using the old behaviour: the main viewport is centred on the vehicle. The second item _follows_ the vehicle, until the viewport is dragged around or centred on something else.

Below is a screenshot of what it looks like right now. Feedback and testing welcome.

![Screenshot (7)](https://user-images.githubusercontent.com/604665/107848930-d43c3f80-6df7-11eb-9dd1-6c1023054bb7.png)
