### PR TITLE
Fix #766: Performance index is off by a factor of 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 - Fix: [#725] Company value graph does not display correctly.
 - Fix: [#744] Rendering issues ('Z-fighting') with vehicles over bridges.
 - Fix: [#766] Performance index is off by a factor of 10 in scenario options window.
-
 - Change: [#690] Default saved game directory is now in OpenLoco user directory.
 
 20.10 (2020-10-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Fix: [#712] Load / save window tries to show preview for item after last.
 - Fix: [#725] Company value graph does not display correctly.
 - Fix: [#744] Rendering issues ('Z-fighting') with vehicles over bridges.
+- Fix: [#766] Performance index is off by a factor of 10 in scenario options window.
+
 - Change: [#690] Default saved game directory is now in OpenLoco user directory.
 
 20.10 (2020-10-25)

--- a/src/OpenLoco/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/Windows/ScenarioOptions.cpp
@@ -429,6 +429,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             }
         }
 
+        // 0x0043FB0C
         static void prepareDraw(window* self)
         {
             Common::prepareDraw(self);
@@ -453,7 +454,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     break;
 
                 case Scenario::objective_type::performance_index:
-                    *(int16_t*)&*commonFormatArgs = *objectivePerformanceIndex;
+                    *(int16_t*)&*commonFormatArgs = *objectivePerformanceIndex * 10;
                     widgets[widx::objective_value].text = StringIds::challenge_performance_index;
                     break;
 


### PR DESCRIPTION
We were just missing a multiplication factor. Verified that the original game was doing something similar in the equivalent prepareDraw event.