### PR TITLE
Fix #721. Incorrect catchment area for airports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix: [#679] Crash when changing ground texture.
 - Fix: [#694] Selecting a song to play is guaranteed to not play it.
 - Fix: [#712] Load / save window tries to show preview for item after last.
+- Fix: [#721] Incorrect catchment area for airports.
 - Fix: [#725] Company value graph does not display correctly.
 - Fix: [#744] Rendering issues ('Z-fighting') with vehicles over bridges.
 - Fix: [#766] Performance index is off by a factor of 10 in scenario options window.

--- a/src/OpenLoco/Objects/AirportObject.h
+++ b/src/OpenLoco/Objects/AirportObject.h
@@ -42,10 +42,10 @@ namespace OpenLoco
         uint8_t num_tiles;            // 0x13
         uint8_t pad_14[0xA0 - 0x14];
         uint32_t large_tiles;   // 0xA0
-        uint8_t min_x;          // 0xA4
-        uint8_t min_y;          // 0xA5
-        uint8_t max_x;          // 0xA6
-        uint8_t max_y;          // 0xA7
+        int8_t min_x;           // 0xA4
+        int8_t min_y;           // 0xA5
+        int8_t max_x;           // 0xA6
+        int8_t max_y;           // 0xA7
         uint16_t designed_year; // 0xA8
         uint16_t obsolete_year; // 0xAA
         uint8_t num_nodes;      // 0xAC

--- a/src/OpenLoco/Station.cpp
+++ b/src/OpenLoco/Station.cpp
@@ -456,11 +456,8 @@ namespace OpenLoco
                 {
                     auto airportObject = ObjectManager::get<airport_object>(stationElement->objectId());
 
-                    map_pos minPos, maxPos;
-                    minPos.x = airportObject->min_x;
-                    minPos.y = airportObject->min_y;
-                    maxPos.x = airportObject->max_x;
-                    maxPos.y = airportObject->max_y;
+                    map_pos minPos = { airportObject->min_x * 32, airportObject->min_y * 32 };
+                    map_pos maxPos = { airportObject->max_x * 32, airportObject->max_y * 32 };
 
                     minPos = rotate2dCoordinate(minPos, stationElement->rotation());
                     maxPos = rotate2dCoordinate(maxPos, stationElement->rotation());

--- a/src/OpenLoco/Station.cpp
+++ b/src/OpenLoco/Station.cpp
@@ -456,8 +456,8 @@ namespace OpenLoco
                 {
                     auto airportObject = ObjectManager::get<airport_object>(stationElement->objectId());
 
-                    map_pos minPos = { airportObject->min_x * 32, airportObject->min_y * 32 };
-                    map_pos maxPos = { airportObject->max_x * 32, airportObject->max_y * 32 };
+                    map_pos minPos(airportObject->min_x * 32, airportObject->min_y * 32);
+                    map_pos maxPos(airportObject->max_x * 32, airportObject->max_y * 32);
 
                     minPos = rotate2dCoordinate(minPos, stationElement->rotation());
                     maxPos = rotate2dCoordinate(maxPos, stationElement->rotation());


### PR DESCRIPTION
Mistake made in implementation. Min/Max are signed and are in TilePos coordinates not MapPos coordinates.