### PR TITLE
Add .editorconfig for VS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+
+[*.txt]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Its the same as in OpenRCT2, this enforces VS to use a specific encoding and line ending.