### PR TITLE
Fix: Town list could show the wrong number of stations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix: [#744] Rendering issues ('Z-fighting') with vehicles over bridges.
 - Fix: [#766] Performance index is off by a factor of 10 in scenario options window.
 - Fix: [#769] Waypoints for road vehicles could not be set.
+- Fix: [#779] Town list displays the wrong amount of stations.
 - Change: [#690] Default saved game directory is now in OpenLoco user directory.
 - Change: [#762] The vehicle window now uses buttons for local/express mode.
 

--- a/src/OpenLoco/Windows/TownList.cpp
+++ b/src/OpenLoco/Windows/TownList.cpp
@@ -191,7 +191,7 @@ namespace OpenLoco::Ui::Windows::TownList
                 {
                     auto args = FormatArguments();
                     args.push(StringIds::int_32);
-                    args.push(town->num_stations);
+                    args.push<int32_t>(town->num_stations);
 
                     Gfx::drawString_494BBF(*dpi, 350, yPos, 68, Colour::black, text_colour_id, &args);
                 }


### PR DESCRIPTION
An int16 was being pushed to the format arguments, rather than an int32.

Bug:
![Screenshot](https://user-images.githubusercontent.com/604665/108565392-e260f300-7304-11eb-9006-4ca53862e518.png)

Fixed:
![Screenshot (4)](https://user-images.githubusercontent.com/604665/108565389-e260f300-7304-11eb-9598-8325ea1cc029.png)
