### PR TITLE
Implement Order Skip game command

### DIFF
--- a/src/OpenLoco/GameCommands.cpp
+++ b/src/OpenLoco/GameCommands.cpp
@@ -81,7 +81,7 @@ namespace OpenLoco::GameCommands
         { GameCommand::gc_unk_33,                     nullptr,                0x004C466C, true  },
         { GameCommand::gc_unk_34,                     nullptr,                0x004C4717, false },
         { GameCommand::vehicle_order_insert,          nullptr,                0x0047036E, false },
-        { GameCommand::vehicle_order_delete,          nullptr,                0x0047057A, false },
+        { GameCommand::vehicle_order_delete,          Vehicles::orderSkip,    0x0047057A, false },
         { GameCommand::vehicle_order_skip,            nullptr,                0x0047071A, false },
         { GameCommand::gc_unk_38,                     nullptr,                0x00475FBC, true  },
         { GameCommand::gc_unk_39,                     nullptr,                0x004775A5, true  },

--- a/src/OpenLoco/Vehicles/OrderSkip.cpp
+++ b/src/OpenLoco/Vehicles/OrderSkip.cpp
@@ -32,17 +32,9 @@ namespace OpenLoco::Vehicles
 
         Ui::WindowManager::sub_4B93A5(head->id);
 
-        OrderTableView orders(head->orderTableOffset);
-        auto curOrder = orders.atOffset(head->currentOrder);
-        curOrder++;
-        if (curOrder->is<OrderEnd>())
-        {
-            head->currentOrder = 0;
-        }
-        else
-        {
-            head->currentOrder = curOrder->getOffset() - head->orderTableOffset;
-        }
+        OrderRingView orders(head->orderTableOffset, head->currentOrder);
+        auto nextOrder = orders.begin()++;
+        head->currentOrder = nextOrder->getOffset() - head->orderTableOffset;
         return 0;
     }
 

--- a/src/OpenLoco/Vehicles/OrderSkip.cpp
+++ b/src/OpenLoco/Vehicles/OrderSkip.cpp
@@ -13,6 +13,7 @@ namespace OpenLoco::Vehicles
     loco_global<uint16_t, 0x009C68E2> gameCommandMapY;
     loco_global<uint16_t, 0x009C68E4> gameCommandMapZ;
 
+    // 0x0047071A
     static uint32_t orderSkip(uint16_t headId, uint8_t flags)
     {
         auto* head = ThingManager::get<Vehicles::VehicleHead>(headId);
@@ -42,6 +43,7 @@ namespace OpenLoco::Vehicles
         {
             head->currentOrder = curOrder->getOffset() - head->orderTableOffset;
         }
+        return 0;
     }
 
     void orderSkip(registers& regs)

--- a/src/OpenLoco/Vehicles/OrderSkip.cpp
+++ b/src/OpenLoco/Vehicles/OrderSkip.cpp
@@ -1,0 +1,51 @@
+#include "../GameCommands.h"
+#include "../Interop/Interop.hpp"
+#include "../Things/ThingManager.h"
+#include "../Ui/WindowManager.h"
+#include "Orders.h"
+#include "Vehicle.h"
+
+using namespace OpenLoco::Interop;
+
+namespace OpenLoco::Vehicles
+{
+    loco_global<uint16_t, 0x009C68E0> gameCommandMapX;
+    loco_global<uint16_t, 0x009C68E2> gameCommandMapY;
+    loco_global<uint16_t, 0x009C68E4> gameCommandMapZ;
+
+    static uint32_t orderSkip(uint16_t headId, uint8_t flags)
+    {
+        auto* head = ThingManager::get<Vehicles::VehicleHead>(headId);
+        if (head == nullptr)
+        {
+            return GameCommands::FAILURE;
+        }
+
+        gameCommandMapX = head->x;
+        gameCommandMapY = head->y;
+        gameCommandMapZ = head->z;
+        if (!(flags & GameCommands::apply))
+        {
+            return 0;
+        }
+
+        Ui::WindowManager::sub_4B93A5(head->id);
+
+        OrderTableView orders(head->orderTableOffset);
+        auto curOrder = orders.atOffset(head->currentOrder);
+        curOrder++;
+        if (curOrder->is<OrderEnd>())
+        {
+            head->currentOrder = 0;
+        }
+        else
+        {
+            head->currentOrder = curOrder->getOffset() - head->orderTableOffset;
+        }
+    }
+
+    void orderSkip(registers& regs)
+    {
+        regs.ebx = orderSkip(regs.di, regs.bl);
+    }
+}

--- a/src/OpenLoco/Vehicles/Vehicle.h
+++ b/src/OpenLoco/Vehicles/Vehicle.h
@@ -14,6 +14,7 @@ namespace OpenLoco::Vehicles
     constexpr auto max_vehicle_length = 176; // TODO: Units?
 
     void create(OpenLoco::Interop::registers& regs);
+    void orderSkip(OpenLoco::Interop::registers& regs);
     void cloneVehicle(OpenLoco::Interop::registers& regs);
 
     namespace Flags0C // commands?

--- a/src/OpenLoco/openloco.vcxproj
+++ b/src/OpenLoco/openloco.vcxproj
@@ -115,6 +115,7 @@
     <ClCompile Include="Vehicles\CloneVehicle.cpp" />
     <ClCompile Include="Vehicles\CreateVehicle.cpp" />
     <ClCompile Include="Vehicles\Orders.cpp" />
+    <ClCompile Include="Vehicles\OrderSkip.cpp" />
     <ClCompile Include="Vehicles\Vehicle.cpp" />
     <ClCompile Include="Vehicles\VehicleBody.cpp" />
     <ClCompile Include="Vehicles\VehicleHead.cpp" />


### PR DESCRIPTION
This was a very simple game command that I implemented to show all of the steps for what needs to be done. 

* Create a new file for your game command (we want exactly 1 per file as it makes it much easier when refactoring these in the future)
* Create a function that interfaces with the game command parameters. (`void xxxxx(registers& regs)`)
* Create a sensible function for the game command with named parameters (`uint32_t orderSkip(uint16_t headId, uint8_t flags)`)
* Change the respective nullptr in GameCommands.cpp.

Things to know about game commands:
* Failure is indicated by `GameCommands::Failure` returned in register `ebx`
* Cost is returned in register `ebx`
* Flags are passed into the function on `bl`. There is always an apply flag so that you can have a query run of the game command to ensure it will work and get costs.
* Use the information from GameCommands.h to find the parameters.