### PR TITLE
Fix waypoint setting function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#294] Crash when setting company name twice.
 - Fix: [#794] Game does not stay paused while in construction mode.
+- Fix: [#798] Setting waypoints on multitile track/road elements corrupts the position.
 
 21.02 (2021-02-20)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/Vehicles/Orders.cpp
+++ b/src/OpenLoco/Vehicles/Orders.cpp
@@ -84,7 +84,7 @@ namespace OpenLoco::Vehicles
     void OrderRouteWaypoint::setTrackId(const uint8_t trackId)
     {
         _data[3] &= ~0xF8;
-        _data[3] = (trackId & 0x1F) << 3;
+        _data[3] |= (trackId & 0x1F) << 3;
         _data[4] = (trackId >> 5) & 0x1;
     }
 

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -2642,10 +2642,9 @@ namespace OpenLoco::Ui::Vehicle
                     const auto& trackPiece = OpenLoco::Map::TrackData::getTrackPiece(trackId);
                     const auto& trackPart = trackPiece[trackElement->sequenceIndex()];
 
-                    auto pos = Map::rotate2dCoordinate({ trackPart.x, trackPart.y }, trackElement->unkDirection());
-                    pos.x += args.x;
-                    pos.y += args.y;
-                    TilePos tPos{ pos };
+                    auto offsetToFirstTile = Map::rotate2dCoordinate({ trackPart.x, trackPart.y }, trackElement->unkDirection());
+                    auto firstTilePos = Map::map_pos(args.x - offsetToFirstTile.x, args.y - offsetToFirstTile.y);
+                    TilePos tPos{ firstTilePos };
                     height -= trackPart.z;
 
                     Vehicles::OrderRouteWaypoint waypoint(tPos, height / 8, trackElement->unkDirection(), trackId);
@@ -2691,10 +2690,9 @@ namespace OpenLoco::Ui::Vehicle
                     const auto& roadPiece = OpenLoco::Map::TrackData::getRoadPiece(roadId);
                     const auto& roadPart = roadPiece[roadElement->sequenceIndex()];
 
-                    auto pos = Map::rotate2dCoordinate({ roadPart.x, roadPart.y }, roadElement->unkDirection());
-                    pos.x += args.x;
-                    pos.y += args.y;
-                    TilePos tPos{ pos };
+                    auto offsetToFirstTile = Map::rotate2dCoordinate({ roadPart.x, roadPart.y }, roadElement->unkDirection());
+                    auto firstTilePos = Map::map_pos(args.x - offsetToFirstTile.x, args.y - offsetToFirstTile.y);
+                    TilePos tPos{ firstTilePos };
                     height -= roadPart.z;
 
                     Vehicles::OrderRouteWaypoint waypoint(tPos, height / 8, roadElement->unkDirection(), roadId);


### PR DESCRIPTION
Calculation was incorrectly adding the offset to the first tile instead of removeing the offset from the current tile. This meant that it would set the waypoint at the wrong location