### PR TITLE
Fix StationManager::zeroUnused

### DIFF
--- a/src/OpenLoco/StationManager.cpp
+++ b/src/OpenLoco/StationManager.cpp
@@ -133,7 +133,6 @@ namespace OpenLoco::StationManager
             {
                 // Zero unused station
                 station = {};
-                station.name = StringIds::null;
             }
             else
             {

--- a/src/OpenLoco/StationManager.cpp
+++ b/src/OpenLoco/StationManager.cpp
@@ -133,7 +133,7 @@ namespace OpenLoco::StationManager
             {
                 // Zero unused station
                 station = {};
-                station.name = StringIds::empty;
+                station.name = StringIds::null;
             }
             else
             {


### PR DESCRIPTION
The station manager is using 0xFFFF (`StringIds::null`) to check where to allocate the next station. However, when saving, these are set to 0x0 (`StringIds::empty`) instead.

I the intention was good, but the wrong constant was used. Obviously, we missed this in the review process as well.