### PR TITLE
Append trailing slash to initial save path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix: [#294] Crash when setting company name twice.
 - Fix: [#794] Game does not stay paused while in construction mode.
 - Fix: [#798] Setting waypoints on multitile track/road elements corrupts the position.
+- Fix: [#801] Initial save path does not contain a trailing slash.
 
 21.02 (2021-02-20)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/Environment.cpp
+++ b/src/OpenLoco/Environment.cpp
@@ -210,7 +210,8 @@ namespace OpenLoco::Environment
         auto basePath = resolveLocoInstallPath();
         setDirectory(_path_install, basePath);
 
-        auto saveDirectory = getPathNoWarning(path_id::save);
+        // NB: vanilla routines do not use std::filesystem yet, so the trailing slash is still needed.
+        auto saveDirectory = getPathNoWarning(path_id::save) / "";
         setDirectory(_path_saves_single_player, saveDirectory);
         setDirectory(_path_saves_two_player, saveDirectory);
         autoCreateDirectory(saveDirectory);


### PR DESCRIPTION
While #752 fixed the issue with savings game to paths that contain a period, the initial save path is still missing its trailing slash. This finally corrects that.

Should this be added to the changelog?