### PR TITLE
Implement title sequence

### DIFF
--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -802,7 +802,7 @@ namespace OpenLoco
         invalidate_map_animations();
         Audio::updateVehicleNoise();
         Audio::updateAmbientNoise();
-        call(0x00444387);
+        Title::update();
 
         S5::getOptions().madeAnyChanges = addr<0x00F25374, uint8_t>();
         if (_50C197 != 0)

--- a/src/OpenLoco/Title.cpp
+++ b/src/OpenLoco/Title.cpp
@@ -203,7 +203,7 @@ namespace OpenLoco::Title
                                    auto main = Ui::WindowManager::getMainWindow();
                                    if (main != nullptr)
                                    {
-                                       auto pos3d = Map::map_pos3(pos, height.landHeight);
+                                       auto pos3d = Map::map_pos3(pos.x, pos.y, height.landHeight);
                                        main->viewportCentreOnTile(pos3d);
                                        main->flags &= ~Ui::WindowFlags::scrolling_to_location;
                                        main->viewportsUpdatePosition();

--- a/src/OpenLoco/Title.cpp
+++ b/src/OpenLoco/Title.cpp
@@ -184,6 +184,9 @@ namespace OpenLoco::Title
 
         do
         {
+            if (_sequenceIterator >= _titleSequence.end())
+                return;
+
             auto& command = *_sequenceIterator++;
             std::visit(overloaded{
                            [](WaitStep step) {

--- a/src/OpenLoco/Title.cpp
+++ b/src/OpenLoco/Title.cpp
@@ -25,11 +25,7 @@ namespace OpenLoco::Title
         uint16_t arg;
     };
 
-    struct MoveStep
-    {
-        coord_t xPos;
-        coord_t yPos;
-    };
+    using MoveStep = Map::TilePos;
 
     struct RotateStep
     {
@@ -202,7 +198,7 @@ namespace OpenLoco::Title
                            [](MoveStep step) {
                                if (addr<0x00525E28, uint32_t>() & 1)
                                {
-                                   auto pos = Map::map_pos(step.xPos * 32 + 16, step.yPos * 32 + 16);
+                                   auto pos = Map::map_pos(step) + Map::map_pos(16, 16);
                                    auto height = Map::TileManager::getHeight(pos);
                                    auto main = Ui::WindowManager::getMainWindow();
                                    if (main != nullptr)

--- a/src/OpenLoco/Title.cpp
+++ b/src/OpenLoco/Title.cpp
@@ -8,12 +8,82 @@
 #include "Scenario.h"
 #include "Ui/WindowManager.h"
 
+#include <variant>
+#include <vector>
+
 using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Title
 {
-    static loco_global<uint16_t*, 0x009DA3CC> _currentTitleCommand;
-    static loco_global<uint16_t, 0x009DA3D0> _waitCounter;
+    struct WaitStep
+    {
+        uint16_t duration;
+    };
+
+    struct ReloadStep
+    {
+        uint16_t arg;
+    };
+
+    struct MoveStep
+    {
+        coord_t xPos;
+        coord_t yPos;
+    };
+
+    struct RotateStep
+    {
+    };
+
+    struct ResetStep
+    {
+    };
+
+    using TitleStep = std::variant<WaitStep, ReloadStep, MoveStep, RotateStep, ResetStep>;
+    using TitleSequence = std::vector<TitleStep>;
+
+    // Helper type for using std::visit on TitleStep
+    template<class... Ts>
+    struct overloaded : Ts...
+    {
+        using Ts::operator()...;
+    };
+
+    // Explicit deduction guide (not needed as of C++20)
+    template<class... Ts>
+    overloaded(Ts...)->overloaded<Ts...>;
+
+    static const TitleSequence _titleSequence = {
+        MoveStep{ 231, 160 },
+        WaitStep{ 368 },
+        MoveStep{ 93, 59 },
+        WaitStep{ 370 },
+        RotateStep{},
+        MoveStep{ 314, 230 },
+        WaitStep{ 370 },
+        MoveStep{ 83, 314 },
+        WaitStep{ 370 },
+        RotateStep{},
+        RotateStep{},
+        MoveStep{ 224, 253 },
+        WaitStep{ 375 },
+        MoveStep{ 210, 322 },
+        WaitStep{ 375 },
+        MoveStep{ 125, 338 },
+        WaitStep{ 375 },
+        MoveStep{ 72, 138 },
+        WaitStep{ 375 },
+        RotateStep{},
+        MoveStep{ 178, 158 },
+        WaitStep{ 375 },
+        MoveStep{ 203, 316 },
+        WaitStep{ 375 },
+        ReloadStep{ 0 },
+        ResetStep{},
+    };
+
+    static TitleSequence::const_iterator _sequenceIterator;
+    static uint16_t _waitCounter;
 
     static void sub_473A95(int32_t eax);
 
@@ -62,7 +132,7 @@ namespace OpenLoco::Title
     // 0x00444357
     static void reset()
     {
-        _currentTitleCommand = (uint16_t*)0x4FB1F3;
+        _sequenceIterator = _titleSequence.begin();
         _waitCounter = 0;
         loadTitle();
         resetScreenAge();
@@ -110,87 +180,55 @@ namespace OpenLoco::Title
 
         resetScreenAge();
 
-        if (_waitCounter != 0)
+        if (_waitCounter > 0)
         {
-            _waitCounter = _waitCounter - 1;
+            _waitCounter -= 1;
             return;
         }
 
         do
         {
-            uint16_t cmd = *(*_currentTitleCommand);
-            _currentTitleCommand++;
-
-            switch (cmd)
-            {
-                case 0: // wait(duration)
-                {
-                    uint16_t arg = *(*_currentTitleCommand);
-                    _currentTitleCommand++;
-                    _waitCounter = arg / 4;
-                    break;
-                }
-
-                case 1: // reload
-                {
-                    uint16_t arg;
-                    do
-                    {
-                        arg = *(*_currentTitleCommand);
-                        _currentTitleCommand++;
-                    } while (arg != 0);
-
-                    loadTitle();
-                    Gfx::invalidateScreen();
-                    resetScreenAge();
-                    addr<0x50C19A, uint16_t>() = 55000;
-                    break;
-                }
-
-                case 2: // move(x, y)
-                {
-                    uint16_t argA = *(*_currentTitleCommand);
-                    _currentTitleCommand++;
-                    uint16_t argB = *(*_currentTitleCommand);
-                    _currentTitleCommand++;
-
-                    if (addr<0x00525E28, uint32_t>() & 1)
-                    {
-                        auto pos = Map::map_pos(argA * 32 + 16, argB * 32 + 16);
-                        auto height = Map::TileManager::getHeight(pos);
-                        auto main = Ui::WindowManager::getMainWindow();
-                        if (main != nullptr)
-                        {
-                            auto pos3d = Map::map_pos3(pos, height.landHeight);
-                            main->viewportCentreOnTile(pos3d);
-                            main->flags &= ~Ui::WindowFlags::scrolling_to_location;
-                            main->viewportsUpdatePosition();
-                        }
-                    }
-
-                    break;
-                }
-
-                case 3: // rotate()
-                {
-                    if (addr<0x00525E28, uint32_t>() & 1)
-                    {
-                        auto main = Ui::WindowManager::getMainWindow();
-                        if (main != nullptr)
-                        {
-                            main->viewportRotateRight();
-                        }
-                    }
-
-                    break;
-                }
-
-                case 4: // reset
-                {
-                    _currentTitleCommand = (uint16_t*)0x4FB1F3;
-                    break;
-                }
-            }
+            auto& command = *_sequenceIterator++;
+            std::visit(overloaded{
+                           [](WaitStep step) {
+                               _waitCounter = step.duration / 4;
+                           },
+                           [](ReloadStep step) {
+                               loadTitle();
+                               Gfx::invalidateScreen();
+                               resetScreenAge();
+                               addr<0x50C19A, uint16_t>() = 55000;
+                           },
+                           [](MoveStep step) {
+                               if (addr<0x00525E28, uint32_t>() & 1)
+                               {
+                                   auto pos = Map::map_pos(step.xPos * 32 + 16, step.yPos * 32 + 16);
+                                   auto height = Map::TileManager::getHeight(pos);
+                                   auto main = Ui::WindowManager::getMainWindow();
+                                   if (main != nullptr)
+                                   {
+                                       auto pos3d = Map::map_pos3(pos, height.landHeight);
+                                       main->viewportCentreOnTile(pos3d);
+                                       main->flags &= ~Ui::WindowFlags::scrolling_to_location;
+                                       main->viewportsUpdatePosition();
+                                   }
+                               }
+                           },
+                           [](RotateStep step) {
+                               if (addr<0x00525E28, uint32_t>() & 1)
+                               {
+                                   auto main = Ui::WindowManager::getMainWindow();
+                                   if (main != nullptr)
+                                   {
+                                       main->viewportRotateRight();
+                                   }
+                               }
+                           },
+                           [](ResetStep step) {
+                               _sequenceIterator = _titleSequence.begin();
+                           },
+                       },
+                       command);
         } while (_waitCounter == 0);
     }
 

--- a/src/OpenLoco/Title.cpp
+++ b/src/OpenLoco/Title.cpp
@@ -190,7 +190,8 @@ namespace OpenLoco::Title
             auto& command = *_sequenceIterator++;
             std::visit(overloaded{
                            [](WaitStep step) {
-                               _waitCounter = step.duration / 4;
+                               // This loop slightly deviates from the original, subtract 1 tick to make up for it.
+                               _waitCounter = (step.duration / 4) - 1;
                            },
                            [](ReloadStep step) {
                                loadTitle();

--- a/src/OpenLoco/Title.cpp
+++ b/src/OpenLoco/Title.cpp
@@ -191,7 +191,7 @@ namespace OpenLoco::Title
             std::visit(overloaded{
                            [](WaitStep step) {
                                // This loop slightly deviates from the original, subtract 1 tick to make up for it.
-                               _waitCounter = (step.duration / 4) - 1;
+                               _waitCounter = step.duration - 1;
                            },
                            [](ReloadStep step) {
                                loadTitle();

--- a/src/OpenLoco/Title.cpp
+++ b/src/OpenLoco/Title.cpp
@@ -3,6 +3,7 @@
 #include "CompanyManager.h"
 #include "Gui.h"
 #include "Interop/Interop.hpp"
+#include "Map/TileManager.h"
 #include "OpenLoco.h"
 #include "Scenario.h"
 #include "Ui/WindowManager.h"
@@ -11,6 +12,9 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Title
 {
+    static loco_global<uint16_t*, 0x009DA3CC> _currentTitleCommand;
+    static loco_global<uint16_t, 0x009DA3D0> _waitCounter;
+
     static void sub_473A95(int32_t eax);
 
     void registerHooks()
@@ -50,10 +54,20 @@ namespace OpenLoco::Title
         call(0x004284C8);
     }
 
-    // 0x00444357
-    static void sub_444357()
+    static void loadTitle()
     {
-        call(0x00444357);
+        call(0x004442C4);
+    }
+
+    // 0x00444357
+    static void reset()
+    {
+        _currentTitleCommand = (uint16_t*)0x4FB1F3;
+        _waitCounter = 0;
+        loadTitle();
+        resetScreenAge();
+        addr<0x50C19A, uint16_t>() = 55000;
+        update();
     }
 
     // 0x0046AD7D
@@ -81,11 +95,103 @@ namespace OpenLoco::Title
         initialiseViewports();
         sub_4284C8();
         Gui::init();
-        sub_444357();
+        reset();
         Gfx::invalidateScreen();
         resetScreenAge();
 
         Audio::playTitleScreenMusic();
+    }
+
+    // 0x00444387
+    void update()
+    {
+        if (!isTitleMode())
+            return;
+
+        resetScreenAge();
+
+        if (_waitCounter != 0)
+        {
+            _waitCounter = _waitCounter - 1;
+            return;
+        }
+
+        do
+        {
+            uint16_t cmd = *(*_currentTitleCommand);
+            _currentTitleCommand++;
+
+            switch (cmd)
+            {
+                case 0: // wait(duration)
+                {
+                    uint16_t arg = *(*_currentTitleCommand);
+                    _currentTitleCommand++;
+                    _waitCounter = arg / 4;
+                    break;
+                }
+
+                case 1: // reload
+                {
+                    uint16_t arg;
+                    do
+                    {
+                        arg = *(*_currentTitleCommand);
+                        _currentTitleCommand++;
+                    } while (arg != 0);
+
+                    loadTitle();
+                    Gfx::invalidateScreen();
+                    resetScreenAge();
+                    addr<0x50C19A, uint16_t>() = 55000;
+                    break;
+                }
+
+                case 2: // move(x, y)
+                {
+                    uint16_t argA = *(*_currentTitleCommand);
+                    _currentTitleCommand++;
+                    uint16_t argB = *(*_currentTitleCommand);
+                    _currentTitleCommand++;
+
+                    if (addr<0x00525E28, uint32_t>() & 1)
+                    {
+                        auto pos = Map::map_pos(argA * 32 + 16, argB * 32 + 16);
+                        auto height = Map::TileManager::getHeight(pos);
+                        auto main = Ui::WindowManager::getMainWindow();
+                        if (main != nullptr)
+                        {
+                            auto pos3d = Map::map_pos3(pos, height.landHeight);
+                            main->viewportCentreOnTile(pos3d);
+                            main->flags &= ~Ui::WindowFlags::scrolling_to_location;
+                            main->viewportsUpdatePosition();
+                        }
+                    }
+
+                    break;
+                }
+
+                case 3: // rotate()
+                {
+                    if (addr<0x00525E28, uint32_t>() & 1)
+                    {
+                        auto main = Ui::WindowManager::getMainWindow();
+                        if (main != nullptr)
+                        {
+                            main->viewportRotateRight();
+                        }
+                    }
+
+                    break;
+                }
+
+                case 4: // reset
+                {
+                    _currentTitleCommand = (uint16_t*)0x4FB1F3;
+                    break;
+                }
+            }
+        } while (_waitCounter == 0);
     }
 
     // 0x00473A95

--- a/src/OpenLoco/Title.h
+++ b/src/OpenLoco/Title.h
@@ -5,4 +5,5 @@ namespace OpenLoco::Title
     void registerHooks();
     void start();
     void sub_4284C8();
+    void update();
 }


### PR DESCRIPTION
This continues from #322, implementing the title update steps and integrating the title sequence script using modern C++.

Each of the command types is encoded using typed structs. A title sequence is a vector of `std::variant` of these. By using `std::visit`, we can then use the type system to run these commands using lambda functions.

Perhaps we should split Title.{cpp,h} into TitleScreen.{cpp,h} and TitleSequence.{cpp,h} (or one .hpp file?). Any thoughts on that?