### PR TITLE
Centralise ownership of game_speed variable in OpenLoco.cpp

### DIFF
--- a/src/OpenLoco/GameCommands.cpp
+++ b/src/OpenLoco/GameCommands.cpp
@@ -20,7 +20,6 @@ namespace OpenLoco::GameCommands
     static loco_global<uint8_t, 0x00508F08> game_command_nest_level;
     static loco_global<company_id_t[2], 0x00525E3C> _player_company;
     static loco_global<uint8_t, 0x00508F17> paused_state;
-    static loco_global<uint8_t, 0x00508F1A> game_speed;
     static loco_global<uint16_t, 0x0050A004> _50A004;
 
     static uint16_t _gameCommandFlags;
@@ -174,9 +173,9 @@ namespace OpenLoco::GameCommands
                 _50A004 = _50A004 | 1;
             }
 
-            if (game_speed != 0)
+            if (getGameSpeed() != 0)
             {
-                game_speed = 0;
+                setGameSpeed(0);
                 WindowManager::invalidate(WindowType::timeToolbar);
             }
 

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cassert>
 #include <cstring>
 #include <iostream>
 #include <setjmp.h>

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -76,7 +76,7 @@ namespace OpenLoco
     loco_global<uint16_t, 0x00508F12> _screen_age;
     loco_global<uint16_t, 0x00508F14> _screenFlags;
     loco_global<uint8_t, 0x00508F17> paused_state;
-    loco_global<uint8_t, 0x00508F1A> game_speed;
+    loco_global<uint8_t, 0x00508F1A> _gameSpeed;
     static loco_global<string_id, 0x0050A018> _mapTooltipFormatArguments;
     static loco_global<int32_t, 0x0052339C> _52339C;
     static loco_global<int8_t, 0x0052336E> _52336E; // bool
@@ -205,13 +205,13 @@ namespace OpenLoco
 
     uint8_t getGameSpeed()
     {
-        return game_speed;
+        return _gameSpeed;
     }
 
     void setGameSpeed(uint8_t speed)
     {
         assert(speed >= 0 && speed <= 3);
-        game_speed = speed;
+        _gameSpeed = speed;
     }
 
     uint32_t scenarioTicks()
@@ -670,10 +670,10 @@ namespace OpenLoco
                 }
                 uint16_t var_F253A0 = std::max<uint16_t>(1, numUpdates);
                 _screen_age = std::min(0xFFFF, (int32_t)_screen_age + var_F253A0);
-                if (game_speed != 0)
+                if (_gameSpeed != 0)
                 {
                     numUpdates *= 3;
-                    if (game_speed != 1)
+                    if (_gameSpeed != 1)
                     {
                         numUpdates *= 3;
                     }

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -202,6 +202,17 @@ namespace OpenLoco
         call(0x00431E32, regs);
     }
 
+    uint8_t getGameSpeed()
+    {
+        return game_speed;
+    }
+
+    void setGameSpeed(uint8_t speed)
+    {
+        assert(speed >= 0 && speed <= 3);
+        game_speed = speed;
+    }
+
     uint32_t scenarioTicks()
     {
         return _scenario_ticks;

--- a/src/OpenLoco/OpenLoco.h
+++ b/src/OpenLoco/OpenLoco.h
@@ -41,6 +41,8 @@ namespace OpenLoco
     bool isPaused();
     uint8_t getPauseFlags();
     void togglePause(bool value);
+    uint8_t getGameSpeed();
+    void setGameSpeed(uint8_t speed);
     uint32_t scenarioTicks();
     Utility::prng& gPrng();
     void initialiseViewports();

--- a/src/OpenLoco/Title.cpp
+++ b/src/OpenLoco/Title.cpp
@@ -11,8 +11,6 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Title
 {
-    static loco_global<uint8_t, 0x00508F1A> _gameSpeed;
-
     static void sub_473A95(int32_t eax);
 
     void registerHooks()
@@ -72,7 +70,7 @@ namespace OpenLoco::Title
         Ui::WindowManager::closeAllFloatingWindows();
         setAllScreenFlags(currentScreenFlags);
         setScreenFlag(ScreenFlags::title);
-        _gameSpeed = 0;
+        setGameSpeed(0);
         sub_472031();
         sub_473A95(1);
         sub_474874();

--- a/src/OpenLoco/Windows/News/Common.cpp
+++ b/src/OpenLoco/Windows/News/Common.cpp
@@ -19,7 +19,7 @@ namespace OpenLoco::Ui::NewsWindow
 
         int16_t y = Ui::height() - _word_525CE0;
 
-        if (_gameSpeed != 0 || isOld)
+        if (getGameSpeed() != 0 || isOld)
         {
             y = Ui::height() - windowSize.height;
             _word_525CE0 = windowSize.height;

--- a/src/OpenLoco/Windows/News/News.h
+++ b/src/OpenLoco/Windows/News/News.h
@@ -21,7 +21,6 @@ namespace OpenLoco::Ui::NewsWindow
     static loco_global<uint16_t[31], 0x004F8BE4> _word_4F8BE4;
     static loco_global<uint8_t[31], 0x004F8C22> _messageTypes;
     static loco_global<uint8_t[31], 0x004F8C41> _messageSounds;
-    static loco_global<uint8_t, 0x00508F1A> _gameSpeed;
     static loco_global<uint8_t[3], 0x005215B5> _unk_5215B5;
     static loco_global<uint32_t, 0x00523338> _cursorX2;
     static loco_global<uint32_t, 0x0052333C> _cursorY2;

--- a/src/OpenLoco/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/Windows/PlayerInfoPanel.cpp
@@ -58,7 +58,6 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     static loco_global<uint16_t, 0x0050A004> _50A004; // maybe date related
     static loco_global<uint16_t, 0x0052338A> _tooltipTimeout;
     static loco_global<int32_t, 0x00e3f0b8> gCurrentRotation;
-    static loco_global<uint8_t, 0x00508F1A> game_speed;
     static loco_global<uint16_t, 0x0113DC78> _113DC78; // Dropdown flags?
 
     static void prepareDraw(window* window);

--- a/src/OpenLoco/Windows/TimePanel.cpp
+++ b/src/OpenLoco/Windows/TimePanel.cpp
@@ -70,7 +70,6 @@ namespace OpenLoco::Ui::TimePanel
     static loco_global<uint8_t, 0x00526231> objectiveFlags;
     static loco_global<uint16_t, 0x0052338A> _tooltipTimeout;
     static loco_global<int32_t, 0x00e3f0b8> gCurrentRotation;
-    static loco_global<uint8_t, 0x00508F1A> game_speed;
 
     static loco_global<uint8_t, 0x00526240> objectiveTimeLimitYears;
     static loco_global<uint16_t, 0x00526243> objectiveMonthsInChallenge;
@@ -125,15 +124,15 @@ namespace OpenLoco::Ui::TimePanel
         {
             _widgets[Widx::pause_btn].image = Gfx::recolour(ImageIds::speed_pause_active);
         }
-        else if (game_speed == 0)
+        else if (getGameSpeed() == 0)
         {
             _widgets[Widx::normal_speed_btn].image = Gfx::recolour(ImageIds::speed_normal_active);
         }
-        else if (game_speed == 1)
+        else if (getGameSpeed() == 1)
         {
             _widgets[Widx::fast_forward_btn].image = Gfx::recolour(ImageIds::speed_fast_forward_active);
         }
-        else if (game_speed == 2)
+        else if (getGameSpeed() == 2)
         {
             _widgets[Widx::extra_fast_forward_btn].image = Gfx::recolour(ImageIds::speed_extra_fast_forward_active);
         }
@@ -406,7 +405,7 @@ namespace OpenLoco::Ui::TimePanel
             GameCommands::do_20();
         }
 
-        game_speed = speed;
+        setGameSpeed(speed);
         w->invalidate();
     }
 


### PR DESCRIPTION
Recently, I've noticed that we're defining the same variables in several files. This PR removes several `loco_global` declarations of the game speed variable. Ownership is now centralised in `OpenLoco.cpp`

I think it's important that we think about data ownership. Ideally, only one file defines the variable, and exposes it only through accessor functions. This will help us down the line, when interop with the original routines is no longer needed.