### PR TITLE
Fix speed based vehicle animations such as hydrofoils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: [#794] Game does not stay paused while in construction mode.
 - Fix: [#798] Setting waypoints on multitile track/road elements corrupts the position.
 - Fix: [#801] Initial save path does not contain a trailing slash.
+- Fix: [#807] Incorrect vehicle animation for speed based animations like hydrofoils when at max speed.
 
 21.02 (2021-02-20)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/Vehicles/VehicleBody.cpp
@@ -171,7 +171,7 @@ namespace OpenLoco::Vehicles
         {
             Vehicle2* veh3 = vehicleUpdate_2;
             al = veh3->currentSpeed / (vehicle_object->speed / vehicle_object->bodySprites[object_sprite_type].numAnimationFrames);
-            al = std::min(al, vehicle_object->bodySprites[object_sprite_type].numAnimationFrames);
+            al = std::min<uint8_t>(al, vehicle_object->bodySprites[object_sprite_type].numAnimationFrames - 1);
         }
         else if (vehicle_object->bodySprites[object_sprite_type].numRollFrames != 1)
         {


### PR DESCRIPTION
When the vehicle reaches its top speed an invalid value for the animation would be set. Mistake was made during implementation