### PR TITLE
Fix return value for S5::save hook

### DIFF
--- a/src/OpenLoco/S5/S5.cpp
+++ b/src/OpenLoco/S5/S5.cpp
@@ -373,7 +373,7 @@ namespace OpenLoco::S5
             0x00441C26,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 auto path = fs::u8path(std::string_view(_savePath));
-                return save(path, static_cast<SaveFlags>(regs.eax)) ? X86_FLAG_CARRY : 0;
+                return save(path, static_cast<SaveFlags>(regs.eax)) ? 0 : X86_FLAG_CARRY;
             });
     }
 }


### PR DESCRIPTION
When S5::save was implemented, the original function (0x00441C26) was hooked to use our implementation. However, the hook is currently wrong: the original sets the carry flag on fail, not success.