### PR TITLE
Fix #802: Scenario save is failing

### DIFF
--- a/src/OpenLoco/S5/S5.cpp
+++ b/src/OpenLoco/S5/S5.cpp
@@ -237,7 +237,7 @@ namespace OpenLoco::S5
 
         auto file = std::make_unique<S5File>();
         file->header = prepareHeader(flags, packedObjects.size());
-        if (file->header.type == S5Type::landscape)
+        if (file->header.type == S5Type::scenario || file->header.type == S5Type::landscape)
         {
             file->landscapeOptions = std::make_unique<Options>(_activeOptions);
         }
@@ -322,7 +322,7 @@ namespace OpenLoco::S5
         {
             SawyerStreamWriter fs(path);
             fs.writeChunk(SawyerEncoding::rotate, file.header);
-            if (file.header.type == S5Type::landscape)
+            if (file.header.type == S5Type::scenario || file.header.type == S5Type::landscape)
             {
                 fs.writeChunk(SawyerEncoding::rotate, *file.landscapeOptions);
             }


### PR DESCRIPTION
For some reason there is a "landscape" S5 type and flag, but they aren't used. Landscapes just seem to be scenarios.