### PR TITLE
Fix compilation on macOS 10.13

### DIFF
--- a/src/OpenLoco/S5/S5.cpp
+++ b/src/OpenLoco/S5/S5.cpp
@@ -372,7 +372,7 @@ namespace OpenLoco::S5
         registerHook(
             0x00441C26,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                auto path = fs::u8path(std::string_view(_savePath));
+                auto path = fs::u8path(std::string(_savePath));
                 return save(path, static_cast<SaveFlags>(regs.eax)) ? 0 : X86_FLAG_CARRY;
             });
     }


### PR DESCRIPTION
For our macOS builds, we use macOS 10.13. This is the last macOS to with a 32 bit compiler toolchain. On this version, using `std::string_view` on `fs::u8path` doesn't compile. Using `std::string` compiles fine.

While `string_view` seems semantically nicer, this seems like the right solution, for now.