### PR TITLE
Implement PromptBrowseWindow::handleInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 21.03+ (???)
 ------------------------------------------------------------------------
+- Fix: [#804] Enter key not confirming save prompt.
 - Fix: [#809] Audio calculation not using the z axis.
 - Fix: [#825] Potential crash when opening town rename prompt.
 - Fix: [#838] Escape key doesn't work in confirmation windows.

--- a/src/OpenLoco/Input/Keyboard.cpp
+++ b/src/OpenLoco/Input/Keyboard.cpp
@@ -330,10 +330,7 @@ namespace OpenLoco::Input
                     if (tryShortcut(Shortcut::screenshot, nextKey->keyCode, _keyModifier))
                         continue;
 
-                    registers regs;
-                    regs.eax = nextKey->charCode;
-                    regs.ebx = nextKey->keyCode;
-                    call(0x0044685C, regs);
+                    Ui::PromptBrowse::handleInput(nextKey->charCode, nextKey->keyCode);
                     continue;
                 }
             }

--- a/src/OpenLoco/Ui/WindowManager.h
+++ b/src/OpenLoco/Ui/WindowManager.h
@@ -179,6 +179,7 @@ namespace OpenLoco::Ui::PromptBrowse
         save = 2
     };
     bool open(browse_type type, char* path, const char* filter, const char* title);
+    void handleInput(uint32_t charCode, uint32_t keyCode);
     void registerHooks();
 }
 


### PR DESCRIPTION
This PR implements PromptBrowseWindow::handleInput (0x0044685C), which fixes #804. This function is analogous to sub_4CE910 in the TextInput window. Ideally, part of it would be shared at least, but I have not yet refactored the lot for this PR. Perhaps both windows should share a namespace with tools to this end.

Unlike #839 from the other day, this window still uses the VK keycodes. This is because we are still converting all SDL2 keycodes to Windows/DirectInput keycodes in `Ui.cpp`. Some happen to match, but not all. With most of the UI now implemented, I think we can drop this conversion in a future PR, and use the SDLK constants instead.