### PR TITLE
Fix monthly town update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix: [#809] Audio calculation not using the z axis.
 - Fix: [#825] Potential crash when opening town rename prompt.
 - Fix: [#838] Escape key doesn't work in confirmation windows.
+- Fix: [#845] Town growth incorrectly calculated causing more aggressive growth than should be possible.
 
 21.03 (2021-03-06)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/Town.h
+++ b/src/OpenLoco/Town.h
@@ -78,7 +78,7 @@ namespace OpenLoco
         uint8_t history[20 * 12];       // 0x5C (20 years, 12 months)
         int32_t history_min_population; // 0x14C
         uint8_t pad_150[0x158 - 0x150];
-        int16_t monthly_cargo_delivered[32];
+        uint16_t monthly_cargo_delivered[32];
         uint32_t cargo_influence_flags;
         uint8_t pad_19C[0x1A4 - 0x19C];
         uint8_t build_speed; // 0x1A4, 1=slow build speed, 4=fast build speed

--- a/src/OpenLoco/TownManager.cpp
+++ b/src/OpenLoco/TownManager.cpp
@@ -129,18 +129,21 @@ namespace OpenLoco::TownManager
             }
 
             // Work towards computing new build speed.
-            int16_t maxCargoDelivered = -1;
+            // will be the smallest of the influence cargo delivered to the town
+            // i.e. to get maximum growth max of the influence cargo must be delivered
+            // every update. If no influence cargo the grows at max rate
+            uint16_t minCargoDelivered = std::numeric_limits<uint16_t>::max();
             uint32_t cargoFlags = currTown.cargo_influence_flags;
             while (cargoFlags != 0)
             {
                 uint32_t cargoId = Utility::bitScanForward(cargoFlags);
                 cargoFlags &= ~(1 << cargoId);
 
-                maxCargoDelivered = std::max(maxCargoDelivered, currTown.monthly_cargo_delivered[cargoId]);
+                minCargoDelivered = std::min(minCargoDelivered, currTown.monthly_cargo_delivered[cargoId]);
             }
 
             // Compute build speed (1=slow build speed, 4=fast build speed)
-            currTown.build_speed = std::clamp((maxCargoDelivered / 100) + 1, 1, 4);
+            currTown.build_speed = std::clamp((minCargoDelivered / 100) + 1, 1, 4);
 
             // Reset all monthly_cargo_delivered intermediaries to zero.
             memset(&currTown.monthly_cargo_delivered, 0, sizeof(currTown.monthly_cargo_delivered));


### PR DESCRIPTION
Noticed this when creating the function that increments `monthly_cargo_delivered`.
It is not a signed value and this was causing the computations to be incorrect.