### PR TITLE
Refactor some includes

### DIFF
--- a/src/OpenLoco/Audio/Audio.h
+++ b/src/OpenLoco/Audio/Audio.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../Environment.h"
+#include "../Location.hpp"
 #include "../Types.hpp"
 #include <string>
 #include <tuple>

--- a/src/OpenLoco/Company.h
+++ b/src/OpenLoco/Company.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Currency.h"
 #include "Localisation/StringManager.h"
 #include "Management/Expenditures.h"
 #include "Types.hpp"

--- a/src/OpenLoco/Currency.h
+++ b/src/OpenLoco/Currency.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdint>
+
+namespace OpenLoco
+{
+    using currency32_t = int32_t;
+
+#pragma pack(push, 1)
+    struct currency48_t
+    {
+        int32_t var_00 = 0;
+        int16_t var_04 = 0;
+
+        currency48_t(int32_t currency)
+            : currency48_t(static_cast<int64_t>(currency))
+        {
+        }
+
+        currency48_t(int64_t currency)
+        {
+            var_00 = currency & 0xFFFFFFFF;
+            var_04 = (currency >> 32) & 0xFFFF;
+        }
+
+        int64_t asInt64()
+        {
+            return var_00 | (static_cast<int64_t>(var_04) << 32);
+        }
+
+        bool operator==(const currency48_t rhs)
+        {
+            return var_00 == rhs.var_00 && var_04 == rhs.var_04;
+        }
+
+        bool operator!=(const currency48_t rhs)
+        {
+            return !(var_00 == rhs.var_00 && var_04 == rhs.var_04);
+        }
+
+        currency48_t operator+(currency48_t& rhs)
+        {
+            return currency48_t(asInt64() + rhs.asInt64());
+        }
+
+        currency48_t& operator+=(currency48_t& rhs)
+        {
+            auto sum = currency48_t(asInt64() + rhs.asInt64());
+            return *this = sum;
+        }
+
+        bool operator<(currency48_t& rhs)
+        {
+            return asInt64() < rhs.asInt64();
+        }
+
+        bool operator<(int rhs)
+        {
+            return var_00 < rhs;
+        }
+    };
+#pragma pack(pop)
+    static_assert(sizeof(currency48_t) == 6);
+
+}

--- a/src/OpenLoco/GameCommands.h
+++ b/src/OpenLoco/GameCommands.h
@@ -1,5 +1,6 @@
-#pragma once
+﻿#pragma once
 
+#include "Currency.h"
 #include "Interop/Interop.hpp"
 #include "Map/Tile.h"
 #include "Objects/ObjectManager.h"

--- a/src/OpenLoco/Location.hpp
+++ b/src/OpenLoco/Location.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+
+#include "Math/Vector.hpp"
+
+namespace OpenLoco
+{
+    using xy32 = Math::Vector::TVector2<int32_t, 1>;
+    using loc16 = Math::Vector::TVector3<int16_t, 1>;
+
+    namespace Location
+    {
+        constexpr int16_t null = (int16_t)0x8000u;
+    }
+}

--- a/src/OpenLoco/Things/Thing.h
+++ b/src/OpenLoco/Things/Thing.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../Location.hpp"
 #include "../Types.hpp"
 #include <cstdint>
 #include <limits>

--- a/src/OpenLoco/Town.h
+++ b/src/OpenLoco/Town.h
@@ -3,6 +3,7 @@
 #include "Company.h"
 #include "Localisation/StringManager.h"
 #include "Map/Tile.h"
+#include "ZoomLevel.hpp"
 #include <cstdint>
 #include <limits>
 
@@ -11,10 +12,10 @@ namespace OpenLoco
 #pragma pack(push, 1)
     struct LabelPosition
     {
-        int16_t left[ZoomLevels::max]{};
-        int16_t right[ZoomLevels::max]{};
-        int16_t top[ZoomLevels::max]{};
-        int16_t bottom[ZoomLevels::max]{};
+        int16_t left[ZoomLevel::max]{};
+        int16_t right[ZoomLevel::max]{};
+        int16_t top[ZoomLevel::max]{};
+        int16_t bottom[ZoomLevel::max]{};
 
         [[nodiscard]] bool contains(OpenLoco::Ui::Rect& rec, uint8_t zoom) const
         {

--- a/src/OpenLoco/Types.hpp
+++ b/src/OpenLoco/Types.hpp
@@ -2,8 +2,6 @@
 
 #include <cstdint>
 
-#include "Math/Vector.hpp"
-
 namespace OpenLoco
 {
     using coord_t = int16_t;

--- a/src/OpenLoco/Types.hpp
+++ b/src/OpenLoco/Types.hpp
@@ -8,7 +8,6 @@ namespace OpenLoco
 {
     using coord_t = int16_t;
     using company_id_t = uint8_t;
-    using currency32_t = int32_t;
     using station_id_t = uint16_t;
     using industry_id_t = uint8_t;
     using string_id = uint16_t;
@@ -16,62 +15,6 @@ namespace OpenLoco
     using tile_coord_t = int16_t;
     using town_id_t = uint16_t;
     using sound_object_id_t = uint8_t;
-
-#pragma pack(push, 1)
-    struct currency48_t
-    {
-        int32_t var_00 = 0;
-        int16_t var_04 = 0;
-
-        currency48_t(int32_t currency)
-            : currency48_t(static_cast<int64_t>(currency))
-        {
-        }
-
-        currency48_t(int64_t currency)
-        {
-            var_00 = currency & 0xFFFFFFFF;
-            var_04 = (currency >> 32) & 0xFFFF;
-        }
-
-        int64_t asInt64()
-        {
-            return var_00 | (static_cast<int64_t>(var_04) << 32);
-        }
-
-        bool operator==(const currency48_t rhs)
-        {
-            return var_00 == rhs.var_00 && var_04 == rhs.var_04;
-        }
-
-        bool operator!=(const currency48_t rhs)
-        {
-            return !(var_00 == rhs.var_00 && var_04 == rhs.var_04);
-        }
-
-        currency48_t operator+(currency48_t& rhs)
-        {
-            return currency48_t(asInt64() + rhs.asInt64());
-        }
-
-        currency48_t& operator+=(currency48_t& rhs)
-        {
-            auto sum = currency48_t(asInt64() + rhs.asInt64());
-            return *this = sum;
-        }
-
-        bool operator<(currency48_t& rhs)
-        {
-            return asInt64() < rhs.asInt64();
-        }
-
-        bool operator<(int rhs)
-        {
-            return var_00 < rhs;
-        }
-    };
-#pragma pack(pop)
-    static_assert(sizeof(currency48_t) == 6);
 
     template<typename T>
     struct location2

--- a/src/OpenLoco/Types.hpp
+++ b/src/OpenLoco/Types.hpp
@@ -14,44 +14,6 @@ namespace OpenLoco
     using town_id_t = uint16_t;
     using sound_object_id_t = uint8_t;
 
-    template<typename T>
-    struct location2
-    {
-        T x = 0;
-        T y = 0;
-
-        location2() = default;
-        location2(T locX, T locY)
-            : x(locX)
-            , y(locY)
-        {
-        }
-    };
-
-    template<typename T>
-    struct location3
-    {
-        T x = 0;
-        T y = 0;
-        T z = 0;
-
-        location3() = default;
-        location3(T locX, T locY, T locZ)
-            : x(locX)
-            , y(locY)
-            , z(locZ)
-        {
-        }
-    };
-
-    using xy32 = location2<int32_t>;
-    using loc16 = location3<int16_t>;
-
-    namespace Location
-    {
-        constexpr int16_t null = (int16_t)0x8000u;
-    }
-
     class FormatArguments;
 
     enum class ZoomLevel : uint8_t

--- a/src/OpenLoco/Types.hpp
+++ b/src/OpenLoco/Types.hpp
@@ -16,14 +16,6 @@ namespace OpenLoco
 
     class FormatArguments;
 
-    enum class ZoomLevel : uint8_t
-    {
-        full = 0,
-        half = 1,
-        quarter = 2,
-        eighth = 3,
-    };
-
     enum class VehicleType : uint8_t
     {
         train = 0,
@@ -41,9 +33,4 @@ namespace OpenLoco
     };
 
     constexpr uint8_t vehicleTypeCount = 6;
-
-    namespace ZoomLevels
-    {
-        constexpr uint8_t max = 4;
-    }
 }

--- a/src/OpenLoco/Viewport.hpp
+++ b/src/OpenLoco/Viewport.hpp
@@ -2,6 +2,7 @@
 
 #include "Graphics/Gfx.h"
 #include "Interop/Interop.hpp"
+#include "Location.hpp"
 #include "Map/Map.hpp"
 #include "Types.hpp"
 #include <algorithm>

--- a/src/OpenLoco/Window.h
+++ b/src/OpenLoco/Window.h
@@ -12,6 +12,7 @@
 #include "Ui.h"
 #include "Ui/WindowType.h"
 #include "Viewport.hpp"
+#include "ZoomLevel.hpp"
 #include <algorithm>
 
 namespace OpenLoco::Ui

--- a/src/OpenLoco/ZoomLevel.hpp
+++ b/src/OpenLoco/ZoomLevel.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+
+namespace OpenLoco
+{
+#pragma pack(push, 1)
+    class ZoomLevel
+    {
+        uint8_t level{};
+
+    public:
+        static constexpr uint8_t full = 0;
+        static constexpr uint8_t half = 1;
+        static constexpr uint8_t quarter = 2;
+        static constexpr uint8_t eighth = 3;
+        static constexpr uint8_t max = 4;
+
+        constexpr ZoomLevel() = default;
+        constexpr ZoomLevel(uint8_t zoom)
+            : level(zoom)
+        {
+            assert(zoom < max);
+        }
+
+        constexpr operator uint8_t()
+        {
+            return level;
+        }
+
+        constexpr bool operator==(const ZoomLevel other) const
+        {
+            return level == other.level;
+        }
+
+        constexpr bool operator!=(const ZoomLevel other) const
+        {
+            return level != other.level;
+        }
+    };
+#pragma pack(pop)
+
+    static_assert(sizeof(ZoomLevel) == sizeof(uint8_t));
+}

--- a/src/OpenLoco/openloco.vcxproj
+++ b/src/OpenLoco/openloco.vcxproj
@@ -229,6 +229,7 @@
     <ClInclude Include="Localisation\StringManager.h" />
     <ClInclude Include="Localisation\StringIds.h" />
     <ClInclude Include="Localisation\Unicode.h" />
+    <ClInclude Include="Location.hpp" />
     <ClInclude Include="Management\Expenditures.h" />
     <ClInclude Include="Map\Map.hpp" />
     <ClInclude Include="Map\MapGenerator.h" />

--- a/src/OpenLoco/openloco.vcxproj
+++ b/src/OpenLoco/openloco.vcxproj
@@ -202,6 +202,7 @@
     <ClInclude Include="Core\FileSystem.hpp" />
     <ClInclude Include="Core\Optional.hpp" />
     <ClInclude Include="Core\Span.hpp" />
+    <ClInclude Include="Currency.h" />
     <ClInclude Include="Date.h" />
     <ClInclude Include="Drawing\SoftwareDrawingEngine.h" />
     <ClInclude Include="Economy.h" />

--- a/src/OpenLoco/openloco.vcxproj
+++ b/src/OpenLoco/openloco.vcxproj
@@ -320,6 +320,7 @@
     <ClInclude Include="Message.h" />
     <ClInclude Include="Windows\News\News.h" />
     <ClInclude Include="Windows\ToolbarTopCommon.h" />
+    <ClInclude Include="ZoomLevel.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\resources\OpenLoco.rc" />


### PR DESCRIPTION
Having multiple types packed into a single header is not ideal as Types.hpp is pretty a prominent included header. I think the "include what you need" philosophy should be applied whenever possible, that also means splitting out types into separate headers, best case they come with their corresponding systems so its usually isolated within a certain section of the code base.
