### PR TITLE
Fix capacity string showing incorrect data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix: [#838] Escape key doesn't work in confirmation windows.
 - Fix: [#845] Town growth incorrectly calculated causing more aggressive growth than should be possible.
 - Fix: [#853] The game run slightly, but noticeably, slower than vanilla Locomotion.
+- Fix: [#860] Incorrect capacity information for vehicles that do not carry cargo (e.g. is a train engine).
 
 21.03 (2021-03-06)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/Objects/VehicleObject.cpp
+++ b/src/OpenLoco/Objects/VehicleObject.cpp
@@ -67,10 +67,15 @@ namespace OpenLoco
             Gfx::drawString_494B3F(dpi, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_max_speed, &args);
         }
         auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
+        // Clear buffer
+        *buffer = '\0';
 
         getCargoString(buffer);
 
-        Gfx::drawString_495224(dpi, rowPosition.x, rowPosition.y, width - 4, Colour::black, StringIds::buffer_1250);
+        if (strlen(buffer) != 0)
+        {
+            Gfx::drawString_495224(dpi, rowPosition.x, rowPosition.y, width - 4, Colour::black, StringIds::buffer_1250);
+        }
     }
 
     void vehicle_object::getCargoString(char* buffer) const


### PR DESCRIPTION
If a vehicle does not carry any cargo (e.g. is a train engine) the previous items capacity string (or anything else) would be shown as the capcity. This is because a global variable is being used that has not been correctly intialised.