### PR TITLE
Remove assert from ZoomLevel, value is used for other things

### DIFF
--- a/src/OpenLoco/ZoomLevel.hpp
+++ b/src/OpenLoco/ZoomLevel.hpp
@@ -21,7 +21,6 @@ namespace OpenLoco
         constexpr ZoomLevel(uint8_t zoom)
             : level(zoom)
         {
-            assert(zoom < max);
         }
 
         constexpr operator uint8_t()


### PR DESCRIPTION
Just to prevent the crash in debug builds for the time being.