### PR TITLE
Fix load save window crashing Windows builds

### DIFF
--- a/src/OpenLoco/GameCommands/LoadSaveQuit.cpp
+++ b/src/OpenLoco/GameCommands/LoadSaveQuit.cpp
@@ -60,11 +60,11 @@ namespace OpenLoco::GameCommands
     }
 
     // 0x00441FA7
-    static bool sub_441FA7()
+    static bool sub_441FA7(uint32_t flags)
     {
         registers regs;
-        call(0x00441FA7);
-        return regs.eax != 0;
+        regs.eax = flags;
+        return !(call(0x00441FA7) & (X86_FLAG_CARRY << 8));
     }
 
     // 0x004424CE
@@ -104,7 +104,7 @@ namespace OpenLoco::GameCommands
                 auto path = fs::path(&_savePath[0]).replace_extension(S5::extensionSV5).u8string();
                 std::strncpy(&_currentScenarioFilename[0], path.c_str(), std::size(_currentScenarioFilename));
 
-                if (sub_441FA7())
+                if (sub_441FA7(0))
                 {
                     resetScreenAge();
                     throw GameException::Interrupt;

--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -894,4 +894,12 @@ void OpenLoco::Interop::registerHooks()
     // quite annoying when it's sometimes only the player's own
     // vehicles that are using it.
     writeNop(0x004776DD, 6);
+    // Remove this when sub_441FA7 has been fully implemented
+    // Although this looks like a basic writeRet it is also changing the flags
+    // to set them all to zero this is required.
+    registerHook(
+        0x004422CD,
+        [](registers& regs) -> uint8_t {
+            return 0;
+        });
 }


### PR DESCRIPTION
Sub_441FA7 in a lot of situations will cause a crash this prevents just one of them which is gauranteed to happen. It is quite likely that there are other crashes here that will still happen. Full implementation of all callers and the function will need to be done before we can be confident that there is no sources of crashes here.