### PR TITLE
Fix vehicle pickup tool abort event

### DIFF
--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -3194,7 +3194,7 @@ namespace OpenLoco::Ui::Vehicle
         static void pickupToolAbort(window& self)
         {
             auto head = getVehicle(&self);
-            if (!head->isPlaced())
+            if (head->tile_x == -1 || !(head->var_38 & Vehicles::Flags38::isGhost))
             {
                 self.invalidate();
                 return;


### PR DESCRIPTION
Regression from #889. The condition is slightly different from an inverted isPlaced. The difference is subtle:
```cpp
// Generalised condition
 isPlaced = tile_x != -1 && !(var_38 & Flags38::isGhost);
!isPlaced = tile_x == -1 ||   var_38 & Flags38::isGhost ;

// Here, though, a mix of both is correct:
            tile_x == -1 || !(var_38 & Flags38::isGhost);
```