### PR TITLE
Stop looking for order station after finding one

### DIFF
--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -514,6 +514,7 @@ namespace OpenLoco::Vehicles
                 auto* station = StationManager::get(stopOrder->getStation());
                 vehStatus.status1 = StringIds::vehicle_status_heading_for;
                 vehStatus.status1Args = (station->town << 16) | station->name;
+                break;
             }
             if (!stopFound)
             {


### PR DESCRIPTION
This was causing the incorrect order station to show as where a vehicle was travelling to