### PR TITLE
Fix #914. Actually fix correctly this time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 21.04.1+ (???)
 ------------------------------------------------------------------------
 - Feature: [#184] Implement cheats window with financial, company, vehicle, and town cheats.
+- Fix: [#914] Boats get stuck in approaching dock mode when water is above a certain height. This was incorrectly fixed in 21.04.1.
 - Fix: [#927] Some available industries are missing in the 'Fund new industries' tab.
 
 21.04.1 (2021-04-14)

--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -2618,7 +2618,7 @@ namespace OpenLoco::Vehicles
         regs.esi = reinterpret_cast<int32_t>(this);
         call(0x00427FC9, regs);
         Map::Pos2 headTarget = { regs.ax, regs.cx };
-        Map::Pos3 stationTarget = { regs.di, regs.bp, static_cast<uint8_t>(regs.dl) };
+        Map::Pos3 stationTarget = { regs.di, regs.bp, regs.dx };
         return std::make_tuple(regs.bx, headTarget, stationTarget);
     }
 


### PR DESCRIPTION
Wrong size of height variable caused truncation at high water levels
which caused docks to not be marked as occupied. Which caused a crash
when trying to unoccupy the dock when removing a boat.