### PR TITLE
Fix #931. Odd pathing at certain speeds due to variable overflow

### DIFF
--- a/src/OpenLoco/Math/Trigonometry.hpp
+++ b/src/OpenLoco/Math/Trigonometry.hpp
@@ -100,16 +100,16 @@ namespace OpenLoco::Math::Trigonometry
         84
     };
 
-    constexpr auto computeXYMagnitude(int16_t height, Pitch pitch)
+    constexpr auto computeXYMagnitude(int32_t height, Pitch pitch)
     {
         return (pitchHorizontalFactor[static_cast<uint8_t>(pitch)] * height) / 256;
     }
 
-    constexpr auto computeXYVector(int16_t magnitude, uint8_t yaw)
+    constexpr auto computeXYVector(int32_t magnitude, uint8_t yaw)
     {
         return (yawToDirectionVector[yaw] * magnitude) / 256;
     }
-    constexpr auto computeXYVector(int16_t height, Pitch pitch, uint8_t yaw)
+    constexpr auto computeXYVector(int32_t height, Pitch pitch, uint8_t yaw)
     {
         return computeXYVector(computeXYMagnitude(height, pitch), yaw);
     }


### PR DESCRIPTION
This was also causing some ship pathing issues

Note that after the trig PR distance calcs are marginally more accurate so there is a subtle difference between vanilla and OpenLoco. I've confirmed that this is the case with a few test scenarios.