### PR TITLE
Fix #945: Station construction preview image is using wrong colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Feature: [#857] Remember last save directory in configuration variable.
 - Fix: [#914] Boats get stuck in approaching dock mode when water is above a certain height. This was incorrectly fixed in 21.04.1.
 - Fix: [#927] Some available industries are missing in the 'Fund new industries' tab.
+- Fix: [#945] Station construction preview image is using wrong colours.
 
 21.04.1 (2021-04-14)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/Windows/Construction/Common.cpp
@@ -575,7 +575,7 @@ namespace OpenLoco::Ui::Windows::Construction
                                 {
                                     colour = 46;
                                 }
-                                imageId = Gfx::recolour(imageId, colour) + 1;
+                                imageId = Gfx::recolourTranslucent(trainStationObj->image, colour) + 1;
                                 Gfx::drawImage(clipped, -4, -9, imageId);
                             }
 

--- a/src/OpenLoco/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/Windows/Construction/Common.cpp
@@ -575,7 +575,7 @@ namespace OpenLoco::Ui::Windows::Construction
                                 {
                                     colour = 46;
                                 }
-                                imageId = Gfx::recolourTranslucent(trainStationObj->image, colour) + 1;
+                                imageId = Gfx::recolourTranslucent(trainStationObj->image + 1, colour);
                                 Gfx::drawImage(clipped, -4, -9, imageId);
                             }
 

--- a/src/OpenLoco/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/Windows/Construction/StationTab.cpp
@@ -271,7 +271,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                 colour = 46;
             }
 
-            imageId = Gfx::recolourTranslucent(roadStationObj->image, colour) + 1;
+            imageId = Gfx::recolourTranslucent(roadStationObj->image + 1, colour);
 
             Gfx::drawImage(dpi, xPos, yPos, imageId);
         }
@@ -290,7 +290,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                 colour = 46;
             }
 
-            imageId = Gfx::recolourTranslucent(trainStationObj->image, colour) + 1;
+            imageId = Gfx::recolourTranslucent(trainStationObj->image + 1, colour);
 
             Gfx::drawImage(dpi, xPos, yPos, imageId);
         }

--- a/src/OpenLoco/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/Windows/Construction/StationTab.cpp
@@ -271,7 +271,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                 colour = 46;
             }
 
-            imageId = Gfx::recolour(imageId, colour) + 1;
+            imageId = Gfx::recolourTranslucent(roadStationObj->image, colour) + 1;
 
             Gfx::drawImage(dpi, xPos, yPos, imageId);
         }
@@ -290,7 +290,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                 colour = 46;
             }
 
-            imageId = Gfx::recolour(imageId, colour) + 1;
+            imageId = Gfx::recolourTranslucent(trainStationObj->image, colour) + 1;
 
             Gfx::drawImage(dpi, xPos, yPos, imageId);
         }


### PR DESCRIPTION
| Before | After |
| - | - |
| ![Screenshot_20210423_191050](https://user-images.githubusercontent.com/604665/115907044-a105d480-a468-11eb-973e-02340dfe5ca5.png) | ![Screenshot_20210423_191757](https://user-images.githubusercontent.com/604665/115907049-a19e6b00-a468-11eb-802d-d93d4708a42c.png) |