### PR TITLE
Fix panel heights in several windows

### DIFF
--- a/src/OpenLoco/Windows/Construction/Construction.h
+++ b/src/OpenLoco/Windows/Construction/Construction.h
@@ -98,7 +98,7 @@ namespace OpenLoco::Ui::Windows::Construction
     makeWidget({ 0, 0 }, { frameWidth, frameHeight }, widget_type::frame, 0),                                                          \
         makeWidget({ 1, 1 }, { frameWidth - 2, 13 }, widget_type::caption_24, 0, windowCaptionId),                                     \
         makeWidget({ frameWidth - 15, 2 }, { 13, 13 }, widget_type::wt_9, 0, ImageIds::close_button, StringIds::tooltip_close_window), \
-        makeWidget({ 0, 41 }, { frameWidth, 235 }, widget_type::wt_3, 1),                                                              \
+        makeWidget({ 0, 41 }, { frameWidth, frameHeight - 41 }, widget_type::wt_3, 1),                                                 \
         makeRemapWidget({ 3, 15 }, { 31, 27 }, widget_type::wt_8, 1, ImageIds::tab, StringIds::tab_track_road_construction),           \
         makeRemapWidget({ 34, 15 }, { 31, 27 }, widget_type::wt_8, 1, ImageIds::tab, StringIds::tab_station_construction),             \
         makeRemapWidget({ 65, 15 }, { 31, 27 }, widget_type::wt_8, 1, ImageIds::tab, StringIds::tab_signal_construction),              \

--- a/src/OpenLoco/Windows/Map.cpp
+++ b/src/OpenLoco/Windows/Map.cpp
@@ -452,7 +452,7 @@ namespace OpenLoco::Ui::Windows::Map
         self->widgets[widx::frame].right = self->width - 1;
         self->widgets[widx::frame].bottom = self->height - 1;
         self->widgets[widx::panel].right = self->width - 1;
-        self->widgets[widx::panel].bottom = self->height + 1;
+        self->widgets[widx::panel].bottom = self->height - 1;
 
         self->widgets[widx::caption].right = self->width - 2;
         self->widgets[widx::closeButton].left = self->width - 15;

--- a/src/OpenLoco/Windows/TileInspector.cpp
+++ b/src/OpenLoco/Windows/TileInspector.cpp
@@ -62,7 +62,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         makeWidget({ 0, 0 }, windowSize, widget_type::frame, 0),
         makeWidget({ 1, 1 }, { windowSize.width - 2, 13 }, widget_type::caption_25, 0, StringIds::tile_inspector),
         makeWidget({ windowSize.width - 15, 2 }, { 13, 13 }, widget_type::wt_9, 0, ImageIds::close_button, StringIds::tooltip_close_window),
-        makeWidget({ 0, 15 }, { windowSize.width, 245 }, widget_type::panel, 1),
+        makeWidget({ 0, 15 }, { windowSize.width, windowSize.height - 15 }, widget_type::panel, 1),
         makeStepperWidgets({ 19, 24 }, { 55, 12 }, widget_type::wt_17, 1),
         makeStepperWidgets({ 92, 24 }, { 55, 12 }, widget_type::wt_17, 1),
         makeWidget({ windowSize.width - 26, 18 }, { 24, 24 }, widget_type::wt_9, 1, ImageIds::construction_new_position, StringIds::tile_inspector_select_btn_tooltip),


### PR DESCRIPTION
While working on #945, I noticed the panel height was off in the construction window, resulting in the bottom window border not being rendered.

I went over the other windows as well, and turns out the map window and tile inspector also suffered a similar same issue. I couldn't find any others.