### PR TITLE
Move all windows into Ui::Windows namespace

### DIFF
--- a/src/OpenLoco/Entities/Misc.cpp
+++ b/src/OpenLoco/Entities/Misc.cpp
@@ -27,7 +27,7 @@ namespace OpenLoco
     {
         if ((uint16_t)loc.x > 12287 || (uint16_t)loc.y > 12287)
             return nullptr;
-        auto surface = OpenLoco::Map::TileManager::get(loc.x & 0xFFE0, loc.y & 0xFFE0).surface();
+        auto surface = Map::TileManager::get(loc.x & 0xFFE0, loc.y & 0xFFE0).surface();
 
         if (surface == nullptr)
             return nullptr;

--- a/src/OpenLoco/GameCommands/TogglePause.cpp
+++ b/src/OpenLoco/GameCommands/TogglePause.cpp
@@ -26,7 +26,7 @@ namespace OpenLoco::GameCommands
         {
             setPauseFlag(1 << 0);
             Audio::pauseSound();
-            Ui::TimePanel::invalidateFrame();
+            Ui::Windows::TimePanel::invalidateFrame();
         }
 
         return 0;

--- a/src/OpenLoco/Gui.cpp
+++ b/src/OpenLoco/Gui.cpp
@@ -27,18 +27,18 @@ namespace OpenLoco::Gui
 
         if (OpenLoco::isTitleMode())
         {
-            Ui::Windows::openTitleMenu();
-            Ui::Windows::openTitleExit();
-            Ui::Windows::openTitleLogo();
-            Ui::Windows::openTitleVersion();
-            Ui::TitleOptions::open();
+            Ui::Windows::TitleMenu::open();
+            Ui::Windows::TitleExit::open();
+            Ui::Windows::TitleLogo::open();
+            Ui::Windows::TitleVersion::open();
+            Ui::Windows::TitleOptions::open();
         }
         else
         {
             Windows::ToolbarTop::Game::open();
 
             Windows::PlayerInfoPanel::open();
-            TimePanel::open();
+            Windows::TimePanel::open();
 
             if (OpenLoco::Tutorial::state() != Tutorial::tutorial_state::none)
             {

--- a/src/OpenLoco/Input/Keyboard.cpp
+++ b/src/OpenLoco/Input/Keyboard.cpp
@@ -129,13 +129,13 @@ namespace OpenLoco::Input
                 if ((_keyModifier & KeyModifier::unknown) == 0)
                     return;
 
-                ToolTip::closeAndReset();
+                Windows::ToolTip::closeAndReset();
 
                 auto tutStringId = Tutorial::nextString();
                 auto main = WindowManager::getMainWindow();
                 auto cursor = getMouseLocation();
 
-                ToolTip::update(main, 0, tutStringId, cursor.x, cursor.y);
+                Windows::ToolTip::update(main, 0, tutStringId, cursor.x, cursor.y);
                 break;
             }
 
@@ -330,7 +330,7 @@ namespace OpenLoco::Input
                     if (tryShortcut(Shortcut::screenshot, nextKey->keyCode, _keyModifier))
                         continue;
 
-                    Ui::PromptBrowse::handleInput(nextKey->charCode, nextKey->keyCode);
+                    Ui::Windows::PromptBrowse::handleInput(nextKey->charCode, nextKey->keyCode);
                     continue;
                 }
             }
@@ -340,7 +340,7 @@ namespace OpenLoco::Input
                 ti = WindowManager::find(WindowType::confirmationPrompt);
                 if (ti != nullptr)
                 {
-                    Ui::Windows::promptOkCancelInput(nextKey->charCode, nextKey->keyCode);
+                    Ui::Windows::PromptOkCancel::handleInput(nextKey->charCode, nextKey->keyCode);
                     continue;
                 }
             }

--- a/src/OpenLoco/Input/MouseInput.cpp
+++ b/src/OpenLoco/Input/MouseInput.cpp
@@ -530,7 +530,7 @@ namespace OpenLoco::Input
                             auto veh = _thing->asVehicle();
                             if (veh != nullptr)
                             {
-                                Ui::Vehicle::Main::open(veh);
+                                Ui::Windows::Vehicle::Main::open(veh);
                             }
                             break;
                         }
@@ -1543,7 +1543,7 @@ namespace OpenLoco::Input
                     {
                         if (tooltipStringId != _currentTooltipStringId)
                         {
-                            Ui::ToolTip::closeAndReset();
+                            Ui::Windows::ToolTip::closeAndReset();
                         }
                     }
                 }
@@ -1562,7 +1562,7 @@ namespace OpenLoco::Input
             }
             else
             {
-                Ui::ToolTip::closeAndReset();
+                Ui::Windows::ToolTip::closeAndReset();
             }
 
             return;
@@ -1584,11 +1584,11 @@ namespace OpenLoco::Input
 
             if (tooltipStringId == StringIds::null)
             {
-                Ui::ToolTip::open(window, widgetIndex, x, y);
+                Ui::Windows::ToolTip::open(window, widgetIndex, x, y);
             }
             else
             {
-                Ui::ToolTip::update(window, widgetIndex, tooltipStringId, x, y);
+                Ui::Windows::ToolTip::update(window, widgetIndex, tooltipStringId, x, y);
             }
         }
 

--- a/src/OpenLoco/Input/ShortcutManager.cpp
+++ b/src/OpenLoco/Input/ShortcutManager.cpp
@@ -205,13 +205,13 @@ namespace OpenLoco::Input::ShortcutManager
         main->viewportRotateRight();
         TownManager::updateLabels();
         StationManager::updateLabels();
-        Windows::Map::centerOnViewPoint();
+        Windows::MapWindow::centerOnViewPoint();
     }
 
     // 0x004BF148
     static void rotateConstructionObject()
     {
-        if (Vehicle::rotate())
+        if (Windows::Vehicle::rotate())
             return;
 
         auto window = WindowManager::find(WindowType::terraform);
@@ -399,7 +399,7 @@ namespace OpenLoco::Input::ShortcutManager
         if (last_build_vehicles_option == 0xFF)
             return;
 
-        BuildVehicle::open(last_build_vehicles_option, 1 << 31);
+        Windows::BuildVehicle::open(last_build_vehicles_option, 1 << 31);
     }
 
     // 0x004BF2D1
@@ -445,7 +445,7 @@ namespace OpenLoco::Input::ShortcutManager
         if (isEditorMode() && S5::getOptions().editorStep == 0)
             return;
 
-        Windows::Map::open();
+        Windows::MapWindow::open();
     }
 
     // 0x004BF359
@@ -481,7 +481,7 @@ namespace OpenLoco::Input::ShortcutManager
         if (isEditorMode())
             return;
 
-        MessageWindow::open();
+        Windows::MessageWindow::open();
     }
 
     // 0x004BF3AB
@@ -499,11 +499,11 @@ namespace OpenLoco::Input::ShortcutManager
         auto window = WindowManager::find(WindowType::news);
         if (window)
         {
-            NewsWindow::close(window);
+            Windows::NewsWindow::close(window);
         }
         else
         {
-            NewsWindow::openLastMessage();
+            Windows::NewsWindow::openLastMessage();
         }
     }
 

--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -676,7 +676,7 @@ void OpenLoco::Interop::registerHooks()
     registerHook(
         0x00446F6B,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-            auto result = promptOkCancel(regs.eax);
+            auto result = Ui::Windows::PromptOkCancel::open(regs.eax);
             regs.eax = result ? 1 : 0;
             return 0;
         });
@@ -764,11 +764,11 @@ void OpenLoco::Interop::registerHooks()
         });
 
     Ui::ProgressBar::registerHooks();
-    Ui::PromptBrowse::registerHooks();
+    Ui::Windows::PromptBrowse::registerHooks();
     Ui::Windows::TextInput::registerHooks();
-    Ui::ToolTip::registerHooks();
-    Ui::Vehicle::registerHooks();
-    Ui::BuildVehicle::registerHooks();
+    Ui::Windows::ToolTip::registerHooks();
+    Ui::Windows::Vehicle::registerHooks();
+    Ui::Windows::BuildVehicle::registerHooks();
     Ui::Windows::Terraform::registerHooks();
     Ui::Windows::Error::registerHooks();
     Ui::Windows::Construction::registerHooks();

--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -789,7 +789,7 @@ void OpenLoco::Interop::registerHooks()
             int16_t x = regs.eax;
             int16_t i = regs.ebx / 6;
             int16_t y = regs.ecx;
-            OpenLoco::Map::surface_element* surface = (OpenLoco::Map::surface_element*)regs.esi;
+            Map::surface_element* surface = (Map::surface_element*)regs.esi;
 
             surface->createWave(x, y, i);
 

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -977,7 +977,7 @@ namespace OpenLoco
                 if (today.month != yesterday.month)
                 {
                     // End of every month
-                    Ui::TimePanel::invalidateFrame();
+                    Ui::Windows::TimePanel::invalidateFrame();
                     addr<0x00526243, uint16_t>()++;
                     TownManager::updateMonthly();
                     call(0x0045383B);

--- a/src/OpenLoco/Ui/WindowManager.cpp
+++ b/src/OpenLoco/Ui/WindowManager.cpp
@@ -96,7 +96,7 @@ namespace OpenLoco::Ui::WindowManager
         registerHook(
             0x0043CB9F,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                Windows::editorInit();
+                Windows::TitleMenu::editorInit();
 
                 return 0;
             });
@@ -125,7 +125,7 @@ namespace OpenLoco::Ui::WindowManager
             0x004B6033,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 registers backup = regs;
-                auto* w = Vehicle::Main::open(reinterpret_cast<Vehicles::VehicleBase*>(regs.edx));
+                auto* w = Windows::Vehicle::Main::open(reinterpret_cast<Vehicles::VehicleBase*>(regs.edx));
                 regs = backup;
                 regs.esi = reinterpret_cast<int32_t>(w);
                 return 0;
@@ -249,7 +249,7 @@ namespace OpenLoco::Ui::WindowManager
             0x00428F8B,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 registers backup = regs;
-                Ui::NewsWindow::open(regs.ax);
+                Ui::Windows::NewsWindow::open(regs.ax);
                 regs = backup;
 
                 return 0;
@@ -1504,7 +1504,7 @@ namespace OpenLoco::Ui::WindowManager
                 }
                 TownManager::updateLabels();
                 StationManager::updateLabels();
-                Windows::Map::centerOnViewPoint();
+                Windows::MapWindow::centerOnViewPoint();
             }
 
             return;

--- a/src/OpenLoco/Ui/WindowManager.h
+++ b/src/OpenLoco/Ui/WindowManager.h
@@ -128,10 +128,10 @@ namespace OpenLoco::Ui::Windows
     namespace Construction
     {
         window* openWithFlags(uint32_t flags);
-        window* openAtTrack(window* main, OpenLoco::Map::track_element* track, const OpenLoco::Map::Pos2 pos);
-        window* openAtRoad(window* main, OpenLoco::Map::road_element* track, const OpenLoco::Map::Pos2 pos);
-        void setToTrackExtra(window* main, OpenLoco::Map::track_element* track, const uint8_t bh, const OpenLoco::Map::Pos2 pos);
-        void setToRoadExtra(window* main, OpenLoco::Map::road_element* track, const uint8_t bh, const OpenLoco::Map::Pos2 pos);
+        window* openAtTrack(window* main, Map::track_element* track, const Map::Pos2 pos);
+        window* openAtRoad(window* main, Map::road_element* track, const Map::Pos2 pos);
+        void setToTrackExtra(window* main, Map::track_element* track, const uint8_t bh, const Map::Pos2 pos);
+        void setToRoadExtra(window* main, Map::road_element* track, const uint8_t bh, const Map::Pos2 pos);
         void sub_4A6FAC();
         void rotate(window* self);
         void registerHooks();

--- a/src/OpenLoco/Ui/WindowManager.h
+++ b/src/OpenLoco/Ui/WindowManager.h
@@ -69,325 +69,341 @@ namespace OpenLoco::Ui::WindowManager
     void viewportSetVisibility(viewport_visibility flags);
 }
 
-namespace OpenLoco::Ui::Windows::Main
-{
-    void open();
-}
-
-namespace OpenLoco::Ui::Windows
-{
-    window* openTitleVersion();
-    window* openTitleExit();
-    window* openTitleMenu();
-    window* openTitleLogo();
-
-    bool promptOkCancel(string_id okButtonStringId);
-    void promptOkCancelInput(uint32_t charCode, uint32_t keyCode);
-
-    void showError(string_id title, string_id message = StringIds::null, bool sound = true);
-
-    void editorInit();
-
-    void showGridlines();
-    void hideGridlines();
-    void showDirectionArrows();
-    void hideDirectionArrows();
-}
-
-namespace OpenLoco::Ui::About
-{
-    void open();
-}
-
-namespace OpenLoco::Ui::KeyboardShortcuts
-{
-    window* open();
-}
-
-namespace OpenLoco::Ui::EditKeyboardShortcut
-{
-    window* open(uint8_t shortcutIndex);
-}
-
-namespace OpenLoco::Ui::AboutMusic
-{
-    void open();
-}
-
-namespace OpenLoco::Ui::Windows::Construction
-{
-    window* openWithFlags(uint32_t flags);
-    window* openAtTrack(window* main, OpenLoco::Map::track_element* track, const OpenLoco::Map::Pos2 pos);
-    window* openAtRoad(window* main, OpenLoco::Map::road_element* track, const OpenLoco::Map::Pos2 pos);
-    void setToTrackExtra(window* main, OpenLoco::Map::track_element* track, const uint8_t bh, const OpenLoco::Map::Pos2 pos);
-    void setToRoadExtra(window* main, OpenLoco::Map::road_element* track, const uint8_t bh, const OpenLoco::Map::Pos2 pos);
-    void sub_4A6FAC();
-    void rotate(window* self);
-    void registerHooks();
-}
-
-namespace OpenLoco::Ui::Windows::Industry
-{
-    window* open(IndustryId_t id);
-}
-
-namespace OpenLoco::Ui::Windows::IndustryList
-{
-    window* open();
-}
-
-namespace OpenLoco::Ui::Windows::LandscapeGeneration
-{
-    window* open();
-}
-
-namespace OpenLoco::Ui::Windows::LandscapeGenerationConfirm
-{
-    window* open(int32_t prompt_type);
-}
-
-namespace OpenLoco::Ui::Windows::Map
-{
-    void open();
-    void centerOnViewPoint();
-}
-
-namespace OpenLoco::Ui::Windows::MusicSelection
-{
-    window* open();
-}
-
-namespace OpenLoco::Ui::Windows::Error
-{
-    void open(string_id title, string_id message);
-    void openWithCompetitor(string_id title, string_id message, uint8_t competitorId);
-    void registerHooks();
-}
-
-namespace OpenLoco::Ui::Options
-{
-    window* open();
-    window* openMusicSettings();
-    constexpr uint8_t tab_offset_music = 2;
-}
-
-namespace OpenLoco::Ui::PromptBrowse
-{
-    enum browse_type : uint8_t
-    {
-        load = 1,
-        save = 2
-    };
-    bool open(browse_type type, char* path, const char* filter, const char* title);
-    void handleInput(uint32_t charCode, uint32_t keyCode);
-    void registerHooks();
-}
-
-namespace OpenLoco::Ui::Windows::ScenarioOptions
-{
-    window* open();
-}
-
-namespace OpenLoco::Ui::Windows::Station
-{
-    window* open(uint16_t id);
-    void showStationCatchment(uint16_t windowNumber);
-}
-
-namespace OpenLoco::Ui::Windows::StationList
-{
-    window* open(CompanyId_t companyId);
-    window* open(CompanyId_t companyId, uint8_t type);
-}
-
-namespace OpenLoco::Ui::Windows::Terraform
-{
-    window* open();
-    void openClearArea();
-    void openAdjustLand();
-    void openAdjustWater();
-    void openPlantTrees();
-    void openBuildWalls();
-    bool rotate(window*);
-    void registerHooks();
-}
-
-namespace OpenLoco::Ui::Windows::TextInput
-{
-    void registerHooks();
-
-    void openTextInput(Ui::window* w, string_id title, string_id message, string_id value, int callingWidget, void* valueArgs);
-    void sub_4CE6C9(WindowType type, window_number number);
-    void cancel();
-    void handleInput(uint32_t charCode, uint32_t keyCode);
-    void sub_4CE6FF();
-}
-
-namespace OpenLoco::Ui::TitleOptions
-{
-    window* open();
-}
-
-namespace OpenLoco::Ui::Windows::ToolbarTop::Game
-{
-    void open();
-}
-
-namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
-{
-    void open();
-}
-
-namespace OpenLoco::Ui::ToolTip
-{
-    void registerHooks();
-    void open(Ui::window* window, int32_t widgetIndex, int16_t x, int16_t y);
-    void update(Ui::window* window, int32_t widgetIndex, string_id stringId, int16_t x, int16_t y);
-    void set_52336E(bool value);
-    void closeAndReset();
-}
-
-namespace OpenLoco::Ui::Windows::MapToolTip
-{
-    void open();
-    void setOwner(CompanyId_t company);
-    void reset();
-}
-
-namespace OpenLoco::Ui::Windows::Town
-{
-    window* open(uint16_t townId);
-}
-
-namespace OpenLoco::Ui::Windows::TownList
-{
-    window* open();
-}
-
 namespace OpenLoco::Vehicles
 {
     struct VehicleBase;
     struct Car;
 }
 
-namespace OpenLoco::Ui::Windows::DragVehiclePart
+namespace OpenLoco::Ui::Windows
 {
-    void open(Vehicles::Car& car);
-}
+    void showError(string_id title, string_id message = StringIds::null, bool sound = true);
 
-namespace OpenLoco::Ui::Vehicle
-{
-    void registerHooks();
+    void showGridlines();
+    void hideGridlines();
+    void showDirectionArrows();
+    void hideDirectionArrows();
+
+    namespace About
+    {
+        void open();
+    }
+
+    namespace AboutMusic
+    {
+        void open();
+    }
+
+    namespace BuildVehicle
+    {
+        window* open(uint32_t vehicle, uint32_t flags);
+        void sub_4B92A5(Ui::window* window);
+        void registerHooks();
+    }
+
+    namespace Cheats
+    {
+        window* open();
+    }
+
+    namespace CompanyFaceSelection
+    {
+        void open(CompanyId_t id);
+    }
+
+    namespace CompanyList
+    {
+        void openPerformanceIndexes();
+        window* open();
+    }
+
+    namespace CompanyWindow
+    {
+        window* open(CompanyId_t companyId);
+        window* openAndSetName();
+        window* openChallenge(CompanyId_t companyId);
+        window* openFinances(CompanyId_t companyId);
+    }
+
+    namespace Construction
+    {
+        window* openWithFlags(uint32_t flags);
+        window* openAtTrack(window* main, OpenLoco::Map::track_element* track, const OpenLoco::Map::Pos2 pos);
+        window* openAtRoad(window* main, OpenLoco::Map::road_element* track, const OpenLoco::Map::Pos2 pos);
+        void setToTrackExtra(window* main, OpenLoco::Map::track_element* track, const uint8_t bh, const OpenLoco::Map::Pos2 pos);
+        void setToRoadExtra(window* main, OpenLoco::Map::road_element* track, const uint8_t bh, const OpenLoco::Map::Pos2 pos);
+        void sub_4A6FAC();
+        void rotate(window* self);
+        void registerHooks();
+    }
+
+    namespace DragVehiclePart
+    {
+        void open(Vehicles::Car& car);
+    }
+
+    namespace EditKeyboardShortcut
+    {
+        window* open(uint8_t shortcutIndex);
+    }
+
+    namespace Error
+    {
+        void open(string_id title, string_id message);
+        void openWithCompetitor(string_id title, string_id message, uint8_t competitorId);
+        void registerHooks();
+    }
+
+    namespace Industry
+    {
+        window* open(IndustryId_t id);
+    }
+
+    namespace IndustryList
+    {
+        window* open();
+    }
+
+    namespace KeyboardShortcuts
+    {
+        window* open();
+    }
+
+    namespace LandscapeGeneration
+    {
+        window* open();
+    }
+
+    namespace LandscapeGenerationConfirm
+    {
+        window* open(int32_t prompt_type);
+    }
+
     namespace Main
     {
-        window* open(const Vehicles::VehicleBase* vehicle);
+        void open();
     }
-    namespace Details
+
+    namespace MapToolTip
     {
-        window* open(const Vehicles::VehicleBase* vehicle);
-        void scrollDrag(const Gfx::point_t& pos);
-        void scrollDragEnd(const Gfx::point_t& pos);
+        void open();
+        void setOwner(CompanyId_t company);
+        void reset();
     }
-    namespace Common
+
+    namespace MapWindow
     {
-        int16_t sub_4B743B(uint8_t al, uint8_t ah, int16_t cx, int16_t dx, Vehicles::VehicleBase* vehicle, Gfx::drawpixelinfo_t* const pDrawpixelinfo);
+        void open();
+        void centerOnViewPoint();
     }
-    bool rotate();
-}
 
-namespace OpenLoco::Ui::Windows::VehicleList
-{
-    window* open(CompanyId_t companyId, VehicleType type);
-}
+    namespace MessageWindow
+    {
+        void open();
+    }
 
-namespace OpenLoco::Ui::BuildVehicle
-{
-    window* open(uint32_t vehicle, uint32_t flags);
-    void sub_4B92A5(Ui::window* window);
-    void registerHooks();
-}
+    namespace MusicSelection
+    {
+        window* open();
+    }
+    namespace NewsWindow
+    {
+        void open(uint16_t messageIndex);
+        void openLastMessage();
+        void close(Ui::window* window);
+    }
 
-namespace OpenLoco::Ui::MessageWindow
-{
-    void open();
-}
+    namespace ObjectSelectionWindow
+    {
+        window* open();
+    }
 
-namespace OpenLoco::Ui::NewsWindow
-{
-    void open(uint16_t messageIndex);
-    void openLastMessage();
-    void close(Ui::window* window);
-}
+    namespace Options
+    {
+        window* open();
+        window* openMusicSettings();
+        constexpr uint8_t tab_offset_music = 2;
+    }
 
-namespace OpenLoco::Ui::Windows::Cheats
-{
-    window* open();
-}
+    namespace PlayerInfoPanel
+    {
+        window* open();
+        void invalidateFrame();
+    }
 
-namespace OpenLoco::Ui::Windows::CompanyFaceSelection
-{
-    void open(CompanyId_t id);
-}
+    namespace ProgressBar
+    {
+        window* open(std::string_view captionString);
+        void setProgress(uint8_t value);
+        void close();
+    }
 
-namespace OpenLoco::Ui::Windows::CompanyList
-{
-    void openPerformanceIndexes();
-    window* open();
-}
+    namespace PromptBrowse
+    {
+        enum browse_type : uint8_t
+        {
+            load = 1,
+            save = 2
+        };
+        bool open(browse_type type, char* path, const char* filter, const char* title);
+        void handleInput(uint32_t charCode, uint32_t keyCode);
+        void registerHooks();
+    }
 
-namespace OpenLoco::Ui::Windows::CompanyWindow
-{
-    window* open(CompanyId_t companyId);
-    window* openAndSetName();
-    window* openChallenge(CompanyId_t companyId);
-    window* openFinances(CompanyId_t companyId);
-}
+    namespace PromptOkCancel
+    {
+        bool open(string_id okButtonStringId);
+        void handleInput(uint32_t charCode, uint32_t keyCode);
+    }
 
-namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
-{
-    window* open();
-}
+    namespace PromptSaveWindow
+    {
+        window* open(uint16_t savePromptType);
+    }
 
-namespace OpenLoco::Ui::Windows::PlayerInfoPanel
-{
-    window* open();
-    void invalidateFrame();
-}
+    namespace ScenarioOptions
+    {
+        window* open();
+    }
 
-namespace OpenLoco::Ui::Windows::ProgressBar
-{
-    window* open(std::string_view captionString);
-    void setProgress(uint8_t value);
-    void close();
-}
+    namespace ScenarioSelect
+    {
+        window* open();
+    }
 
-namespace OpenLoco::Ui::Windows::PromptSaveWindow
-{
-    window* open(uint16_t savePromptType);
-}
+    namespace Station
+    {
+        window* open(uint16_t id);
+        void showStationCatchment(uint16_t windowNumber);
+    }
 
-namespace OpenLoco::Ui::Windows::ScenarioSelect
-{
-    window* open();
-}
+    namespace StationList
+    {
+        window* open(CompanyId_t companyId);
+        window* open(CompanyId_t companyId, uint8_t type);
+    }
 
-namespace OpenLoco::Ui::Windows::TileInspector
-{
-    window* open();
-}
+    namespace Terraform
+    {
+        window* open();
+        void openClearArea();
+        void openAdjustLand();
+        void openAdjustWater();
+        void openPlantTrees();
+        void openBuildWalls();
+        bool rotate(window*);
+        void registerHooks();
+    }
 
-namespace OpenLoco::Ui::TimePanel
-{
-    window* open();
-    void invalidateFrame();
-}
+    namespace TextInput
+    {
+        void registerHooks();
 
-namespace OpenLoco::Ui::Windows::Tutorial
-{
-    window* open();
-}
+        void openTextInput(Ui::window* w, string_id title, string_id message, string_id value, int callingWidget, void* valueArgs);
+        void sub_4CE6C9(WindowType type, window_number number);
+        void cancel();
+        void handleInput(uint32_t charCode, uint32_t keyCode);
+        void sub_4CE6FF();
+    }
 
-namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
-{
-    void open();
+    namespace TileInspector
+    {
+        window* open();
+    }
+
+    namespace TimePanel
+    {
+        window* open();
+        void invalidateFrame();
+    }
+
+    namespace TitleExit
+    {
+        window* open();
+    }
+
+    namespace TitleLogo
+    {
+        window* open();
+    }
+
+    namespace TitleMenu
+    {
+        window* open();
+        void editorInit();
+    }
+
+    namespace TitleOptions
+    {
+        window* open();
+    }
+
+    namespace TitleVersion
+    {
+        window* open();
+    }
+
+    namespace ToolbarBottom::Editor
+    {
+        void open();
+    }
+
+    namespace ToolbarTop::Game
+    {
+        void open();
+    }
+
+    namespace ToolbarTop::Editor
+    {
+        void open();
+    }
+
+    namespace ToolTip
+    {
+        void registerHooks();
+        void open(Ui::window* window, int32_t widgetIndex, int16_t x, int16_t y);
+        void update(Ui::window* window, int32_t widgetIndex, string_id stringId, int16_t x, int16_t y);
+        void set_52336E(bool value);
+        void closeAndReset();
+    }
+
+    namespace Town
+    {
+        window* open(uint16_t townId);
+    }
+
+    namespace TownList
+    {
+        window* open();
+    }
+
+    namespace Tutorial
+    {
+        window* open();
+    }
+
+    namespace Vehicle
+    {
+        void registerHooks();
+        namespace Main
+        {
+            window* open(const Vehicles::VehicleBase* vehicle);
+        }
+        namespace Details
+        {
+            window* open(const Vehicles::VehicleBase* vehicle);
+            void scrollDrag(const Gfx::point_t& pos);
+            void scrollDragEnd(const Gfx::point_t& pos);
+        }
+        namespace Common
+        {
+            int16_t sub_4B743B(uint8_t al, uint8_t ah, int16_t cx, int16_t dx, Vehicles::VehicleBase* vehicle, Gfx::drawpixelinfo_t* const pDrawpixelinfo);
+        }
+        bool rotate();
+    }
+
+    namespace VehicleList
+    {
+        window* open(CompanyId_t companyId, VehicleType type);
+    }
 }

--- a/src/OpenLoco/Window.h
+++ b/src/OpenLoco/Window.h
@@ -317,7 +317,7 @@ namespace OpenLoco::Ui
             return (flags & (1 << 15)) != 0;
         }
 
-        OpenLoco::Map::Pos3 getPos() const
+        Map::Pos3 getPos() const
         {
             if (isThingView())
                 return {};

--- a/src/OpenLoco/Windows/About.cpp
+++ b/src/OpenLoco/Windows/About.cpp
@@ -68,7 +68,7 @@ namespace OpenLoco::Ui::Windows::About
                 break;
 
             case widx::music_acknowledgements_btn:
-                Windows::AboutMusic::open();
+                AboutMusic::open();
                 break;
         }
     }

--- a/src/OpenLoco/Windows/About.cpp
+++ b/src/OpenLoco/Windows/About.cpp
@@ -6,7 +6,7 @@
 #include "../Objects/ObjectManager.h"
 #include "../Ui/WindowManager.h"
 
-namespace OpenLoco::Ui::About
+namespace OpenLoco::Ui::Windows::About
 {
     constexpr Gfx::ui_size_t windowSize = { 400, 260 };
 
@@ -68,7 +68,7 @@ namespace OpenLoco::Ui::About
                 break;
 
             case widx::music_acknowledgements_btn:
-                AboutMusic::open();
+                Windows::AboutMusic::open();
                 break;
         }
     }

--- a/src/OpenLoco/Windows/AboutMusic.cpp
+++ b/src/OpenLoco/Windows/AboutMusic.cpp
@@ -10,7 +10,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::AboutMusic
+namespace OpenLoco::Ui::Windows::AboutMusic
 {
     constexpr Gfx::ui_size_t windowSize = { 500, 312 };
 

--- a/src/OpenLoco/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/Windows/BuildVehicle.cpp
@@ -743,7 +743,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         }
 
         auto pan = window->width / 2 + window->x;
-        Audio::playSound(Audio::SoundId::clickDown, OpenLoco::Map::Pos3{ x, y, static_cast<int16_t>(pan) }, pan);
+        Audio::playSound(Audio::SoundId::clickDown, Map::Pos3{ x, y, static_cast<int16_t>(pan) }, pan);
         auto item = window->row_info[scrollItem];
         auto vehicleObj = ObjectManager::get<VehicleObject>(item);
         FormatArguments args{};

--- a/src/OpenLoco/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/Windows/BuildVehicle.cpp
@@ -23,7 +23,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::BuildVehicle
+namespace OpenLoco::Ui::Windows::BuildVehicle
 {
     static const Gfx::ui_size_t window_size = { 380, 233 };
 
@@ -767,7 +767,7 @@ namespace OpenLoco::Ui::BuildVehicle
         if (_buildTargetVehicle == -1)
         {
             auto vehicle = EntityManager::get<Vehicles::VehicleBase>(_113642A);
-            Vehicle::Details::open(vehicle);
+            Windows::Vehicle::Details::open(vehicle);
         }
         sub_4B92A5(window);
     }

--- a/src/OpenLoco/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/Windows/BuildVehicle.cpp
@@ -767,7 +767,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         if (_buildTargetVehicle == -1)
         {
             auto vehicle = EntityManager::get<Vehicles::VehicleBase>(_113642A);
-            Windows::Vehicle::Details::open(vehicle);
+            Vehicle::Details::open(vehicle);
         }
         sub_4B92A5(window);
     }

--- a/src/OpenLoco/Windows/CompanyList.cpp
+++ b/src/OpenLoco/Windows/CompanyList.cpp
@@ -365,7 +365,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             if (currentCompany == -1)
                 return;
 
-            Windows::CompanyWindow::open(currentCompany);
+            CompanyWindow::open(currentCompany);
         }
 
         // 0x00436361

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -1023,7 +1023,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 return;
             }
             int8_t rotation = static_cast<int8_t>(self->viewports[0]->getRotation());
-            OpenLoco::Map::Pos3 loc = {
+            Map::Pos3 loc = {
                 static_cast<coord_t>(company->headquarters_x + 32),
                 static_cast<coord_t>(company->headquarters_y + 32),
                 static_cast<coord_t>((company->headquarters_z + 8) * 4)

--- a/src/OpenLoco/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/Windows/Construction/Common.cpp
@@ -690,8 +690,8 @@ namespace OpenLoco::Ui::Windows::Construction
             WindowManager::viewportSetVisibility(WindowManager::viewport_visibility::reset);
             TileManager::mapInvalidateMapSelectionTiles();
             _mapSelectionFlags = _mapSelectionFlags & ~MapSelectFlag::enableConstruct;
-            Windows::hideDirectionArrows();
-            Windows::hideGridlines();
+            hideDirectionArrows();
+            hideGridlines();
         }
 
         // 0x0049E437, 0x0049E76F, 0x0049ECD1

--- a/src/OpenLoco/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/Windows/Construction/ConstructionTab.cpp
@@ -299,13 +299,13 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             roadId = road->id;
         }
 
-        const auto& roadPiece = OpenLoco::Map::TrackData::getRoadPiece(roadId);
+        const auto& roadPiece = Map::TrackData::getRoadPiece(roadId);
         auto posId = 0;
         rotation &= 3;
 
         for (const auto& roadPart : roadPiece)
         {
-            if (roadPart.flags & OpenLoco::Map::TrackData::PreviewTrackFlags::diagonal)
+            if (roadPart.flags & Map::TrackData::PreviewTrackFlags::diagonal)
             {
                 continue;
             }
@@ -493,13 +493,13 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             trackId = track->id;
         }
 
-        const auto& trackPiece = OpenLoco::Map::TrackData::getTrackPiece(trackId);
+        const auto& trackPiece = Map::TrackData::getTrackPiece(trackId);
         auto posId = 0;
         rotation &= 3;
 
         for (const auto& trackPart : trackPiece)
         {
-            if (trackPart.flags & OpenLoco::Map::TrackData::PreviewTrackFlags::diagonal)
+            if (trackPart.flags & Map::TrackData::PreviewTrackFlags::diagonal)
             {
                 continue;
             }
@@ -1703,7 +1703,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             auto maxRetries = 0;
             if (Input::hasKeyModifier(Input::KeyModifier::shift) || _byte_113605D != 1)
             {
-                const auto& roadPiece = OpenLoco::Map::TrackData::getRoadPiece(_byte_1136065);
+                const auto& roadPiece = Map::TrackData::getRoadPiece(_byte_1136065);
                 auto maxRoadPieceHeight = 0;
 
                 for (const auto& roadPart : roadPiece)
@@ -1806,7 +1806,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             auto maxRetries = 0;
             if (Input::hasKeyModifier(Input::KeyModifier::shift) || _byte_113605D != 1)
             {
-                const auto& trackPiece = OpenLoco::Map::TrackData::getTrackPiece(_byte_1136065);
+                const auto& trackPiece = Map::TrackData::getTrackPiece(_byte_1136065);
                 auto maxTrackPieceHeight = 0;
 
                 for (const auto& trackPart : trackPiece)
@@ -2018,12 +2018,12 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
             if (Gfx::clipDrawpixelinfo(&clipped, dpi, x, y, width, height))
             {
-                const auto& roadPiece = OpenLoco::Map::TrackData::getRoadPiece(_lastSelectedTrackPieceId);
+                const auto& roadPiece = Map::TrackData::getRoadPiece(_lastSelectedTrackPieceId);
                 const auto& lastRoadPart = roadPiece.back();
 
                 Pos3 pos3D = { lastRoadPart.x, lastRoadPart.y, lastRoadPart.z };
 
-                if (lastRoadPart.flags & OpenLoco::Map::TrackData::PreviewTrackFlags::unused)
+                if (lastRoadPart.flags & Map::TrackData::PreviewTrackFlags::unused)
                 {
                     pos3D.x = 0;
                     pos3D.y = 0;
@@ -2068,12 +2068,12 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
             if (Gfx::clipDrawpixelinfo(&clipped, dpi, x, y, width, height))
             {
-                const auto& trackPiece = OpenLoco::Map::TrackData::getTrackPiece(_lastSelectedTrackPieceId);
+                const auto& trackPiece = Map::TrackData::getTrackPiece(_lastSelectedTrackPieceId);
                 const auto& lastTrackPart = trackPiece.back();
 
                 Pos3 pos3D = { lastTrackPart.x, lastTrackPart.y, lastTrackPart.z };
 
-                if (lastTrackPart.flags & OpenLoco::Map::TrackData::PreviewTrackFlags::unused)
+                if (lastTrackPart.flags & Map::TrackData::PreviewTrackFlags::unused)
                 {
                     pos3D.x = 0;
                     pos3D.y = 0;

--- a/src/OpenLoco/Windows/DragVehiclePart.cpp
+++ b/src/OpenLoco/Windows/DragVehiclePart.cpp
@@ -36,7 +36,7 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
         WindowManager::invalidate(WindowType::vehicle, car.front->head);
 
         initEvents();
-        uint16_t width = Vehicle::Common::sub_4B743B(1, 0, 0, 0, car.front, nullptr);
+        uint16_t width = Windows::Vehicle::Common::sub_4B743B(1, 0, 0, 0, car.front, nullptr);
         auto pos = Input::getTooltipMouseLocation();
         pos.y -= 30;
         pos.x -= width / 2;
@@ -51,7 +51,7 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
     static Ui::cursor_id cursor(window* const self, const int16_t widgetIdx, const int16_t x, const int16_t y, const Ui::cursor_id fallback)
     {
         self->height = 0; // Set to zero so that skipped in window find
-        Vehicle::Details::scrollDrag(Input::getScrollLastLocation());
+        Windows::Vehicle::Details::scrollDrag(Input::getScrollLastLocation());
         self->height = 60;
         return cursor_id::unk_26;
     }
@@ -59,7 +59,7 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
     static void onMove(window& self, const int16_t x, const int16_t y)
     {
         self.height = 0; // Set to zero so that skipped in window find
-        Vehicle::Details::scrollDragEnd(Input::getScrollLastLocation());
+        Windows::Vehicle::Details::scrollDragEnd(Input::getScrollLastLocation());
         WindowManager::close(&self);
         _dragCarComponent = nullptr;
         WindowManager::invalidate(WindowType::vehicle, _dragVehicleHead);
@@ -70,7 +70,7 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
         Gfx::drawpixelinfo_t* clipped;
         if (Gfx::clipDrawpixelinfo(&clipped, context, self->x, self->y, self->width, self->height))
         {
-            Vehicle::Common::sub_4B743B(0, 0, 0, 19, _dragCarComponent, clipped);
+            Windows::Vehicle::Common::sub_4B743B(0, 0, 0, 19, _dragCarComponent, clipped);
         }
     }
 

--- a/src/OpenLoco/Windows/DragVehiclePart.cpp
+++ b/src/OpenLoco/Windows/DragVehiclePart.cpp
@@ -36,7 +36,7 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
         WindowManager::invalidate(WindowType::vehicle, car.front->head);
 
         initEvents();
-        uint16_t width = Windows::Vehicle::Common::sub_4B743B(1, 0, 0, 0, car.front, nullptr);
+        uint16_t width = Vehicle::Common::sub_4B743B(1, 0, 0, 0, car.front, nullptr);
         auto pos = Input::getTooltipMouseLocation();
         pos.y -= 30;
         pos.x -= width / 2;
@@ -51,7 +51,7 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
     static Ui::cursor_id cursor(window* const self, const int16_t widgetIdx, const int16_t x, const int16_t y, const Ui::cursor_id fallback)
     {
         self->height = 0; // Set to zero so that skipped in window find
-        Windows::Vehicle::Details::scrollDrag(Input::getScrollLastLocation());
+        Vehicle::Details::scrollDrag(Input::getScrollLastLocation());
         self->height = 60;
         return cursor_id::unk_26;
     }
@@ -59,7 +59,7 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
     static void onMove(window& self, const int16_t x, const int16_t y)
     {
         self.height = 0; // Set to zero so that skipped in window find
-        Windows::Vehicle::Details::scrollDragEnd(Input::getScrollLastLocation());
+        Vehicle::Details::scrollDragEnd(Input::getScrollLastLocation());
         WindowManager::close(&self);
         _dragCarComponent = nullptr;
         WindowManager::invalidate(WindowType::vehicle, _dragVehicleHead);
@@ -70,7 +70,7 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
         Gfx::drawpixelinfo_t* clipped;
         if (Gfx::clipDrawpixelinfo(&clipped, context, self->x, self->y, self->width, self->height))
         {
-            Windows::Vehicle::Common::sub_4B743B(0, 0, 0, 19, _dragCarComponent, clipped);
+            Vehicle::Common::sub_4B743B(0, 0, 0, 19, _dragCarComponent, clipped);
         }
     }
 

--- a/src/OpenLoco/Windows/EditKeyboardShortcut.cpp
+++ b/src/OpenLoco/Windows/EditKeyboardShortcut.cpp
@@ -13,7 +13,7 @@
 using namespace OpenLoco::Interop;
 using namespace OpenLoco::Input;
 
-namespace OpenLoco::Ui::EditKeyboardShortcut
+namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
 {
     constexpr Gfx::ui_size_t windowSize = { 280, 72 };
 

--- a/src/OpenLoco/Windows/IndustryList.cpp
+++ b/src/OpenLoco/Windows/IndustryList.cpp
@@ -706,7 +706,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     _lastSelectedIndustry = static_cast<uint8_t>(rowInfo);
 
                     int32_t pan = (self->width >> 1) + self->x;
-                    OpenLoco::Map::Pos3 loc = { xPos, yPos, static_cast<int16_t>(pan) };
+                    Map::Pos3 loc = { xPos, yPos, static_cast<int16_t>(pan) };
                     Audio::playSound(Audio::SoundId::clickDown, loc, pan);
                     self->saved_view.mapX = -16;
                     dword_E0C39C = 0x80000000;

--- a/src/OpenLoco/Windows/IndustryList.cpp
+++ b/src/OpenLoco/Windows/IndustryList.cpp
@@ -187,7 +187,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
             if (currentIndustry == -1)
                 return;
 
-            Windows::Industry::open(currentIndustry);
+            Industry::open(currentIndustry);
         }
 
         // 0x00458140

--- a/src/OpenLoco/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/Windows/IndustryWindow.cpp
@@ -260,7 +260,7 @@ namespace OpenLoco::Ui::Windows::Industry
             if (self->viewports[0] == nullptr)
             {
                 auto widget = &self->widgets[widx::viewport];
-                auto tile = OpenLoco::Map::Pos3({ industry->x, industry->y, tileZ });
+                auto tile = Map::Pos3({ industry->x, industry->y, tileZ });
                 auto origin = Gfx::point_t(widget->left + self->x + 1, widget->top + self->y + 1);
                 auto size = Gfx::ui_size_t(widget->width() - 2, widget->height() - 2);
                 ViewportManager::create(self, 0, origin, size, self->saved_view.zoomLevel, tile);

--- a/src/OpenLoco/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/Windows/KeyboardShortcuts.cpp
@@ -12,7 +12,7 @@
 using namespace OpenLoco::Interop;
 using namespace OpenLoco::Input;
 
-namespace OpenLoco::Ui::KeyboardShortcuts
+namespace OpenLoco::Ui::Windows::KeyboardShortcuts
 {
 
     static const int rowHeight = 10; // CJK: 13
@@ -200,6 +200,6 @@ namespace OpenLoco::Ui::KeyboardShortcuts
         if (row >= self->row_count)
             return;
 
-        EditKeyboardShortcut::open(row);
+        Windows::EditKeyboardShortcut::open(row);
     }
 }

--- a/src/OpenLoco/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/Windows/KeyboardShortcuts.cpp
@@ -200,6 +200,6 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
         if (row >= self->row_count)
             return;
 
-        Windows::EditKeyboardShortcut::open(row);
+        EditKeyboardShortcut::open(row);
     }
 }

--- a/src/OpenLoco/Windows/Main.cpp
+++ b/src/OpenLoco/Windows/Main.cpp
@@ -51,7 +51,7 @@ namespace OpenLoco::Ui::Windows::Main
             { window->x, window->y },
             { window->width, window->height },
             ZoomLevel::full,
-            { (OpenLoco::Map::map_rows * OpenLoco::Map::tile_size) / 2 - 1, (OpenLoco::Map::map_rows * OpenLoco::Map::tile_size) / 2 - 1, 480 });
+            { (Map::map_rows * Map::tile_size) / 2 - 1, (Map::map_rows * Map::tile_size) / 2 - 1, 480 });
     }
 
     // 0x0043B2E4

--- a/src/OpenLoco/Windows/MapWindow.cpp
+++ b/src/OpenLoco/Windows/MapWindow.cpp
@@ -26,7 +26,7 @@
 using namespace OpenLoco::Interop;
 using namespace OpenLoco::Ui::WindowManager;
 
-namespace OpenLoco::Ui::Windows::Map
+namespace OpenLoco::Ui::Windows::MapWindow
 {
     static loco_global<int32_t, 0x00523338> _cursorX2;
     static loco_global<int32_t, 0x0052333C> _cursorY2;

--- a/src/OpenLoco/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/Windows/MessageWindow.cpp
@@ -24,7 +24,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::MessageWindow
+namespace OpenLoco::Ui::Windows::MessageWindow
 {
     static loco_global<Ui::window_number, 0x00523390> _toolWindowNumber;
     static loco_global<Ui::WindowType, 0x00523392> _toolWindowType;

--- a/src/OpenLoco/Windows/News/Common.cpp
+++ b/src/OpenLoco/Windows/News/Common.cpp
@@ -11,7 +11,7 @@
 using namespace OpenLoco::Interop;
 using namespace OpenLoco::Config;
 
-namespace OpenLoco::Ui::NewsWindow
+namespace OpenLoco::Ui::Windows::NewsWindow
 {
     static void createNewsWindow(Gfx::ui_size_t windowSize, widget_t* widgets, uint8_t colour, bool isOld, uint32_t flags)
     {

--- a/src/OpenLoco/Windows/News/News.cpp
+++ b/src/OpenLoco/Windows/News/News.cpp
@@ -21,7 +21,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::NewsWindow
+namespace OpenLoco::Ui::Windows::NewsWindow
 {
     namespace News1
     {
@@ -97,7 +97,7 @@ namespace OpenLoco::Ui::NewsWindow
                             {
                                 auto vehicle = EntityManager::get<Vehicles::VehicleBase>(itemId);
 
-                                Ui::Vehicle::Main::open(vehicle);
+                                Ui::Windows::Vehicle::Main::open(vehicle);
                                 break;
                             }
 
@@ -111,7 +111,7 @@ namespace OpenLoco::Ui::NewsWindow
 
                             case newsItemSubTypes::vehicleTab:
                                 auto vehicleObj = ObjectManager::get<VehicleObject>(itemId);
-                                auto window = Ui::BuildVehicle::open(static_cast<uint32_t>(vehicleObj->type), (1 << 31));
+                                auto window = Ui::Windows::BuildVehicle::open(static_cast<uint32_t>(vehicleObj->type), (1 << 31));
                                 window->row_hover = itemId;
                                 if (vehicleObj->mode == TransportMode::rail || vehicleObj->mode == TransportMode::road)
                                 {
@@ -131,7 +131,7 @@ namespace OpenLoco::Ui::NewsWindow
 
                                 auto rowHover = window->row_hover;
 
-                                Ui::BuildVehicle::sub_4B92A5(window);
+                                Ui::Windows::BuildVehicle::sub_4B92A5(window);
 
                                 window->row_hover = rowHover;
                                 break;

--- a/src/OpenLoco/Windows/News/News.h
+++ b/src/OpenLoco/Windows/News/News.h
@@ -6,7 +6,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::NewsWindow
+namespace OpenLoco::Ui::Windows::NewsWindow
 {
 #pragma pack(push, 1)
     struct messageItemType

--- a/src/OpenLoco/Windows/News/Ticker.cpp
+++ b/src/OpenLoco/Windows/News/Ticker.cpp
@@ -7,7 +7,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::NewsWindow::Ticker
+namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
 {
     widget_t widgets[] = {
         makeWidget({ 0, 0 }, { 111, 26 }, widget_type::wt_3, 0),

--- a/src/OpenLoco/Windows/Options.cpp
+++ b/src/OpenLoco/Windows/Options.cpp
@@ -231,7 +231,7 @@ namespace OpenLoco::Ui::Windows::Options
                 case Common::Widx::tab_regional:
                 case Common::Widx::tab_controls:
                 case Common::Widx::tab_miscellaneous:
-                    Windows::Options::tabOnMouseUp(w, wi);
+                    Options::tabOnMouseUp(w, wi);
                     return;
 
                 case Widx::show_fps:
@@ -765,7 +765,7 @@ namespace OpenLoco::Ui::Windows::Options
                 case Common::Widx::tab_regional:
                 case Common::Widx::tab_controls:
                 case Common::Widx::tab_miscellaneous:
-                    Windows::Options::tabOnMouseUp(w, wi);
+                    Options::tabOnMouseUp(w, wi);
                     return;
 
                 case Widx::play_title_music:
@@ -994,7 +994,7 @@ namespace OpenLoco::Ui::Windows::Options
                 case Common::Widx::tab_regional:
                 case Common::Widx::tab_controls:
                 case Common::Widx::tab_miscellaneous:
-                    Windows::Options::tabOnMouseUp(w, wi);
+                    Options::tabOnMouseUp(w, wi);
                     return;
 
                 case Widx::music_controls_stop:
@@ -1010,7 +1010,7 @@ namespace OpenLoco::Ui::Windows::Options
                     return;
 
                 case Widx::edit_selection:
-                    Windows::MusicSelection::open();
+                    MusicSelection::open();
                     return;
             }
         }
@@ -1393,7 +1393,7 @@ namespace OpenLoco::Ui::Windows::Options
                 case Common::Widx::tab_regional:
                 case Common::Widx::tab_controls:
                 case Common::Widx::tab_miscellaneous:
-                    Windows::Options::tabOnMouseUp(w, wi);
+                    Options::tabOnMouseUp(w, wi);
                     return;
 
                 case Widx::preferred_currency_for_new_games:
@@ -1813,7 +1813,7 @@ namespace OpenLoco::Ui::Windows::Options
                 case Common::Widx::tab_regional:
                 case Common::Widx::tab_controls:
                 case Common::Widx::tab_miscellaneous:
-                    Windows::Options::tabOnMouseUp(w, wi);
+                    Options::tabOnMouseUp(w, wi);
                     return;
 
                 case Widx::customize_keys:
@@ -1852,7 +1852,7 @@ namespace OpenLoco::Ui::Windows::Options
         // 0x004C118D
         static void openKeyboardShortcuts()
         {
-            Windows::KeyboardShortcuts::open();
+            KeyboardShortcuts::open();
         }
 
         // 0x004C1195
@@ -2127,7 +2127,7 @@ namespace OpenLoco::Ui::Windows::Options
                 case Common::Widx::tab_regional:
                 case Common::Widx::tab_controls:
                 case Common::Widx::tab_miscellaneous:
-                    Windows::Options::tabOnMouseUp(w, wi);
+                    Options::tabOnMouseUp(w, wi);
                     return;
 
                 case Widx::enableCheatsToolbarButton:
@@ -2201,7 +2201,7 @@ namespace OpenLoco::Ui::Windows::Options
             strcpy(buffer, playerName);
             buffer[strlen(playerName)] = '\0';
 
-            Windows::TextInput::openTextInput(w, StringIds::preferred_owner_name, StringIds::enter_preferred_owner_name, StringIds::buffer_2039, Widx::use_preferred_owner_name, nullptr);
+            TextInput::openTextInput(w, StringIds::preferred_owner_name, StringIds::enter_preferred_owner_name, StringIds::buffer_2039, Widx::use_preferred_owner_name, nullptr);
         }
 
         // 0x004C1342
@@ -2435,7 +2435,7 @@ namespace OpenLoco::Ui::Windows::Options
     {
         Input::toolCancel(w->type, w->number);
 
-        Windows::TextInput::sub_4CE6C9(w->type, w->number);
+        TextInput::sub_4CE6C9(w->type, w->number);
         w->current_tab = wi - Common::Widx::tab_display;
         w->frame_no = 0;
         w->flags &= ~(WindowFlags::flag_16);

--- a/src/OpenLoco/Windows/Options.cpp
+++ b/src/OpenLoco/Windows/Options.cpp
@@ -21,7 +21,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::Options
+namespace OpenLoco::Ui::Windows::Options
 {
     static void tabOnMouseUp(window* w, widget_index wi);
     static void sub_4C13BE(window* w);
@@ -231,7 +231,7 @@ namespace OpenLoco::Ui::Options
                 case Common::Widx::tab_regional:
                 case Common::Widx::tab_controls:
                 case Common::Widx::tab_miscellaneous:
-                    Options::tabOnMouseUp(w, wi);
+                    Windows::Options::tabOnMouseUp(w, wi);
                     return;
 
                 case Widx::show_fps:
@@ -765,7 +765,7 @@ namespace OpenLoco::Ui::Options
                 case Common::Widx::tab_regional:
                 case Common::Widx::tab_controls:
                 case Common::Widx::tab_miscellaneous:
-                    Options::tabOnMouseUp(w, wi);
+                    Windows::Options::tabOnMouseUp(w, wi);
                     return;
 
                 case Widx::play_title_music:
@@ -994,7 +994,7 @@ namespace OpenLoco::Ui::Options
                 case Common::Widx::tab_regional:
                 case Common::Widx::tab_controls:
                 case Common::Widx::tab_miscellaneous:
-                    Options::tabOnMouseUp(w, wi);
+                    Windows::Options::tabOnMouseUp(w, wi);
                     return;
 
                 case Widx::music_controls_stop:
@@ -1393,7 +1393,7 @@ namespace OpenLoco::Ui::Options
                 case Common::Widx::tab_regional:
                 case Common::Widx::tab_controls:
                 case Common::Widx::tab_miscellaneous:
-                    Options::tabOnMouseUp(w, wi);
+                    Windows::Options::tabOnMouseUp(w, wi);
                     return;
 
                 case Widx::preferred_currency_for_new_games:
@@ -1813,7 +1813,7 @@ namespace OpenLoco::Ui::Options
                 case Common::Widx::tab_regional:
                 case Common::Widx::tab_controls:
                 case Common::Widx::tab_miscellaneous:
-                    Options::tabOnMouseUp(w, wi);
+                    Windows::Options::tabOnMouseUp(w, wi);
                     return;
 
                 case Widx::customize_keys:
@@ -1852,7 +1852,7 @@ namespace OpenLoco::Ui::Options
         // 0x004C118D
         static void openKeyboardShortcuts()
         {
-            KeyboardShortcuts::open();
+            Windows::KeyboardShortcuts::open();
         }
 
         // 0x004C1195
@@ -2127,7 +2127,7 @@ namespace OpenLoco::Ui::Options
                 case Common::Widx::tab_regional:
                 case Common::Widx::tab_controls:
                 case Common::Widx::tab_miscellaneous:
-                    Options::tabOnMouseUp(w, wi);
+                    Windows::Options::tabOnMouseUp(w, wi);
                     return;
 
                 case Widx::enableCheatsToolbarButton:

--- a/src/OpenLoco/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/Windows/PlayerInfoPanel.cpp
@@ -149,14 +149,14 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
         // If its index is bigger than the list then its the company list extra item
         if (static_cast<uint16_t>(itemIndex) >= _sortedCompanies.size())
         {
-            Windows::CompanyList::open();
+            CompanyList::open();
         }
         else
         {
             auto company = _sortedCompanies[itemIndex];
             if (!company->empty())
             {
-                Windows::CompanyWindow::open(company->id());
+                CompanyWindow::open(company->id());
             }
         }
     }
@@ -311,13 +311,13 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     // 0x4395C7
     static void companyValueMouseUp()
     {
-        Windows::CompanyWindow::openFinances(CompanyManager::getControllingId());
+        CompanyWindow::openFinances(CompanyManager::getControllingId());
     }
 
     // 0x4395D6
     static void performanceIndexMouseUp()
     {
-        Windows::CompanyList::openPerformanceIndexes();
+        CompanyList::openPerformanceIndexes();
     }
 
     // 0x004395DE

--- a/src/OpenLoco/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/Windows/PromptBrowseWindow.cpp
@@ -36,7 +36,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::PromptBrowse
+namespace OpenLoco::Ui::Windows::PromptBrowse
 {
     static fs::path getDirectory(const fs::path& path);
     static std::string getBasename(const fs::path& path);
@@ -124,7 +124,7 @@ namespace OpenLoco::Ui::PromptBrowse
     static loco_global<int16_t, 0x009D1084> _numFiles;
     static loco_global<file_entry*, 0x0050AEA4> _files;
 
-    static TextInput::InputSession inputSession;
+    static Ui::TextInput::InputSession inputSession;
 
     static std::vector<file_entry> _newFiles;
 
@@ -189,7 +189,7 @@ namespace OpenLoco::Ui::PromptBrowse
         Utility::strcpy_safe(_filter, filter);
 
         Utility::strcpy_safe(_directory, directory.make_preferred().u8string().c_str());
-        inputSession = TextInput::InputSession(baseName);
+        inputSession = Ui::TextInput::InputSession(baseName);
 
         refreshDirectoryList();
 
@@ -923,7 +923,7 @@ namespace OpenLoco::Ui::PromptBrowse
                 StringManager::formatString(&descriptionBuffer[0], StringIds::replace_existing_file_prompt, &args);
 
                 // Ask for confirmation to replace the file.
-                if (!Windows::promptOkCancel(StringIds::replace_existing_file_button))
+                if (!Windows::PromptOkCancel::open(StringIds::replace_existing_file_button))
                     return;
             }
 
@@ -975,7 +975,7 @@ namespace OpenLoco::Ui::PromptBrowse
         StringManager::formatString(&descriptionBuffer[0], StringIds::delete_file_prompt, &args);
 
         // Ask for confirmation to delete the file.
-        if (!Windows::promptOkCancel(StringIds::delete_file_button))
+        if (!Windows::PromptOkCancel::open(StringIds::delete_file_button))
             return;
 
         // Actually remove the file..!

--- a/src/OpenLoco/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/Windows/PromptBrowseWindow.cpp
@@ -177,7 +177,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         auto directory = getDirectory(path);
         auto baseName = getBasename(path);
 
-        Windows::TextInput::cancel();
+        TextInput::cancel();
 
         *_type = type;
         *_fileType = browse_file_type::saved_game;
@@ -895,7 +895,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         {
             if (filenameContainsInvalidChars())
             {
-                Windows::showError(StringIds::error_invalid_filename);
+                showError(StringIds::error_invalid_filename);
                 return;
             }
 

--- a/src/OpenLoco/Windows/PromptOkCancelWindow.cpp
+++ b/src/OpenLoco/Windows/PromptOkCancelWindow.cpp
@@ -11,7 +11,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::Windows
+namespace OpenLoco::Ui::Windows::PromptOkCancel
 {
 #pragma pack(push, 1)
     struct text_buffers_t
@@ -52,7 +52,7 @@ namespace OpenLoco::Ui::Windows
     // 0x00446F6B
     // eax: okButtonStringId
     // eax: {return}
-    bool promptOkCancel(string_id okButtonStringId)
+    bool open(string_id okButtonStringId)
     {
         text_buffers_t buffers;
         std::memcpy(buffers.title, byte_112CC04, 512);
@@ -99,7 +99,7 @@ namespace OpenLoco::Ui::Windows
     }
 
     // 0x00447125
-    void promptOkCancelInput(uint32_t charCode, uint32_t keyCode)
+    void handleInput(uint32_t charCode, uint32_t keyCode)
     {
         auto window = WindowManager::find(WindowType::confirmationPrompt);
         if (window == nullptr)

--- a/src/OpenLoco/Windows/StationList.cpp
+++ b/src/OpenLoco/Windows/StationList.cpp
@@ -692,7 +692,7 @@ namespace OpenLoco::Ui::Windows::StationList
         if (currentStation == -1)
             return;
 
-        Windows::Station::open(currentStation);
+        Station::open(currentStation);
     }
 
     // 0x004919D1

--- a/src/OpenLoco/Windows/StationWindow.cpp
+++ b/src/OpenLoco/Windows/StationWindow.cpp
@@ -234,7 +234,7 @@ namespace OpenLoco::Ui::Windows::Station
             if (self->viewports[0] == nullptr)
             {
                 auto widget = &self->widgets[widx::viewport];
-                auto tile = OpenLoco::Map::Pos3({ station->x, station->y, station->z });
+                auto tile = Map::Pos3({ station->x, station->y, station->z });
                 auto origin = Gfx::point_t(widget->left + self->x + 1, widget->top + self->y + 1);
                 auto size = Gfx::ui_size_t(widget->width() - 2, widget->height() - 2);
                 ViewportManager::create(self, 0, origin, size, self->saved_view.zoomLevel, tile);

--- a/src/OpenLoco/Windows/TerraForm.cpp
+++ b/src/OpenLoco/Windows/TerraForm.cpp
@@ -459,7 +459,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     updateTreeColours(self);
 
                     int32_t pan = (self->width >> 1) + self->x;
-                    OpenLoco::Map::Pos3 loc = { xPos, yPos, static_cast<int16_t>(pan) };
+                    Map::Pos3 loc = { xPos, yPos, static_cast<int16_t>(pan) };
                     Audio::playSound(Audio::SoundId::clickDown, loc, pan);
                     self->saved_view.mapX = -16;
                     _lastTreeCost = 0x80000000;
@@ -1844,7 +1844,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     _lastSelectedWall = static_cast<uint8_t>(rowInfo);
 
                     int32_t pan = (self->width >> 1) + self->x;
-                    OpenLoco::Map::Pos3 loc = { xPos, yPos, static_cast<int16_t>(pan) };
+                    Map::Pos3 loc = { xPos, yPos, static_cast<int16_t>(pan) };
                     Audio::playSound(Audio::SoundId::clickDown, loc, pan);
                     self->saved_view.mapX = -16;
                     self->invalidate();

--- a/src/OpenLoco/Windows/TileInspector.cpp
+++ b/src/OpenLoco/Windows/TileInspector.cpp
@@ -139,13 +139,13 @@ namespace OpenLoco::Ui::Windows::TileInspector
         // Coord X/Y values
         {
             FormatArguments args = {};
-            args.push<int16_t>(_currentPosition.x / OpenLoco::Map::tile_size);
+            args.push<int16_t>(_currentPosition.x / Map::tile_size);
             auto& widget = self->widgets[widx::xPos];
             Gfx::drawString_494B3F(*context, self->x + widget.left + 2, self->y + widget.top + 1, Colour::black, StringIds::tile_inspector_coord, &args);
         }
         {
             FormatArguments args = {};
-            args.push<int16_t>(_currentPosition.y / OpenLoco::Map::tile_size);
+            args.push<int16_t>(_currentPosition.y / Map::tile_size);
             auto& widget = self->widgets[widx::yPos];
             Gfx::drawString_494B3F(*context, self->x + widget.left + 2, self->y + widget.top + 1, Colour::black, StringIds::tile_inspector_coord, &args);
         }
@@ -425,22 +425,22 @@ namespace OpenLoco::Ui::Windows::TileInspector
                 break;
 
             case widx::xPosDecrease:
-                _currentPosition.x = std::clamp<coord_t>(_currentPosition.x - OpenLoco::Map::tile_size, 1, OpenLoco::Map::map_width);
+                _currentPosition.x = std::clamp<coord_t>(_currentPosition.x - Map::tile_size, 1, Map::map_width);
                 self->invalidate();
                 break;
 
             case widx::xPosIncrease:
-                _currentPosition.x = std::clamp<coord_t>(_currentPosition.x + OpenLoco::Map::tile_size, 1, OpenLoco::Map::map_width);
+                _currentPosition.x = std::clamp<coord_t>(_currentPosition.x + Map::tile_size, 1, Map::map_width);
                 self->invalidate();
                 break;
 
             case widx::yPosDecrease:
-                _currentPosition.y = std::clamp<coord_t>(_currentPosition.y - OpenLoco::Map::tile_size, 1, OpenLoco::Map::map_height);
+                _currentPosition.y = std::clamp<coord_t>(_currentPosition.y - Map::tile_size, 1, Map::map_height);
                 self->invalidate();
                 break;
 
             case widx::yPosIncrease:
-                _currentPosition.y = std::clamp<coord_t>(_currentPosition.y + OpenLoco::Map::tile_size, 1, OpenLoco::Map::map_height);
+                _currentPosition.y = std::clamp<coord_t>(_currentPosition.y + Map::tile_size, 1, Map::map_height);
                 self->invalidate();
                 break;
         }

--- a/src/OpenLoco/Windows/TimePanel.cpp
+++ b/src/OpenLoco/Windows/TimePanel.cpp
@@ -209,7 +209,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
         switch (widgetIndex)
         {
             case Widx::date_btn:
-                Windows::MessageWindow::open();
+                MessageWindow::open();
                 break;
             case Widx::pause_btn:
                 togglePaused();

--- a/src/OpenLoco/Windows/TimePanel.cpp
+++ b/src/OpenLoco/Windows/TimePanel.cpp
@@ -18,7 +18,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::TimePanel
+namespace OpenLoco::Ui::Windows::TimePanel
 {
     static const Gfx::ui_size_t window_size = { 140, 27 };
 
@@ -209,7 +209,7 @@ namespace OpenLoco::Ui::TimePanel
         switch (widgetIndex)
         {
             case Widx::date_btn:
-                MessageWindow::open();
+                Windows::MessageWindow::open();
                 break;
             case Widx::pause_btn:
                 togglePaused();
@@ -260,11 +260,11 @@ namespace OpenLoco::Ui::TimePanel
                 {
                     auto opponent = CompanyManager::getOpponent();
                     _common_format_args[4] = opponent->owner_name;
-                    Ui::Windows::TextInput::openTextInput(self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, widgetIndex, &*_common_format_args);
+                    TextInput::openTextInput(self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, widgetIndex, &*_common_format_args);
                     break;
                 }
                 case 1:
-                    Windows::Map::open();
+                    MapWindow::open();
                     break;
             }
         }
@@ -273,7 +273,7 @@ namespace OpenLoco::Ui::TimePanel
             switch (itemIndex)
             {
                 case 0:
-                    Windows::Map::open();
+                    MapWindow::open();
                     break;
             }
         }

--- a/src/OpenLoco/Windows/TitleExit.cpp
+++ b/src/OpenLoco/Windows/TitleExit.cpp
@@ -10,7 +10,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::Windows
+namespace OpenLoco::Ui::Windows::TitleExit
 {
     static const Gfx::ui_size_t window_size = { 40, 28 };
 
@@ -33,7 +33,7 @@ namespace OpenLoco::Ui::Windows
     static void prepareDraw(Ui::window* self);
     static void draw(Ui::window* window, Gfx::drawpixelinfo_t* dpi);
 
-    window* openTitleExit()
+    window* open()
     {
         _events.on_mouse_up = onMouseUp;
         _events.prepare_draw = prepareDraw;

--- a/src/OpenLoco/Windows/TitleLogo.cpp
+++ b/src/OpenLoco/Windows/TitleLogo.cpp
@@ -63,7 +63,7 @@ namespace OpenLoco::Ui::Windows::TitleLogo
         switch (widgetIndex)
         {
             case Widx::logo:
-                Windows::About::open();
+                About::open();
                 break;
         }
     }

--- a/src/OpenLoco/Windows/TitleLogo.cpp
+++ b/src/OpenLoco/Windows/TitleLogo.cpp
@@ -6,7 +6,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::Windows
+namespace OpenLoco::Ui::Windows::TitleLogo
 {
     static const Gfx::ui_size_t window_size = { 298, 170 };
 
@@ -28,7 +28,7 @@ namespace OpenLoco::Ui::Windows
     static void onMouseUp(window* window, widget_index widgetIndex);
     static void draw(Ui::window* window, Gfx::drawpixelinfo_t* dpi);
 
-    Ui::window* openTitleLogo()
+    window* open()
     {
         _events.on_mouse_up = onMouseUp;
         _events.draw = draw;
@@ -63,7 +63,7 @@ namespace OpenLoco::Ui::Windows
         switch (widgetIndex)
         {
             case Widx::logo:
-                About::open();
+                Windows::About::open();
                 break;
         }
     }

--- a/src/OpenLoco/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/Windows/TitleMenu.cpp
@@ -21,7 +21,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::Windows
+namespace OpenLoco::Ui::Windows::TitleMenu
 {
     static const uint8_t btn_main_size = 74;
     static const uint8_t btn_sub_height = 18;
@@ -144,7 +144,7 @@ namespace OpenLoco::Ui::Windows
 
     // static loco_global<window_event_list[1], 0x004f9ec8> _events;
 
-    Ui::window* openTitleMenu()
+    window* open()
     {
         _events.on_mouse_up = onMouseUp;
         _events.on_mouse_down = onMouseDown;

--- a/src/OpenLoco/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/Windows/TitleMenu.cpp
@@ -379,7 +379,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     // 0x0043CB9F
     void editorInit()
     {
-        Windows::Main::open();
+        Main::open();
 
         addr<0x00F2533F, int8_t>() = 0; // grid lines
         addr<0x0112C2e1, int8_t>() = 0;

--- a/src/OpenLoco/Windows/TitleOptions.cpp
+++ b/src/OpenLoco/Windows/TitleOptions.cpp
@@ -10,7 +10,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::TitleOptions
+namespace OpenLoco::Ui::Windows::TitleOptions
 {
     static const Gfx::ui_size_t window_size = { 60, 15 };
 
@@ -77,7 +77,7 @@ namespace OpenLoco::Ui::TitleOptions
         switch (widgetIndex)
         {
             case Widx::options_button:
-                Ui::Options::open();
+                Ui::Windows::Options::open();
                 break;
         }
     }

--- a/src/OpenLoco/Windows/TitleVersion.cpp
+++ b/src/OpenLoco/Windows/TitleVersion.cpp
@@ -7,7 +7,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::Windows
+namespace OpenLoco::Ui::Windows::TitleVersion
 {
     static widget_t widgets[] = {
         { widget_type::end, 0, 0, 0, 0, 0, { 0 }, 0 }
@@ -17,7 +17,7 @@ namespace OpenLoco::Ui::Windows
 
     static void draw(Ui::window* window, Gfx::drawpixelinfo_t* dpi);
 
-    window* openTitleVersion()
+    window* open()
     {
         auto width = 512;
         auto height = 16;

--- a/src/OpenLoco/Windows/ToolTip.cpp
+++ b/src/OpenLoco/Windows/ToolTip.cpp
@@ -13,7 +13,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::ToolTip
+namespace OpenLoco::Ui::Windows::ToolTip
 {
     static loco_global<bool, 0x0052336E> _52336E;
 
@@ -50,13 +50,13 @@ namespace OpenLoco::Ui::ToolTip
         registerHook(
             0x004C906B,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                Ui::ToolTip::open((Ui::window*)regs.esi, regs.edx, regs.ax, regs.bx);
+                Ui::Windows::ToolTip::open((Ui::window*)regs.esi, regs.edx, regs.ax, regs.bx);
                 return 0;
             });
         registerHook(
             0x004C9216,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                Ui::ToolTip::update((Ui::window*)regs.esi, regs.edx, regs.di, regs.ax, regs.bx);
+                Ui::Windows::ToolTip::update((Ui::window*)regs.esi, regs.edx, regs.di, regs.ax, regs.bx);
                 return 0;
             });
     }

--- a/src/OpenLoco/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/Windows/ToolbarTop.cpp
@@ -194,11 +194,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                 break;
 
             case 3:
-                About::open();
+                Windows::About::open();
                 break;
 
             case 4:
-                Options::open();
+                Windows::Options::open();
                 break;
 
             case 5:
@@ -267,7 +267,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             }
 
             case 3:
-                Options::openMusicSettings();
+                Windows::Options::openMusicSettings();
                 break;
         }
     }
@@ -501,7 +501,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         itemIndex = menu_options[itemIndex];
         last_build_vehicles_option = itemIndex;
 
-        BuildVehicle::open(itemIndex, 1 << 31);
+        Windows::BuildVehicle::open(itemIndex, 1 << 31);
     }
 
     // 0x0043ABCB

--- a/src/OpenLoco/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/Windows/ToolbarTop.cpp
@@ -194,11 +194,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                 break;
 
             case 3:
-                Windows::About::open();
+                About::open();
                 break;
 
             case 4:
-                Windows::Options::open();
+                Options::open();
                 break;
 
             case 5:
@@ -267,7 +267,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             }
 
             case 3:
-                Windows::Options::openMusicSettings();
+                Options::openMusicSettings();
                 break;
         }
     }
@@ -501,7 +501,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         itemIndex = menu_options[itemIndex];
         last_build_vehicles_option = itemIndex;
 
-        Windows::BuildVehicle::open(itemIndex, 1 << 31);
+        BuildVehicle::open(itemIndex, 1 << 31);
     }
 
     // 0x0043ABCB
@@ -565,7 +565,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         auto vehicleType = VehicleType(menu_options[itemIndex]);
         last_vehicles_option = vehicleType;
 
-        Windows::VehicleList::open(CompanyManager::getControllingId(), vehicleType);
+        VehicleList::open(CompanyManager::getControllingId(), vehicleType);
     }
 
     // 0x0043A4E9
@@ -596,7 +596,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         if (itemIndex > 4)
             return;
 
-        Windows::StationList::open(CompanyManager::getControllingId(), itemIndex);
+        StationList::open(CompanyManager::getControllingId(), itemIndex);
     }
 
     // 0x0043A071

--- a/src/OpenLoco/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/Windows/ToolbarTopAlt.cpp
@@ -141,11 +141,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
                 break;
 
             case 3:
-                Windows::About::open();
+                About::open();
                 break;
 
             case 4:
-                Windows::Options::open();
+                Options::open();
                 break;
 
             case 5:

--- a/src/OpenLoco/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/Windows/ToolbarTopAlt.cpp
@@ -141,11 +141,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
                 break;
 
             case 3:
-                About::open();
+                Windows::About::open();
                 break;
 
             case 4:
-                Options::open();
+                Windows::Options::open();
                 break;
 
             case 5:

--- a/src/OpenLoco/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/Windows/ToolbarTopCommon.cpp
@@ -269,7 +269,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
         }
         else if (itemIndex == 2)
         {
-            Windows::Map::open();
+            Windows::MapWindow::open();
         }
     }
 
@@ -287,14 +287,14 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
             window->viewportRotateLeft();
             TownManager::updateLabels();
             StationManager::updateLabels();
-            Windows::Map::centerOnViewPoint();
+            Windows::MapWindow::centerOnViewPoint();
         }
         else if (itemIndex == 0)
         {
             window->viewportRotateRight();
             TownManager::updateLabels();
             StationManager::updateLabels();
-            Windows::Map::centerOnViewPoint();
+            Windows::MapWindow::centerOnViewPoint();
         }
     }
 

--- a/src/OpenLoco/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/Windows/ToolbarTopCommon.cpp
@@ -269,7 +269,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
         }
         else if (itemIndex == 2)
         {
-            Windows::MapWindow::open();
+            MapWindow::open();
         }
     }
 
@@ -287,14 +287,14 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
             window->viewportRotateLeft();
             TownManager::updateLabels();
             StationManager::updateLabels();
-            Windows::MapWindow::centerOnViewPoint();
+            MapWindow::centerOnViewPoint();
         }
         else if (itemIndex == 0)
         {
             window->viewportRotateRight();
             TownManager::updateLabels();
             StationManager::updateLabels();
-            Windows::MapWindow::centerOnViewPoint();
+            MapWindow::centerOnViewPoint();
         }
     }
 
@@ -336,23 +336,23 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
         switch (itemIndex)
         {
             case 0:
-                Windows::Terraform::openClearArea();
+                Terraform::openClearArea();
                 break;
 
             case 1:
-                Windows::Terraform::openAdjustLand();
+                Terraform::openAdjustLand();
                 break;
 
             case 2:
-                Windows::Terraform::openAdjustWater();
+                Terraform::openAdjustWater();
                 break;
 
             case 3:
-                Windows::Terraform::openPlantTrees();
+                Terraform::openPlantTrees();
                 break;
 
             case 4:
-                Windows::Terraform::openBuildWalls();
+                Terraform::openBuildWalls();
                 break;
         }
     }
@@ -378,12 +378,12 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
 
         if (itemIndex == 0)
         {
-            Windows::TownList::open();
+            TownList::open();
             last_town_option = 0;
         }
         else if (itemIndex == 1)
         {
-            Windows::IndustryList::open();
+            IndustryList::open();
             last_town_option = 1;
         }
     }

--- a/src/OpenLoco/Windows/TownList.cpp
+++ b/src/OpenLoco/Windows/TownList.cpp
@@ -264,7 +264,7 @@ namespace OpenLoco::Ui::Windows::TownList
             if (currentTown == -1)
                 return;
 
-            Windows::Town::open(currentTown);
+            Town::open(currentTown);
         }
 
         // 0x0049A532

--- a/src/OpenLoco/Windows/TownList.cpp
+++ b/src/OpenLoco/Windows/TownList.cpp
@@ -1143,7 +1143,7 @@ namespace OpenLoco::Ui::Windows::TownList
                     updateBuildingColours(self);
 
                     int32_t pan = (self->width >> 1) + self->x;
-                    OpenLoco::Map::Pos3 loc = { xPos, yPos, static_cast<int16_t>(pan) };
+                    Map::Pos3 loc = { xPos, yPos, static_cast<int16_t>(pan) };
 
                     Audio::playSound(Audio::SoundId::clickDown, loc, pan);
                     self->saved_view.mapX = -16;

--- a/src/OpenLoco/Windows/TownWindow.cpp
+++ b/src/OpenLoco/Windows/TownWindow.cpp
@@ -207,7 +207,7 @@ namespace OpenLoco::Ui::Windows::Town
 
                     // Play construction sound at the town centre.
                     int16_t tileZ = TileManager::getHeight({ town->x, town->y }).landHeight;
-                    Audio::playSound(Audio::SoundId::construct, OpenLoco::Map::Pos3(town->x + 16, town->y + 16, tileZ));
+                    Audio::playSound(Audio::SoundId::construct, Map::Pos3(town->x + 16, town->y + 16, tileZ));
                     break;
                 }
 
@@ -299,7 +299,7 @@ namespace OpenLoco::Ui::Windows::Town
             if (self->viewports[0] == nullptr)
             {
                 auto widget = &self->widgets[widx::viewport];
-                auto tile = OpenLoco::Map::Pos3({ town->x, town->y, tileZ });
+                auto tile = Map::Pos3({ town->x, town->y, tileZ });
                 auto origin = Gfx::point_t(widget->left + self->x + 1, widget->top + self->y + 1);
                 auto size = Gfx::ui_size_t(widget->width() - 2, widget->height() - 2);
                 ViewportManager::create(self, 0, origin, size, self->saved_view.zoomLevel, tile);

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -30,7 +30,7 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::Ui::Vehicle
+namespace OpenLoco::Ui::Windows::Vehicle
 {
     namespace Common
     {
@@ -982,7 +982,7 @@ namespace OpenLoco::Ui::Vehicle
                 auto* newVehicle = EntityManager::get<Vehicles::VehicleBase>(_113642A);
                 if (newVehicle != nullptr)
                 {
-                    OpenLoco::Ui::Vehicle::Details::open(newVehicle);
+                    OpenLoco::Ui::Windows::Vehicle::Details::open(newVehicle);
                 }
             }
         }
@@ -1059,7 +1059,7 @@ namespace OpenLoco::Ui::Vehicle
 
             if (itemIndex <= 0)
             {
-                BuildVehicle::open(self->number, 0);
+                Windows::BuildVehicle::open(self->number, 0);
             }
             else if (itemIndex == 1)
             {
@@ -2677,7 +2677,7 @@ namespace OpenLoco::Ui::Vehicle
                         break;
                     auto height = trackElement->baseZ() * 4;
                     auto trackId = trackElement->trackId();
-                    const auto& trackPiece = OpenLoco::Map::TrackData::getTrackPiece(trackId);
+                    const auto& trackPiece = Map::TrackData::getTrackPiece(trackId);
                     const auto& trackPart = trackPiece[trackElement->sequenceIndex()];
 
                     auto offsetToFirstTile = Map::rotate2dCoordinate({ trackPart.x, trackPart.y }, trackElement->unkDirection());
@@ -2725,7 +2725,7 @@ namespace OpenLoco::Ui::Vehicle
                         break;
                     auto height = roadElement->baseZ() * 4;
                     auto roadId = roadElement->roadId();
-                    const auto& roadPiece = OpenLoco::Map::TrackData::getRoadPiece(roadId);
+                    const auto& roadPiece = Map::TrackData::getRoadPiece(roadId);
                     const auto& roadPart = roadPiece[roadElement->sequenceIndex()];
 
                     auto offsetToFirstTile = Map::rotate2dCoordinate({ roadPart.x, roadPart.y }, roadElement->unkDirection());

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -1059,7 +1059,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             if (itemIndex <= 0)
             {
-                Windows::BuildVehicle::open(self->number, 0);
+                BuildVehicle::open(self->number, 0);
             }
             else if (itemIndex == 1)
             {
@@ -1170,7 +1170,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             {
                 if (c.front == car->front)
                 {
-                    Windows::DragVehiclePart::open(c);
+                    DragVehiclePart::open(c);
                     break;
                 }
             }
@@ -3339,7 +3339,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 args.push(StringIds::getVehicleType(vehicle->vehicleType)); // 0
                 args.skip(6);
                 args.push(StringIds::getVehicleType(vehicle->vehicleType)); // 8
-                Windows::TextInput::openTextInput(self, StringIds::title_name_vehicle, StringIds::prompt_enter_new_vehicle_name, vehicle->name, widgetIndex, &vehicle->ordinalNumber);
+                TextInput::openTextInput(self, StringIds::title_name_vehicle, StringIds::prompt_enter_new_vehicle_name, vehicle->name, widgetIndex, &vehicle->ordinalNumber);
             }
         }
 
@@ -3347,7 +3347,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void switchTab(window* self, widget_index widgetIndex)
         {
             Input::toolCancel(self->type, self->number);
-            Windows::TextInput::sub_4CE6C9(self->type, self->number);
+            TextInput::sub_4CE6C9(self->type, self->number);
 
             self->current_tab = widgetIndex - Common::widx::tabMain;
             self->frame_no = 0;

--- a/src/OpenLoco/Windows/VehicleList.cpp
+++ b/src/OpenLoco/Windows/VehicleList.cpp
@@ -811,7 +811,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
         self->widgets[Widx::scrollview].tooltip = tooltipId;
         self->var_85C = self->row_hover;
-        Ui::ToolTip::closeAndReset();
+        Ui::Windows::ToolTip::closeAndReset();
 
         if (self->row_hover == -1)
             return;
@@ -859,9 +859,9 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
         auto head = EntityManager::get<VehicleHead>(currentVehicleId);
         if (head->isPlaced())
-            Ui::Vehicle::Main::open(head);
+            Ui::Windows::Vehicle::Main::open(head);
         else
-            Ui::Vehicle::Details::open(head);
+            Ui::Windows::Vehicle::Details::open(head);
     }
 
     // 0x004C2820

--- a/src/OpenLoco/openloco.vcxproj
+++ b/src/OpenLoco/openloco.vcxproj
@@ -161,8 +161,8 @@
     <ClCompile Include="Windows\LandscapeGeneration.cpp" />
     <ClCompile Include="Windows\LandscapeGenerationConfirm.cpp" />
     <ClCompile Include="Windows\Main.cpp" />
-    <ClCompile Include="Windows\Map.cpp" />
     <ClCompile Include="Windows\MapToolTip.cpp" />
+    <ClCompile Include="Windows\MapWindow.cpp" />
     <ClCompile Include="Windows\MessageWindow.cpp" />
     <ClCompile Include="Windows\MusicSelection.cpp" />
     <ClCompile Include="Windows\News\Common.cpp" />


### PR DESCRIPTION
Part of the in-game windows were defined in the OpenLoco::Ui namespace. This PR moves these windows into the OpenLoco::Ui::Windows.

As a bonus:
- The window declarations in WindowManager.h are now ordered alphabetically
- The Map window is now known as MapWindow to stop having to disambiguate it from OpenLoco::Map

In a future PR, I aim to move some of the Ui files around, and remove some unnecessary disambiguation there as well.