### PR TITLE
CMake: Remove reference to non-existing lib directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,12 +163,9 @@ set(DEBUG_LEVEL 0 CACHE STRING "Select debug level for compilation. Use value in
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DDEBUG=${DEBUG_LEVEL}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEBUG=${DEBUG_LEVEL}")
 
-# include lib
-include_directories("lib/")
 # add source files
 file(GLOB_RECURSE OLOCO_SOURCES "src/*.cpp")
 file(GLOB_RECURSE OLOCO_HEADERS "src/*.h" "src/*.hpp")
-
 
 if (APPLE)
     file(GLOB_RECURSE OLOCO_MM_SOURCES "src/*.mm")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,8 +322,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set_target_properties(${PROJECT}-headers-check PROPERTIES LINKER_LANGUAGE CXX)
 	set_source_files_properties(${OLOCO_HEADERS} PROPERTIES LANGUAGE CXX)
     add_definitions("-x c++ -Wno-pragma-once-outside-header -Wno-unused-const-variable")
-	get_target_property(OPENLOCO_INCLUDE_DIRS ${PROJECT} INCLUDE_DIRECTORIES)
-	set_target_properties(${PROJECT}-headers-check PROPERTIES INCLUDE_DIRECTORIES "${OPENLOCO_INCLUDE_DIRS}")
 else ()
     # Dummy target to ease invocation
     add_custom_target(${PROJECT}-headers-check)


### PR DESCRIPTION
This is probably a leftover from our early macOS toolchain, since replaced by vcpkg.