### PR TITLE
Fix dropdown assertions

### DIFF
--- a/src/OpenLoco/Ui/Dropdown.cpp
+++ b/src/OpenLoco/Ui/Dropdown.cpp
@@ -122,21 +122,24 @@ namespace OpenLoco::Ui::Dropdown
 
     void setItemDisabled(size_t index)
     {
-        assert(index < std::numeric_limits<uint8_t>::max());
+        // Ensure that a valid item index is passed, or -1 to disable.
+        assert(index < std::numeric_limits<uint8_t>::max() || index == std::numeric_limits<size_t>::max());
 
         _dropdownDisabledItems |= (1U << static_cast<uint8_t>(index));
     }
 
     void setHighlightedItem(size_t index)
     {
-        assert(index < std::numeric_limits<uint8_t>::max());
+        // Ensure that a valid item index is passed, or -1 to disable.
+        assert(index < std::numeric_limits<uint8_t>::max() || index == std::numeric_limits<size_t>::max());
 
         _dropdownHighlightedIndex = static_cast<uint8_t>(index);
     }
 
     void setItemSelected(size_t index)
     {
-        assert(index < std::numeric_limits<uint8_t>::max());
+        // Ensure that a valid item index is passed, or -1 to disable.
+        assert(index < std::numeric_limits<uint8_t>::max() || index == std::numeric_limits<size_t>::max());
 
         _dropdownSelection |= (1U << static_cast<uint8_t>(index));
     }

--- a/src/OpenLoco/Ui/Dropdown.cpp
+++ b/src/OpenLoco/Ui/Dropdown.cpp
@@ -122,8 +122,7 @@ namespace OpenLoco::Ui::Dropdown
 
     void setItemDisabled(size_t index)
     {
-        // Ensure that a valid item index is passed, or -1 to disable.
-        assert(index < std::numeric_limits<uint8_t>::max() || index == std::numeric_limits<size_t>::max());
+        assert(index < std::numeric_limits<uint8_t>::max());
 
         _dropdownDisabledItems |= (1U << static_cast<uint8_t>(index));
     }
@@ -138,8 +137,7 @@ namespace OpenLoco::Ui::Dropdown
 
     void setItemSelected(size_t index)
     {
-        // Ensure that a valid item index is passed, or -1 to disable.
-        assert(index < std::numeric_limits<uint8_t>::max() || index == std::numeric_limits<size_t>::max());
+        assert(index < std::numeric_limits<uint8_t>::max());
 
         _dropdownSelection |= (1U << static_cast<uint8_t>(index));
     }


### PR DESCRIPTION
Opening a company selection dropdown, sets the highlighted item to -1. The `size_t` type is unsigned, so that would be interpreted as bigger than the uint8_t max.