### PR TITLE
Add missing includes for gcc 11.1 compilation

### DIFF
--- a/src/OpenLoco/Config.h
+++ b/src/OpenLoco/Config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 

--- a/src/OpenLoco/TrackData.h
+++ b/src/OpenLoco/TrackData.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Types.hpp"
+#include <cstddef>
 #include <vector>
 
 namespace OpenLoco::Map::TrackData


### PR DESCRIPTION
This allows compilation to finish when using gcc 11.1. Unfortunately, the resulting builds still segfault:
```
* thread #1, name = 'openloco', stop reason = signal SIGSEGV: invalid address (fault address: 0x0)
  * frame #0: 0xf76fe200 libX11.so.6`_XSend + 368
    frame #1: 0xf76fe68a libX11.so.6`_XFlush + 42
    frame #2: 0xf76dfee1 libX11.so.6`XFlush + 49
    frame #3: 0xf7ee6092 libSDL2-2.0.so.0`___lldb_unnamed_symbol2437$$libSDL2-2.0.so.0 + 178
    frame #4: 0x011fd27a openloco`OpenLoco::Ui::setCursor(OpenLoco::Ui::CursorId) + 160
    frame #5: 0x011acef0 openloco`OpenLoco::Input::processMouseOver(short, short) + 1101
    frame #6: 0x011ff157 openloco`OpenLoco::Ui::handleInput() + 819
    frame #7: 0x011d8ac0 openloco`OpenLoco::sub_431695(unsigned short) + 125
    frame #8: 0x011b4e93 openloco`OpenLoco::Interop::registerHooks()::'lambda'(OpenLoco::Interop::registers&)::operator()(OpenLoco::Interop::registers&) const + 97
    frame #9: 0x011b4efa openloco`OpenLoco::Interop::registerHooks()::'lambda'(OpenLoco::Interop::registers&)::_FUN(OpenLoco::Interop::registers&) + 29
```