### PR TITLE
Fix memcpy size in Rename{Town,Industry}

### DIFF
--- a/src/OpenLoco/GameCommands/RenameIndustry.cpp
+++ b/src/OpenLoco/GameCommands/RenameIndustry.cpp
@@ -53,7 +53,7 @@ namespace OpenLoco::GameCommands
             return 0;
 
         char renameStringBuffer[37] = "";
-        memcpy(renameStringBuffer, renameBuffer, sizeof(renameStringBuffer));
+        memcpy(renameStringBuffer, renameBuffer, sizeof(renameBuffer));
         renameStringBuffer[36] = '\0';
 
         // Ensure the new name isn't empty.

--- a/src/OpenLoco/GameCommands/RenameTown.cpp
+++ b/src/OpenLoco/GameCommands/RenameTown.cpp
@@ -54,7 +54,7 @@ namespace OpenLoco::GameCommands
             return 0;
 
         char renameStringBuffer[37] = "";
-        memcpy(renameStringBuffer, renameBuffer, sizeof(renameStringBuffer));
+        memcpy(renameStringBuffer, renameBuffer, sizeof(renameBuffer));
         renameStringBuffer[36] = '\0';
 
         // Ensure the new name isn't empty.


### PR DESCRIPTION
This would cause reading more bytes than present in source buffer