### PR TITLE
Clarify availability of release builds and need for compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Regardless of platform, the following libraries/dependencies are required:
 2. Open a new Developer Command Prompt for VS 2019, then navigate to the repository (e.g. `cd C:\GitHub\OpenLoco`).
 3. Run `msbuild openloco.sln /t:restore;build`
 4. Run `mklink /D bin\data ..\data` or `xcopy data bin\data /EIY`
-5. Run the game, `bin\openloco`
+5. Run `mklink openloco.exe bin\` or `copy openloco.exe bin\`
+6. Run the game, `bin\openloco`
 
 ### Linux / macOS:
 The standard CMake build procedure is to install the required libraries, then:

--- a/README.md
+++ b/README.md
@@ -40,17 +40,30 @@ Recent implementation efforts have focussed on re-implementing the UI, so that t
 
 # 2 Downloading the game (pre-built)
 
-OpenLoco requires original files of Chris Sawyer's Locomotion to play. It can be bought at either [Steam](https://store.steampowered.com/app/356430/) or [GOG.com](https://www.gog.com/game/chris_sawyers_locomotion).
+The latest releases can be [downloaded from GitHub](https://github.com/OpenLoco/OpenLoco/releases). Releases are currently provided for Windows and macOS (32-bit only).
+For Linux and BSD distributions, we currently do not provide any builds. Please refer to the next section to compile the game manually.
 
-The latest release can be found on [GitHub](https://github.com/OpenLoco/OpenLoco/releases).
+Please note that OpenLoco requires the asset files of the original Chris Sawyer's Locomotion to play the game.
+It can be bought at e.g. [Steam](https://store.steampowered.com/app/356430/) or [GOG.com](https://www.gog.com/game/chris_sawyers_locomotion).
 
 ---
 
-# 3 Building the game
+# 3 Contributing
 
-## 3.1 Building prerequisites
+We warmly welcome any contributions to the project, e.g. for C++ code (game implementation, bug fixes, features) or localisation (new translations).
+Please have a look at our [issues for newcomers](https://github.com/OpenLoco/OpenLoco/labels/good%20first%20issue).
 
-OpenLoco requires original files of Chris Sawyer's Locomotion to play. It can be bought at either [Steam](https://store.steampowered.com/app/356430/) or [GOG.com](https://www.gog.com/game/chris_sawyers_locomotion).
+---
+
+# 4 Compiling the game
+
+If you would like to contribute code to OpenLoco, please follow the instructions below to get started compiling the game.
+Alternatively, we have platform-specific guides for [Ubuntu](https://github.com/OpenLoco/OpenLoco/wiki/Building-on-Ubuntu) and [macOS](https://github.com/OpenLoco/OpenLoco/wiki/Building-on-macOS).
+
+If you just want to play the game, you can just [download the latest release](https://github.com/OpenLoco/OpenLoco/releases) from GitHub.
+Releases are currently provided for Windows and macOS (32-bit only).
+
+## 4.1 Building prerequisites
 
 Regardless of platform, the following libraries/dependencies are required:
 - [libpng](http://www.libpng.org/pub/png/libpng.html)
@@ -72,7 +85,7 @@ Regardless of platform, the following libraries/dependencies are required:
 
 ---
 
-## 3.2 Compiling and running
+## 4.2 Compiling and running
 ### Windows:
 1. Check out the repository. This can be done using [GitHub Desktop](https://desktop.github.com) or [other tools](https://help.github.com/articles/which-remote-url-should-i-use).
 2. Open a new Developer Command Prompt for VS 2019, then navigate to the repository (e.g. `cd C:\GitHub\OpenLoco`).
@@ -97,7 +110,7 @@ cp -r ../data ./data
 ```
 ---
 
-# 4 Licence
+# 5 Licence
 **OpenLoco** is licensed under the MIT License.
 
 ---


### PR DESCRIPTION
From time to time, we get users on Discord asking how to compile the game when they just want to play it. This PR aims to clarify that binary releases are indeed available.

I am wondering whether we should just move compilation instructions to the wiki entirely. However, I recall there was a bit of hesitance to do so in the past. I have left the instructions as-is, for now.