### PR TITLE
Remove duplicated tab widget enablement

### DIFF
--- a/src/OpenLoco/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/Windows/ScenarioOptions.cpp
@@ -1179,7 +1179,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             }
 
             // Activate the current tab.
-            self->activated_widgets &= ~((1 << widx::tab_challenge) | (1 << widx::tab_companies) | (1 << widx::tab_challenge) | (1 << widx::tab_scenario));
+            self->activated_widgets &= ~((1 << widx::tab_challenge) | (1 << widx::tab_companies) | (1 << widx::tab_finances) | (1 << widx::tab_scenario));
             widx widgetIndex = tabInformationByTabOffset[self->current_tab].widgetIndex;
             self->activated_widgets |= (1ULL << widgetIndex);
 


### PR DESCRIPTION
I'm not actually sure if this is the correct solution - or if it should perhaps by changed to `tab_finances`?

https://github.com/OpenLoco/OpenLoco/blob/121d0be7b8d6263f3464e570122c0e578a59a3e6/src/OpenLoco/Windows/ScenarioOptions.cpp#L59-L62