### PR TITLE
Fix access to embedded object name

### DIFF
--- a/src/OpenLoco/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/Objects/ObjectManager.cpp
@@ -737,13 +737,15 @@ namespace OpenLoco::ObjectManager
         // Prepare progress bar
         char caption[512];
         auto* str = StringManager::formatString(caption, sizeof(caption), StringIds::installing_new_data);
-        strcat(str, objectHeader.name);
+        // Convert object name to string so it is properly terminated
+        std::string objectname(objectHeader.getName());
+        strcat(str, objectname.c_str());
         Ui::ProgressBar::begin(caption);
         Ui::ProgressBar::setProgress(50);
         miniMessageLoop();
 
         // Get new file path
-        std::string filename(objectHeader.getName());
+        std::string filename = objectname;
         sanatiseObjectFilename(filename);
         auto objPath = findObjectPath(filename);
 


### PR DESCRIPTION
Object name is not truly a string, but an array of 8 chars that are not expected to be null-terminated

https://github.com/OpenLoco/OpenLoco/blob/7bdc32d8b2c59fea9d9d37498752bf6144ff06f2/src/OpenLoco/Objects/ObjectManager.h#L105