### PR TITLE
Close #1030: Guard exploratory tile loops

### DIFF
--- a/src/OpenLoco/Map/Map.hpp
+++ b/src/OpenLoco/Map/Map.hpp
@@ -38,12 +38,12 @@ namespace OpenLoco::Map
     }
 
     template<typename TType>
-    constexpr bool validCoords(TType coords)
+    constexpr bool validCoords(const TType& coords)
     {
         return validCoord(coords.x) && validCoord(coords.y);
     }
 
-    constexpr bool validCoords(TilePos2 coords)
+    constexpr bool validCoords(const TilePos2& coords)
     {
         return validTileCoord(coords.x) && validTileCoord(coords.y);
     }

--- a/src/OpenLoco/Map/Map.hpp
+++ b/src/OpenLoco/Map/Map.hpp
@@ -26,4 +26,25 @@ namespace OpenLoco::Map
     static_assert(sizeof(Pos2) == 4);
     static_assert(sizeof(Pos3) == 6);
     static_assert(sizeof(TilePos2) == 4);
+
+    constexpr bool validCoord(coord_t coord)
+    {
+        return coord >= 0 && coord < map_columns;
+    }
+
+    constexpr bool validTileCoord(coord_t coord)
+    {
+        return coord >= 0 && coord < map_width;
+    }
+
+    template<typename TType>
+    constexpr bool validCoords(TType coords)
+    {
+        return validCoord(coords.x) && validCoord(coords.y);
+    }
+
+    constexpr bool validCoords(TilePos2 coords)
+    {
+        return validTileCoord(coords.x) && validTileCoord(coords.y);
+    }
 }

--- a/src/OpenLoco/Map/TileManager.cpp
+++ b/src/OpenLoco/Map/TileManager.cpp
@@ -561,7 +561,11 @@ namespace OpenLoco::Map::TileManager
         {
             for (uint8_t xOffset = 0; xOffset < 11; xOffset++)
             {
-                auto tile = get(initialTilePos + Map::TilePos2(xOffset, yOffset));
+                auto tilePos = initialTilePos + Map::TilePos2(xOffset, yOffset);
+                if (tilePos.x < 0 || tilePos.y < 0)
+                    continue;
+
+                auto tile = get(tilePos);
                 auto* surface = tile.surface();
                 if (surface != nullptr && surface->water() > 0)
                     surroundingWaterTiles++;
@@ -583,7 +587,11 @@ namespace OpenLoco::Map::TileManager
         {
             for (uint8_t xOffset = 0; xOffset < 11; xOffset++)
             {
-                auto tile = get(initialTilePos + Map::TilePos2(xOffset, yOffset));
+                auto tilePos = initialTilePos + Map::TilePos2(xOffset, yOffset);
+                if (tilePos.x < 0 || tilePos.y < 0)
+                    continue;
+
+                auto tile = get(tilePos);
                 for (auto& element : tile)
                 {
                     // NB: vanilla was checking for trees above the surface element.

--- a/src/OpenLoco/Map/TileManager.cpp
+++ b/src/OpenLoco/Map/TileManager.cpp
@@ -562,7 +562,7 @@ namespace OpenLoco::Map::TileManager
             for (uint8_t xOffset = 0; xOffset < 11; xOffset++)
             {
                 auto tilePos = initialTilePos + Map::TilePos2(xOffset, yOffset);
-                if (tilePos.x < 0 || tilePos.y < 0)
+                if (!Map::validCoords(tilePos))
                     continue;
 
                 auto tile = get(tilePos);
@@ -588,7 +588,7 @@ namespace OpenLoco::Map::TileManager
             for (uint8_t xOffset = 0; xOffset < 11; xOffset++)
             {
                 auto tilePos = initialTilePos + Map::TilePos2(xOffset, yOffset);
-                if (tilePos.x < 0 || tilePos.y < 0)
+                if (!Map::validCoords(tilePos))
                     continue;
 
                 auto tile = get(tilePos);


### PR DESCRIPTION
Our implementation is more sensitive with respect to memory space. This change ensures we don't trigger any alarm bells for going outside the valid coordinate space.