### PR TITLE
Remove template parameter and name type

### DIFF
--- a/src/OpenLoco/Map/Map.hpp
+++ b/src/OpenLoco/Map/Map.hpp
@@ -37,8 +37,7 @@ namespace OpenLoco::Map
         return coord >= 0 && coord < map_width;
     }
 
-    template<typename TType>
-    constexpr bool validCoords(const TType& coords)
+    constexpr bool validCoords(const Pos2& coords)
     {
         return validCoord(coords.x) && validCoord(coords.y);
     }


### PR DESCRIPTION
There is no requirement for this function to take anything other than Pos2 so best make it an explicit type.