### PR TITLE
Implement alternative clip string

### DIFF
--- a/src/OpenLoco/Graphics/Gfx.cpp
+++ b/src/OpenLoco/Graphics/Gfx.cpp
@@ -301,12 +301,17 @@ namespace OpenLoco::Gfx
                 case ControlCodes::window_colour_1:
                 case ControlCodes::window_colour_2:
                 case ControlCodes::window_colour_3:
-                case 0x10:
+                case ControlCodes::window_colour_4:
                     break;
 
                 case ControlCodes::inline_sprite_str:
                     curString.push_back(*++chr);
                     curString.push_back(*++chr);
+                    curString.push_back(*++chr);
+                    curString.push_back(*++chr);
+                    break;
+
+                case ControlCodes::newline_x_y:
                     curString.push_back(*++chr);
                     curString.push_back(*++chr);
                     break;


### PR DESCRIPTION
I looked at the assembly for this one and decided it would be a pain to implement that way as it's inlining all the string width calc.
It's somewhat based on the openrct2 equivalent with some minor tweaks as we don't have the same format code handling.