### PR TITLE
Provide further notes for string control codes

### DIFF
--- a/src/OpenLoco/Localisation/StringManager.h
+++ b/src/OpenLoco/Localisation/StringManager.h
@@ -38,10 +38,13 @@ namespace OpenLoco
 
     namespace ControlCodes
     {
-        // Arguments: uint8_t
+        // Arguments (1 byte): uint8_t
         constexpr uint8_t move_x = 1;
+        constexpr uint8_t adjust_palette = 2; // Not used
+        // 3 Not used
+        // 4 Not used
 
-        constexpr uint8_t adjust_palette = 2;
+        // Arguements: none
         constexpr uint8_t newline = 5;
         constexpr uint8_t newline_smaller = 6;
         constexpr uint8_t font_small = 7;
@@ -53,14 +56,34 @@ namespace OpenLoco
         constexpr uint8_t window_colour_1 = 13;
         constexpr uint8_t window_colour_2 = 14;
         constexpr uint8_t window_colour_3 = 15;
-        constexpr uint8_t window_colour_4 = 16;
+        constexpr uint8_t window_colour_4 = 16; // Not used
 
-        // Arguments: int8_t, int8_t
+        // Arguments (2 bytes): int8_t, int8_t
         constexpr uint8_t newline_x_y = 17;
+        // 18 Not used
+        // 19 Not used
+        // 20 Not used
+        // 21 Not used
+        // 22 Not used
 
-        // Arguments: uint32_t
+        // Arguments (4 bytes): uint32_t
         constexpr uint8_t inline_sprite_str = 23;
+        // 24 Not used
+        // 25 Not used
+        // 26 Not used
+        // 27 Not used
+        // 28 Not used
+        // 29 Not used
+        // 30 Not used
+        // 31 Not used
 
+        // Arguments in Args buffer
+        // Note:
+        // Pre formatString:
+        //     ControlCodes valid args in args buffer.
+        // Post formatString:
+        //     ControlCodes are invalid
+        //     inline_sprite_args replaced with inline_sprite_str, arg is in string
         constexpr uint8_t int32_grouped = 123 + 0;
         constexpr uint8_t int32_ungrouped = 123 + 1;
         constexpr uint8_t int16_decimals = 123 + 2;
@@ -83,6 +106,7 @@ namespace OpenLoco
         constexpr uint8_t power = 123 + 19;
         constexpr uint8_t inline_sprite_args = 123 + 20;
 
+        // Arguments: none
         constexpr uint8_t colour_black = 144;
         constexpr uint8_t colour_grey = 145;
         constexpr uint8_t colour_white = 146;

--- a/src/OpenLoco/Localisation/StringManager.h
+++ b/src/OpenLoco/Localisation/StringManager.h
@@ -41,10 +41,9 @@ namespace OpenLoco
         // Arguments (1 byte): uint8_t
         constexpr uint8_t move_x = 1;
         constexpr uint8_t adjust_palette = 2; // Not used
-        // 3 Not used
-        // 4 Not used
+        // 3-4 Not used
 
-        // Arguements: none
+        // Arguments: none
         constexpr uint8_t newline = 5;
         constexpr uint8_t newline_smaller = 6;
         constexpr uint8_t font_small = 7;
@@ -60,22 +59,11 @@ namespace OpenLoco
 
         // Arguments (2 bytes): int8_t, int8_t
         constexpr uint8_t newline_x_y = 17;
-        // 18 Not used
-        // 19 Not used
-        // 20 Not used
-        // 21 Not used
-        // 22 Not used
+        // 18-22 Not used
 
         // Arguments (4 bytes): uint32_t
         constexpr uint8_t inline_sprite_str = 23;
-        // 24 Not used
-        // 25 Not used
-        // 26 Not used
-        // 27 Not used
-        // 28 Not used
-        // 29 Not used
-        // 30 Not used
-        // 31 Not used
+        // 24-31 Not used
 
         // Arguments in Args buffer
         // Note:


### PR DESCRIPTION
This makes it a bit easier to understand what the control codes are being used for and keeps the known gaps.