### PR TITLE
Unify pointer to x86-register casts

### DIFF
--- a/src/OpenLoco/Audio/VehicleChannel.cpp
+++ b/src/OpenLoco/Audio/VehicleChannel.cpp
@@ -10,7 +10,7 @@ using namespace OpenLoco::Interop;
 static std::pair<SoundId, ChannelAttributes> sub_48A590(const Vehicles::Vehicle2or6* v)
 {
     registers regs;
-    regs.esi = (int32_t)v;
+    regs.esi = X86Pointer(v);
     call(0x0048A590, regs);
     return { static_cast<SoundId>(regs.eax), { regs.ecx, regs.edx, regs.ebx } };
 }

--- a/src/OpenLoco/Company.cpp
+++ b/src/OpenLoco/Company.cpp
@@ -41,7 +41,7 @@ namespace OpenLoco
     void Company::aiThink()
     {
         registers regs;
-        regs.esi = (int32_t)this;
+        regs.esi = X86Pointer(this);
         call(0x00430762, regs);
     }
 

--- a/src/OpenLoco/CompanyManager.cpp
+++ b/src/OpenLoco/CompanyManager.cpp
@@ -191,7 +191,7 @@ namespace OpenLoco::CompanyManager
     string_id getOwnerStatus(CompanyId_t id, FormatArguments& args)
     {
         registers regs;
-        regs.esi = (int32_t)get(id);
+        regs.esi = X86Pointer(get(id));
         call(0x00438047, regs);
 
         args.push(regs.ecx);
@@ -202,7 +202,7 @@ namespace OpenLoco::CompanyManager
     OwnerStatus getOwnerStatus(CompanyId_t id)
     {
         registers regs;
-        regs.esi = (int32_t)get(id);
+        regs.esi = X86Pointer(get(id));
         call(0x00438047, regs);
 
         OwnerStatus ownerStatus;

--- a/src/OpenLoco/Entities/Entity.cpp
+++ b/src/OpenLoco/Entities/Entity.cpp
@@ -20,7 +20,7 @@ void EntityBase::moveTo(const Map::Pos3& loc)
     regs.ax = loc.x;
     regs.cx = loc.y;
     regs.dx = loc.z;
-    regs.esi = (int32_t)this;
+    regs.esi = X86Pointer(this);
     call(0x0046FC83, regs);
 }
 

--- a/src/OpenLoco/Entities/Misc.cpp
+++ b/src/OpenLoco/Entities/Misc.cpp
@@ -14,7 +14,7 @@ namespace OpenLoco
     void MiscBase::update()
     {
         registers regs;
-        regs.esi = reinterpret_cast<uint32_t>(this);
+        regs.esi = X86Pointer(this);
         call(0x004405CD, regs);
     }
 

--- a/src/OpenLoco/GameCommands/GameCommands.h
+++ b/src/OpenLoco/GameCommands/GameCommands.h
@@ -190,7 +190,7 @@ namespace OpenLoco::GameCommands
         regs.bl = Flags::apply;
         regs.dx = vehicleHead;
         // Bug in game command 3 requires to set edi to a vehicle prior to calling
-        regs.edi = reinterpret_cast<uint32_t>(head);
+        regs.edi = X86Pointer(head);
 
         doCommand(GameCommand::vehicleReverse, regs);
     }
@@ -1009,7 +1009,7 @@ namespace OpenLoco::GameCommands
     {
         registers regs;
         regs.bl = Flags::apply;
-        regs.ebp = reinterpret_cast<int32_t>(filename);
+        regs.ebp = X86Pointer(filename);
         doCommand(GameCommand::loadMultiplayerMap, regs);
     }
 

--- a/src/OpenLoco/Graphics/Gfx.cpp
+++ b/src/OpenLoco/Graphics/Gfx.cpp
@@ -1419,7 +1419,7 @@ namespace OpenLoco::Gfx
         regs.dx = height;
         regs.cx = y;
         call(0x4cec50, regs);
-        *dst = (Gfx::Context*)regs.edi;
+        *dst = X86Pointer<Gfx::Context>(regs.edi);
 
         return *dst != nullptr;
     }

--- a/src/OpenLoco/Graphics/Gfx.cpp
+++ b/src/OpenLoco/Graphics/Gfx.cpp
@@ -907,8 +907,8 @@ namespace OpenLoco::Gfx
         regs.bp = width;
         regs.cx = x;
         regs.dx = y;
-        regs.esi = (int32_t)args;
-        regs.edi = (int32_t)&context;
+        regs.esi = X86Pointer(args);
+        regs.edi = X86Pointer(&context);
         call(0x00495224, regs);
 
         return regs.dx;
@@ -934,8 +934,8 @@ namespace OpenLoco::Gfx
         regs.bx = stringId;
         regs.cx = x;
         regs.dx = y;
-        regs.esi = (int32_t)args;
-        regs.edi = (int32_t)&context;
+        regs.esi = X86Pointer(args);
+        regs.edi = X86Pointer(&context);
         call(0x00494B3F, regs);
     }
 
@@ -959,8 +959,8 @@ namespace OpenLoco::Gfx
         regs.bx = stringId;
         regs.cx = origin->x;
         regs.dx = origin->y;
-        regs.esi = (int32_t)args;
-        regs.edi = (int32_t)&context;
+        regs.esi = X86Pointer(args);
+        regs.edi = X86Pointer(&context);
         call(0x00494B3F, regs);
 
         origin->x = regs.cx;
@@ -989,8 +989,8 @@ namespace OpenLoco::Gfx
         regs.bx = stringId;
         regs.cx = x;
         regs.dx = y;
-        regs.esi = (int32_t)args;
-        regs.edi = (int32_t)&context;
+        regs.esi = X86Pointer(args);
+        regs.edi = X86Pointer(&context);
         regs.bp = width;
         call(0x00494BBF, regs);
     }
@@ -1015,8 +1015,8 @@ namespace OpenLoco::Gfx
         regs.bx = stringId;
         regs.cx = x;
         regs.dx = y;
-        regs.esi = (int32_t)args;
-        regs.edi = (int32_t)&context;
+        regs.esi = X86Pointer(args);
+        regs.edi = X86Pointer(&context);
         call(0x00494C78, regs);
     }
 
@@ -1040,8 +1040,8 @@ namespace OpenLoco::Gfx
         regs.bx = stringId;
         regs.cx = x;
         regs.dx = y;
-        regs.esi = (int32_t)args;
-        regs.edi = (int32_t)&context;
+        regs.esi = X86Pointer(args);
+        regs.edi = X86Pointer(&context);
         call(0x00494CB2, regs);
     }
 
@@ -1065,8 +1065,8 @@ namespace OpenLoco::Gfx
         regs.bx = stringId;
         regs.cx = x;
         regs.dx = y;
-        regs.esi = (int32_t)args;
-        regs.edi = (int32_t)&context;
+        regs.esi = X86Pointer(args);
+        regs.edi = X86Pointer(&context);
         call(0x00494D78, regs);
     }
 
@@ -1090,8 +1090,8 @@ namespace OpenLoco::Gfx
         regs.bx = stringId;
         regs.cx = x;
         regs.dx = y;
-        regs.esi = (int32_t)args;
-        regs.edi = (int32_t)&context;
+        regs.esi = X86Pointer(args);
+        regs.edi = X86Pointer(&context);
         call(0x00494DE8, regs);
     }
 
@@ -1113,8 +1113,8 @@ namespace OpenLoco::Gfx
         const void* args)
     {
         registers regs;
-        regs.edi = (int32_t)&context;
-        regs.esi = (int32_t)args;
+        regs.edi = X86Pointer(&context);
+        regs.esi = X86Pointer(args);
         regs.ebx = stringId;
         regs.cx = x;
         regs.dx = y;
@@ -1143,8 +1143,8 @@ namespace OpenLoco::Gfx
         const void* args)
     {
         registers regs;
-        regs.edi = (uintptr_t)context;
-        regs.esi = (uintptr_t)args;
+        regs.edi = X86Pointer(context);
+        regs.esi = X86Pointer(args);
         regs.cx = origin->x;
         regs.dx = origin->y;
         regs.bp = width;
@@ -1174,8 +1174,8 @@ namespace OpenLoco::Gfx
         const void* args)
     {
         registers regs;
-        regs.edi = (int32_t)&context;
-        regs.esi = (int32_t)args;
+        regs.edi = X86Pointer(&context);
+        regs.esi = X86Pointer(args);
         regs.cx = x;
         regs.dx = y;
         regs.al = colour;
@@ -1189,7 +1189,7 @@ namespace OpenLoco::Gfx
     uint16_t getStringWidthNewLined(const char* buffer)
     {
         registers regs;
-        regs.esi = (uintptr_t)buffer;
+        regs.esi = X86Pointer(buffer);
         call(0x00495715, regs);
         return regs.cx;
     }
@@ -1198,7 +1198,7 @@ namespace OpenLoco::Gfx
     {
         // gfx_wrap_string
         registers regs;
-        regs.esi = (uintptr_t)buffer;
+        regs.esi = X86Pointer(buffer);
         regs.di = stringWidth;
         call(0x00495301, regs);
 
@@ -1214,7 +1214,7 @@ namespace OpenLoco::Gfx
         regs.cx = top;
         regs.dx = bottom;
         regs.ebp = colour;
-        regs.edi = (uint32_t)context;
+        regs.edi = X86Pointer(context);
         call(0x004474BA, regs);
     }
 
@@ -1237,7 +1237,7 @@ namespace OpenLoco::Gfx
         regs.cx = top;
         regs.dx = bottom;
         regs.ebp = colour;
-        regs.edi = (uint32_t)context;
+        regs.edi = X86Pointer(context);
         regs.si = flags;
         call(0x004C58C7, regs);
     }
@@ -1257,7 +1257,7 @@ namespace OpenLoco::Gfx
         regs.cx = right;
         regs.dx = bottom;
         regs.ebp = colour;
-        regs.edi = (uint32_t)context;
+        regs.edi = X86Pointer(context);
         call(0x00452DA4, regs);
     }
 
@@ -1357,7 +1357,7 @@ namespace OpenLoco::Gfx
         regs.cx = x;
         regs.dx = y;
         regs.ebx = image;
-        regs.edi = (uint32_t)context;
+        regs.edi = X86Pointer(context);
         call(0x00448C79, regs);
     }
 
@@ -1406,7 +1406,7 @@ namespace OpenLoco::Gfx
         regs.cx = x;
         regs.dx = y;
         regs.ebx = image;
-        regs.edi = (uint32_t)context;
+        regs.edi = X86Pointer(context);
         call(0x00448D90, regs);
     }
 
@@ -1415,7 +1415,7 @@ namespace OpenLoco::Gfx
         registers regs;
         regs.ax = x;
         regs.bx = width;
-        regs.edi = (int32_t)src;
+        regs.edi = X86Pointer(src);
         regs.dx = height;
         regs.cx = y;
         call(0x4cec50, regs);

--- a/src/OpenLoco/Input/MouseInput.cpp
+++ b/src/OpenLoco/Input/MouseInput.cpp
@@ -411,9 +411,9 @@ namespace OpenLoco::Input
 
         registers regs;
         regs.ebp = (int32_t)state();
-        regs.esi = (uint32_t)window;
+        regs.esi = X86Pointer(window);
         regs.edx = widgetIndex;
-        regs.edi = (uint32_t)widget;
+        regs.edi = X86Pointer(widget);
         regs.cx = (uint16_t)button;
         regs.ax = x;
         regs.bx = y;

--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -607,7 +607,7 @@ static void registerAudioHooks()
     registerHook(
         0x0048A4BF,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-            Audio::playSound((Vehicles::Vehicle2or6*)regs.esi);
+            Audio::playSound(X86Pointer<Vehicles::Vehicle2or6>(regs.esi));
             return 0;
         });
     registerHook(
@@ -696,7 +696,7 @@ void OpenLoco::Interop::registerHooks()
         0x00451025,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             registers backup = regs;
-            auto pos = Gfx::drawString((Gfx::Context*)regs.edi, regs.cx, regs.dx, regs.al, (uint8_t*)regs.esi);
+            auto pos = Gfx::drawString(X86Pointer<Gfx::Context>(regs.edi), regs.cx, regs.dx, regs.al, X86Pointer<uint8_t>(regs.esi));
             regs = backup;
             regs.cx = pos.x;
             regs.dx = pos.y;
@@ -716,7 +716,9 @@ void OpenLoco::Interop::registerHooks()
         0x004958C6,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             registers backup = regs;
-            char* buffer = StringManager::formatString((char*)regs.edi, regs.eax, (void*)regs.ecx);
+            char* buffer = X86Pointer<char>(regs.edi);
+            void* args = X86Pointer(regs.ecx);
+            buffer = StringManager::formatString(buffer, regs.eax, args);
             regs = backup;
             regs.edi = X86Pointer(buffer);
             return 0;
@@ -751,8 +753,8 @@ void OpenLoco::Interop::registerHooks()
         0x004CA4DF,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             registers backup = regs;
-            auto window = (Ui::Window*)regs.esi;
-            auto context = (Gfx::Context*)regs.edi;
+            Ui::Window* window = X86Pointer<Ui::Window>(regs.esi);
+            auto context = X86Pointer<Gfx::Context>(regs.edi);
             window->draw(context);
             regs = backup;
             return 0;
@@ -795,7 +797,7 @@ void OpenLoco::Interop::registerHooks()
             int16_t x = regs.eax;
             int16_t i = regs.ebx / 6;
             int16_t y = regs.ecx;
-            Map::SurfaceElement* surface = (Map::SurfaceElement*)regs.esi;
+            Map::SurfaceElement* surface = X86Pointer<Map::SurfaceElement>(regs.esi);
 
             surface->createWave(x, y, i);
 
@@ -806,7 +808,7 @@ void OpenLoco::Interop::registerHooks()
     registerHook(
         0x004AB655,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-            auto v = (Vehicles::VehicleBase*)regs.esi;
+            Vehicles::VehicleBase* v = X86Pointer<Vehicles::VehicleBase>(regs.esi);
             v->asVehicleBody()->secondaryAnimationUpdate();
 
             return 0;
@@ -823,7 +825,7 @@ void OpenLoco::Interop::registerHooks()
         0x004C6456,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             registers backup = regs;
-            auto window = (Ui::Window*)regs.esi;
+            Ui::Window* window = X86Pointer<Ui::Window>(regs.esi);
             window->viewportsUpdatePosition();
             regs = backup;
             return 0;
@@ -833,7 +835,7 @@ void OpenLoco::Interop::registerHooks()
         0x004C9513,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             registers backup = regs;
-            auto window = (Ui::Window*)regs.esi;
+            Ui::Window* window = X86Pointer<Ui::Window>(regs.esi);
             int16_t x = regs.ax;
             int16_t y = regs.bx;
 
@@ -857,7 +859,7 @@ void OpenLoco::Interop::registerHooks()
         0x004CA115,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             registers backup = regs;
-            auto window = (Ui::Window*)regs.esi;
+            Ui::Window* window = X86Pointer<Ui::Window>(regs.esi);
             window->updateScrollWidgets();
             regs = backup;
 
@@ -868,7 +870,7 @@ void OpenLoco::Interop::registerHooks()
         0x004CA17F,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             registers backup = regs;
-            auto window = (Ui::Window*)regs.esi;
+            Ui::Window* window = X86Pointer<Ui::Window>(regs.esi);
             window->initScrollWidgets();
             regs = backup;
 

--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -657,7 +657,7 @@ void OpenLoco::Interop::registerHooks()
             // TODO: use Utility::strlcpy with the buffer size instead of std::strcpy, if possible
             std::strcpy(buffer, path.make_preferred().u8string().c_str());
 
-            regs.ebx = (int32_t)buffer;
+            regs.ebx = X86Pointer(buffer);
             return 0;
         });
 
@@ -718,7 +718,7 @@ void OpenLoco::Interop::registerHooks()
             registers backup = regs;
             char* buffer = StringManager::formatString((char*)regs.edi, regs.eax, (void*)regs.ecx);
             regs = backup;
-            regs.edi = (uint32_t)buffer;
+            regs.edi = X86Pointer(buffer);
             return 0;
         });
 
@@ -843,11 +843,11 @@ void OpenLoco::Interop::registerHooks()
             regs.edx = widgetIndex;
             if (widgetIndex == -1)
             {
-                regs.edi = (uintptr_t)&window->widgets[0];
+                regs.edi = X86Pointer(&window->widgets[0]);
             }
             else
             {
-                regs.edi = (uintptr_t)&window->widgets[widgetIndex];
+                regs.edi = X86Pointer(&window->widgets[widgetIndex]);
             }
 
             return 0;

--- a/src/OpenLoco/Interop/Interop.hpp
+++ b/src/OpenLoco/Interop/Interop.hpp
@@ -23,20 +23,32 @@ constexpr int32_t DEFAULT_REG_VAL = 0xCCCCCCCC;
 
 namespace OpenLoco::Interop
 {
+    template<typename T = void>
     class X86Pointer
     {
     private:
         uintptr_t _ptr;
 
     public:
-        X86Pointer(const void* x)
+        X86Pointer(const T* x)
         {
             _ptr = reinterpret_cast<uintptr_t>(x);
         }
+
+        X86Pointer(const uint32_t ptr)
+        {
+            _ptr = ptr;
+        }
+
         operator uint32_t() const
         {
             return (uint32_t)_ptr;
         }
+
+        operator T*() const
+        {
+            return reinterpret_cast<T*>(_ptr);
+        };
     };
 
 #pragma pack(push, 1)

--- a/src/OpenLoco/Interop/Interop.hpp
+++ b/src/OpenLoco/Interop/Interop.hpp
@@ -19,6 +19,22 @@ constexpr int32_t DEFAULT_REG_VAL = 0xCCCCCCCC;
 
 namespace OpenLoco::Interop
 {
+    class X86Pointer
+    {
+    private:
+        uintptr_t _ptr;
+
+    public:
+        X86Pointer(const void* x)
+        {
+            _ptr = reinterpret_cast<uintptr_t>(x);
+        }
+        operator uint32_t() const
+        {
+            return (uint32_t)_ptr;
+        }
+    };
+
 #pragma pack(push, 1)
     /**
     * x86 register structure, only used for easy interop to Locomotion code.

--- a/src/OpenLoco/Interop/Interop.hpp
+++ b/src/OpenLoco/Interop/Interop.hpp
@@ -7,7 +7,11 @@
 #include <stdexcept>
 #include <vector>
 
+#if defined(__i386__)
 #define assert_struct_size(x, y) static_assert(sizeof(x) == (y), "Improper struct size")
+#else
+#define assert_struct_size(x, y)
+#endif
 
 #if defined(__clang__) || (defined(__GNUC__) && !defined(__MINGW32__))
 #define FORCE_ALIGN_ARG_POINTER __attribute__((force_align_arg_pointer))

--- a/src/OpenLoco/Localisation/StringManager.cpp
+++ b/src/OpenLoco/Localisation/StringManager.cpp
@@ -99,7 +99,7 @@ namespace OpenLoco::StringManager
     {
         registers regs;
         regs.eax = (uint32_t)value;
-        regs.edi = (uint32_t)buffer;
+        regs.edi = X86Pointer(buffer);
 
         call(0x00495F35, regs);
         return (char*)regs.edi;
@@ -109,7 +109,7 @@ namespace OpenLoco::StringManager
     {
         registers regs;
         regs.eax = (uint32_t)value;
-        regs.edi = (uint32_t)buffer;
+        regs.edi = X86Pointer(buffer);
 
         call(0x495E2A, regs);
         return (char*)regs.edi;
@@ -120,7 +120,7 @@ namespace OpenLoco::StringManager
         registers regs;
         regs.eax = (uint32_t)value;
         regs.edx = (uint32_t)(value / (1ULL << 32)); // regs.dx = (uint16_t)(value >> 32);
-        regs.edi = (uint32_t)buffer;
+        regs.edi = X86Pointer(buffer);
         regs.ebx = (uint32_t)separator;
 
         call(0x496052, regs);
@@ -131,7 +131,7 @@ namespace OpenLoco::StringManager
     {
         registers regs;
         regs.eax = (uint32_t)value;
-        regs.edi = (uint32_t)buffer;
+        regs.edi = X86Pointer(buffer);
 
         call(0x4963FC, regs);
         return (char*)regs.edi;
@@ -141,7 +141,7 @@ namespace OpenLoco::StringManager
     {
         registers regs;
         regs.eax = (uint32_t)value;
-        regs.edi = (uint32_t)buffer;
+        regs.edi = X86Pointer(buffer);
 
         call(0x4962F1, regs);
         return (char*)regs.edi;

--- a/src/OpenLoco/Localisation/StringManager.cpp
+++ b/src/OpenLoco/Localisation/StringManager.cpp
@@ -102,7 +102,7 @@ namespace OpenLoco::StringManager
         regs.edi = X86Pointer(buffer);
 
         call(0x00495F35, regs);
-        return (char*)regs.edi;
+        return X86Pointer<char>(regs.edi);
     }
 
     static char* formatInt32Ungrouped(int32_t value, char* buffer)
@@ -112,7 +112,7 @@ namespace OpenLoco::StringManager
         regs.edi = X86Pointer(buffer);
 
         call(0x495E2A, regs);
-        return (char*)regs.edi;
+        return X86Pointer<char>(regs.edi);
     }
 
     static char* formatInt48Grouped(uint64_t value, char* buffer, uint8_t separator)
@@ -124,7 +124,7 @@ namespace OpenLoco::StringManager
         regs.ebx = (uint32_t)separator;
 
         call(0x496052, regs);
-        return (char*)regs.edi;
+        return X86Pointer<char>(regs.edi);
     }
 
     static char* formatShortWithDecimals(int16_t value, char* buffer)
@@ -134,7 +134,7 @@ namespace OpenLoco::StringManager
         regs.edi = X86Pointer(buffer);
 
         call(0x4963FC, regs);
-        return (char*)regs.edi;
+        return X86Pointer<char>(regs.edi);
     }
 
     static char* formatIntWithDecimals(int32_t value, char* buffer)
@@ -144,7 +144,7 @@ namespace OpenLoco::StringManager
         regs.edi = X86Pointer(buffer);
 
         call(0x4962F1, regs);
-        return (char*)regs.edi;
+        return X86Pointer<char>(regs.edi);
     }
 
     // 0x00495D09

--- a/src/OpenLoco/Objects/BuildingObject.cpp
+++ b/src/OpenLoco/Objects/BuildingObject.cpp
@@ -29,8 +29,8 @@ namespace OpenLoco
         regs.dx = y;
         regs.esi = colour;
         regs.eax = buildingRotation;
-        regs.edi = (int32_t)clipped;
-        regs.ebp = (uint32_t)this;
+        regs.edi = X86Pointer(clipped);
+        regs.ebp = X86Pointer(this);
         call(0x0042DB95, regs);
     }
 

--- a/src/OpenLoco/Objects/IndustryObject.cpp
+++ b/src/OpenLoco/Objects/IndustryObject.cpp
@@ -98,8 +98,8 @@ namespace OpenLoco
         registers regs;
         regs.cx = x;
         regs.dx = y;
-        regs.edi = (uint32_t)clipped;
-        regs.ebp = (uint32_t)this;
+        regs.edi = X86Pointer(clipped);
+        regs.ebp = X86Pointer(this);
         call(0x00458C7F, regs);
     }
 }

--- a/src/OpenLoco/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/Objects/ObjectManager.cpp
@@ -417,7 +417,7 @@ namespace OpenLoco::ObjectManager
     void getScenarioText(ObjectHeader& object)
     {
         registers regs;
-        regs.ebp = reinterpret_cast<int32_t>(&object);
+        regs.ebp = X86Pointer(&object);
         call(0x0047176D, regs);
     }
 
@@ -498,7 +498,7 @@ namespace OpenLoco::ObjectManager
 
         registers regs;
         regs.al = static_cast<uint8_t>(proc);
-        regs.esi = reinterpret_cast<uint32_t>(&obj);
+        regs.esi = X86Pointer(&obj);
         return (call(objectProc, regs) & X86_FLAG_CARRY) == 0;
     }
 
@@ -520,7 +520,7 @@ namespace OpenLoco::ObjectManager
     static bool load(const ObjectHeader& header, LoadedObjectId id)
     {
         registers regs;
-        regs.ebp = reinterpret_cast<uint32_t>(&header);
+        regs.ebp = X86Pointer(&header);
         regs.ecx = static_cast<int32_t>(id);
         return (call(0x00471BC5, regs) & X86_FLAG_CARRY) == 0;
     }

--- a/src/OpenLoco/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/Objects/ObjectManager.cpp
@@ -34,7 +34,7 @@ namespace OpenLoco::ObjectManager
         Object** objects;
         ObjectEntry2* object_entry_extendeds;
     };
-    static_assert(sizeof(ObjectRepositoryItem) == 8);
+    assert_struct_size(ObjectRepositoryItem, 8);
 #pragma pack(pop)
 
     loco_global<ObjectEntry2[maxObjects], 0x1125A90> objectEntries;

--- a/src/OpenLoco/Objects/VehicleObject.cpp
+++ b/src/OpenLoco/Objects/VehicleObject.cpp
@@ -24,8 +24,8 @@ namespace OpenLoco
         regs.esi = esi;
         regs.bl = Colour::saturated_green;
         regs.bh = 2;
-        regs.ebp = (uintptr_t)vehicleObject;
-        regs.edi = (uintptr_t)context;
+        regs.ebp = X86Pointer(vehicleObject);
+        regs.edi = X86Pointer(context);
         call(0x4B7733, regs);
     }
 

--- a/src/OpenLoco/Paint/Paint.cpp
+++ b/src/OpenLoco/Paint/Paint.cpp
@@ -31,7 +31,7 @@ namespace OpenLoco::Paint
     {
         registers regs;
         regs.bx = stringId;
-        regs.edi = reinterpret_cast<int32_t>(y_offsets);
+        regs.edi = X86Pointer(y_offsets);
         regs.si = offset_x;
         regs.eax = amount;
         regs.cx = y;
@@ -45,7 +45,7 @@ namespace OpenLoco::Paint
     {
         registers regs;
         regs.bx = stringId;
-        regs.edi = reinterpret_cast<int32_t>(y_offsets);
+        regs.edi = X86Pointer(y_offsets);
         regs.si = offset_x;
         regs.eax = amount;
         regs.cx = y;
@@ -461,7 +461,7 @@ namespace OpenLoco::Paint
         _paletteMap = paletteMap.data();
         registers regs{};
         regs.ebx = imageId;
-        regs.edi = reinterpret_cast<int32_t>(context);
+        regs.edi = X86Pointer(context);
         regs.cx = coords.x;
         regs.dx = coords.y;
         call(0x00447A5F, regs);

--- a/src/OpenLoco/Paint/Paint.h
+++ b/src/OpenLoco/Paint/Paint.h
@@ -43,7 +43,7 @@ namespace OpenLoco::Paint
         uint8_t pad_0D;
         AttachedPaintStruct* next; // 0x0E
     };
-    static_assert(sizeof(AttachedPaintStruct) == 0x12);
+    assert_struct_size(AttachedPaintStruct, 0x12);
 
     struct PaintStringStruct
     {
@@ -56,7 +56,7 @@ namespace OpenLoco::Paint
         uint8_t* yOffsets; // 0x1A
         uint16_t colour;   // 0x1E
     };
-    static_assert(sizeof(PaintStringStruct) == 0x20);
+    assert_struct_size(PaintStringStruct, 0x20);
 
     struct PaintStructBoundBox
     {
@@ -104,7 +104,7 @@ namespace OpenLoco::Paint
             EntityBase* entity;            // 0x30
         };
     };
-    static_assert(sizeof(PaintStruct) == 0x34);
+    assert_struct_size(PaintStruct, 0x34);
 
     union PaintEntry
     {
@@ -112,7 +112,7 @@ namespace OpenLoco::Paint
         AttachedPaintStruct attached;
         PaintStringStruct string;
     };
-    static_assert(sizeof(PaintEntry) == 0x34);
+    assert_struct_size(PaintEntry, 0x34);
 #pragma pack(pop)
     struct GenerationParameters;
 

--- a/src/OpenLoco/S5/S5.cpp
+++ b/src/OpenLoco/S5/S5.cpp
@@ -486,8 +486,8 @@ namespace OpenLoco::S5
     static void object_create_identifier_name(char* dst, const ObjectHeader& header)
     {
         registers regs;
-        regs.edi = reinterpret_cast<int32_t>(dst);
-        regs.ebp = reinterpret_cast<int32_t>(&header);
+        regs.edi = X86Pointer(dst);
+        regs.ebp = X86Pointer(&header);
         call(0x00473BC7, regs);
     }
 

--- a/src/OpenLoco/Scenario.cpp
+++ b/src/OpenLoco/Scenario.cpp
@@ -285,7 +285,7 @@ namespace OpenLoco::Scenario
             filename = reinterpret_cast<const char*>(-1);
 
         registers regs;
-        regs.ebx = reinterpret_cast<int32_t>(filename);
+        regs.ebx = X86Pointer(filename);
         call(0x0044400C, regs);
     }
 

--- a/src/OpenLoco/Station.cpp
+++ b/src/OpenLoco/Station.cpp
@@ -746,7 +746,7 @@ namespace OpenLoco
     void Station::updateLabel()
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         call(0x0048DCA5, regs);
     }
 

--- a/src/OpenLoco/Town.cpp
+++ b/src/OpenLoco/Town.cpp
@@ -17,7 +17,7 @@ namespace OpenLoco
     void Town::update()
     {
         registers regs;
-        regs.esi = (int32_t)this;
+        regs.esi = X86Pointer(this);
         call(0x0049742F, regs);
     }
 
@@ -25,7 +25,7 @@ namespace OpenLoco
     void Town::updateLabel()
     {
         registers regs;
-        regs.esi = (int32_t)this;
+        regs.esi = X86Pointer(this);
         call(0x00497616, regs);
     }
 

--- a/src/OpenLoco/Ui/ScrollView.cpp
+++ b/src/OpenLoco/Ui/ScrollView.cpp
@@ -307,9 +307,9 @@ namespace OpenLoco::Ui::ScrollView
     {
         registers regs;
 
-        regs.esi = (uintptr_t)window;
+        regs.esi = X86Pointer(window);
         regs.ebx = window->getScrollDataIndex(widgetIndex) * sizeof(ScrollArea);
-        regs.edi = (uintptr_t)&window->widgets[widgetIndex];
+        regs.edi = X86Pointer(&window->widgets[widgetIndex]);
         call(0x4CA1ED, regs);
     }
 

--- a/src/OpenLoco/Ui/WindowManager.cpp
+++ b/src/OpenLoco/Ui/WindowManager.cpp
@@ -128,7 +128,7 @@ namespace OpenLoco::Ui::WindowManager
                 registers backup = regs;
                 auto* w = Windows::Vehicle::Main::open(reinterpret_cast<Vehicles::VehicleBase*>(regs.edx));
                 regs = backup;
-                regs.esi = reinterpret_cast<int32_t>(w);
+                regs.esi = X86Pointer(w);
                 return 0;
             });
 
@@ -219,7 +219,7 @@ namespace OpenLoco::Ui::WindowManager
                 registers backup = regs;
                 auto window = Windows::Town::open(regs.dx);
                 regs = backup;
-                regs.esi = (uintptr_t)window;
+                regs.esi = X86Pointer(window);
 
                 return 0;
             });
@@ -230,7 +230,7 @@ namespace OpenLoco::Ui::WindowManager
                 registers backup = regs;
                 auto window = Windows::Station::open(regs.dx);
                 regs = backup;
-                regs.esi = (uintptr_t)window;
+                regs.esi = X86Pointer(window);
 
                 return 0;
             });
@@ -241,7 +241,7 @@ namespace OpenLoco::Ui::WindowManager
                 registers backup = regs;
                 auto window = Windows::IndustryList::open();
                 regs = backup;
-                regs.esi = (uintptr_t)window;
+                regs.esi = X86Pointer(window);
 
                 return 0;
             });
@@ -292,7 +292,7 @@ namespace OpenLoco::Ui::WindowManager
                 registers backup = regs;
                 auto window = findAt(regs.ax, regs.bx);
                 regs = backup;
-                regs.esi = (uintptr_t)window;
+                regs.esi = X86Pointer(window);
 
                 return 0;
             });
@@ -303,7 +303,7 @@ namespace OpenLoco::Ui::WindowManager
                 registers backup = regs;
                 auto window = findAtAlt(regs.ax, regs.bx);
                 regs = backup;
-                regs.esi = (uintptr_t)window;
+                regs.esi = X86Pointer(window);
 
                 return 0;
             });
@@ -321,7 +321,7 @@ namespace OpenLoco::Ui::WindowManager
                     w = find((WindowType)regs.cx, regs.dx);
                 }
 
-                regs.esi = (uintptr_t)w;
+                regs.esi = X86Pointer(w);
                 if (w == nullptr)
                 {
                     return X86_FLAG_ZERO;
@@ -423,7 +423,7 @@ namespace OpenLoco::Ui::WindowManager
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 auto w = getMainWindow();
 
-                regs.esi = (uintptr_t)w;
+                regs.esi = X86Pointer(w);
                 if (w == nullptr)
                 {
                     return X86_FLAG_CARRY;
@@ -450,7 +450,7 @@ namespace OpenLoco::Ui::WindowManager
                 auto w = createWindow((WindowType)regs.cl, Gfx::point_t(regs.ax, regs.eax >> 16), Gfx::ui_size_t(regs.bx, regs.ebx >> 16), regs.ecx >> 8, (WindowEventList*)regs.edx);
                 regs = backup;
 
-                regs.esi = (uintptr_t)w;
+                regs.esi = X86Pointer(w);
                 return 0;
             });
 
@@ -462,7 +462,7 @@ namespace OpenLoco::Ui::WindowManager
                 auto w = createWindow((WindowType)regs.cl, Gfx::ui_size_t(regs.bx, (((uint32_t)regs.ebx) >> 16)), regs.ecx >> 8, (WindowEventList*)regs.edx);
                 regs = backup;
 
-                regs.esi = (uintptr_t)w;
+                regs.esi = X86Pointer(w);
                 return 0;
             });
 
@@ -484,7 +484,7 @@ namespace OpenLoco::Ui::WindowManager
                 auto w = bringToFront((WindowType)regs.cx, regs.dx);
                 regs = backup;
 
-                regs.esi = (uintptr_t)w;
+                regs.esi = X86Pointer(w);
                 if (w == nullptr)
                 {
                     return X86_FLAG_ZERO;
@@ -795,7 +795,7 @@ namespace OpenLoco::Ui::WindowManager
     Window* bringToFront(Window* w)
     {
         registers regs;
-        regs.esi = (uint32_t)w;
+        regs.esi = X86Pointer(w);
         call(0x004CC750, regs);
 
         return (Window*)regs.esi;

--- a/src/OpenLoco/Ui/WindowManager.cpp
+++ b/src/OpenLoco/Ui/WindowManager.cpp
@@ -798,7 +798,7 @@ namespace OpenLoco::Ui::WindowManager
         regs.esi = X86Pointer(w);
         call(0x004CC750, regs);
 
-        return (Window*)regs.esi;
+        return X86Pointer<Window>(regs.esi);
     }
 
     // 0x004CD3A9

--- a/src/OpenLoco/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/Vehicles/CreateVehicle.cpp
@@ -635,7 +635,7 @@ namespace OpenLoco::Vehicles
     static void sub_4AF7A4(VehicleHead* const veh0)
     {
         registers regs{};
-        regs.esi = reinterpret_cast<int32_t>(veh0);
+        regs.esi = X86Pointer(veh0);
         call(0x004AF7A4, regs);
     }
 
@@ -643,7 +643,7 @@ namespace OpenLoco::Vehicles
     static void placeDownVehicle(VehicleHead* const head, const coord_t x, const coord_t y, const uint8_t baseZ, const uint16_t unk1, const uint16_t unk2)
     {
         registers regs{};
-        regs.esi = reinterpret_cast<int32_t>(head);
+        regs.esi = X86Pointer(head);
         regs.ax = x;
         regs.cx = y;
         regs.bx = unk2;

--- a/src/OpenLoco/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/Vehicles/Vehicle.cpp
@@ -81,7 +81,7 @@ namespace OpenLoco::Vehicles
     void VehicleBase::sub_4AA464()
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         call(0x004AA464, regs);
     }
 
@@ -89,7 +89,7 @@ namespace OpenLoco::Vehicles
     {
         int32_t result = 0;
         registers regs;
-        regs.esi = (int32_t)this;
+        regs.esi = X86Pointer(this);
         switch (getSubType())
         {
             case VehicleThingType::head:

--- a/src/OpenLoco/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/Vehicles/VehicleBody.cpp
@@ -51,7 +51,7 @@ namespace OpenLoco::Vehicles
     int32_t VehicleBody::update()
     {
         registers regs;
-        regs.esi = (int32_t)this;
+        regs.esi = X86Pointer(this);
 
         if (mode == TransportMode::air || mode == TransportMode::water)
         {

--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -814,7 +814,7 @@ namespace OpenLoco::Vehicles
     void VehicleHead::removeDanglingTrain()
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         call(0x004AF06E, regs);
     }
 
@@ -2256,7 +2256,7 @@ namespace OpenLoco::Vehicles
     void VehicleHead::updateLastJourneyAverageSpeed()
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         call(0x004BACAF, regs);
     }
 
@@ -2800,7 +2800,7 @@ namespace OpenLoco::Vehicles
     bool VehicleHead::updateLoadCargo()
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         return call(0x004BA142, regs) & (1 << 8);
     }
 
@@ -2862,7 +2862,7 @@ namespace OpenLoco::Vehicles
     std::tuple<StationId_t, Map::Pos2, Map::Pos3> VehicleHead::sub_427FC9()
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         call(0x00427FC9, regs);
         Map::Pos2 headTarget = { regs.ax, regs.cx };
         Map::Pos3 stationTarget = { regs.di, regs.bp, regs.dx };
@@ -2889,7 +2889,7 @@ namespace OpenLoco::Vehicles
     void VehicleHead::sub_4AD778()
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         call(0x004AD778, regs);
     }
 
@@ -2897,7 +2897,7 @@ namespace OpenLoco::Vehicles
     void VehicleHead::sub_4AA625()
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         call(0x004AA625, regs);
     }
 
@@ -2905,7 +2905,7 @@ namespace OpenLoco::Vehicles
     std::tuple<uint8_t, uint8_t, StationId_t> VehicleHead::sub_4ACEE7(uint32_t unk1, uint32_t var_113612C)
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         regs.eax = unk1;
         regs.ebx = var_113612C;
         call(0x004ACEE7, regs);
@@ -2917,7 +2917,7 @@ namespace OpenLoco::Vehicles
     bool VehicleHead::sub_4AC1C2()
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         return call(0x004AC1C2, regs) & (1 << 8);
     }
 
@@ -2925,7 +2925,7 @@ namespace OpenLoco::Vehicles
     bool VehicleHead::sub_4AC0A3()
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         return call(0x004AC0A3, regs) & (1 << 8);
     }
 
@@ -2933,7 +2933,7 @@ namespace OpenLoco::Vehicles
     bool VehicleHead::sub_4ACCDC()
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         return call(0x004ACCDC, regs) & (1 << 8);
     }
 
@@ -2941,7 +2941,7 @@ namespace OpenLoco::Vehicles
     void VehicleHead::sub_4AD93A()
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         call(0x004AD93A, regs);
     }
 
@@ -3043,7 +3043,7 @@ namespace OpenLoco::Vehicles
     void VehicleHead::sub_4ADB47(bool unk)
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         regs.eax = unk ? 1 : 0;
         call(0x004ADB47, regs);
     }
@@ -3173,7 +3173,7 @@ namespace OpenLoco::Vehicles
     void VehicleHead::sub_4B7CC3()
     {
         registers regs{};
-        regs.esi = reinterpret_cast<int32_t>(this);
+        regs.esi = X86Pointer(this);
         call(0x004B7CC3, regs);
     }
 
@@ -3251,7 +3251,7 @@ namespace OpenLoco::Vehicles
     void VehicleHead::liftUpVehicle()
     {
         registers regs{};
-        regs.esi = reinterpret_cast<uint32_t>(this);
+        regs.esi = X86Pointer(this);
         call(0x004B08DD, regs);
     }
 

--- a/src/OpenLoco/Vehicles/VehicleManager.cpp
+++ b/src/OpenLoco/Vehicles/VehicleManager.cpp
@@ -10,7 +10,7 @@ namespace OpenLoco::VehicleManager
     void determineAvailableVehicles(Company& company)
     {
         registers regs;
-        regs.esi = reinterpret_cast<int32_t>(&company);
+        regs.esi = X86Pointer(&company);
         call(0x004C3A0C, regs);
     }
 }

--- a/src/OpenLoco/Viewport.cpp
+++ b/src/OpenLoco/Viewport.cpp
@@ -44,8 +44,8 @@ namespace OpenLoco::Ui
         regs.bx = rect.top();
         regs.dx = rect.right();
         regs.bp = rect.bottom();
-        regs.esi = reinterpret_cast<uint32_t>(this);
-        regs.edi = reinterpret_cast<uint32_t>(context);
+        regs.esi = X86Pointer(this);
+        regs.edi = X86Pointer(context);
         call(0x0045A1A4, regs);
     }
 

--- a/src/OpenLoco/ViewportManager.cpp
+++ b/src/OpenLoco/ViewportManager.cpp
@@ -348,7 +348,7 @@ namespace OpenLoco::Ui::ViewportManager
                 registers backup = regs;
                 auto viewport = create(regs, 0);
                 regs = backup;
-                regs.edi = reinterpret_cast<uint32_t>(viewport);
+                regs.edi = X86Pointer(viewport);
                 return 0;
             });
         registerHook(
@@ -357,7 +357,7 @@ namespace OpenLoco::Ui::ViewportManager
                 registers backup = regs;
                 auto viewport = create(regs, 1);
                 regs = backup;
-                regs.edi = reinterpret_cast<uint32_t>(viewport);
+                regs.edi = X86Pointer(viewport);
                 return 0;
             });
         registerHook(
@@ -451,7 +451,7 @@ namespace OpenLoco::Ui::ViewportManager
                 regs.bl = static_cast<uint8_t>(interaction.type);
                 regs.bh = static_cast<uint8_t>(interaction.unkBh);
                 regs.edx = static_cast<uint32_t>(interaction.value);
-                regs.edi = reinterpret_cast<uint32_t>(vp);
+                regs.edi = X86Pointer(vp);
                 return 0;
             });
     }

--- a/src/OpenLoco/Window.cpp
+++ b/src/OpenLoco/Window.cpp
@@ -387,7 +387,7 @@ namespace OpenLoco::Ui
     void Window::invalidatePressedImageButtons()
     {
         registers regs;
-        regs.esi = (int32_t)this;
+        regs.esi = X86Pointer(this);
         call(0x004C99B9, regs);
     }
 
@@ -500,7 +500,7 @@ namespace OpenLoco::Ui
     {
         registers regs;
         regs.eax = (int32_t)_disabled_widgets;
-        regs.esi = (int32_t)this;
+        regs.esi = X86Pointer(this);
         call(0x004CC7CB, regs);
     }
 
@@ -917,7 +917,7 @@ namespace OpenLoco::Ui
         if (isInteropEvent(event_handlers->on_close))
         {
             registers regs;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call((uint32_t)this->event_handlers->on_close, regs);
             return;
         }
@@ -933,7 +933,7 @@ namespace OpenLoco::Ui
         if (isInteropEvent(event_handlers->on_periodic_update))
         {
             registers regs;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call((uint32_t)this->event_handlers->on_periodic_update, regs);
             return;
         }
@@ -949,7 +949,7 @@ namespace OpenLoco::Ui
         if (isInteropEvent(event_handlers->on_update))
         {
             registers regs;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call((uintptr_t)this->event_handlers->on_update, regs);
             return;
         }
@@ -965,7 +965,7 @@ namespace OpenLoco::Ui
         if (isInteropEvent(event_handlers->event_08))
         {
             registers regs;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call((uintptr_t)this->event_handlers->event_08, regs);
             return;
         }
@@ -981,7 +981,7 @@ namespace OpenLoco::Ui
         if (isInteropEvent(event_handlers->event_09))
         {
             registers regs;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call((uintptr_t)this->event_handlers->event_09, regs);
             return;
         }
@@ -997,7 +997,7 @@ namespace OpenLoco::Ui
         if (isInteropEvent(event_handlers->on_tool_update))
         {
             registers regs;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             regs.dx = widget_index;
             regs.ax = xPos;
             regs.bx = yPos;
@@ -1019,7 +1019,7 @@ namespace OpenLoco::Ui
             regs.ax = xPos;
             regs.bx = yPos;
             regs.dx = widget_index;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call((uint32_t)this->event_handlers->on_tool_down, regs);
             return;
         }
@@ -1038,7 +1038,7 @@ namespace OpenLoco::Ui
             regs.ax = xPos;
             regs.bx = yPos;
             regs.dx = widget_index;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call((uint32_t)this->event_handlers->toolDragContinue, regs);
             return;
         }
@@ -1055,7 +1055,7 @@ namespace OpenLoco::Ui
         {
             registers regs;
             regs.dx = widget_index;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call((uint32_t)this->event_handlers->toolDragEnd, regs);
             return;
         }
@@ -1072,7 +1072,7 @@ namespace OpenLoco::Ui
         {
             registers regs;
             regs.dx = widget_index;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call((uint32_t)this->event_handlers->on_tool_abort, regs);
             return;
         }
@@ -1091,7 +1091,7 @@ namespace OpenLoco::Ui
             regs.bl = *out;
             regs.cx = yPos;
             regs.edi = (int32_t)fallback;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call(reinterpret_cast<uint32_t>(this->event_handlers->event_15), regs);
 
             *out = regs.bl;
@@ -1114,8 +1114,8 @@ namespace OpenLoco::Ui
             regs.dx = yPos;
             regs.ax = widgetIdx;
             regs.ebx = -1;
-            regs.edi = (int32_t) & this->widgets[widgetIdx];
-            regs.esi = (int32_t)this;
+            regs.edi = X86Pointer(&this->widgets[widgetIdx]);
+            regs.esi = X86Pointer(this);
             call((uintptr_t)this->event_handlers->cursor, regs);
 
             if (regs.ebx == -1)
@@ -1138,10 +1138,10 @@ namespace OpenLoco::Ui
         {
             registers regs;
             regs.edx = widgetIndex;
-            regs.esi = (uint32_t)this;
+            regs.esi = X86Pointer(this);
 
             // Not sure if this is used
-            regs.edi = (uint32_t) & this->widgets[widgetIndex];
+            regs.edi = X86Pointer(&this->widgets[widgetIndex]);
 
             call((uintptr_t)this->event_handlers->on_mouse_up, regs);
             return;
@@ -1158,7 +1158,7 @@ namespace OpenLoco::Ui
         if (isInteropEvent(event_handlers->on_resize))
         {
             registers regs;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call((uint32_t)event_handlers->on_resize, regs);
             return (Window*)regs.esi;
         }
@@ -1176,8 +1176,8 @@ namespace OpenLoco::Ui
         {
             registers regs;
             regs.edx = widget_index;
-            regs.esi = (uint32_t)this;
-            regs.edi = (uint32_t) & this->widgets[widget_index];
+            regs.esi = X86Pointer(this);
+            regs.edi = X86Pointer(&this->widgets[widget_index]);
             call((uint32_t)this->event_handlers->event_03, regs);
             return;
         }
@@ -1194,8 +1194,8 @@ namespace OpenLoco::Ui
         {
             registers regs;
             regs.edx = widget_index;
-            regs.esi = (uint32_t)this;
-            regs.edi = (uint32_t) & this->widgets[widget_index];
+            regs.esi = X86Pointer(this);
+            regs.edi = X86Pointer(&this->widgets[widget_index]);
             call((uint32_t)this->event_handlers->on_mouse_down, regs);
             return;
         }
@@ -1213,7 +1213,7 @@ namespace OpenLoco::Ui
             registers regs;
             regs.ax = item_index;
             regs.edx = widget_index;
-            regs.esi = (uint32_t)this;
+            regs.esi = X86Pointer(this);
             call((uint32_t)this->event_handlers->on_dropdown, regs);
             return;
         }
@@ -1230,7 +1230,7 @@ namespace OpenLoco::Ui
         {
             registers regs;
             regs.eax = scrollIndex;
-            regs.esi = (uintptr_t)this;
+            regs.esi = X86Pointer(this);
             call((uint32_t)this->event_handlers->get_scroll_size, regs);
             *scrollWidth = regs.cx;
             *scrollHeight = regs.dx;
@@ -1249,7 +1249,7 @@ namespace OpenLoco::Ui
         {
             registers regs;
             regs.ax = scroll_index;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             regs.cx = xPos;
             regs.dx = yPos;
             call((uint32_t)this->event_handlers->scroll_mouse_down, regs);
@@ -1268,7 +1268,7 @@ namespace OpenLoco::Ui
         {
             registers regs;
             regs.ax = scroll_index;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             regs.cx = xPos;
             regs.dx = yPos;
             call((uint32_t)this->event_handlers->scroll_mouse_drag, regs);
@@ -1287,7 +1287,7 @@ namespace OpenLoco::Ui
         {
             registers regs;
             regs.ax = scroll_index;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             regs.cx = xPos;
             regs.dx = yPos;
             call((uint32_t)this->event_handlers->scroll_mouse_over, regs);
@@ -1306,9 +1306,9 @@ namespace OpenLoco::Ui
         {
             registers regs;
             regs.dx = caller;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             regs.cl = 1;
-            regs.edi = (uintptr_t)buffer;
+            regs.edi = X86Pointer(buffer);
             call((uintptr_t)this->event_handlers->text_input, regs);
             return;
         }
@@ -1324,7 +1324,7 @@ namespace OpenLoco::Ui
         if (isInteropEvent(event_handlers->viewport_rotate))
         {
             registers regs;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call((uintptr_t)this->event_handlers->viewport_rotate, regs);
             return;
         }
@@ -1342,7 +1342,7 @@ namespace OpenLoco::Ui
         {
             registers regs;
             regs.ax = widget_index;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call((int32_t)this->event_handlers->tooltip, regs);
             auto args = FormatArguments();
             if (regs.ax == (int16_t)StringIds::null)
@@ -1363,7 +1363,7 @@ namespace OpenLoco::Ui
             registers regs;
             regs.cx = xPos;
             regs.dx = yPos;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call(reinterpret_cast<int32_t>(this->event_handlers->on_move), regs);
         }
         this->event_handlers->on_move(*this, xPos, yPos);
@@ -1377,7 +1377,7 @@ namespace OpenLoco::Ui
         if (isInteropEvent(event_handlers->prepare_draw))
         {
             registers regs;
-            regs.esi = (int32_t)this;
+            regs.esi = X86Pointer(this);
             call((int32_t)this->event_handlers->prepare_draw, regs);
             return;
         }
@@ -1393,8 +1393,8 @@ namespace OpenLoco::Ui
         if (isInteropEvent(this->event_handlers->draw))
         {
             registers regs;
-            regs.esi = (int32_t)this;
-            regs.edi = (int32_t)context;
+            regs.esi = X86Pointer(this);
+            regs.edi = X86Pointer(context);
             call((int32_t)this->event_handlers->draw, regs);
             return;
         }
@@ -1411,8 +1411,8 @@ namespace OpenLoco::Ui
         {
             registers regs;
             regs.ax = scrollIndex;
-            regs.esi = (int32_t)this;
-            regs.edi = (int32_t)context;
+            regs.esi = X86Pointer(this);
+            regs.edi = X86Pointer(context);
             call((int32_t)event_handlers->draw_scroll, regs);
             return;
         }

--- a/src/OpenLoco/Window.h
+++ b/src/OpenLoco/Window.h
@@ -430,7 +430,7 @@ namespace OpenLoco::Ui
         void callDraw(Gfx::Context* context);                                                          // 27
         void callDrawScroll(Gfx::Context* context, uint32_t scrollIndex);                              // 28
     };
-    static_assert(sizeof(Window) == 0x88E);
+    assert_struct_size(Window, 0x88E);
 
     Map::Pos2 viewportCoordToMapCoord(int16_t x, int16_t y, int16_t z, int32_t rotation);
     std::optional<Map::Pos2> screenGetMapXyWithZ(const xy32& mouse, const int16_t z);

--- a/src/OpenLoco/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/Windows/BuildVehicle.cpp
@@ -386,7 +386,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 registers backup = regs;
                 auto window = open(regs.eax, regs.eax);
                 regs = backup;
-                regs.esi = (int32_t)window;
+                regs.esi = X86Pointer(window);
                 return 0;
             });
     }
@@ -1402,7 +1402,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         regs.esi = esi;
         regs.ebx = company;
         regs.ebp = vehicleTypeIdx;
-        regs.edi = (uintptr_t)context;
+        regs.edi = X86Pointer(context);
         call(0x4B7741, regs);
     }
 
@@ -1415,7 +1415,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         regs.ebx = company;
         regs.cx = loc.x;
         regs.dx = loc.y;
-        regs.edi = (uintptr_t)context;
+        regs.edi = X86Pointer(context);
         regs.ebp = vehicleTypeIdx;
         call(0x4B7711, regs);
         // Returns right coordinate of the drawing

--- a/src/OpenLoco/Windows/CompanyList.cpp
+++ b/src/OpenLoco/Windows/CompanyList.cpp
@@ -1647,8 +1647,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
         static void drawGraph(Window* self, Gfx::Context* context)
         {
             registers regs;
-            regs.esi = (uint32_t)self;
-            regs.edi = (uint32_t)context;
+            regs.esi = X86Pointer(self);
+            regs.edi = X86Pointer(context);
             call(0x004CF824, regs);
         }
 

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -1993,7 +1993,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void sub_4C8DBF(Window* self)
         {
             registers regs;
-            regs.esi = (int32_t)self;
+            regs.esi = X86Pointer(self);
             call(0x004C8DBF, regs);
         }
 

--- a/src/OpenLoco/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/Windows/Construction/Common.cpp
@@ -204,8 +204,8 @@ namespace OpenLoco::Ui::Windows::Construction
     Window* openAtTrack(Window* main, TrackElement* track, const Pos2 pos)
     {
         registers regs{};
-        regs.esi = reinterpret_cast<uint32_t>(main);
-        regs.edx = reinterpret_cast<uint32_t>(track);
+        regs.esi = X86Pointer(main);
+        regs.edx = X86Pointer(track);
         regs.ax = pos.x;
         regs.cx = pos.y;
         call(0x004A0EAD, regs);
@@ -217,8 +217,8 @@ namespace OpenLoco::Ui::Windows::Construction
     Window* openAtRoad(Window* main, RoadElement* track, const Pos2 pos)
     {
         registers regs{};
-        regs.esi = reinterpret_cast<uint32_t>(main);
-        regs.edx = reinterpret_cast<uint32_t>(track);
+        regs.esi = X86Pointer(main);
+        regs.edx = X86Pointer(track);
         regs.ax = pos.x;
         regs.cx = pos.y;
         call(0x004A147F, regs);
@@ -230,8 +230,8 @@ namespace OpenLoco::Ui::Windows::Construction
     void setToTrackExtra(Window* main, TrackElement* track, const uint8_t bh, const Pos2 pos)
     {
         registers regs{};
-        regs.esi = reinterpret_cast<uint32_t>(main);
-        regs.edx = reinterpret_cast<uint32_t>(track);
+        regs.esi = X86Pointer(main);
+        regs.edx = X86Pointer(track);
         regs.bh = bh;
         regs.ax = pos.x;
         regs.cx = pos.y;
@@ -242,8 +242,8 @@ namespace OpenLoco::Ui::Windows::Construction
     void setToRoadExtra(Window* main, RoadElement* road, const uint8_t bh, const Pos2 pos)
     {
         registers regs{};
-        regs.esi = reinterpret_cast<uint32_t>(main);
-        regs.edx = reinterpret_cast<uint32_t>(road);
+        regs.esi = X86Pointer(main);
+        regs.edx = X86Pointer(road);
         regs.bh = bh;
         regs.ax = pos.x;
         regs.cx = pos.y;

--- a/src/OpenLoco/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/Windows/Construction/ConstructionTab.cpp
@@ -128,7 +128,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     {
         registers regs;
         regs.edx = widgetIndex;
-        regs.esi = (int32_t)self;
+        regs.esi = X86Pointer(self);
         call(0x0049F92D, regs);
     }
 
@@ -137,7 +137,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     {
         registers regs;
         regs.edx = widgetIndex;
-        regs.esi = (int32_t)self;
+        regs.esi = X86Pointer(self);
         call(0x004A0121, regs);
     }
 
@@ -1601,7 +1601,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
     {
         registers regs;
-        regs.esi = (int32_t)&self;
+        regs.esi = X86Pointer(&self);
         regs.dx = widgetIndex;
         regs.ax = x;
         regs.bx = y;

--- a/src/OpenLoco/Windows/Construction/OverheadTab.cpp
+++ b/src/OpenLoco/Windows/Construction/OverheadTab.cpp
@@ -125,7 +125,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
     static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
     {
         registers regs;
-        regs.esi = (int32_t)&self;
+        regs.esi = X86Pointer(&self);
         regs.dx = widgetIndex;
         regs.ax = x;
         regs.bx = y;
@@ -136,7 +136,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
     static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
     {
         registers regs;
-        regs.esi = (int32_t)&self;
+        regs.esi = X86Pointer(&self);
         regs.dx = widgetIndex;
         regs.ax = x;
         regs.bx = y;

--- a/src/OpenLoco/Windows/Construction/SignalTab.cpp
+++ b/src/OpenLoco/Windows/Construction/SignalTab.cpp
@@ -118,7 +118,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
     static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
     {
         registers regs;
-        regs.esi = (int32_t)&self;
+        regs.esi = X86Pointer(&self);
         regs.dx = widgetIndex;
         regs.ax = x;
         regs.bx = y;
@@ -129,7 +129,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
     static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
     {
         registers regs;
-        regs.esi = (int32_t)&self;
+        regs.esi = X86Pointer(&self);
         regs.dx = widgetIndex;
         regs.ax = x;
         regs.bx = y;

--- a/src/OpenLoco/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/Windows/Construction/StationTab.cpp
@@ -160,7 +160,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
     {
         registers regs;
-        regs.esi = (int32_t)&self;
+        regs.esi = X86Pointer(&self);
         regs.dx = widgetIndex;
         regs.ax = x;
         regs.bx = y;
@@ -171,7 +171,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
     {
         registers regs;
-        regs.esi = (int32_t)&self;
+        regs.esi = X86Pointer(&self);
         regs.dx = widgetIndex;
         regs.ax = x;
         regs.bx = y;

--- a/src/OpenLoco/Windows/MapWindow.cpp
+++ b/src/OpenLoco/Windows/MapWindow.cpp
@@ -217,7 +217,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     static void sub_46C544(Window* self)
     {
         registers regs;
-        regs.esi = (int32_t)self;
+        regs.esi = X86Pointer(self);
         call(0x0046C544, regs);
     }
 

--- a/src/OpenLoco/Windows/News/News.cpp
+++ b/src/OpenLoco/Windows/News/News.cpp
@@ -468,9 +468,9 @@ namespace OpenLoco::Ui::Windows::NewsWindow
         static void sub_42A136(Window* self, Gfx::Context* context, Message* news)
         {
             registers regs;
-            regs.edi = (int32_t)context;
-            regs.esi = (int32_t)self;
-            regs.ebp = (int32_t)news;
+            regs.edi = X86Pointer(context);
+            regs.esi = X86Pointer(self);
+            regs.ebp = X86Pointer(news);
             call(0x0042A136, regs);
         }
 

--- a/src/OpenLoco/Windows/News/Ticker.cpp
+++ b/src/OpenLoco/Windows/News/Ticker.cpp
@@ -145,7 +145,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
         regs.cx = x;
         regs.dx = y;
         regs.ebp = ebp;
-        regs.edi = (int32_t)clipped;
+        regs.edi = X86Pointer(clipped);
         call(0x004950EF, regs);
     }
 

--- a/src/OpenLoco/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/Windows/ObjectSelectionWindow.cpp
@@ -101,7 +101,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static void sub_473154(Window* self)
     {
         registers regs;
-        regs.esi = (uintptr_t)self;
+        regs.esi = X86Pointer(self);
         call(0x00473154, regs);
     }
 
@@ -110,7 +110,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     {
         registers regs;
         regs.eax = static_cast<uint32_t>(eax);
-        regs.esi = (uintptr_t)self;
+        regs.esi = X86Pointer(self);
         call(0x004731EE, regs);
     }
 
@@ -786,7 +786,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     {
         registers regs;
         regs.bx = bx;
-        regs.ebp = (uintptr_t)ebp;
+        regs.ebp = X86Pointer(ebp);
 
         return call(0x00473D1D, regs) & (1 << 8);
     }

--- a/src/OpenLoco/Windows/Options.cpp
+++ b/src/OpenLoco/Windows/Options.cpp
@@ -1536,12 +1536,12 @@ namespace OpenLoco::Ui::Windows::Options
                     if (ebp.index != -1)
                     {
                         registers regs2;
-                        regs2.ebp = (uintptr_t)ebp.object._header;
+                        regs2.ebp = X86Pointer(ebp.object._header);
                         call(0x00471FF8, regs2); // unload object
                     }
 
                     registers regs3;
-                    regs3.ebp = (uintptr_t)object.second._header;
+                    regs3.ebp = X86Pointer(object.second._header);
 
                     call(0x00471BCE, regs3);
                     ObjectManager::reloadAll();

--- a/src/OpenLoco/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/Windows/PromptBrowseWindow.cpp
@@ -404,8 +404,8 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
 
         // Resume the original prepare_draw routine beyond the widget repositioning.
         registers regs;
-        regs.edi = (int32_t)buffer;
-        regs.esi = (int32_t)self;
+        regs.edi = X86Pointer(buffer);
+        regs.esi = X86Pointer(self);
         call(0x00445D91, regs);
     }
 
@@ -995,7 +995,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     static void sub_446E87(Window* self)
     {
         registers regs;
-        regs.esi = (int32_t)self;
+        regs.esi = X86Pointer(self);
         call(0x00446E87, regs);
     }
 }

--- a/src/OpenLoco/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/Windows/ScenarioSelect.cpp
@@ -198,7 +198,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 
             // Load required object
             registers regs2;
-            regs2.ebp = reinterpret_cast<int32_t>(&scenarioInfo->currency);
+            regs2.ebp = X86Pointer(&scenarioInfo->currency);
             call(0x00471BCE, regs2);
             call(0x0047237D); // reset_loaded_objects
             call(0x0046E07B); // load currency gfx

--- a/src/OpenLoco/Windows/TerraForm.cpp
+++ b/src/OpenLoco/Windows/TerraForm.cpp
@@ -400,7 +400,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             registers regs;
-            regs.esi = uint32_t(&self);
+            regs.esi = X86Pointer(&self);
             regs.dx = widgetIndex;
             regs.ax = x;
             regs.bx = y;
@@ -411,7 +411,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             registers regs;
-            regs.esi = uint32_t(&self);
+            regs.esi = X86Pointer(&self);
             regs.dx = widgetIndex;
             regs.ax = x;
             regs.bx = y;
@@ -812,7 +812,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             registers regs;
-            regs.esi = int32_t(&self);
+            regs.esi = X86Pointer(&self);
             regs.dx = widgetIndex;
             regs.ax = x;
             regs.bx = y;
@@ -1407,7 +1407,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             registers regs;
-            regs.esi = int32_t(&self);
+            regs.esi = X86Pointer(&self);
             regs.dx = widgetIndex;
             regs.ax = x;
             regs.bx = y;
@@ -1418,7 +1418,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             registers regs;
-            regs.esi = int32_t(&self);
+            regs.esi = X86Pointer(&self);
             regs.dx = widgetIndex;
             regs.ax = x;
             regs.bx = y;
@@ -1765,7 +1765,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             registers regs;
-            regs.esi = int32_t(&self);
+            regs.esi = X86Pointer(&self);
             regs.dx = widgetIndex;
             regs.ax = x;
             regs.bx = y;
@@ -1776,7 +1776,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             registers regs;
-            regs.esi = int32_t(&self);
+            regs.esi = X86Pointer(&self);
             regs.dx = widgetIndex;
             regs.ax = x;
             regs.bx = y;

--- a/src/OpenLoco/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/Windows/ToolbarTop.cpp
@@ -337,7 +337,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     {
         // Load objects.
         registers regs;
-        regs.edi = (uint32_t)&available_objects[0];
+        regs.edi = X86Pointer(&available_objects[0]);
         call(0x004A6841, regs);
 
         // Sanity check: any objects available?

--- a/src/OpenLoco/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/Windows/ToolbarTopCommon.cpp
@@ -194,7 +194,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     {
         // Load objects.
         registers regs;
-        regs.edi = (uint32_t)&available_objects[0];
+        regs.edi = X86Pointer(&available_objects[0]);
         call(0x00478265, regs);
 
         // Sanity check: any objects available?

--- a/src/OpenLoco/Windows/TownList.cpp
+++ b/src/OpenLoco/Windows/TownList.cpp
@@ -695,7 +695,7 @@ namespace OpenLoco::Ui::Windows::TownList
         static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             registers regs;
-            regs.esi = (int32_t)&self;
+            regs.esi = X86Pointer(&self);
             regs.dx = widgetIndex;
             regs.ax = x;
             regs.bx = y;
@@ -706,7 +706,7 @@ namespace OpenLoco::Ui::Windows::TownList
         static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             registers regs;
-            regs.esi = (int32_t)&self;
+            regs.esi = X86Pointer(&self);
             regs.dx = widgetIndex;
             regs.ax = x;
             regs.bx = y;

--- a/src/OpenLoco/Windows/TownWindow.cpp
+++ b/src/OpenLoco/Windows/TownWindow.cpp
@@ -188,7 +188,7 @@ namespace OpenLoco::Ui::Windows::Town
                         for (uint32_t j = ebx; j > 0; j--)
                         {
                             registers regs;
-                            regs.esi = (int32_t)town;
+                            regs.esi = X86Pointer(town);
                             regs.eax = 0xFF;
 
                             call(0x00498116, regs);

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -2634,7 +2634,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static std::pair<Ui::ViewportInteraction::InteractionItem, Ui::ViewportInteraction::InteractionArg> sub_4B5A1A(Window& self, const int16_t x, const int16_t y)
         {
             registers regs{};
-            regs.esi = reinterpret_cast<uint32_t>(&self);
+            regs.esi = X86Pointer(&self);
             regs.ax = x;
             regs.cx = y;
             regs.bl = 0; // Not set during function but needed to indicate failure
@@ -3875,7 +3875,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void pickupToolDown(Window& self, const int16_t x, const int16_t y)
         {
             registers regs;
-            regs.esi = reinterpret_cast<int32_t>(&self);
+            regs.esi = X86Pointer(&self);
             regs.ax = x;
             regs.bx = y;
             call(0x004B2C74, regs);
@@ -4067,8 +4067,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             regs.ah = ah;
             regs.cx = cx;
             regs.dx = dx;
-            regs.esi = reinterpret_cast<uint32_t>(vehicle);
-            regs.edi = reinterpret_cast<uint32_t>(pDrawpixelinfo);
+            regs.esi = X86Pointer(vehicle);
+            regs.edi = X86Pointer(pDrawpixelinfo);
             call(0x004B743B, regs);
             return regs.cx;
         }

--- a/src/OpenLoco/Windows/VehicleList.cpp
+++ b/src/OpenLoco/Windows/VehicleList.cpp
@@ -693,8 +693,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
     static void drawVehicle(VehicleHead* vehicle, Gfx::Context* context, uint16_t yPos)
     {
         registers regs;
-        regs.esi = (int32_t)vehicle;
-        regs.edi = (int32_t)context;
+        regs.esi = X86Pointer(vehicle);
+        regs.edi = X86Pointer(context);
         regs.al = 0x40;
         regs.cx = 0;
         regs.dx = yPos;


### PR DESCRIPTION
Work in progress thingy. Both me and @janisozaur's 64-bit stuff requires all of these to change, so I figured I'd start the discussion.

The way I see it, there's two options:

Create an intermediate type
```c
#if X86
typedef uintptr_t ptr32_t
#else
class ptr32_t {
    private:
        uint32_t _value;

    public:
        // Some conversion methods to/from uint32_t and T*
}
#endif
```

Create ax X86Register32 class, and use that as type for `/(e[abcd]x|e[sd]i|ebp)/` (eax, ebx, etc.)
This'd need to support directly assigning a pointer, so we don't need the cast. Did some experiments with that, and ended up with the following. Though someone that's good at C++ probably has better ideas.

```cpp
class X86Register32 {
    private:
        uint32_t _value;
    public:
        explicit X86Register32(const int32_t i){
            _value = i;
        }
        void operator = (const void* value) {
            _value = (uint32_t)(uintptr_t)value;
        }
        void operator = (const loco_ptr value) {
            _value = (uint32_t)(uintptr_t)value;
        }
        void operator = (const uint32_t value) {
            _value = value;
        }
        void operator = (const int value) {
            _value = value;
        }
        void operator = (const uint64_t value) {
            _value = value;
        }
        void operator = (const unsigned long value) {
            _value = value;
        }
       explicit operator uint32_t() const { return _value; }
        operator int() const { return _value; }
        operator uintptr_t () const { return _value; }

        template<typename T>
        operator T*() const {
            return ( T*)(uintptr_t)_value;
        }

        template<typename T>
        operator T() const {
            return ( T)_value;
        }
    };

    assert_struct_size(X86Register32, 4);
```

