### PR TITLE
Further coords work

### DIFF
--- a/src/OpenLoco/Input.cpp
+++ b/src/OpenLoco/Input.cpp
@@ -60,7 +60,9 @@ namespace OpenLoco::Input
         if (_cursor_drag_state == 0)
         {
             _cursor_drag_state = 1;
-            Ui::getCursorPos(_cursor_drag_start_x, _cursor_drag_start_y);
+            auto cursor = Ui::getCursorPos();
+            _cursor_drag_start_x = cursor.x;
+            _cursor_drag_start_y = cursor.y;
             Ui::hideCursor();
         }
     }
@@ -77,11 +79,10 @@ namespace OpenLoco::Input
 
     Gfx::point_t getNextDragOffset()
     {
-        int32_t currentX, currentY;
-        Ui::getCursorPos(currentX, currentY);
+        auto current = Ui::getCursorPos();
 
-        auto deltaX = currentX - _cursor_drag_start_x;
-        auto deltaY = currentY - _cursor_drag_start_y;
+        auto deltaX = current.x - _cursor_drag_start_x;
+        auto deltaY = current.y - _cursor_drag_start_y;
 
         Ui::setCursorPos(_cursor_drag_start_x, _cursor_drag_start_y);
 

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -638,7 +638,9 @@ namespace OpenLoco
             if (Config::get().var_72 == 0)
             {
                 Config::get().var_72 = 16;
-                Ui::getCursorPos(addr<0x00F2538C, int32_t>(), addr<0x00F25390, int32_t>());
+                const auto cursor = Ui::getCursorPos();
+                addr<0x00F2538C, int32_t>() = cursor.x;
+                addr<0x00F25390, int32_t>() = cursor.y;
                 Gfx::clear(Gfx::screenContext(), 0);
                 addr<0x00F2539C, int32_t>() = 0;
             }
@@ -786,7 +788,9 @@ namespace OpenLoco
                 if (Config::get().var_72 == 2)
                 {
                     addr<0x005252DC, int32_t>() = 1;
-                    Ui::getCursorPos(addr<0x00F2538C, int32_t>(), addr<0x00F25390, int32_t>());
+                    const auto cursor = Ui::getCursorPos();
+                    addr<0x00F2538C, int32_t>() = cursor.x;
+                    addr<0x00F25390, int32_t>() = cursor.y;
                     Ui::setCursorPos(addr<0x00F2538C, int32_t>(), addr<0x00F25390, int32_t>());
                 }
             }

--- a/src/OpenLoco/Ui.cpp
+++ b/src/OpenLoco/Ui.cpp
@@ -319,13 +319,15 @@ namespace OpenLoco::Ui
     }
 
     // 0x00407FCD
-    void getCursorPos(int32_t& x, int32_t& y)
+    xy32 getCursorPos()
     {
+        int x = 0, y = 0;
         SDL_GetMouseState(&x, &y);
 
         auto scale = Config::getNew().scale_factor;
         x /= scale;
         y /= scale;
+        return { x, y };
     }
 
     // 0x00407FEE

--- a/src/OpenLoco/Ui.h
+++ b/src/OpenLoco/Ui.h
@@ -118,7 +118,7 @@ namespace OpenLoco::Ui
     void disposeInput();
     void disposeCursors();
     void setCursor(CursorId id);
-    void getCursorPos(int32_t& x, int32_t& y);
+    xy32 getCursorPos();
     void setCursorPos(int32_t x, int32_t y);
     void hideCursor();
     void showCursor();

--- a/src/OpenLoco/Viewport.cpp
+++ b/src/OpenLoco/Viewport.cpp
@@ -50,12 +50,11 @@ namespace OpenLoco::Ui
     }
 
     // 0x004CA444
-    void Viewport::centre2dCoordinates(int16_t _x, int16_t _y, int16_t _z, int16_t* outX, int16_t* outY)
+    viewport_pos Viewport::centre2dCoordinates(const Pos3& loc)
     {
-        auto centre = Map::gameToScreen({ _x, _y, _z }, getRotation());
+        auto centre = Map::gameToScreen(loc, getRotation());
 
-        *outX = centre.x - view_width / 2;
-        *outY = centre.y - view_height / 2;
+        return viewport_pos(centre.x - view_width / 2, centre.y - view_height / 2);
     }
 
     SavedViewSimple Viewport::toSavedView() const

--- a/src/OpenLoco/Viewport.hpp
+++ b/src/OpenLoco/Viewport.hpp
@@ -144,7 +144,7 @@ namespace OpenLoco::Ui
         }
 
         void render(Gfx::Context* context);
-        viewport_pos centre2dCoordinates(const Pos3& loc);
+        viewport_pos centre2dCoordinates(const Map::Pos3& loc);
         SavedViewSimple toSavedView() const;
 
         viewport_pos getCentre() const;

--- a/src/OpenLoco/Viewport.hpp
+++ b/src/OpenLoco/Viewport.hpp
@@ -144,7 +144,7 @@ namespace OpenLoco::Ui
         }
 
         void render(Gfx::Context* context);
-        void centre2dCoordinates(int16_t x, int16_t y, int16_t z, int16_t* outX, int16_t* outY);
+        viewport_pos centre2dCoordinates(const Pos3& loc);
         SavedViewSimple toSavedView() const;
 
         viewport_pos getCentre() const;

--- a/src/OpenLoco/ViewportManager.cpp
+++ b/src/OpenLoco/ViewportManager.cpp
@@ -73,12 +73,11 @@ namespace OpenLoco::Ui::ViewportManager
 
         auto t = EntityManager::get<EntityBase>(dx);
 
-        int16_t dest_x, dest_y;
-        viewport->centre2dCoordinates(t->position.x, t->position.y, t->position.z, &dest_x, &dest_y);
-        w->viewport_configurations[index].saved_view_x = dest_x;
-        w->viewport_configurations[index].saved_view_y = dest_y;
-        viewport->view_x = dest_x;
-        viewport->view_y = dest_y;
+        const auto dest = viewport->centre2dCoordinates(t->position);
+        w->viewport_configurations[index].saved_view_x = dest.x;
+        w->viewport_configurations[index].saved_view_y = dest.y;
+        viewport->view_x = dest.x;
+        viewport->view_y = dest.y;
     }
 
     static void focusViewportOn(Window* w, int index, Map::Pos3 tile)
@@ -88,12 +87,11 @@ namespace OpenLoco::Ui::ViewportManager
 
         w->viewport_configurations[index].viewport_target_sprite = 0xFFFF;
 
-        int16_t dest_x, dest_y;
-        viewport->centre2dCoordinates(tile.x, tile.y, tile.z, &dest_x, &dest_y);
-        w->viewport_configurations[index].saved_view_x = dest_x;
-        w->viewport_configurations[index].saved_view_y = dest_y;
-        viewport->view_x = dest_x;
-        viewport->view_y = dest_y;
+        const auto dest = viewport->centre2dCoordinates(tile);
+        w->viewport_configurations[index].saved_view_x = dest.x;
+        w->viewport_configurations[index].saved_view_y = dest.y;
+        viewport->view_x = dest.x;
+        viewport->view_y = dest.y;
     }
 
     static Viewport* create(registers regs, int index)

--- a/src/OpenLoco/Window.cpp
+++ b/src/OpenLoco/Window.cpp
@@ -507,11 +507,10 @@ namespace OpenLoco::Ui
     void Window::viewportGetMapCoordsByCursor(int16_t* map_x, int16_t* map_y, int16_t* offset_x, int16_t* offset_y)
     {
         // Get mouse position to offset against.
-        int32_t mouse_x, mouse_y;
-        Ui::getCursorPos(mouse_x, mouse_y);
+        const auto mouse = Ui::getCursorPos();
 
         // Compute map coordinate by mouse position.
-        auto res = ViewportInteraction::getMapCoordinatesFromPos(mouse_x, mouse_y, 0);
+        auto res = ViewportInteraction::getMapCoordinatesFromPos(mouse.x, mouse.y, 0);
         auto& interaction = res.first;
         *map_x = interaction.pos.x;
         *map_y = interaction.pos.y;
@@ -522,8 +521,8 @@ namespace OpenLoco::Ui
         const auto dest = v->centre2dCoordinates({ *map_x, *map_y, base_height });
 
         // Rebase mouse position onto centre of window, and compensate for zoom level.
-        int16_t rebased_x = ((this->width >> 1) - mouse_x) * (1 << v->zoom),
-                rebased_y = ((this->height >> 1) - mouse_y) * (1 << v->zoom);
+        int16_t rebased_x = ((this->width >> 1) - mouse.x) * (1 << v->zoom),
+                rebased_y = ((this->height >> 1) - mouse.y) * (1 << v->zoom);
 
         // Compute cursor offset relative to tile.
         ViewportConfig* vc = &this->viewport_configurations[0];
@@ -612,12 +611,11 @@ namespace OpenLoco::Ui
         const auto dest = v->centre2dCoordinates({ map_x, map_y, base_height });
 
         // Get mouse position to offset against.
-        int32_t mouse_x, mouse_y;
-        Ui::getCursorPos(mouse_x, mouse_y);
+        const auto mouse = Ui::getCursorPos();
 
         // Rebase mouse position onto centre of window, and compensate for zoom level.
-        int16_t rebased_x = ((this->width >> 1) - mouse_x) * (1 << v->zoom),
-                rebased_y = ((this->height >> 1) - mouse_y) * (1 << v->zoom);
+        int16_t rebased_x = ((this->width >> 1) - mouse.x) * (1 << v->zoom),
+                rebased_y = ((this->height >> 1) - mouse.y) * (1 << v->zoom);
 
         // Apply offset to the viewport.
         ViewportConfig* vc = &this->viewport_configurations[0];

--- a/src/OpenLoco/Window.cpp
+++ b/src/OpenLoco/Window.cpp
@@ -285,7 +285,7 @@ namespace OpenLoco::Ui
             }
             this->callOnResize();
 
-            int16_t centreX, centreY;
+            viewport_pos centre;
 
             if (config->viewport_target_sprite != 0xFFFF)
             {
@@ -296,7 +296,7 @@ namespace OpenLoco::Ui
 
                 viewportSetUndergroundFlag(underground, viewport);
 
-                viewport->centre2dCoordinates(entity->position.x, entity->position.y, entity->position.z + 12, &centreX, &centreY);
+                centre = viewport->centre2dCoordinates(entity->position + Pos3{ 0, 0, 12 });
             }
             else
             {
@@ -336,50 +336,50 @@ namespace OpenLoco::Ui
                     config->saved_view_y = coord_2d.y - viewport->view_height / 2;
                 }
 
-                centreX = config->saved_view_x;
-                centreY = config->saved_view_y;
+                centre.x = config->saved_view_x;
+                centre.y = config->saved_view_y;
 
                 if (this->flags & WindowFlags::scrolling_to_location)
                 {
                     bool flippedX = false;
-                    centreX -= viewport->view_x;
-                    if (centreX < 0)
+                    centre.x -= viewport->view_x;
+                    if (centre.x < 0)
                     {
-                        centreX = -centreX;
+                        centre.x = -centre.x;
                         flippedX = true;
                     }
 
                     bool flippedY = false;
-                    centreY -= viewport->view_y;
-                    if (centreY < 0)
+                    centre.y -= viewport->view_y;
+                    if (centre.y < 0)
                     {
-                        centreY = -centreY;
+                        centre.y = -centre.y;
                         flippedY = true;
                     }
 
-                    centreX = (centreX + 7) / 8; // ceil(centreX / 8.0);
-                    centreY = (centreY + 7) / 8; // ceil(centreX / 8.0);
+                    centre.x = (centre.x + 7) / 8; // ceil(centreX / 8.0);
+                    centre.y = (centre.y + 7) / 8; // ceil(centreX / 8.0);
 
-                    if (centreX == 0 && centreY == 0)
+                    if (centre.x == 0 && centre.y == 0)
                     {
                         this->flags &= ~WindowFlags::scrolling_to_location;
                     }
 
                     if (flippedX)
                     {
-                        centreX = -centreX;
+                        centre.x = -centre.x;
                     }
 
                     if (flippedY)
                     {
-                        centreY = -centreY;
+                        centre.y = -centre.y;
                     }
 
-                    centreX += viewport->view_x;
-                    centreY += viewport->view_y;
+                    centre.x += viewport->view_x;
+                    centre.y += viewport->view_y;
                 }
             }
-            viewportMove(centreX, centreY, this, viewport);
+            viewportMove(centre.x, centre.y, this, viewport);
         }
     }
 
@@ -517,10 +517,9 @@ namespace OpenLoco::Ui
         *map_y = interaction.pos.y;
 
         // Get viewport coordinates centring around the tile.
-        int32_t base_height = TileManager::getHeight({ *map_x, *map_y }).landHeight;
-        int16_t dest_x, dest_y;
+        auto base_height = TileManager::getHeight({ *map_x, *map_y }).landHeight;
         Viewport* v = this->viewports[0];
-        v->centre2dCoordinates(*map_x, *map_y, base_height, &dest_x, &dest_y);
+        const auto dest = v->centre2dCoordinates({ *map_x, *map_y, base_height });
 
         // Rebase mouse position onto centre of window, and compensate for zoom level.
         int16_t rebased_x = ((this->width >> 1) - mouse_x) * (1 << v->zoom),
@@ -528,8 +527,8 @@ namespace OpenLoco::Ui
 
         // Compute cursor offset relative to tile.
         ViewportConfig* vc = &this->viewport_configurations[0];
-        *offset_x = (vc->saved_view_x - (dest_x + rebased_x)) * (1 << v->zoom);
-        *offset_y = (vc->saved_view_y - (dest_y + rebased_y)) * (1 << v->zoom);
+        *offset_x = (vc->saved_view_x - (dest.x + rebased_x)) * (1 << v->zoom);
+        *offset_y = (vc->saved_view_y - (dest.y + rebased_y)) * (1 << v->zoom);
     }
 
     // 0x004C6801
@@ -608,10 +607,9 @@ namespace OpenLoco::Ui
     void Window::viewportCentreTileAroundCursor(int16_t map_x, int16_t map_y, int16_t offset_x, int16_t offset_y)
     {
         // Get viewport coordinates centring around the tile.
-        int16_t dest_x, dest_y;
-        int32_t base_height = TileManager::getHeight({ map_x, map_y }).landHeight;
+        auto base_height = TileManager::getHeight({ map_x, map_y }).landHeight;
         Viewport* v = this->viewports[0];
-        v->centre2dCoordinates(map_x, map_y, base_height, &dest_x, &dest_y);
+        const auto dest = v->centre2dCoordinates({ map_x, map_y, base_height });
 
         // Get mouse position to offset against.
         int32_t mouse_x, mouse_y;
@@ -623,8 +621,8 @@ namespace OpenLoco::Ui
 
         // Apply offset to the viewport.
         ViewportConfig* vc = &this->viewport_configurations[0];
-        vc->saved_view_x = dest_x + rebased_x + (offset_x / (1 << v->zoom));
-        vc->saved_view_y = dest_y + rebased_y + (offset_y / (1 << v->zoom));
+        vc->saved_view_x = dest.x + rebased_x + (offset_x / (1 << v->zoom));
+        vc->saved_view_y = dest.y + rebased_y + (offset_y / (1 << v->zoom));
     }
 
     void Window::viewportFocusOnEntity(uint16_t targetEntity)


### PR DESCRIPTION
Reworks two functions to stop using out parameters and use proper types. I know this looks a bit counter productive in one or two spots but i think its better overall. It looks like it would be useful to have both an xy32 and xy16 for use in loco globals. (Also yes I know xy32 is not the name we want)