### PR TITLE
Some viewport functions

### DIFF
--- a/src/OpenLoco/CompanyManager.cpp
+++ b/src/OpenLoco/CompanyManager.cpp
@@ -258,11 +258,9 @@ namespace OpenLoco::CompanyManager
         if (viewport == nullptr)
             return;
 
-        Gfx::point_t screenPosition;
-        screenPosition.x = viewport->x + viewport->width / 2;
-        screenPosition.y = viewport->y + viewport->height / 2;
+        auto screenPosition = viewport->getUiCentre();
 
-        auto res = Map::TileManager::screenGetMapXY({ screenPosition.x, screenPosition.y });
+        auto res = Map::TileManager::screenGetMapXY(screenPosition);
 
         Map::Pos2 mapPosition{};
         if (!res || res->second != viewport)

--- a/src/OpenLoco/CompanyManager.cpp
+++ b/src/OpenLoco/CompanyManager.cpp
@@ -262,17 +262,17 @@ namespace OpenLoco::CompanyManager
         screenPosition.x = viewport->x + viewport->width / 2;
         screenPosition.y = viewport->y + viewport->height / 2;
 
-        registers r1;
-        r1.ax = screenPosition.x;
-        r1.bx = screenPosition.y;
-        call(0x0045F1A7, r1); // TileManager::screenGetMapXY
-        Ui::Viewport* vp = (Ui::Viewport*)r1.edi;
-        auto mapPosition = Map::Pos2(r1.ax, r1.bx);
+        auto res = Map::TileManager::screenGetMapXY({ screenPosition.x, screenPosition.y });
 
-        // Happens if center of viewport is obstructed. Probably estimates the centre location
-        if (mapPosition.x == Location::null || viewport != vp)
+        Map::Pos2 mapPosition{};
+        if (!res || res->second != viewport)
         {
+            // Happens if center of viewport is obstructed. Probably estimates the centre location
             mapPosition = viewport->getCentreMapPosition();
+        }
+        else
+        {
+            mapPosition = res->first;
         }
 
         GameCommands::do_73(mapPosition);

--- a/src/OpenLoco/CompanyManager.cpp
+++ b/src/OpenLoco/CompanyManager.cpp
@@ -298,11 +298,11 @@ namespace OpenLoco::CompanyManager
             }
 
             auto centre = view->getCentreScreenMapPosition();
-            if (centre.x == Location::null)
+            if (!centre)
             {
                 return;
             }
-            pos = Map::Pos3(centre.x, centre.y, Map::TileManager::getHeight(centre).landHeight);
+            pos = Map::Pos3(centre->x, centre->y, Map::TileManager::getHeight(*centre).landHeight);
         }
 
         pos.z += 10;

--- a/src/OpenLoco/CompanyManager.cpp
+++ b/src/OpenLoco/CompanyManager.cpp
@@ -265,7 +265,7 @@ namespace OpenLoco::CompanyManager
         registers r1;
         r1.ax = screenPosition.x;
         r1.bx = screenPosition.y;
-        call(0x0045F1A7, r1);
+        call(0x0045F1A7, r1); // TileManager::screenGetMapXY
         Ui::Viewport* vp = (Ui::Viewport*)r1.edi;
         auto mapPosition = Map::Pos2(r1.ax, r1.bx);
 

--- a/src/OpenLoco/CompanyManager.cpp
+++ b/src/OpenLoco/CompanyManager.cpp
@@ -260,7 +260,7 @@ namespace OpenLoco::CompanyManager
 
         auto screenPosition = viewport->getUiCentre();
 
-        auto res = Map::TileManager::screenGetMapXY(screenPosition);
+        auto res = Ui::ViewportInteraction::getSurfaceLocFromUi(screenPosition);
 
         Map::Pos2 mapPosition{};
         if (!res || res->second != viewport)

--- a/src/OpenLoco/Map/TileManager.cpp
+++ b/src/OpenLoco/Map/TileManager.cpp
@@ -440,21 +440,12 @@ namespace OpenLoco::Map::TileManager
         return count;
     }
 
-    // 0x0045FD8E
+    // 0x0045FE05
     // NOTE: Original call screenGetMapXY within this function
     // instead OpenLoco has split it in two. Also note that result of original
     // was a Pos2 start i.e. (& 0xFFE0) both components
-    uint8_t getQuadrantFromPos(const Map::Pos2& loc)
+    static uint8_t getQuadrantFromPos(const Map::Pos2& loc)
     {
-        // Determine to which quadrants the cursor is closest 4 == all quadrants
-        const auto xNibbleCentre = std::abs((loc.x & 0xFFE0) + 16 - loc.x);
-        const auto yNibbleCentre = std::abs((loc.y & 0xFFE0) + 16 - loc.y);
-        if (std::max(xNibbleCentre, yNibbleCentre) <= 7)
-        {
-            // Is centre so all quadrants
-            return 4;
-        }
-
         const auto xNibble = loc.x & 0x1F;
         const auto yNibble = loc.y & 0x1F;
         if (xNibble > 16)
@@ -481,6 +472,24 @@ namespace OpenLoco::Map::TileManager
         }
     }
 
+    // 0x0045FD8E
+    // NOTE: Original call screenGetMapXY within this function
+    // instead OpenLoco has split it in two. Also note that result of original
+    // was a Pos2 start i.e. (& 0xFFE0) both components
+    uint8_t getQuadrantOrCentreFromPos(const Map::Pos2& loc)
+    {
+        // Determine to which quadrants the cursor is closest 4 == all quadrants
+        const auto xNibbleCentre = std::abs((loc.x & 0xFFE0) + 16 - loc.x);
+        const auto yNibbleCentre = std::abs((loc.y & 0xFFE0) + 16 - loc.y);
+        if (std::max(xNibbleCentre, yNibbleCentre) <= 7)
+        {
+            // Is centre so all quadrants
+            return 4;
+        }
+
+        return getQuadrantFromPos(loc);
+    }
+
     uint16_t setMapSelectionSingleTile(int16_t x, int16_t y, bool setQuadrant)
     {
         auto res = screenGetMapXY({ x, y });
@@ -491,7 +500,7 @@ namespace OpenLoco::Map::TileManager
 
         uint16_t xPos = res->first.x & 0xFFE0;
         uint16_t yPos = res->first.y & 0xFFE0;
-        uint16_t cursorQuadrant = getQuadrantFromPos(res->first);
+        uint16_t cursorQuadrant = getQuadrantOrCentreFromPos(res->first);
 
         auto count = 0;
         if (!Input::hasMapSelectionFlag(Input::MapSelectionFlags::enable))

--- a/src/OpenLoco/Map/TileManager.h
+++ b/src/OpenLoco/Map/TileManager.h
@@ -22,7 +22,7 @@ namespace OpenLoco::Map::TileManager
     void reorganise();
     std::optional<std::pair<Pos2, Ui::Viewport*>> screenGetMapXY(const xy32& screenCoords);
     uint16_t setMapSelectionTiles(int16_t x, int16_t y);
-    Pos3 screenPosToMapPos(int16_t x, int16_t y);
+    uint8_t getQuadrantFromPos(const Map::Pos2& loc);
     uint16_t setMapSelectionSingleTile(int16_t x, int16_t y, bool setQuadrant = false);
     void mapInvalidateSelectionRect();
     void mapInvalidateTileFull(Map::Pos2 pos);

--- a/src/OpenLoco/Map/TileManager.h
+++ b/src/OpenLoco/Map/TileManager.h
@@ -20,9 +20,7 @@ namespace OpenLoco::Map::TileManager
     TileHeight getHeight(const Pos2& pos);
     void updateTilePointers();
     void reorganise();
-    std::optional<std::pair<Pos2, Ui::Viewport*>> screenGetMapXY(const xy32& screenCoords);
     uint16_t setMapSelectionTiles(int16_t x, int16_t y);
-    uint8_t getQuadrantOrCentreFromPos(const Map::Pos2& loc);
     uint16_t setMapSelectionSingleTile(int16_t x, int16_t y, bool setQuadrant = false);
     void mapInvalidateSelectionRect();
     void mapInvalidateTileFull(Map::Pos2 pos);

--- a/src/OpenLoco/Map/TileManager.h
+++ b/src/OpenLoco/Map/TileManager.h
@@ -20,7 +20,7 @@ namespace OpenLoco::Map::TileManager
     TileHeight getHeight(const Pos2& pos);
     void updateTilePointers();
     void reorganise();
-    Pos2 screenGetMapXY(int16_t x, int16_t y);
+    std::optional<std::pair<Pos2, Ui::Viewport*>> screenGetMapXY(const xy32& screenCoords);
     uint16_t setMapSelectionTiles(int16_t x, int16_t y);
     Pos3 screenPosToMapPos(int16_t x, int16_t y);
     uint16_t setMapSelectionSingleTile(int16_t x, int16_t y, bool setQuadrant = false);

--- a/src/OpenLoco/Map/TileManager.h
+++ b/src/OpenLoco/Map/TileManager.h
@@ -22,7 +22,7 @@ namespace OpenLoco::Map::TileManager
     void reorganise();
     std::optional<std::pair<Pos2, Ui::Viewport*>> screenGetMapXY(const xy32& screenCoords);
     uint16_t setMapSelectionTiles(int16_t x, int16_t y);
-    uint8_t getQuadrantFromPos(const Map::Pos2& loc);
+    uint8_t getQuadrantOrCentreFromPos(const Map::Pos2& loc);
     uint16_t setMapSelectionSingleTile(int16_t x, int16_t y, bool setQuadrant = false);
     void mapInvalidateSelectionRect();
     void mapInvalidateTileFull(Map::Pos2 pos);

--- a/src/OpenLoco/S5/S5.cpp
+++ b/src/OpenLoco/S5/S5.cpp
@@ -255,8 +255,8 @@ namespace OpenLoco::S5
         }
         std::memcpy(file->requiredObjects, requiredObjects.data(), sizeof(file->requiredObjects));
         file->gameState = _gameState;
-        file->gameState.savedViewX = savedView.mapX;
-        file->gameState.savedViewY = savedView.mapY;
+        file->gameState.savedViewX = savedView.viewX;
+        file->gameState.savedViewY = savedView.viewY;
         file->gameState.savedViewZoom = static_cast<uint8_t>(savedView.zoomLevel);
         file->gameState.savedViewRotation = savedView.rotation;
         file->gameState.magicNumber = magicNumber; // Match implementation at 0x004437FC
@@ -632,8 +632,8 @@ namespace OpenLoco::S5
             if (mainWindow != nullptr)
             {
                 SavedViewSimple savedView;
-                savedView.mapX = file->gameState.savedViewX;
-                savedView.mapY = file->gameState.savedViewY;
+                savedView.viewX = file->gameState.savedViewX;
+                savedView.viewY = file->gameState.savedViewY;
                 savedView.zoomLevel = static_cast<ZoomLevel>(file->gameState.savedViewZoom);
                 savedView.rotation = file->gameState.savedViewRotation;
                 mainWindow->viewportFromSavedView(savedView);

--- a/src/OpenLoco/Ui.h
+++ b/src/OpenLoco/Ui.h
@@ -212,6 +212,8 @@ namespace OpenLoco::Ui
         InteractionArg rightOver(int16_t x, int16_t y);
 
         std::pair<ViewportInteraction::InteractionArg, Ui::Viewport*> getMapCoordinatesFromPos(int32_t screenX, int32_t screenY, int32_t flags);
-        std::optional<Map::Pos2> getTileStartAtCursor(const xy32& screenCoords);
+        std::optional<Map::Pos2> getSurfaceOrWaterLocFromUi(const xy32& screenCoords);
+        uint8_t getQuadrantOrCentreFromPos(const Map::Pos2& loc);
+        std::optional<std::pair<Map::Pos2, Ui::Viewport*>> getSurfaceLocFromUi(const xy32& screenCoords);
     }
 }

--- a/src/OpenLoco/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/Ui/ViewportInteraction.cpp
@@ -517,7 +517,7 @@ namespace OpenLoco::Ui::ViewportInteraction
     // regs.ax = mapX, 0x8000 - in case of failure
     // regs.bx = mapY
     // regs.ecx = closestEdge (unsure if ever used)
-    std::optional<Pos2> getTileStartAtCursor(const xy32& screenCoords)
+    std::optional<Pos2> getSurfaceOrWaterLocFromUi(const xy32& screenCoords)
     {
         auto [info, viewport] = getMapCoordinatesFromPos(screenCoords.x, screenCoords.y, ~(InteractionItemFlags::surface | InteractionItemFlags::water));
 
@@ -577,5 +577,81 @@ namespace OpenLoco::Ui::ViewportInteraction
             }
         }
         return { Pos2(mapPos.x & 0xFFE0, mapPos.y & 0xFFE0) };
+    }
+
+    // 0x0045F1A7
+    std::optional<std::pair<Pos2, Ui::Viewport*>> getSurfaceLocFromUi(const xy32& screenCoords)
+    {
+        auto [info, viewport] = Ui::ViewportInteraction::getMapCoordinatesFromPos(screenCoords.x, screenCoords.y, ~Ui::ViewportInteraction::InteractionItemFlags::surface);
+
+        if (info.type == Ui::ViewportInteraction::InteractionItem::noInteraction)
+        {
+            return {};
+        }
+
+        const auto minPosition = info.pos;                  // E40128/A
+        const auto maxPosition = info.pos + Pos2{ 31, 31 }; // E4012C/E
+        auto mapPos = info.pos + Pos2{ 16, 16 };
+        const auto initialVPPos = viewport->uiToMap(screenCoords);
+
+        for (int32_t i = 0; i < 5; i++)
+        {
+            const auto z = TileManager::getHeight(mapPos);
+            mapPos = Ui::viewportCoordToMapCoord(initialVPPos.x, initialVPPos.y, z, viewport->getRotation());
+            mapPos.x = std::clamp(mapPos.x, minPosition.x, maxPosition.x);
+            mapPos.y = std::clamp(mapPos.y, minPosition.y, maxPosition.y);
+        }
+
+        return { std::make_pair(mapPos, viewport) };
+    }
+
+    // 0x0045FE05
+    // NOTE: Original call getSurfaceLocFromUi within this function
+    // instead OpenLoco has split it in two. Also note that result of original
+    // was a Pos2 start i.e. (& 0xFFE0) both components
+    static uint8_t getQuadrantFromPos(const Map::Pos2& loc)
+    {
+        const auto xNibble = loc.x & 0x1F;
+        const auto yNibble = loc.y & 0x1F;
+        if (xNibble > 16)
+        {
+            if (yNibble >= 16)
+            {
+                return 0;
+            }
+            else
+            {
+                return 1;
+            }
+        }
+        else
+        {
+            if (yNibble >= 16)
+            {
+                return 3;
+            }
+            else
+            {
+                return 2;
+            }
+        }
+    }
+
+    // 0x0045FD8E
+    // NOTE: Original call getSurfaceLocFromUi within this function
+    // instead OpenLoco has split it in two. Also note that result of original
+    // was a Pos2 start i.e. (& 0xFFE0) both components
+    uint8_t getQuadrantOrCentreFromPos(const Map::Pos2& loc)
+    {
+        // Determine to which quadrants the cursor is closest 4 == all quadrants
+        const auto xNibbleCentre = std::abs((loc.x & 0xFFE0) + 16 - loc.x);
+        const auto yNibbleCentre = std::abs((loc.y & 0xFFE0) + 16 - loc.y);
+        if (std::max(xNibbleCentre, yNibbleCentre) <= 7)
+        {
+            // Is centre so all quadrants
+            return 4;
+        }
+
+        return getQuadrantFromPos(loc);
     }
 }

--- a/src/OpenLoco/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/Ui/ViewportInteraction.cpp
@@ -580,11 +580,11 @@ namespace OpenLoco::Ui::ViewportInteraction
     }
 
     // 0x0045F1A7
-    std::optional<std::pair<Pos2, Ui::Viewport*>> getSurfaceLocFromUi(const xy32& screenCoords)
+    std::optional<std::pair<Pos2, Viewport*>> getSurfaceLocFromUi(const xy32& screenCoords)
     {
-        auto [info, viewport] = Ui::ViewportInteraction::getMapCoordinatesFromPos(screenCoords.x, screenCoords.y, ~Ui::ViewportInteraction::InteractionItemFlags::surface);
+        auto [info, viewport] = getMapCoordinatesFromPos(screenCoords.x, screenCoords.y, ~InteractionItemFlags::surface);
 
-        if (info.type == Ui::ViewportInteraction::InteractionItem::noInteraction)
+        if (info.type == InteractionItem::noInteraction)
         {
             return {};
         }
@@ -597,7 +597,7 @@ namespace OpenLoco::Ui::ViewportInteraction
         for (int32_t i = 0; i < 5; i++)
         {
             const auto z = TileManager::getHeight(mapPos);
-            mapPos = Ui::viewportCoordToMapCoord(initialVPPos.x, initialVPPos.y, z, viewport->getRotation());
+            mapPos = viewportCoordToMapCoord(initialVPPos.x, initialVPPos.y, z, viewport->getRotation());
             mapPos.x = std::clamp(mapPos.x, minPosition.x, maxPosition.x);
             mapPos.y = std::clamp(mapPos.y, minPosition.y, maxPosition.y);
         }

--- a/src/OpenLoco/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/Ui/ViewportInteraction.cpp
@@ -556,25 +556,11 @@ namespace OpenLoco::Ui::ViewportInteraction
         const auto yNibble = mapPos.y & 0x1F;
         if (xNibble < yNibble)
         {
-            if (xNibble + yNibble < 32)
-            {
-                closestEdge = 0;
-            }
-            else
-            {
-                closestEdge = 1;
-            }
+            closestEdge = (xNibble + yNibble < 32) ? 0 : 1;
         }
         else
         {
-            if (xNibble + yNibble < 32)
-            {
-                closestEdge = 3;
-            }
-            else
-            {
-                closestEdge = 2;
-            }
+            closestEdge = (xNibble + yNibble < 32) ? 3 : 2;
         }
         return { Pos2(mapPos.x & 0xFFE0, mapPos.y & 0xFFE0) };
     }
@@ -615,25 +601,11 @@ namespace OpenLoco::Ui::ViewportInteraction
         const auto yNibble = loc.y & 0x1F;
         if (xNibble > 16)
         {
-            if (yNibble >= 16)
-            {
-                return 0;
-            }
-            else
-            {
-                return 1;
-            }
+            return (yNibble >= 16) ? 0 : 1;
         }
         else
         {
-            if (yNibble >= 16)
-            {
-                return 3;
-            }
-            else
-            {
-                return 2;
-            }
+            return (yNibble >= 16) ? 3 : 2;
         }
     }
 

--- a/src/OpenLoco/Viewport.cpp
+++ b/src/OpenLoco/Viewport.cpp
@@ -87,8 +87,13 @@ namespace OpenLoco::Ui
         return result;
     }
 
-    Pos2 Viewport::getCentreScreenMapPosition() const
+    std::optional<Pos2> Viewport::getCentreScreenMapPosition() const
     {
-        return TileManager::screenGetMapXY(x + width / 2, y + height / 2);
+        auto res = TileManager::screenGetMapXY({ x + width / 2, y + height / 2 });
+        if (!res)
+        {
+            return {};
+        }
+        return { res->first };
     }
 }

--- a/src/OpenLoco/Viewport.cpp
+++ b/src/OpenLoco/Viewport.cpp
@@ -71,8 +71,7 @@ namespace OpenLoco::Ui
 
     viewport_pos Viewport::getCentre() const
     {
-        return { view_x + view_width / 2,
-                 view_y + view_height / 2 };
+        return viewport_pos(view_x + view_width / 2, view_y + view_height / 2);
     }
 
     xy32 Viewport::getUiCentre() const

--- a/src/OpenLoco/Viewport.cpp
+++ b/src/OpenLoco/Viewport.cpp
@@ -61,18 +61,30 @@ namespace OpenLoco::Ui
     SavedViewSimple Viewport::toSavedView() const
     {
         SavedViewSimple result;
-        result.mapX = view_x + (view_width >> 1);
-        result.mapY = view_y + (view_height >> 1);
+        const auto centre = getCentre();
+        result.viewX = centre.x;
+        result.viewY = centre.y;
         result.zoomLevel = static_cast<ZoomLevel>(zoom);
         result.rotation = getRotation();
         return result;
     }
 
+    viewport_pos Viewport::getCentre() const
+    {
+        return { view_x + view_width / 2,
+                 view_y + view_height / 2 };
+    }
+
+    xy32 Viewport::getUiCentre() const
+    {
+        return { x + width / 2,
+                 y + height / 2 };
+    }
+
     // 0x0045F997
     Pos2 Viewport::getCentreMapPosition() const
     {
-        viewport_pos initialVPPos = { view_x + view_width / 2,
-                                      view_y + view_height / 2 };
+        const viewport_pos initialVPPos = getCentre();
 
         const auto rotation = getRotation();
         // Vanilla unrolled on rotation at this point
@@ -89,7 +101,7 @@ namespace OpenLoco::Ui
 
     std::optional<Pos2> Viewport::getCentreScreenMapPosition() const
     {
-        auto res = TileManager::screenGetMapXY({ x + width / 2, y + height / 2 });
+        auto res = TileManager::screenGetMapXY(getUiCentre());
         if (!res)
         {
             return {};

--- a/src/OpenLoco/Viewport.cpp
+++ b/src/OpenLoco/Viewport.cpp
@@ -101,7 +101,7 @@ namespace OpenLoco::Ui
 
     std::optional<Pos2> Viewport::getCentreScreenMapPosition() const
     {
-        auto res = TileManager::screenGetMapXY(getUiCentre());
+        auto res = Ui::ViewportInteraction::getSurfaceLocFromUi(getUiCentre());
         if (!res)
         {
             return {};

--- a/src/OpenLoco/Viewport.hpp
+++ b/src/OpenLoco/Viewport.hpp
@@ -147,7 +147,7 @@ namespace OpenLoco::Ui
         void centre2dCoordinates(int16_t x, int16_t y, int16_t z, int16_t* outX, int16_t* outY);
         SavedViewSimple toSavedView() const;
         Map::Pos2 getCentreMapPosition() const;
-        Map::Pos2 getCentreScreenMapPosition() const;
+        std::optional<Map::Pos2> getCentreScreenMapPosition() const;
 
     private:
         void paint(Gfx::Context* context, const Ui::Rect& rect);

--- a/src/OpenLoco/Viewport.hpp
+++ b/src/OpenLoco/Viewport.hpp
@@ -146,6 +146,9 @@ namespace OpenLoco::Ui
         void render(Gfx::Context* context);
         void centre2dCoordinates(int16_t x, int16_t y, int16_t z, int16_t* outX, int16_t* outY);
         SavedViewSimple toSavedView() const;
+
+        viewport_pos getCentre() const;
+        xy32 getUiCentre() const;
         Map::Pos2 getCentreMapPosition() const;
         std::optional<Map::Pos2> getCentreScreenMapPosition() const;
 

--- a/src/OpenLoco/Window.cpp
+++ b/src/OpenLoco/Window.cpp
@@ -755,8 +755,8 @@ namespace OpenLoco::Ui
         {
             auto& config = viewport_configurations[0];
             config.viewport_target_sprite = EntityId::null;
-            config.saved_view_x = savedView.mapX;
-            config.saved_view_y = savedView.mapY;
+            config.saved_view_x = savedView.viewX;
+            config.saved_view_y = savedView.viewY;
 
             auto zoom = static_cast<int32_t>(savedView.zoomLevel) - viewport->zoom;
             if (zoom != 0)

--- a/src/OpenLoco/Window.h
+++ b/src/OpenLoco/Window.h
@@ -163,8 +163,8 @@ namespace OpenLoco::Ui
 
     struct SavedViewSimple
     {
-        coord_t mapX;
-        coord_t mapY;
+        coord_t viewX;
+        coord_t viewY;
         ZoomLevel zoomLevel;
         int8_t rotation;
     };

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -948,12 +948,12 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         // regs.dx = dx - company index (value 1 in testing case)
         static std::optional<GameCommands::HeadquarterPlacementArgs> getHeadquarterPlacementArgsFromCursor(const int16_t mouseX, const int16_t mouseY)
         {
-            auto pos = ViewportInteraction::getTileStartAtCursor({ mouseX, mouseY });
+            auto pos = ViewportInteraction::getSurfaceOrWaterLocFromUi({ mouseX, mouseY });
             if (!pos)
             {
                 return {};
             }
-            // TODO: modify getTileStartAtCursor to return the viewport then use its rotation
+            // TODO: modify getSurfaceOrWaterLocFromUi to return the viewport then use its rotation
             static loco_global<int32_t, 0x00E3F0B8> gCurrentRotation;
 
             GameCommands::HeadquarterPlacementArgs args;

--- a/src/OpenLoco/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/Windows/Construction/ConstructionTab.cpp
@@ -1665,7 +1665,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
             if (!height || !mapPos)
             {
-                mapPos = ViewportInteraction::getTileStartAtCursor({ x, y });
+                mapPos = ViewportInteraction::getSurfaceOrWaterLocFromUi({ x, y });
 
                 if (!mapPos)
                     return;
@@ -1762,7 +1762,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
             if (!height || !mapPos || _word_4F7B62[track->id * 8] != 0)
             {
-                mapPos = ViewportInteraction::getTileStartAtCursor({ x, y });
+                mapPos = ViewportInteraction::getSurfaceOrWaterLocFromUi({ x, y });
 
                 if (!mapPos)
                     return;

--- a/src/OpenLoco/Windows/IndustryList.cpp
+++ b/src/OpenLoco/Windows/IndustryList.cpp
@@ -964,7 +964,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 return {};
             }
 
-            const auto pos = ViewportInteraction::getTileStartAtCursor({ x, y }); //ax,cx
+            const auto pos = ViewportInteraction::getSurfaceOrWaterLocFromUi({ x, y }); //ax,cx
             if (!pos)
             {
                 return {};

--- a/src/OpenLoco/Windows/TileInspector.cpp
+++ b/src/OpenLoco/Windows/TileInspector.cpp
@@ -34,7 +34,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
 {
     static loco_global<int8_t, 0x00523393> _currentTool;
 
-    static Pos2 _currentPosition{};
+    static TilePos2 _currentPosition{};
 
     constexpr Gfx::ui_size_t windowSize = { 250, 182 };
 
@@ -139,13 +139,13 @@ namespace OpenLoco::Ui::Windows::TileInspector
         // Coord X/Y values
         {
             FormatArguments args = {};
-            args.push<int16_t>(_currentPosition.x / Map::tile_size);
+            args.push<int16_t>(_currentPosition.x);
             auto& widget = self->widgets[widx::xPos];
             Gfx::drawString_494B3F(*context, self->x + widget.left + 2, self->y + widget.top + 1, Colour::black, StringIds::tile_inspector_coord, &args);
         }
         {
             FormatArguments args = {};
-            args.push<int16_t>(_currentPosition.y / Map::tile_size);
+            args.push<int16_t>(_currentPosition.y);
             auto& widget = self->widgets[widx::yPos];
             Gfx::drawString_494B3F(*context, self->x + widget.left + 2, self->y + widget.top + 1, Colour::black, StringIds::tile_inspector_coord, &args);
         }
@@ -335,7 +335,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
 
     static void drawScroll(Ui::Window* self, Gfx::Context* const context, uint32_t)
     {
-        if (_currentPosition == Pos2(0, 0))
+        if (_currentPosition == TilePos2(0, 0))
             return;
 
         auto tile = TileManager::get(_currentPosition);
@@ -426,22 +426,22 @@ namespace OpenLoco::Ui::Windows::TileInspector
                 break;
 
             case widx::xPosDecrease:
-                _currentPosition.x = std::clamp<coord_t>(_currentPosition.x - Map::tile_size, 1, Map::map_width);
+                _currentPosition.x = std::clamp<coord_t>(_currentPosition.x - 1, 1, Map::map_columns);
                 self->invalidate();
                 break;
 
             case widx::xPosIncrease:
-                _currentPosition.x = std::clamp<coord_t>(_currentPosition.x + Map::tile_size, 1, Map::map_width);
+                _currentPosition.x = std::clamp<coord_t>(_currentPosition.x + 1, 1, Map::map_columns);
                 self->invalidate();
                 break;
 
             case widx::yPosDecrease:
-                _currentPosition.y = std::clamp<coord_t>(_currentPosition.y - Map::tile_size, 1, Map::map_height);
+                _currentPosition.y = std::clamp<coord_t>(_currentPosition.y - 1, 1, Map::map_rows);
                 self->invalidate();
                 break;
 
             case widx::yPosIncrease:
-                _currentPosition.y = std::clamp<coord_t>(_currentPosition.y + Map::tile_size, 1, Map::map_height);
+                _currentPosition.y = std::clamp<coord_t>(_currentPosition.y + 1, 1, Map::map_rows);
                 self->invalidate();
                 break;
         }
@@ -449,7 +449,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
 
     static void getScrollSize(Ui::Window* self, uint32_t, uint16_t*, uint16_t* const scrollHeight)
     {
-        if (_currentPosition == Pos2(0, 0))
+        if (_currentPosition == TilePos2(0, 0))
         {
             *scrollHeight = 0;
             return;
@@ -473,7 +473,12 @@ namespace OpenLoco::Ui::Windows::TileInspector
         if (widgetIndex != widx::panel || !Input::hasMapSelectionFlag(Input::MapSelectionFlags::enable))
             return;
 
-        _currentPosition = TileManager::screenPosToMapPos(x, y);
+        auto res = TileManager::screenGetMapXY({ x, y });
+        if (!res)
+        {
+            return;
+        }
+        _currentPosition = res->first;
         auto tile = TileManager::get(_currentPosition);
 
         self.row_count = static_cast<uint16_t>(tile.size());

--- a/src/OpenLoco/Windows/TileInspector.cpp
+++ b/src/OpenLoco/Windows/TileInspector.cpp
@@ -473,7 +473,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         if (widgetIndex != widx::panel || !Input::hasMapSelectionFlag(Input::MapSelectionFlags::enable))
             return;
 
-        auto res = TileManager::screenGetMapXY({ x, y });
+        auto res = Ui::ViewportInteraction::getSurfaceLocFromUi({ x, y });
         if (!res)
         {
             return;

--- a/src/OpenLoco/Windows/TownList.cpp
+++ b/src/OpenLoco/Windows/TownList.cpp
@@ -1003,13 +1003,13 @@ namespace OpenLoco::Ui::Windows::TownList
                 return {};
             }
 
-            const auto pos = ViewportInteraction::getTileStartAtCursor({ x, y }); //ax,cx
+            const auto pos = ViewportInteraction::getSurfaceOrWaterLocFromUi({ x, y }); //ax,cx
             if (!pos)
             {
                 return {};
             }
 
-            // TODO: modify getTileStartAtCursor to return the viewport then use its rotation
+            // TODO: modify getSurfaceOrWaterLocFromUi to return the viewport then use its rotation
             static loco_global<int32_t, 0x00E3F0B8> gCurrentRotation;
 
             GameCommands::BuildingPlacementArgs args;

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -3295,7 +3295,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             _113600C = x;
             _113600E = y;
 
-            auto pos = ViewportInteraction::getTileStartAtCursor({ x, y });
+            auto pos = ViewportInteraction::getSurfaceOrWaterLocFromUi({ x, y });
             if (!pos)
             {
                 return {};


### PR DESCRIPTION
These are all really similar to OpenRCT2 functions and also really similar to ViewportInteraction functions. There is perhaps scope for trying to streamline these functions.
`getCentreScreenMapPosition()` should probably be removed and make it so it only returns the viewport position. That would make it more flexible.