### PR TITLE
Cleanup duplicated call instances and add notes

### DIFF
--- a/src/OpenLoco/Map/MapGenerator.cpp
+++ b/src/OpenLoco/Map/MapGenerator.cpp
@@ -527,7 +527,7 @@ namespace OpenLoco::Map::MapGenerator
         updateProgress(255);
 
         call(0x004969E0);
-        call(0x004748D4);
+        Scenario::sub_4748D4();
         Ui::ProgressBar::end();
     }
 }

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -436,7 +436,7 @@ namespace OpenLoco
         Ui::ProgressBar::end();
         Ui::initialise();
         initialiseViewports();
-        call(0x004284C8);
+        Title::sub_4284C8();
         call(0x004969DA);
         call(0x0043C88C);
         setScreenFlag(ScreenFlags::initialised);
@@ -996,7 +996,7 @@ namespace OpenLoco
                     Ui::Windows::TimePanel::invalidateFrame();
                     addr<0x00526243, uint16_t>()++;
                     TownManager::updateMonthly();
-                    call(0x0045383B);
+                    IndustryManager::updateMonthly();
                     call(0x0043037B);
                     call(0x0042F213);
                     call(0x004C3C54);

--- a/src/OpenLoco/S5/S5.cpp
+++ b/src/OpenLoco/S5/S5.cpp
@@ -519,11 +519,6 @@ namespace OpenLoco::S5
         }
     };
 
-    static void sub_42F7F8()
-    {
-        call(0x0042F7F8);
-    }
-
     static void sub_4BAEC4()
     {
         addr<0x001136496, uint8_t>() = 2;
@@ -598,7 +593,7 @@ namespace OpenLoco::S5
                 setObjectErrorMessage(loadObjectResult.problemObject);
                 if (flags & LoadFlags::twoPlayer)
                 {
-                    sub_42F7F8();
+                    CompanyManager::reset();
                     addr<0x00525F62, uint16_t>() = 0;
                     return false;
                 }

--- a/src/OpenLoco/Title.cpp
+++ b/src/OpenLoco/Title.cpp
@@ -93,14 +93,14 @@ namespace OpenLoco::Title
     // ?load selected objects?
     static void sub_474874()
     {
-        call(0x00474874);
+        call(0x00474874); // editorLoadSelectedObjects
     }
 
     // 0x00473B91
     // object flags free 0
     static void sub_473B91()
     {
-        call(0x00473B91);
+        call(0x00473B91); // editorObjectFlagsFree0
     }
 
     // 0x004284C8

--- a/src/OpenLoco/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/Windows/ObjectSelectionWindow.cpp
@@ -138,6 +138,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     // 0x00473A95
     static void sub_473A95()
     {
+        // Title::sub_473A95
         registers regs;
         regs.eax = 0;
         call(0x00473A95, regs);

--- a/src/OpenLoco/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/Windows/ScenarioSelect.cpp
@@ -200,7 +200,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             registers regs2;
             regs2.ebp = X86Pointer(&scenarioInfo->currency);
             call(0x00471BCE, regs2);
-            call(0x0047237D); // reset_loaded_objects
+            ObjectManager::reloadAll();
             call(0x0046E07B); // load currency gfx
         }
 


### PR DESCRIPTION
There are still a couple duplicates related to object loading/unloading but there wasn't a nice simple way to reduce their instances.