### PR TITLE
Use system cursors for pointer and hand cursors

### DIFF
--- a/src/OpenLoco/Ui.cpp
+++ b/src/OpenLoco/Ui.cpp
@@ -245,11 +245,11 @@ namespace OpenLoco::Ui
     // 0x00452001
     void initialiseCursors()
     {
-        _cursors[CursorId::pointer] = loadCursor(Cursor::pointer);
+        _cursors[CursorId::pointer] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
         _cursors[CursorId::blank] = loadCursor(Cursor::blank);
         _cursors[CursorId::upArrow] = loadCursor(Cursor::upArrow);
         _cursors[CursorId::upDownArrow] = loadCursor(Cursor::upDownArrow);
-        _cursors[CursorId::handPointer] = loadCursor(Cursor::handPointer);
+        _cursors[CursorId::handPointer] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
         _cursors[CursorId::busy] = loadCursor(Cursor::busy);
         _cursors[CursorId::diagonalArrows] = loadCursor(Cursor::diagonalArrows);
         _cursors[CursorId::unk_7] = loadCursor(Cursor::cursor124);

--- a/src/OpenLoco/Ui/Cursor.cpp
+++ b/src/OpenLoco/Ui/Cursor.cpp
@@ -6,41 +6,6 @@
 
 namespace OpenLoco::Ui
 {
-    Cursor Cursor::pointer = Cursor(
-        0, 0,
-        "X                               "
-        "XX                              "
-        "X.X                             "
-        "X..X                            "
-        "X...X                           "
-        "X....X                          "
-        "X.....X                         "
-        "X......X                        "
-        "X.......X                       "
-        "X........X                      "
-        "X.....XXXXX                     "
-        "X..X..X                         "
-        "X.X X..X                        "
-        "XX  X..X                        "
-        "X    X..X                       "
-        "     X..X                       "
-        "      X..X                      "
-        "      X..X                      "
-        "       XX                       "
-        "                                "
-        "                                "
-        "                                "
-        "                                "
-        "                                "
-        "                                "
-        "                                "
-        "                                "
-        "                                "
-        "                                "
-        "                                "
-        "                                "
-        "                                ");
-
     Cursor Cursor::blank = Cursor(
         0, 0,
         "                                "
@@ -144,41 +109,6 @@ namespace OpenLoco::Ui
         "              X.X.X             "
         "               X.X              "
         "                X               "
-        "                                ");
-
-    Cursor Cursor::handPointer = Cursor(
-        9, 3,
-        "                                "
-        "                                "
-        "                                "
-        "         XX                     "
-        "        X..X                    "
-        "        X..X                    "
-        "        X..X                    "
-        "        X..X                    "
-        "        X..XXX                  "
-        "        X..X..XXX               "
-        "        X..X..X..XX             "
-        "        X..X..X..X.X            "
-        "    XXX X..X..X..X..X           "
-        "    X..XX........X..X           "
-        "    X...X...........X           "
-        "     X..X...........X           "
-        "      X.X...........X           "
-        "      X.............X           "
-        "       X............X           "
-        "       X...........X            "
-        "        X..........X            "
-        "        X..........X            "
-        "         X........X             "
-        "         X........X             "
-        "         XXXXXXXXXX             "
-        "                                "
-        "                                "
-        "                                "
-        "                                "
-        "                                "
-        "                                "
         "                                ");
 
     Cursor Cursor::busy = Cursor(

--- a/src/OpenLoco/Ui/Cursor.h
+++ b/src/OpenLoco/Ui/Cursor.h
@@ -21,11 +21,9 @@ namespace OpenLoco::Ui
         uint8_t data[encodedCursorSize]{};
         uint8_t mask[encodedCursorSize]{};
 
-        static Cursor pointer;
         static Cursor blank;
         static Cursor upArrow;
         static Cursor upDownArrow;
-        static Cursor handPointer;
         static Cursor busy;
         static Cursor diagonalArrows;
         static Cursor cursor124;


### PR DESCRIPTION
Recently, #674 introduced support for Locomotion's custom cursors on Linux and macOS. As a result of that PR, however, the pointer and hand cursors regressed to their Windows 9x/2000 counterparts. This PR changes only these specific cursors to use the appropriate system cursors.

- [x] The ASCII art definitions for the two cursors have not yet been removed. I think they be removed safely, though.
- [x] ~I noticed that the cursor data arrays have not been declared const. We should probably change that.~
- [x] ~I considered doing something similar with the window resizing cursors, but wanted to gauge interest in that first. Any thoughts?~