### PR TITLE
Allow rotating buildings in town list by keyboard shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#1035] Incorrect colour selection when building buildings.
 - Fix: [#1070] Crash when naming stations after exhausting natural names.
+- Change: [#1079] Allow rotating buildings in town list by keyboard shortcut.
 
 21.07 (2021-07-18)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/Input/ShortcutManager.cpp
+++ b/src/OpenLoco/Input/ShortcutManager.cpp
@@ -225,7 +225,15 @@ namespace OpenLoco::Input::ShortcutManager
         window = WindowManager::find(WindowType::construction);
         if (window != nullptr)
         {
-            Ui::Windows::Construction::rotate(window);
+            if (Ui::Windows::Construction::rotate(window))
+                return;
+        }
+
+        window = WindowManager::find(WindowType::townList);
+        if (window != nullptr)
+        {
+            if (Ui::Windows::TownList::rotate(window))
+                return;
         }
     }
 

--- a/src/OpenLoco/Ui/WindowManager.h
+++ b/src/OpenLoco/Ui/WindowManager.h
@@ -135,7 +135,7 @@ namespace OpenLoco::Ui::Windows
         void setToRoadExtra(Window* main, Map::RoadElement* track, const uint8_t bh, const Map::Pos2 pos);
         void sub_4A6FAC();
         bool isStationTabOpen();
-        void rotate(Window* self);
+        bool rotate(Window* self);
         void sub_49FEC7();
         void registerHooks();
     }
@@ -379,6 +379,7 @@ namespace OpenLoco::Ui::Windows
     {
         Window* open();
         void reset();
+        bool rotate(Window* self);
     }
 
     namespace Tutorial

--- a/src/OpenLoco/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/Windows/Construction/Common.cpp
@@ -1242,7 +1242,7 @@ namespace OpenLoco::Ui::Windows::Construction
         }
     }
 
-    void rotate(Window* self)
+    bool rotate(Window* self)
     {
         switch (self->current_tab)
         {
@@ -1251,6 +1251,7 @@ namespace OpenLoco::Ui::Windows::Construction
                 {
                     self->callOnMouseUp(Construction::widx::rotate_90);
                     sub_49FEC7();
+                    return true;
                 }
                 break;
 
@@ -1258,9 +1259,11 @@ namespace OpenLoco::Ui::Windows::Construction
                 if (self->widgets[Station::widx::rotate].type != WidgetType::none)
                 {
                     self->callOnMouseUp(Station::widx::rotate);
+                    return true;
                 }
                 break;
         }
+        return false;
     }
 
     void registerHooks()

--- a/src/OpenLoco/Windows/TownList.cpp
+++ b/src/OpenLoco/Windows/TownList.cpp
@@ -1406,6 +1406,23 @@ namespace OpenLoco::Ui::Windows::TownList
         }
     }
 
+    bool rotate(Window* self)
+    {
+        if (self->current_tab >= Common::widx::tab_build_buildings - Common::widx::tab_town_list)
+        {
+            if (!self->isDisabled(BuildBuildings::widx::rotate_object))
+            {
+                if (self->widgets[BuildBuildings::widx::rotate_object].type != WidgetType::none)
+                {
+                    self->callOnMouseUp(BuildBuildings::widx::rotate_object);
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     namespace Common
     {
         struct TabInformation


### PR DESCRIPTION
Currently, only the track construction tool and terraform windows use the item rotation hotkey (default Z). This extends this functionality to the building tabs in the town list (editor and sandbox mode).

Part of #1075.