### PR TITLE
Modify drawScroll event to pass by reference

### DIFF
--- a/src/OpenLoco/Window.cpp
+++ b/src/OpenLoco/Window.cpp
@@ -1413,7 +1413,7 @@ namespace OpenLoco::Ui
             return;
         }
 
-        event_handlers->draw_scroll(this, context, scrollIndex);
+        event_handlers->draw_scroll(*this, *context, scrollIndex);
     }
 
     // 0x004CA4DF

--- a/src/OpenLoco/Window.h
+++ b/src/OpenLoco/Window.h
@@ -150,7 +150,7 @@ namespace OpenLoco::Ui
                 void (*on_move)(Window&, const int16_t x, const int16_t y);
                 void (*prepare_draw)(Window*);
                 void (*draw)(Window*, Gfx::Context*);
-                void (*draw_scroll)(Window*, Gfx::Context*, uint32_t scrollIndex);
+                void (*draw_scroll)(Window&, Gfx::Context&, const uint32_t scrollIndex);
             };
         };
 

--- a/src/OpenLoco/Windows/AboutMusic.cpp
+++ b/src/OpenLoco/Windows/AboutMusic.cpp
@@ -98,7 +98,7 @@ namespace OpenLoco::Ui::Windows::AboutMusic
     }
 
     // 0x0043B8BE
-    static void drawScroll(Ui::Window*, Gfx::Context* const context, uint32_t)
+    static void drawScroll(Ui::Window&, Gfx::Context& context, const uint32_t)
     {
         static const std::pair<string_id, string_id> stringsToDraw[numSongs] = {
             { StringIds::locomotion_title, StringIds::locomotion_title_credit },
@@ -142,15 +142,15 @@ namespace OpenLoco::Ui::Windows::AboutMusic
             // TODO: optimisation: don't draw past fold.
 
             // Song name
-            drawStringCentred(*context, x, y, Colour::black, songStrings.first, nullptr);
+            drawStringCentred(context, x, y, Colour::black, songStrings.first, nullptr);
             y += 10;
 
             // Credit line
-            drawStringCentred(*context, x, y, Colour::black, songStrings.second, nullptr);
+            drawStringCentred(context, x, y, Colour::black, songStrings.second, nullptr);
             y += 10;
 
             // Show CS' copyright after every two lines.
-            drawStringCentred(*context, x, y, Colour::black, StringIds::music_copyright, nullptr);
+            drawStringCentred(context, x, y, Colour::black, StringIds::music_copyright, nullptr);
             y += 14;
         }
     }

--- a/src/OpenLoco/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/Windows/BuildVehicle.cpp
@@ -1033,15 +1033,15 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     }
 
     // 0x4C3307
-    static void drawScroll(Ui::Window* window, Gfx::Context* context, uint32_t scrollIndex)
+    static void drawScroll(Ui::Window& window, Gfx::Context& context, const uint32_t scrollIndex)
     {
         switch (scrollIndex)
         {
             case scrollIdx::vehicle_selection:
             {
-                auto colour = Colour::getShade(window->getColour(WindowColour::secondary), 4);
-                Gfx::clear(*context, colour * 0x01010101);
-                if (window->var_83C == 0)
+                auto colour = Colour::getShade(window.getColour(WindowColour::secondary), 4);
+                Gfx::clear(context, colour * 0x01010101);
+                if (window.var_83C == 0)
                 {
                     auto defaultMessage = StringIds::no_vehicles_available;
                     FormatArguments args{};
@@ -1053,67 +1053,67 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                         args.push(vehicle->ordinalNumber);
                     }
 
-                    auto widget = window->widgets[widx::scrollview_vehicle_selection];
+                    auto widget = window.widgets[widx::scrollview_vehicle_selection];
                     auto width = widget.right - widget.left - 17;
-                    auto y = (window->row_height - 10) / 2;
-                    Gfx::drawString_495224(*context, 3, y, width, Colour::black, defaultMessage, &args);
+                    auto y = (window.row_height - 10) / 2;
+                    Gfx::drawString_495224(context, 3, y, width, Colour::black, defaultMessage, &args);
                 }
                 else
                 {
                     int16_t y = 0;
-                    for (auto i = 0; i < window->var_83C; ++i, y += window->row_height)
+                    for (auto i = 0; i < window.var_83C; ++i, y += window.row_height)
                     {
-                        if (y + window->row_height + 30 <= context->y)
+                        if (y + window.row_height + 30 <= context.y)
                         {
                             continue;
                         }
 
-                        if (y >= context->y + context->height + 30)
+                        if (y >= context.y + context.height + 30)
                         {
                             continue;
                         }
 
-                        auto vehicleType = window->row_info[i];
+                        auto vehicleType = window.row_info[i];
                         if (vehicleType == -1)
                         {
                             continue;
                         }
 
                         auto colouredString = StringIds::black_stringid;
-                        if (window->row_hover == vehicleType)
+                        if (window.row_hover == vehicleType)
                         {
-                            Gfx::fillRect(context, 0, y, window->width, y + window->row_height - 1, 0x2000030);
+                            Gfx::fillRect(&context, 0, y, window.width, y + window.row_height - 1, 0x2000030);
                             colouredString = StringIds::wcolour2_stringid;
                         }
 
-                        int16_t half = (window->row_height - 22) / 2;
-                        auto x = drawVehicleInline(context, vehicleType, 0, CompanyManager::getControllingId(), { 0, static_cast<int16_t>(y + half) });
+                        int16_t half = (window.row_height - 22) / 2;
+                        auto x = drawVehicleInline(&context, vehicleType, 0, CompanyManager::getControllingId(), { 0, static_cast<int16_t>(y + half) });
 
                         auto vehicleObj = ObjectManager::get<VehicleObject>(vehicleType);
                         FormatArguments args{};
                         args.push(vehicleObj->name);
-                        half = (window->row_height - 10) / 2;
-                        Gfx::drawString_494B3F(*context, x + 3, y + half, Colour::black, colouredString, &args);
+                        half = (window.row_height - 10) / 2;
+                        Gfx::drawString_494B3F(context, x + 3, y + half, Colour::black, colouredString, &args);
                     }
                 }
                 break;
             }
             case scrollIdx::vehicle_preview:
             {
-                auto colour = Colour::getShade(window->getColour(WindowColour::secondary), 0);
+                auto colour = Colour::getShade(window.getColour(WindowColour::secondary), 0);
                 // Gfx::clear needs the colour copied to each byte of eax
-                Gfx::clear(*context, colour * 0x01010101);
+                Gfx::clear(context, colour * 0x01010101);
 
-                if (window->row_hover == -1)
+                if (window.row_hover == -1)
                 {
                     break;
                 }
 
                 uint8_t unk1 = _52622E & 0x3F;
                 uint8_t unk2 = ((_52622E + 2) / 4) & 0x3F;
-                drawVehicleOverview(context, window->row_hover, CompanyManager::getControllingId(), unk1, unk2, { 90, 37 });
+                drawVehicleOverview(&context, window.row_hover, CompanyManager::getControllingId(), unk1, unk2, { 90, 37 });
 
-                auto vehicleObj = ObjectManager::get<VehicleObject>(window->row_hover);
+                auto vehicleObj = ObjectManager::get<VehicleObject>(window.row_hover);
                 auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
                 buffer = StringManager::formatString(buffer, vehicleObj->name);
                 auto usableCargoTypes = vehicleObj->primary_cargo_types | vehicleObj->secondary_cargo_types;
@@ -1131,7 +1131,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 *buffer++ = '\0';
                 FormatArguments args{};
                 args.push(StringIds::buffer_1250);
-                Gfx::drawStringCentredClipped(*context, 89, 52, 177, 0x20, StringIds::wcolour2_stringid, &args);
+                Gfx::drawStringCentredClipped(context, 89, 52, 177, 0x20, StringIds::wcolour2_stringid, &args);
                 break;
             }
         }

--- a/src/OpenLoco/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/Windows/CompanyFaceSelection.cpp
@@ -247,9 +247,9 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x00435152
-    static void drawScroll(Window* const self, Gfx::Context* const context, const uint32_t scrollIndex)
+    static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
     {
-        Gfx::clearSingle(*context, Colour::getShade(self->getColour(WindowColour::secondary), 4));
+        Gfx::clearSingle(context, Colour::getShade(self.getColour(WindowColour::secondary), 4));
 
         auto index = 0;
         for (const auto& object : ObjectManager::getAvailableObjects(ObjectType::competitor))
@@ -257,10 +257,10 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
             const auto y = index * rowHeight;
             uint8_t inlineColour = ControlCodes::colour_black;
 
-            if (index == self->row_hover)
+            if (index == self.row_hover)
             {
                 inlineColour = ControlCodes::window_colour_2;
-                Gfx::fillRect(context, 0, y, self->width, y + 9, 0x2000000 | 48);
+                Gfx::fillRect(&context, 0, y, self.width, y + 9, 0x2000000 | 48);
             }
 
             std::string name(object.second._name);
@@ -271,9 +271,9 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
             if (isInUseCompetitor(object.first))
             {
                 _currentFontSpriteBase = Font::m1;
-                stringColour = Colour::opaque(self->getColour(WindowColour::secondary)) | (1 << 6);
+                stringColour = Colour::opaque(self.getColour(WindowColour::secondary)) | (1 << 6);
             }
-            Gfx::drawString(context, 0, y - 1, stringColour, const_cast<char*>(name.c_str()));
+            Gfx::drawString(&context, 0, y - 1, stringColour, const_cast<char*>(name.c_str()));
 
             index++;
         }

--- a/src/OpenLoco/Windows/CompanyList.cpp
+++ b/src/OpenLoco/Windows/CompanyList.cpp
@@ -449,34 +449,34 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00435EA7
-        static void drawScroll(Window* self, Gfx::Context* context, uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
         {
-            auto colour = Colour::getShade(self->getColour(WindowColour::secondary), 3);
-            Gfx::clearSingle(*context, colour);
+            auto colour = Colour::getShade(self.getColour(WindowColour::secondary), 3);
+            Gfx::clearSingle(context, colour);
 
             auto yBottom = 0;
-            for (auto i = 0; i < self->var_83C; i++, yBottom += 25)
+            for (auto i = 0; i < self.var_83C; i++, yBottom += 25)
             {
                 auto yTop = yBottom + 25;
 
-                if (yTop <= context->y)
+                if (yTop <= context.y)
                     continue;
 
-                yTop = context->y + context->height;
+                yTop = context.y + context.height;
 
                 if (yBottom >= yTop)
                     continue;
 
-                auto rowItem = self->row_info[i];
+                auto rowItem = self.row_info[i];
 
                 if (rowItem == -1)
                     continue;
 
                 auto stringId = StringIds::black_stringid;
 
-                if (rowItem == self->row_hover)
+                if (rowItem == self.row_hover)
                 {
-                    Gfx::drawRect(context, 0, yBottom, self->width, 24, (1 << 25) | PaletteIndex::index_30);
+                    Gfx::drawRect(&context, 0, yBottom, self.width, 24, (1 << 25) | PaletteIndex::index_30);
 
                     stringId = StringIds::wcolour2_stringid;
                 }
@@ -491,7 +491,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     args.push(imageId);
                     args.push(company->name);
 
-                    Gfx::drawString_494BBF(*context, 0, yBottom - 1, 173, Colour::black, stringId, &args);
+                    Gfx::drawString_494BBF(context, 0, yBottom - 1, 173, Colour::black, stringId, &args);
                 }
 
                 {
@@ -502,7 +502,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     args.push(ownerStatus.argument1);
                     args.push(ownerStatus.argument2);
 
-                    Gfx::drawString_494BBF(*context, 175, yBottom + 7, 208, Colour::black, stringId, &args);
+                    Gfx::drawString_494BBF(context, 175, yBottom + 7, 208, Colour::black, stringId, &args);
                 }
 
                 auto performanceStringId = StringIds::performance_index;
@@ -523,7 +523,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     args.push(performanceStringId);
                     formatPerformanceIndex(company->performance_index, args);
 
-                    Gfx::drawString_494BBF(*context, 385, yBottom - 1, 143, Colour::black, stringId, &args);
+                    Gfx::drawString_494BBF(context, 385, yBottom - 1, 143, Colour::black, stringId, &args);
                 }
 
                 {
@@ -532,7 +532,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     args.push(StringIds::company_value_currency);
                     args.push(company->companyValueHistory[0]);
 
-                    Gfx::drawString_494BBF(*context, 530, yBottom - 1, 98, Colour::black, stringId, &args);
+                    Gfx::drawString_494BBF(context, 530, yBottom - 1, 98, Colour::black, stringId, &args);
                 }
             }
         }

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -1870,38 +1870,38 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x0043361E
-        static void drawScroll(Window* self, Gfx::Context* context, uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
         {
-            int16_t y = 47 - self->widgets[widx::scrollview].top + 14;
+            int16_t y = 47 - self.widgets[widx::scrollview].top + 14;
 
             for (uint8_t i = 0; i < static_cast<uint8_t>(ExpenditureType::Count); i++)
             {
                 // Add zebra stripes to even labels.
                 if (i % 2 == 0)
                 {
-                    auto colour = Colour::getShade(self->getColour(WindowColour::secondary), 6) | 0x1000000;
-                    Gfx::fillRect(context, 0, y, expenditureColumnWidth * 17, y + 9, colour);
+                    auto colour = Colour::getShade(self.getColour(WindowColour::secondary), 6) | 0x1000000;
+                    Gfx::fillRect(&context, 0, y, expenditureColumnWidth * 17, y + 9, colour);
                 }
 
                 y += 10;
             }
 
-            const auto company = CompanyManager::get(self->number);
+            const auto company = CompanyManager::get(self.number);
 
             uint32_t curYear = getCurrentYear();
             uint8_t expenditureYears = std::min<uint8_t>(company->numExpenditureMonths, expenditureHistoryCapacity);
 
             // Paint years on top of scroll area.
-            int16_t x = 132 - self->widgets[widx::scrollview].left + expenditureColumnWidth;
+            int16_t x = 132 - self.widgets[widx::scrollview].left + expenditureColumnWidth;
             for (auto i = 0; i < expenditureYears; i++)
             {
-                y = 46 - self->widgets[widx::scrollview].top;
+                y = 46 - self.widgets[widx::scrollview].top;
 
                 uint16_t columnYear = curYear - (expenditureYears - i) + 1;
                 uint8_t columnIndex = expenditureYears - i - 1;
-                drawFinanceYear(context, x, y, columnYear, curYear);
-                auto sum = drawFinanceExpenditureColumn(context, x, y, columnIndex, *company);
-                drawFinanceSum(context, x, y, sum);
+                drawFinanceYear(&context, x, y, columnYear, curYear);
+                auto sum = drawFinanceExpenditureColumn(&context, x, y, columnIndex, *company);
+                drawFinanceSum(&context, x, y, sum);
 
                 x += expenditureColumnWidth;
             }

--- a/src/OpenLoco/Windows/IndustryList.cpp
+++ b/src/OpenLoco/Windows/IndustryList.cpp
@@ -378,18 +378,18 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00457D2A
-        static void drawScroll(Ui::Window* self, Gfx::Context* context, uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex)
         {
-            auto shade = Colour::getShade(self->getColour(WindowColour::secondary), 4);
-            Gfx::clearSingle(*context, shade);
+            auto shade = Colour::getShade(self.getColour(WindowColour::secondary), 4);
+            Gfx::clearSingle(context, shade);
 
             uint16_t yPos = 0;
-            for (uint16_t i = 0; i < self->var_83C; i++)
+            for (uint16_t i = 0; i < self.var_83C; i++)
             {
-                IndustryId_t industryId = self->row_info[i];
+                IndustryId_t industryId = self.row_info[i];
 
                 // Skip items outside of view, or irrelevant to the current filter.
-                if (yPos + rowHeight < context->y || yPos >= yPos + rowHeight + context->height || industryId == IndustryId::null)
+                if (yPos + rowHeight < context.y || yPos >= yPos + rowHeight + context.height || industryId == IndustryId::null)
                 {
                     yPos += rowHeight;
                     continue;
@@ -398,9 +398,9 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 string_id text_colour_id = StringIds::black_stringid;
 
                 // Highlight selection.
-                if (industryId == self->row_hover)
+                if (industryId == self.row_hover)
                 {
-                    Gfx::drawRect(context, 0, yPos, self->width, rowHeight, 0x2000030);
+                    Gfx::drawRect(&context, 0, yPos, self.width, rowHeight, 0x2000030);
                     text_colour_id = StringIds::wcolour2_stringid;
                 }
 
@@ -414,7 +414,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     args.push(industry->name);
                     args.push(industry->town);
 
-                    Gfx::drawString_494BBF(*context, 0, yPos, 198, Colour::black, text_colour_id, &args);
+                    Gfx::drawString_494BBF(context, 0, yPos, 198, Colour::black, text_colour_id, &args);
                 }
                 // Industry Status
                 {
@@ -424,7 +424,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     auto args = FormatArguments();
                     args.push(StringIds::buffer_1250);
 
-                    Gfx::drawString_494BBF(*context, 200, yPos, 238, Colour::black, text_colour_id, &args);
+                    Gfx::drawString_494BBF(context, 200, yPos, 238, Colour::black, text_colour_id, &args);
                 }
                 // Industry Production Delivered
                 {
@@ -439,7 +439,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     auto args = FormatArguments();
                     args.push<uint16_t>(productionTransported);
 
-                    Gfx::drawString_494BBF(*context, 440, yPos, 138, Colour::black, StringIds::production_transported_percent, &args);
+                    Gfx::drawString_494BBF(context, 440, yPos, 138, Colour::black, StringIds::production_transported_percent, &args);
                 }
                 yPos += rowHeight;
             }
@@ -868,36 +868,36 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458352
-        static void drawScroll(Ui::Window* self, Gfx::Context* context, uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex)
         {
-            auto shade = Colour::getShade(self->getColour(WindowColour::secondary), 4);
-            Gfx::clearSingle(*context, shade);
+            auto shade = Colour::getShade(self.getColour(WindowColour::secondary), 4);
+            Gfx::clearSingle(context, shade);
 
             loco_global<uint16_t, 0x00E0C3C6> word_E0C3C6;
             uint16_t xPos = 0;
             uint16_t yPos = 0;
-            for (uint16_t i = 0; i < self->var_83C; i++)
+            for (uint16_t i = 0; i < self.var_83C; i++)
             {
                 word_E0C3C6 = 0xFFFF;
-                if (self->row_info[i] != self->row_hover)
+                if (self.row_info[i] != self.row_hover)
                 {
-                    if (self->row_info[i] == self->var_846)
+                    if (self.row_info[i] == self.var_846)
                     {
                         word_E0C3C6 = Colour::translucent_flag;
-                        Gfx::drawRectInset(context, xPos, yPos, rowHeight, rowHeight, self->getColour(WindowColour::secondary), Colour::translucent_flag);
+                        Gfx::drawRectInset(&context, xPos, yPos, rowHeight, rowHeight, self.getColour(WindowColour::secondary), Colour::translucent_flag);
                     }
                 }
                 else
                 {
                     word_E0C3C6 = Colour::translucent_flag | Colour::outline_flag;
-                    Gfx::drawRectInset(context, xPos, yPos, rowHeight, rowHeight, self->getColour(WindowColour::secondary), (Colour::translucent_flag | Colour::outline_flag));
+                    Gfx::drawRectInset(&context, xPos, yPos, rowHeight, rowHeight, self.getColour(WindowColour::secondary), (Colour::translucent_flag | Colour::outline_flag));
                 }
 
-                auto industryObj = ObjectManager::get<IndustryObject>(self->row_info[i]);
+                auto industryObj = ObjectManager::get<IndustryObject>(self.row_info[i]);
 
                 Gfx::Context* clipped = nullptr;
 
-                if (Gfx::clipContext(&clipped, context, xPos + 1, yPos + 1, 110, 110))
+                if (Gfx::clipContext(&clipped, &context, xPos + 1, yPos + 1, 110, 110))
                 {
                     industryObj->drawIndustry(clipped, 56, 96);
                 }

--- a/src/OpenLoco/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/Windows/KeyboardShortcuts.cpp
@@ -43,7 +43,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     }
 
     static void draw(Ui::Window* self, Gfx::Context* context);
-    static void drawScroll(Ui::Window* self, Gfx::Context* context, uint32_t scrollIndex);
+    static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex);
     static void onMouseUp(Window* self, WidgetIndex_t widgetIndex);
     static void loc_4BE832(Window* self);
     static std::optional<FormatArguments> tooltip(Window*, WidgetIndex_t);
@@ -98,19 +98,19 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     }
 
     // 0x004BE72C
-    static void drawScroll(Ui::Window* self, Gfx::Context* context, uint32_t scrollIndex)
+    static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex)
     {
-        auto colour = self->getColour(WindowColour::secondary);
+        auto colour = self.getColour(WindowColour::secondary);
         auto shade = Colour::getShade(colour, 4);
-        Gfx::clearSingle(*context, shade);
+        Gfx::clearSingle(context, shade);
 
         auto yPos = 0;
-        for (auto i = 0; i < self->row_count; i++)
+        for (auto i = 0; i < self.row_count; i++)
         {
             string_id format = StringIds::black_stringid;
-            if (i == self->row_hover)
+            if (i == self.row_hover)
             {
-                Gfx::drawRect(context, 0, yPos, 800, rowHeight, 0x2000030);
+                Gfx::drawRect(&context, 0, yPos, 800, rowHeight, 0x2000030);
                 format = StringIds::wcolour2_stringid;
             }
 
@@ -139,7 +139,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
             formatter.push(modifierStringId);
             formatter.push(baseStringId);
 
-            Gfx::drawString_494B3F(*context, 0, yPos - 1, Colour::black, format, &formatter);
+            Gfx::drawString_494B3F(context, 0, yPos - 1, Colour::black, format, &formatter);
             yPos += rowHeight;
         }
     }

--- a/src/OpenLoco/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/Windows/LandscapeGeneration.cpp
@@ -425,7 +425,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         };
 
         // 0x0043E01C
-        static void drawScroll(Ui::Window* window, Gfx::Context* context, uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& window, Gfx::Context& context, const uint32_t scrollIndex)
         {
             uint16_t yPos = 0;
             for (uint16_t i = 0; i < maxLandObjects; i++)
@@ -436,26 +436,26 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
                 // Draw tile icon.
                 const uint32_t imageId = landObject->var_16 + OpenLoco::Land::ImageIds::landscape_generator_tile_icon;
-                Gfx::drawImage(context, 2, yPos + 1, imageId);
+                Gfx::drawImage(&context, 2, yPos + 1, imageId);
 
                 // Draw land description.
                 commonFormatArgs[0] = landObject->name;
-                Gfx::drawString_494BBF(*context, 24, yPos + 5, 121, Colour::black, StringIds::wcolour2_stringid, &*commonFormatArgs);
+                Gfx::drawString_494BBF(context, 24, yPos + 5, 121, Colour::black, StringIds::wcolour2_stringid, &*commonFormatArgs);
 
                 // Draw rectangle.
-                Gfx::fillRectInset(context, 150, yPos + 5, 340, yPos + 16, window->getColour(WindowColour::secondary), 0b110000);
+                Gfx::fillRectInset(&context, 150, yPos + 5, 340, yPos + 16, window.getColour(WindowColour::secondary), 0b110000);
 
                 // Draw current distribution setting.
                 const string_id distributionId = landDistributionLabelIds[S5::getOptions().landDistributionPatterns[i]];
                 commonFormatArgs[0] = distributionId;
-                Gfx::drawString_494BBF(*context, 151, yPos + 5, 177, Colour::black, StringIds::black_stringid, &*commonFormatArgs);
+                Gfx::drawString_494BBF(context, 151, yPos + 5, 177, Colour::black, StringIds::black_stringid, &*commonFormatArgs);
 
                 // Draw rectangle (knob).
-                const uint8_t flags = window->row_hover == i ? 0b110000 : 0;
-                Gfx::fillRectInset(context, 329, yPos + 6, 339, yPos + 15, window->getColour(WindowColour::secondary), flags);
+                const uint8_t flags = window.row_hover == i ? 0b110000 : 0;
+                Gfx::fillRectInset(&context, 329, yPos + 6, 339, yPos + 15, window.getColour(WindowColour::secondary), flags);
 
                 // Draw triangle (knob).
-                Gfx::drawString_494B3F(*context, 330, yPos + 6, Colour::black, StringIds::dropdown, nullptr);
+                Gfx::drawString_494B3F(context, 330, yPos + 6, Colour::black, StringIds::dropdown, nullptr);
 
                 yPos += rowHeight;
             }

--- a/src/OpenLoco/Windows/MapWindow.cpp
+++ b/src/OpenLoco/Windows/MapWindow.cpp
@@ -1385,12 +1385,12 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046B806
-    static void drawScroll(Window* self, Gfx::Context* context, uint32_t scrollIndex)
+    static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
     {
         if (!(_dword_525E28 & (1 << 0)))
             return;
 
-        Gfx::clearSingle(*context, PaletteIndex::index_0A);
+        Gfx::clearSingle(context, PaletteIndex::index_0A);
 
         auto element = Gfx::getG1Element(0);
         auto backupElement = *element;
@@ -1406,22 +1406,22 @@ namespace OpenLoco::Ui::Windows::MapWindow
         Gfx::getG1Element(0)->y_offset = -8;
         Gfx::getG1Element(0)->flags = 0;
 
-        Gfx::drawImage(context, 0, 0, 0);
+        Gfx::drawImage(&context, 0, 0, 0);
 
         *element = backupElement;
 
-        if (self->current_tab + widx::tabOverall == widx::tabVehicles)
+        if (self.current_tab + widx::tabOverall == widx::tabVehicles)
         {
             countVehiclesOnMap();
         }
 
-        drawVehiclesOnMap(context, self->current_tab + widx::tabOverall);
+        drawVehiclesOnMap(&context, self.current_tab + widx::tabOverall);
 
-        drawViewportPosition(context);
+        drawViewportPosition(&context);
 
-        if (self->saved_view.mapX & (1 << 0))
+        if (self.saved_view.mapX & (1 << 0))
         {
-            drawTownNames(context);
+            drawTownNames(&context);
         }
     }
 

--- a/src/OpenLoco/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/Windows/MessageWindow.cpp
@@ -215,22 +215,22 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042A5D7
-        static void drawScroll(Ui::Window* self, Gfx::Context* context, uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex)
         {
-            auto colour = Colour::getShade(self->getColour(WindowColour::secondary), 4);
+            auto colour = Colour::getShade(self.getColour(WindowColour::secondary), 4);
 
-            Gfx::clearSingle(*context, colour);
+            Gfx::clearSingle(context, colour);
 
             auto height = 0;
             for (auto i = 0; i < _messageCount; i++)
             {
-                if (height + messageHeight <= context->y)
+                if (height + messageHeight <= context.y)
                 {
                     height += messageHeight;
                     continue;
                 }
 
-                if (height >= context->y + context->height)
+                if (height >= context.y + context.height)
                 {
                     height += messageHeight;
                     continue;
@@ -244,9 +244,9 @@ namespace OpenLoco::Ui::Windows::MessageWindow
 
                 auto stringId = StringIds::black_stringid;
 
-                if (self->row_hover == i)
+                if (self.row_hover == i)
                 {
-                    Gfx::drawRect(context, 0, height, self->width, 38, (1 << 25) | PaletteIndex::index_30);
+                    Gfx::drawRect(&context, 0, height, self.width, 38, (1 << 25) | PaletteIndex::index_30);
                     stringId = StringIds::wcolour2_stringid;
                 }
 
@@ -255,14 +255,14 @@ namespace OpenLoco::Ui::Windows::MessageWindow
                     args.push(StringIds::tiny_font_date);
                     args.push(message->date);
 
-                    Gfx::drawString_494B3F(*context, 0, height, Colour::black, stringId, &args);
+                    Gfx::drawString_494B3F(context, 0, height, Colour::black, stringId, &args);
                 }
                 {
                     auto args = FormatArguments();
                     args.push(StringIds::buffer_2039);
 
-                    auto width = self->widgets[widx::scrollview].width() - 14;
-                    Gfx::drawString_495224(*context, 0, height + 6, width, Colour::black, stringId, &args);
+                    auto width = self.widgets[widx::scrollview].width() - 14;
+                    Gfx::drawString_495224(context, 0, height + 6, width, Colour::black, stringId, &args);
                     height += messageHeight;
                 }
             }

--- a/src/OpenLoco/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/Windows/MusicSelection.cpp
@@ -40,7 +40,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     static WindowEventList _events;
 
     static void draw(Ui::Window* window, Gfx::Context* context);
-    static void drawScroll(Ui::Window* window, Gfx::Context* context, uint32_t scrollIndex);
+    static void drawScroll(Ui::Window& window, Gfx::Context& context, const uint32_t scrollIndex);
     static void getScrollSize(Ui::Window* window, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);
     static void onMouseUp(Ui::Window* window, WidgetIndex_t widgetIndex);
     static void onScrollMouseDown(Ui::Window* window, int16_t x, int16_t y, uint8_t scroll_index);
@@ -98,35 +98,35 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     }
 
     // 0x004C1663
-    static void drawScroll(Ui::Window* window, Gfx::Context* context, uint32_t scrollIndex)
+    static void drawScroll(Ui::Window& window, Gfx::Context& context, const uint32_t scrollIndex)
     {
-        auto shade = Colour::getShade(window->getColour(WindowColour::secondary), 4);
-        Gfx::clearSingle(*context, shade);
+        auto shade = Colour::getShade(window.getColour(WindowColour::secondary), 4);
+        Gfx::clearSingle(context, shade);
 
         auto config = Config::get();
 
         uint16_t y = 0;
-        for (uint16_t i = 0; i < window->row_count; i++)
+        for (uint16_t i = 0; i < window.row_count; i++)
         {
             string_id text_colour_id = StringIds::black_stringid;
 
             // Draw hovered track
-            if (i == window->row_hover)
+            if (i == window.row_hover)
             {
-                Gfx::drawRect(context, 0, y, 800, rowHeight, 0x2000030);
+                Gfx::drawRect(&context, 0, y, 800, rowHeight, 0x2000030);
                 text_colour_id = StringIds::wcolour2_stringid;
             }
 
             // Draw checkbox.
-            Gfx::fillRectInset(context, 2, y, 11, y + 10, window->getColour(WindowColour::secondary), 0xE0);
+            Gfx::fillRectInset(&context, 2, y, 11, y + 10, window.getColour(WindowColour::secondary), 0xE0);
 
             // Draw checkmark if track is enabled.
             if (config.enabled_music[i])
-                Gfx::drawString_494B3F(*context, 2, y, window->getColour(WindowColour::secondary), StringIds::wcolour2_stringid, (void*)&StringIds::checkmark);
+                Gfx::drawString_494B3F(context, 2, y, window.getColour(WindowColour::secondary), StringIds::wcolour2_stringid, (void*)&StringIds::checkmark);
 
             // Draw track name.
             string_id music_title_id = Audio::getMusicInfo(i)->title_id;
-            Gfx::drawString_494B3F(*context, 15, y, window->getColour(WindowColour::secondary), text_colour_id, (void*)&music_title_id);
+            Gfx::drawString_494B3F(context, 15, y, window.getColour(WindowColour::secondary), text_colour_id, (void*)&music_title_id);
 
             y += rowHeight;
         }

--- a/src/OpenLoco/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/Windows/ObjectSelectionWindow.cpp
@@ -586,29 +586,29 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x0047361D
-    static void drawScroll(Window* self, Gfx::Context* context, uint32_t)
+    static void drawScroll(Window& self, Gfx::Context& context, const uint32_t)
     {
-        Gfx::clearSingle(*context, Colour::getShade(self->getColour(WindowColour::secondary), 4));
+        Gfx::clearSingle(context, Colour::getShade(self.getColour(WindowColour::secondary), 4));
 
         if (ObjectManager::getNumInstalledObjects() == 0)
             return;
 
         int y = 0;
-        auto objects = ObjectManager::getAvailableObjects(static_cast<ObjectType>(self->current_tab));
+        auto objects = ObjectManager::getAvailableObjects(static_cast<ObjectType>(self.current_tab));
         for (auto [i, object] : objects)
         {
             uint8_t flags = (1 << 7) | (1 << 6) | (1 << 5);
-            Gfx::fillRectInset(context, 2, y, 11, y + 10, self->getColour(WindowColour::secondary), flags);
+            Gfx::fillRectInset(&context, 2, y, 11, y + 10, self.getColour(WindowColour::secondary), flags);
 
             uint8_t textColour = ControlCodes::colour_black;
 
-            auto objectPtr = self->object;
+            auto objectPtr = self.object;
             if (objectPtr != nullptr)
             {
                 auto windowObjectName = ObjectManager::ObjectIndexEntry::read(&objectPtr)._name;
                 if (object._name == windowObjectName)
                 {
-                    Gfx::fillRect(context, 0, y, self->width, y + rowHeight - 1, (1 << 25) | PaletteIndex::index_30);
+                    Gfx::fillRect(&context, 0, y, self.width, y + rowHeight - 1, (1 << 25) | PaletteIndex::index_30);
                     textColour = ControlCodes::window_colour_2;
                 }
             }
@@ -623,14 +623,14 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                     _currentFontSpriteBase = Font::m1;
                 }
 
-                auto checkColour = Colour::opaque(self->getColour(WindowColour::secondary));
+                auto checkColour = Colour::opaque(self.getColour(WindowColour::secondary));
 
                 if (_50D144[i] & 0x1C)
                 {
                     checkColour = Colour::inset(checkColour);
                 }
 
-                Gfx::drawString(context, x, y, checkColour, _strCheckmark);
+                Gfx::drawString(&context, x, y, checkColour, _strCheckmark);
             }
 
             char buffer[512]{};
@@ -638,7 +638,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             strncpy(&buffer[1], object._name, 510);
             _currentFontSpriteBase = Font::medium_bold;
 
-            Gfx::drawString(context, 15, y, Colour::black, buffer);
+            Gfx::drawString(&context, 15, y, Colour::black, buffer);
             y += rowHeight;
         }
     }

--- a/src/OpenLoco/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/Windows/PromptBrowseWindow.cpp
@@ -142,7 +142,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     static void drawSavePreview(Ui::Window& window, Gfx::Context& context, int32_t x, int32_t y, int32_t width, int32_t height, const S5::SaveDetails& saveInfo);
     static void drawLandscapePreview(Ui::Window& window, Gfx::Context& context, int32_t x, int32_t y, int32_t width, int32_t height);
     static void drawTextInput(Ui::Window* window, Gfx::Context& context, const char* text, int32_t caret, bool showCaret);
-    static void drawScroll(Ui::Window* window, Gfx::Context* context, uint32_t scrollIndex);
+    static void drawScroll(Ui::Window& window, Gfx::Context& context, const uint32_t scrollIndex);
     static void upOneLevel();
     static void appendDirectory(const char* to_append);
     static void processFileForLoadSave(Window* window);
@@ -610,29 +610,29 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x00446314
-    static void drawScroll(Ui::Window* window, Gfx::Context* context, uint32_t scrollIndex)
+    static void drawScroll(Ui::Window& window, Gfx::Context& context, const uint32_t scrollIndex)
     {
         loco_global<char[16], 0x0112C826> _commonFormatArgs;
 
         static std::string _nameBuffer;
 
         // Background
-        Gfx::clearSingle(*context, Colour::getShade(window->getColour(WindowColour::secondary), 4));
+        Gfx::clearSingle(context, Colour::getShade(window.getColour(WindowColour::secondary), 4));
 
         // Directories / files
         auto y = 0;
-        auto lineHeight = window->row_height;
+        auto lineHeight = window.row_height;
         for (auto i = 0; i < _numFiles; i++)
         {
-            if (y + lineHeight >= context->y && y <= context->y + context->height)
+            if (y + lineHeight >= context.y && y <= context.y + context.height)
             {
                 auto file = _files[i];
 
                 // Draw the row highlight
                 auto stringId = StringIds::black_stringid;
-                if (i == window->var_85A)
+                if (i == window.var_85A)
                 {
-                    Gfx::drawRect(context, 0, y, window->width, lineHeight, 0x2000000 | 48);
+                    Gfx::drawRect(&context, 0, y, window.width, lineHeight, 0x2000000 | 48);
                     stringId = StringIds::wcolour2_stringid;
                 }
 
@@ -640,7 +640,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                 auto x = 1;
                 if (file.is_directory())
                 {
-                    Gfx::drawImage(context, x, y, ImageIds::icon_folder);
+                    Gfx::drawImage(&context, x, y, ImageIds::icon_folder);
                     x += 14;
                 }
 
@@ -649,7 +649,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
 
                 // Draw the name
                 setCommonArgsStringptr(_nameBuffer.c_str());
-                Gfx::drawString_494B3F(*context, x, y, 0, stringId, _commonFormatArgs);
+                Gfx::drawString_494B3F(context, x, y, 0, stringId, _commonFormatArgs);
             }
             y += lineHeight;
         }

--- a/src/OpenLoco/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/Windows/ScenarioSelect.cpp
@@ -326,22 +326,22 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     }
 
     // 0x00443D02
-    static void drawScroll(Window* self, Gfx::Context* const context, uint32_t)
+    static void drawScroll(Window& self, Gfx::Context& context, const uint32_t)
     {
-        auto colour = Colour::getShade(self->getColour(WindowColour::secondary), 4);
-        Gfx::clearSingle(*context, colour);
+        auto colour = Colour::getShade(self.getColour(WindowColour::secondary), 4);
+        Gfx::clearSingle(context, colour);
 
         using namespace ScenarioManager;
-        auto scenarioCount = getScenarioCountByCategory(self->current_tab);
+        auto scenarioCount = getScenarioCountByCategory(self.current_tab);
 
         int16_t y = 0;
         for (auto i = 0; i < scenarioCount; i++)
         {
-            auto* scenarioInfo = getNthScenarioFromCategory(self->current_tab, i);
+            auto* scenarioInfo = getNthScenarioFromCategory(self.current_tab, i);
             if (scenarioInfo == nullptr)
                 continue;
 
-            if (y + rowHeight < context->y || y > context->y + context->height)
+            if (y + rowHeight < context.y || y > context.y + context.height)
             {
                 y += rowHeight;
                 continue;
@@ -349,9 +349,9 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 
             // Highlight selected item
             auto formatStringId = StringIds::black_stringid;
-            if (scenarioInfo == reinterpret_cast<ScenarioIndexEntry*>(self->info))
+            if (scenarioInfo == reinterpret_cast<ScenarioIndexEntry*>(self.info))
             {
-                Gfx::drawRect(context, 0, y, self->width, rowHeight - 1, 0x2000000 | 48);
+                Gfx::drawRect(&context, 0, y, self.width, rowHeight - 1, 0x2000000 | 48);
                 formatStringId = StringIds::wcolour2_stringid;
             }
 
@@ -364,7 +364,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
                 args.push(StringIds::buffer_2039);
 
                 const int16_t x = 210;
-                Gfx::drawStringCentred(*context, x, y + 1, Colour::black, formatStringId, &args);
+                Gfx::drawStringCentred(context, x, y + 1, Colour::black, formatStringId, &args);
             }
 
             // Completed?
@@ -375,7 +375,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             }
 
             // Draw checkmark to indicate completion
-            Gfx::drawImage(context, self->widgets[widx::list].width() - ScrollView::barWidth - 25, y + 1, ImageIds::scenario_completed_tick);
+            Gfx::drawImage(&context, self.widgets[widx::list].width() - ScrollView::barWidth - 25, y + 1, ImageIds::scenario_completed_tick);
 
             // 'Completed by' info
             {
@@ -388,8 +388,8 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
                 args.push<uint16_t>(scenarioInfo->completedMonths / 12);
                 args.push<uint16_t>(scenarioInfo->completedMonths % 12);
 
-                const int16_t x = (self->widgets[widx::list].width() - ScrollView::barWidth) / 2;
-                Gfx::drawStringCentred(*context, x, y + 10, Colour::black, formatStringId, &args);
+                const int16_t x = (self.widgets[widx::list].width() - ScrollView::barWidth) / 2;
+                Gfx::drawStringCentred(context, x, y + 10, Colour::black, formatStringId, &args);
             }
 
             y += rowHeight;

--- a/src/OpenLoco/Windows/StationList.cpp
+++ b/src/OpenLoco/Windows/StationList.cpp
@@ -95,7 +95,7 @@ namespace OpenLoco::Ui::Windows::StationList
 
     static Ui::CursorId cursor(Window* window, int16_t widgetIdx, int16_t xPos, int16_t yPos, Ui::CursorId fallback);
     static void draw(Ui::Window* window, Gfx::Context* context);
-    static void drawScroll(Ui::Window* window, Gfx::Context* context, uint32_t scrollIndex);
+    static void drawScroll(Ui::Window& window, Gfx::Context& context, const uint32_t scrollIndex);
     static void event_08(Window* window);
     static void event_09(Window* window);
     static void getScrollSize(Ui::Window* window, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);
@@ -460,18 +460,18 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x0049157F
-    static void drawScroll(Ui::Window* window, Gfx::Context* context, uint32_t scrollIndex)
+    static void drawScroll(Ui::Window& window, Gfx::Context& context, const uint32_t scrollIndex)
     {
-        auto shade = Colour::getShade(window->getColour(WindowColour::secondary), 4);
-        Gfx::clearSingle(*context, shade);
+        auto shade = Colour::getShade(window.getColour(WindowColour::secondary), 4);
+        Gfx::clearSingle(context, shade);
 
         uint16_t yPos = 0;
-        for (uint16_t i = 0; i < window->var_83C; i++)
+        for (uint16_t i = 0; i < window.var_83C; i++)
         {
-            StationId_t stationId = window->row_info[i];
+            StationId_t stationId = window.row_info[i];
 
             // Skip items outside of view, or irrelevant to the current filter.
-            if (yPos + rowHeight < context->y || yPos >= yPos + rowHeight + context->height || stationId == (uint16_t)-1)
+            if (yPos + rowHeight < context.y || yPos >= yPos + rowHeight + context.height || stationId == (uint16_t)-1)
             {
                 yPos += rowHeight;
                 continue;
@@ -480,9 +480,9 @@ namespace OpenLoco::Ui::Windows::StationList
             string_id text_colour_id = StringIds::black_stringid;
 
             // Highlight selection.
-            if (stationId == window->row_hover)
+            if (stationId == window.row_hover)
             {
-                Gfx::drawRect(context, 0, yPos, window->width, rowHeight, 0x2000030);
+                Gfx::drawRect(&context, 0, yPos, window.width, rowHeight, 0x2000030);
                 text_colour_id = StringIds::wcolour2_stringid;
             }
 
@@ -494,14 +494,14 @@ namespace OpenLoco::Ui::Windows::StationList
             _common_format_args[2] = station->town;
             _common_format_args[3] = getTransportIconsFromStationFlags(station->flags);
 
-            Gfx::drawString_494BBF(*context, 0, yPos, 198, Colour::black, text_colour_id, &*_common_format_args);
+            Gfx::drawString_494BBF(context, 0, yPos, 198, Colour::black, text_colour_id, &*_common_format_args);
 
             // Then the station's current status.
             char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
             station->getStatusString(buffer);
 
             _common_format_args[0] = StringIds::buffer_1250;
-            Gfx::drawString_494BBF(*context, 200, yPos, 198, Colour::black, text_colour_id, &*_common_format_args);
+            Gfx::drawString_494BBF(context, 200, yPos, 198, Colour::black, text_colour_id, &*_common_format_args);
 
             // Total units waiting.
             uint16_t totalUnits = 0;
@@ -510,7 +510,7 @@ namespace OpenLoco::Ui::Windows::StationList
 
             _common_format_args[0] = StringIds::num_units;
             *(uint32_t*)&_common_format_args[1] = totalUnits;
-            Gfx::drawString_494BBF(*context, 400, yPos, 88, Colour::black, text_colour_id, &*_common_format_args);
+            Gfx::drawString_494BBF(context, 400, yPos, 88, Colour::black, text_colour_id, &*_common_format_args);
 
             // And, finally, what goods the station accepts.
             char* ptr = buffer;
@@ -530,7 +530,7 @@ namespace OpenLoco::Ui::Windows::StationList
             }
 
             _common_format_args[0] = StringIds::buffer_1250;
-            Gfx::drawString_494BBF(*context, 490, yPos, 118, Colour::black, text_colour_id, &*_common_format_args);
+            Gfx::drawString_494BBF(context, 490, yPos, 118, Colour::black, text_colour_id, &*_common_format_args);
 
             yPos += rowHeight;
         }

--- a/src/OpenLoco/Windows/StationWindow.cpp
+++ b/src/OpenLoco/Windows/StationWindow.cpp
@@ -459,11 +459,11 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048E986
-        static void drawScroll(Window* self, Gfx::Context* context, uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
         {
-            Gfx::clearSingle(*context, Colour::getShade(self->getColour(WindowColour::secondary), 4));
+            Gfx::clearSingle(context, Colour::getShade(self.getColour(WindowColour::secondary), 4));
 
-            const auto station = StationManager::get(self->number);
+            const auto station = StationManager::get(self.number);
             int16_t y = 1;
             auto cargoId = 0;
             for (const auto& cargoStats : station->cargo_stats)
@@ -488,7 +488,7 @@ namespace OpenLoco::Ui::Windows::Station
                     for (; units > 0; units--)
                     {
                         {
-                            Gfx::drawImage(context, xPos, y, cargoObj->unit_inline_sprite);
+                            Gfx::drawImage(&context, xPos, y, cargoObj->unit_inline_sprite);
                             xPos += 10;
                         }
                     }
@@ -503,21 +503,21 @@ namespace OpenLoco::Ui::Windows::Station
                 args.push<uint32_t>(cargo.quantity);
                 auto cargoStr = StringIds::station_cargo;
 
-                if (cargo.origin != self->number)
+                if (cargo.origin != self.number)
                     cargoStr = StringIds::station_cargo_en_route_start;
-                const auto& widget = self->widgets[widx::scrollview];
+                const auto& widget = self.widgets[widx::scrollview];
                 auto xPos = widget.width() - 14;
 
-                Gfx::drawString_494C78(*context, xPos, y, Colour::outline(Colour::black), cargoStr, &args);
+                Gfx::drawString_494C78(context, xPos, y, Colour::outline(Colour::black), cargoStr, &args);
                 y += 10;
-                if (cargo.origin != self->number)
+                if (cargo.origin != self.number)
                 {
                     auto originStation = StationManager::get(cargo.origin);
                     auto args2 = FormatArguments();
                     args2.push(originStation->name);
                     args2.push(originStation->town);
 
-                    Gfx::drawString_494C78(*context, xPos, y, Colour::outline(Colour::black), StringIds::station_cargo_en_route_end, &args2);
+                    Gfx::drawString_494C78(context, xPos, y, Colour::outline(Colour::black), StringIds::station_cargo_en_route_end, &args2);
                     y += 10;
                 }
                 y += 2;
@@ -532,7 +532,7 @@ namespace OpenLoco::Ui::Windows::Station
             {
                 auto args = FormatArguments();
                 args.push(StringIds::nothing_waiting);
-                Gfx::drawString_494B3F(*context, 1, 0, Colour::black, StringIds::black_stringid, &args);
+                Gfx::drawString_494B3F(context, 1, 0, Colour::black, StringIds::black_stringid, &args);
             }
         }
 
@@ -665,11 +665,11 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048ED2F
-        static void drawScroll(Window* self, Gfx::Context* context, uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
         {
-            Gfx::clearSingle(*context, Colour::getShade(self->getColour(WindowColour::secondary), 4));
+            Gfx::clearSingle(context, Colour::getShade(self.getColour(WindowColour::secondary), 4));
 
-            const auto station = StationManager::get(self->number);
+            const auto station = StationManager::get(self.number);
             int16_t y = 0;
             auto cargoId = 0;
             for (const auto& cargoStats : station->cargo_stats)
@@ -682,7 +682,7 @@ namespace OpenLoco::Ui::Windows::Station
                 }
 
                 auto cargoObj = ObjectManager::get<CargoObject>(cargoId);
-                Gfx::drawString_494BBF(*context, 1, y, 98, 0, StringIds::wcolour2_stringid, &cargoObj->name);
+                Gfx::drawString_494BBF(context, 1, y, 98, 0, StringIds::wcolour2_stringid, &cargoObj->name);
 
                 auto rating = cargo.rating;
                 auto colour = Colour::moss_green;
@@ -696,10 +696,10 @@ namespace OpenLoco::Ui::Windows::Station
                 }
 
                 uint8_t amount = (rating * 327) / 256;
-                drawRatingBar(self, context, 100, y, amount, colour);
+                drawRatingBar(&self, &context, 100, y, amount, colour);
 
                 uint16_t percent = rating / 2;
-                Gfx::drawString_494B3F(*context, 201, y, 0, StringIds::station_cargo_rating_percent, &percent);
+                Gfx::drawString_494B3F(context, 201, y, 0, StringIds::station_cargo_rating_percent, &percent);
                 y += 10;
                 cargoId++;
             }

--- a/src/OpenLoco/Windows/TerraForm.cpp
+++ b/src/OpenLoco/Windows/TerraForm.cpp
@@ -895,34 +895,34 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BB982
-        static void drawScroll(Window* self, Gfx::Context* context, uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
         {
-            auto shade = Colour::getShade(self->getColour(WindowColour::secondary), 3);
-            Gfx::clearSingle(*context, shade);
+            auto shade = Colour::getShade(self.getColour(WindowColour::secondary), 3);
+            Gfx::clearSingle(context, shade);
 
             uint16_t xPos = 0;
             uint16_t yPos = 0;
-            for (uint16_t i = 0; i < self->var_83C; i++)
+            for (uint16_t i = 0; i < self.var_83C; i++)
             {
                 _lastTreeColourFlag = 0xFFFF;
-                if (self->row_info[i] != self->row_hover)
+                if (self.row_info[i] != self.row_hover)
                 {
-                    if (self->row_info[i] == self->var_846)
+                    if (self.row_info[i] == self.var_846)
                     {
                         _lastTreeColourFlag = Colour::translucent_flag;
-                        Gfx::drawRectInset(context, xPos, yPos, 65, rowHeight - 1, self->getColour(WindowColour::secondary), Colour::translucent_flag);
+                        Gfx::drawRectInset(&context, xPos, yPos, 65, rowHeight - 1, self.getColour(WindowColour::secondary), Colour::translucent_flag);
                     }
                 }
                 else
                 {
                     _lastTreeColourFlag = Colour::translucent_flag | Colour::outline_flag;
-                    Gfx::drawRectInset(context, xPos, yPos, 65, rowHeight - 1, self->getColour(WindowColour::secondary), (Colour::translucent_flag | Colour::outline_flag));
+                    Gfx::drawRectInset(&context, xPos, yPos, 65, rowHeight - 1, self.getColour(WindowColour::secondary), (Colour::translucent_flag | Colour::outline_flag));
                 }
 
-                auto treeObj = ObjectManager::get<TreeObject>(self->row_info[i]);
+                auto treeObj = ObjectManager::get<TreeObject>(self.row_info[i]);
                 Gfx::Context* clipped = nullptr;
 
-                if (Gfx::clipContext(&clipped, context, xPos + 1, yPos + 1, 64, rowHeight - 2))
+                if (Gfx::clipContext(&clipped, &context, xPos + 1, yPos + 1, 64, rowHeight - 2))
                 {
                     drawTreeThumb(treeObj, clipped);
                 }
@@ -2332,32 +2332,32 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC11C
-        static void drawScroll(Window* self, Gfx::Context* context, uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::Context& context, uint32_t scrollIndex)
         {
-            auto shade = Colour::getShade(self->getColour(WindowColour::secondary), 3);
-            Gfx::clearSingle(*context, shade);
+            auto shade = Colour::getShade(self.getColour(WindowColour::secondary), 3);
+            Gfx::clearSingle(context, shade);
 
             uint16_t xPos = 0;
             uint16_t yPos = 0;
-            for (uint16_t i = 0; i < self->var_83C; i++)
+            for (uint16_t i = 0; i < self.var_83C; i++)
             {
-                if (self->row_info[i] != self->row_hover)
+                if (self.row_info[i] != self.row_hover)
                 {
-                    if (self->row_info[i] == self->var_846)
+                    if (self.row_info[i] == self.var_846)
                     {
-                        Gfx::drawRectInset(context, xPos, yPos, 40, rowHeight, self->getColour(WindowColour::secondary), Colour::translucent_flag);
+                        Gfx::drawRectInset(&context, xPos, yPos, 40, rowHeight, self.getColour(WindowColour::secondary), Colour::translucent_flag);
                     }
                 }
                 else
                 {
-                    Gfx::drawRectInset(context, xPos, yPos, 40, rowHeight, self->getColour(WindowColour::secondary), (Colour::translucent_flag | Colour::outline_flag));
+                    Gfx::drawRectInset(&context, xPos, yPos, 40, rowHeight, self.getColour(WindowColour::secondary), (Colour::translucent_flag | Colour::outline_flag));
                 }
 
-                auto wallObj = ObjectManager::get<WallObject>(self->row_info[i]);
+                auto wallObj = ObjectManager::get<WallObject>(self.row_info[i]);
 
                 Gfx::Context* clipped = nullptr;
 
-                if (Gfx::clipContext(&clipped, context, xPos + 1, yPos + 1, 39, 47))
+                if (Gfx::clipContext(&clipped, &context, xPos + 1, yPos + 1, 39, 47))
                     Gfx::drawImage(clipped, 34, 28, wallObj->sprite);
 
                 xPos += 40;

--- a/src/OpenLoco/Windows/TileInspector.cpp
+++ b/src/OpenLoco/Windows/TileInspector.cpp
@@ -331,7 +331,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         return StringIds::empty;
     }
 
-    static void drawScroll(Ui::Window* self, Gfx::Context* const context, uint32_t)
+    static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t)
     {
         if (_currentPosition == TilePos2(0, 0))
             return;
@@ -342,14 +342,14 @@ namespace OpenLoco::Ui::Windows::TileInspector
         for (auto& element : tile)
         {
             string_id formatString;
-            if (self->var_842 == rowNum)
+            if (self.var_842 == rowNum)
             {
-                Gfx::fillRect(context, 0, yPos, self->width, yPos + self->row_height, Colour::aquamarine);
+                Gfx::fillRect(&context, 0, yPos, self.width, yPos + self.row_height, Colour::aquamarine);
                 formatString = StringIds::white_stringid;
             }
-            else if (self->row_hover == rowNum)
+            else if (self.row_hover == rowNum)
             {
-                Gfx::fillRect(context, 0, yPos, self->width, yPos + self->row_height, 0x2000030);
+                Gfx::fillRect(&context, 0, yPos, self.width, yPos + self.row_height, 0x2000030);
                 formatString = StringIds::wcolour2_stringid;
             }
             else
@@ -378,9 +378,9 @@ namespace OpenLoco::Ui::Windows::TileInspector
                 args.push(elementName);
             }
 
-            Gfx::drawString_494B3F(*context, 0, yPos, Colour::black, formatString, &args);
+            Gfx::drawString_494B3F(context, 0, yPos, Colour::black, formatString, &args);
             rowNum++;
-            yPos += self->row_height;
+            yPos += self.row_height;
         }
     }
 

--- a/src/OpenLoco/Windows/TownList.cpp
+++ b/src/OpenLoco/Windows/TownList.cpp
@@ -142,18 +142,18 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A0F8
-        static void drawScroll(Ui::Window* self, Gfx::Context* context, uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex)
         {
-            auto shade = Colour::getShade(self->getColour(WindowColour::secondary), 3);
-            Gfx::clearSingle(*context, shade);
+            auto shade = Colour::getShade(self.getColour(WindowColour::secondary), 3);
+            Gfx::clearSingle(context, shade);
 
             uint16_t yPos = 0;
-            for (uint16_t i = 0; i < self->var_83C; i++)
+            for (uint16_t i = 0; i < self.var_83C; i++)
             {
-                TownId_t townId = self->row_info[i];
+                TownId_t townId = self.row_info[i];
 
                 // Skip items outside of view, or irrelevant to the current filter.
-                if (yPos + rowHeight < context->y || yPos >= yPos + rowHeight + context->height || townId == (uint16_t)-1)
+                if (yPos + rowHeight < context.y || yPos >= yPos + rowHeight + context.height || townId == (uint16_t)-1)
                 {
                     yPos += rowHeight;
                     continue;
@@ -162,9 +162,9 @@ namespace OpenLoco::Ui::Windows::TownList
                 string_id text_colour_id = StringIds::black_stringid;
 
                 // Highlight selection.
-                if (townId == self->row_hover)
+                if (townId == self.row_hover)
                 {
-                    Gfx::drawRect(context, 0, yPos, self->width, rowHeight, 0x2000030);
+                    Gfx::drawRect(&context, 0, yPos, self.width, rowHeight, 0x2000030);
                     text_colour_id = StringIds::wcolour2_stringid;
                 }
 
@@ -177,14 +177,14 @@ namespace OpenLoco::Ui::Windows::TownList
                     auto args = FormatArguments();
                     args.push(town->name);
 
-                    Gfx::drawString_494BBF(*context, 0, yPos, 198, Colour::black, text_colour_id, &args);
+                    Gfx::drawString_494BBF(context, 0, yPos, 198, Colour::black, text_colour_id, &args);
                 }
                 // Town Type
                 {
                     auto args = FormatArguments();
                     args.push(town->getTownSizeString());
 
-                    Gfx::drawString_494BBF(*context, 200, yPos, 278, Colour::black, text_colour_id, &args);
+                    Gfx::drawString_494BBF(context, 200, yPos, 278, Colour::black, text_colour_id, &args);
                 }
                 // Town Population
                 {
@@ -192,7 +192,7 @@ namespace OpenLoco::Ui::Windows::TownList
                     args.push(StringIds::int_32);
                     args.push(town->population);
 
-                    Gfx::drawString_494BBF(*context, 280, yPos, 68, Colour::black, text_colour_id, &args);
+                    Gfx::drawString_494BBF(context, 280, yPos, 68, Colour::black, text_colour_id, &args);
                 }
                 // Town Stations
                 {
@@ -200,7 +200,7 @@ namespace OpenLoco::Ui::Windows::TownList
                     args.push(StringIds::int_32);
                     args.push<int32_t>(town->num_stations);
 
-                    Gfx::drawString_494BBF(*context, 350, yPos, 68, Colour::black, text_colour_id, &args);
+                    Gfx::drawString_494BBF(context, 350, yPos, 68, Colour::black, text_colour_id, &args);
                 }
                 yPos += rowHeight;
             }
@@ -1159,35 +1159,35 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AA1C
-        static void drawScroll(Ui::Window* self, Gfx::Context* context, uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex)
         {
-            auto shade = Colour::getShade(self->getColour(WindowColour::secondary), 3);
-            Gfx::clearSingle(*context, shade);
+            auto shade = Colour::getShade(self.getColour(WindowColour::secondary), 3);
+            Gfx::clearSingle(context, shade);
 
             uint16_t xPos = 0;
             uint16_t yPos = 0;
-            for (uint16_t i = 0; i < self->var_83C; i++)
+            for (uint16_t i = 0; i < self.var_83C; i++)
             {
-                if (self->row_info[i] != self->row_hover)
+                if (self.row_info[i] != self.row_hover)
                 {
-                    if (self->row_info[i] == self->var_846)
+                    if (self.row_info[i] == self.var_846)
                     {
-                        Gfx::drawRectInset(context, xPos, yPos, 112, 112, self->getColour(WindowColour::secondary), Colour::translucent_flag);
+                        Gfx::drawRectInset(&context, xPos, yPos, 112, 112, self.getColour(WindowColour::secondary), Colour::translucent_flag);
                     }
                 }
                 else
                 {
-                    Gfx::drawRectInset(context, xPos, yPos, 112, 112, self->getColour(WindowColour::secondary), (Colour::translucent_flag | Colour::outline_flag));
+                    Gfx::drawRectInset(&context, xPos, yPos, 112, 112, self.getColour(WindowColour::secondary), (Colour::translucent_flag | Colour::outline_flag));
                 }
 
-                auto buildingObj = ObjectManager::get<BuildingObject>(self->row_info[i]);
+                auto buildingObj = ObjectManager::get<BuildingObject>(self.row_info[i]);
 
                 Gfx::Context* clipped = nullptr;
 
-                if (Gfx::clipContext(&clipped, context, xPos + 1, yPos + 1, 110, 110))
+                if (Gfx::clipContext(&clipped, &context, xPos + 1, yPos + 1, 110, 110))
                 {
                     Colour_t colour = _buildingColour;
-                    if (self->row_hover != self->row_info[i])
+                    if (self.row_hover != self.row_info[i])
                     {
                         colour = Utility::bitScanReverse(buildingObj->colours);
                         if (colour == 0xFF)

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -1437,53 +1437,53 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B36A3
-        static void drawScroll(Window* const self, Gfx::Context* const context, const uint32_t i)
+        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t i)
         {
-            Gfx::clearSingle(*context, Colour::getShade(self->getColour(WindowColour::secondary), 4));
-            auto head = Common::getVehicle(self);
+            Gfx::clearSingle(context, Colour::getShade(self.getColour(WindowColour::secondary), 4));
+            auto head = Common::getVehicle(&self);
             OpenLoco::Vehicles::Vehicle train{ head };
             Gfx::point_t pos{ 0, 0 };
             for (auto& car : train.cars)
             {
                 string_id carStr = StringIds::black_stringid;
-                if (self->row_hover == car.front->id)
+                if (self.row_hover == car.front->id)
                 {
                     carStr = StringIds::wcolour2_stringid;
 
                     int16_t top = pos.y;
-                    int16_t bottom = pos.y + self->row_height - 1;
+                    int16_t bottom = pos.y + self.row_height - 1;
                     if (_dragCarComponent != nullptr)
                     {
                         bottom = pos.y;
                         top = pos.y - 1;
                         carStr = StringIds::black_stringid;
                     }
-                    Gfx::fillRect(context, 0, top, self->width, bottom, 0x2000030);
+                    Gfx::fillRect(&context, 0, top, self.width, bottom, 0x2000030);
                 }
 
-                int16_t y = pos.y + (self->row_height - 22) / 2;
+                int16_t y = pos.y + (self.row_height - 22) / 2;
                 uint8_t al = 0;
                 uint8_t ah = 0;
                 if (car.front == _dragCarComponent)
                 {
                     al = 12;
-                    ah = self->getColour(WindowColour::secondary);
+                    ah = self.getColour(WindowColour::secondary);
                 }
-                auto x = Common::sub_4B743B(al, ah, 0, y, car.front, context);
+                auto x = Common::sub_4B743B(al, ah, 0, y, car.front, &context);
 
                 auto vehicleObj = ObjectManager::get<VehicleObject>(car.front->object_id);
                 FormatArguments args{};
                 args.push(vehicleObj->name);
                 x += 2;
-                y = pos.y + (self->row_height / 2) - 6;
-                Gfx::drawString_494B3F(*context, x, y, Colour::black, carStr, &args);
+                y = pos.y + (self.row_height / 2) - 6;
+                Gfx::drawString_494B3F(context, x, y, Colour::black, carStr, &args);
 
-                pos.y += self->row_height;
+                pos.y += self.row_height;
             }
 
-            if (self->row_hover == train.tail->id && _dragCarComponent != nullptr)
+            if (self.row_hover == train.tail->id && _dragCarComponent != nullptr)
             {
-                Gfx::fillRect(context, 0, pos.y - 1, self->width, pos.y, 0x2000030);
+                Gfx::fillRect(&context, 0, pos.y - 1, self.width, pos.y, 0x2000030);
             }
         }
 
@@ -1699,7 +1699,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // based on 0x004B40C7
-        static void drawCargoText(Gfx::Context* const pDrawpixelinfo, const int16_t x, int16_t& y, const string_id strFormat, uint8_t cargoQty, uint8_t cargoType, StationId_t stationId)
+        static void drawCargoText(Gfx::Context& context, const int16_t x, int16_t& y, const string_id strFormat, uint8_t cargoQty, uint8_t cargoType, StationId_t stationId)
         {
             if (cargoQty == 0)
             {
@@ -1715,53 +1715,53 @@ namespace OpenLoco::Ui::Windows::Vehicle
             args.push<uint32_t>(cargoQty);
             args.push(station->name);
             args.push(station->town);
-            Gfx::drawString_494B3F(*pDrawpixelinfo, x, y, Colour::black, strFormat, &args);
+            Gfx::drawString_494B3F(context, x, y, Colour::black, strFormat, &args);
             y += 10;
         }
 
         // 004B3F62
-        static void drawScroll(Window* const self, Gfx::Context* const pDrawpixelinfo, const uint32_t i)
+        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t i)
         {
-            Gfx::clearSingle(*pDrawpixelinfo, Colour::getShade(self->getColour(WindowColour::secondary), 4));
-            Vehicles::Vehicle train{ Common::getVehicle(self) };
+            Gfx::clearSingle(context, Colour::getShade(self.getColour(WindowColour::secondary), 4));
+            Vehicles::Vehicle train{ Common::getVehicle(&self) };
             int16_t y = 0;
             for (auto& car : train.cars)
             {
                 string_id strFormat = StringIds::black_stringid;
                 auto front = car.front;
                 auto body = car.body;
-                if (front->id == self->row_hover)
+                if (front->id == self.row_hover)
                 {
-                    Gfx::fillRect(pDrawpixelinfo, 0, y, self->width, y + self->row_height - 1, 0x2000030);
+                    Gfx::fillRect(&context, 0, y, self.width, y + self.row_height - 1, 0x2000030);
                     strFormat = StringIds::wcolour2_stringid;
                 }
                 // Get width of the drawing
-                auto width = Common::sub_4B743B(1, 0, 0, y, front, pDrawpixelinfo);
+                auto width = Common::sub_4B743B(1, 0, 0, y, front, &context);
                 // Actually draw it
-                width = Common::sub_4B743B(0, 0, 24 - width, (self->row_height - 22) / 2 + y, car.front, pDrawpixelinfo);
+                width = Common::sub_4B743B(0, 0, 24 - width, (self.row_height - 22) / 2 + y, car.front, &context);
 
                 if (body->primaryCargo.type != 0xFF)
                 {
 
-                    int16_t cargoTextHeight = self->row_height / 2 + y - ((self->row_height - 22) / 2) - 10;
+                    int16_t cargoTextHeight = self.row_height / 2 + y - ((self.row_height - 22) / 2) - 10;
                     if (front->secondaryCargo.qty != 0 || body->primaryCargo.qty != 0)
                     {
                         if (body->primaryCargo.qty == 0 || front->secondaryCargo.qty == 0)
                         {
                             cargoTextHeight += 5;
                         }
-                        drawCargoText(pDrawpixelinfo, width, cargoTextHeight, strFormat, body->primaryCargo.qty, body->primaryCargo.type, body->primaryCargo.townFrom);
-                        drawCargoText(pDrawpixelinfo, width, cargoTextHeight, strFormat, front->secondaryCargo.qty, front->secondaryCargo.type, front->secondaryCargo.townFrom);
+                        drawCargoText(context, width, cargoTextHeight, strFormat, body->primaryCargo.qty, body->primaryCargo.type, body->primaryCargo.townFrom);
+                        drawCargoText(context, width, cargoTextHeight, strFormat, front->secondaryCargo.qty, front->secondaryCargo.type, front->secondaryCargo.townFrom);
                     }
                     else
                     {
                         FormatArguments args{};
                         args.push<string_id>(StringIds::cargo_empty);
-                        Gfx::drawString_494B3F(*pDrawpixelinfo, width, cargoTextHeight + 5, Colour::black, strFormat, &args);
+                        Gfx::drawString_494B3F(context, width, cargoTextHeight + 5, Colour::black, strFormat, &args);
                     }
                 }
 
-                y += self->row_height;
+                y += self.row_height;
             }
         }
 
@@ -3067,33 +3067,33 @@ namespace OpenLoco::Ui::Windows::Vehicle
         };
 
         // 0x004B4A58 based on
-        static void sub_4B4A58(Window* const self, Gfx::Context* const context, const string_id strFormat, FormatArguments& args, Vehicles::Order& order, int16_t& y)
+        static void sub_4B4A58(Window& self, Gfx::Context& context, const string_id strFormat, FormatArguments& args, Vehicles::Order& order, int16_t& y)
         {
             Gfx::point_t loc = { 8, static_cast<int16_t>(y - 1) };
-            Gfx::drawString_494B3F(*context, &loc, Colour::black, strFormat, &args);
+            Gfx::drawString_494B3F(context, &loc, Colour::black, strFormat, &args);
             if (order.hasFlag(Vehicles::OrderFlags::HasNumber))
             {
-                if (Input::isToolActive(self->type, self->number))
+                if (Input::isToolActive(self.type, self.number))
                 {
                     auto imageId = numberCircle[_113646A - 1];
-                    Gfx::drawImage(context, loc.x + 3, loc.y + 1, Gfx::recolour(imageId, Colour::white));
+                    Gfx::drawImage(&context, loc.x + 3, loc.y + 1, Gfx::recolour(imageId, Colour::white));
                 }
                 _113646A++;
             }
         }
 
         // 0x004B48BA
-        static void drawScroll(Window* const self, Gfx::Context* const pDrawpixelinfo, const uint32_t i)
+        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t i)
         {
-            Gfx::clearSingle(*pDrawpixelinfo, Colour::getShade(self->getColour(WindowColour::secondary), 4));
+            Gfx::clearSingle(context, Colour::getShade(self.getColour(WindowColour::secondary), 4));
 
-            auto head = Common::getVehicle(self);
+            auto head = Common::getVehicle(&self);
             Vehicles::Vehicle train(head);
 
             auto rowNum = 0;
             if (head->sizeOfOrderTable == 1)
             {
-                Gfx::drawString_494B3F(*pDrawpixelinfo, 8, 0, Colour::black, StringIds::no_route_defined);
+                Gfx::drawString_494B3F(context, 8, 0, Colour::black, StringIds::no_route_defined);
                 rowNum++; // Used to move down the text
             }
 
@@ -3102,15 +3102,15 @@ namespace OpenLoco::Ui::Windows::Vehicle
             {
                 int16_t y = rowNum * lineHeight;
                 auto strFormat = StringIds::black_stringid;
-                if (self->var_842 == rowNum)
+                if (self.var_842 == rowNum)
                 {
-                    Gfx::fillRect(pDrawpixelinfo, 0, y, self->width, y + 9, Colour::aquamarine);
+                    Gfx::fillRect(&context, 0, y, self.width, y + 9, Colour::aquamarine);
                     strFormat = StringIds::white_stringid;
                 }
-                if (self->row_hover == rowNum)
+                if (self.row_hover == rowNum)
                 {
                     strFormat = StringIds::wcolour2_stringid;
-                    Gfx::fillRect(pDrawpixelinfo, 0, y, self->width, y + 9, 0x2000030);
+                    Gfx::fillRect(&context, 0, y, self.width, y + 9, 0x2000030);
                 }
 
                 FormatArguments args{};
@@ -3138,10 +3138,10 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     }
                 }
 
-                sub_4B4A58(self, pDrawpixelinfo, strFormat, args, order, y);
+                sub_4B4A58(self, context, strFormat, args, order, y);
                 if (head->currentOrder + head->orderTableOffset == order.getOffset())
                 {
-                    Gfx::drawString_494B3F(*pDrawpixelinfo, 1, y - 1, Colour::black, StringIds::orders_current_order);
+                    Gfx::drawString_494B3F(context, 1, y - 1, Colour::black, StringIds::orders_current_order);
                 }
 
                 rowNum++;
@@ -3150,20 +3150,20 @@ namespace OpenLoco::Ui::Windows::Vehicle
             // Output the end of orders
             Gfx::point_t loc = { 8, static_cast<int16_t>(rowNum * lineHeight) };
             auto strFormat = StringIds::black_stringid;
-            if (self->var_842 == rowNum)
+            if (self.var_842 == rowNum)
             {
-                Gfx::fillRect(pDrawpixelinfo, 0, loc.y, self->width, loc.y + lineHeight, Colour::aquamarine);
+                Gfx::fillRect(&context, 0, loc.y, self.width, loc.y + lineHeight, Colour::aquamarine);
                 strFormat = StringIds::white_stringid;
             }
-            if (self->row_hover == rowNum)
+            if (self.row_hover == rowNum)
             {
                 strFormat = StringIds::wcolour2_stringid;
-                Gfx::fillRect(pDrawpixelinfo, 0, loc.y, self->width, loc.y + lineHeight, 0x2000030);
+                Gfx::fillRect(&context, 0, loc.y, self.width, loc.y + lineHeight, 0x2000030);
             }
 
             loc.y -= 1;
             auto args = FormatArguments::common(orderString[0]);
-            Gfx::drawString_494B3F(*pDrawpixelinfo, &loc, Colour::black, strFormat, &args);
+            Gfx::drawString_494B3F(context, &loc, Colour::black, strFormat, &args);
         }
 
         static void initEvents()

--- a/src/OpenLoco/Windows/VehicleList.cpp
+++ b/src/OpenLoco/Windows/VehicleList.cpp
@@ -702,31 +702,31 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C21CD
-    static void drawScroll(Window* self, Gfx::Context* context, uint32_t scrollIndex)
+    static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
     {
-        auto shade = Colour::getShade(self->getColour(WindowColour::secondary), 1);
-        Gfx::clearSingle(*context, shade);
+        auto shade = Colour::getShade(self.getColour(WindowColour::secondary), 1);
+        Gfx::clearSingle(context, shade);
 
         auto yPos = 0;
-        for (auto i = 0; i < self->var_83C; i++)
+        for (auto i = 0; i < self.var_83C; i++)
         {
-            auto vehicleId = self->row_info[i];
+            auto vehicleId = self.row_info[i];
 
             // Item not in rendering context, or no vehicle available for this slot?
-            if (yPos + self->row_height < context->y || yPos >= context->y + context->height + self->row_height || vehicleId == -1)
+            if (yPos + self.row_height < context.y || yPos >= context.y + context.height + self.row_height || vehicleId == -1)
             {
-                yPos += self->row_height;
+                yPos += self.row_height;
                 continue;
             }
 
             auto head = EntityManager::get<VehicleHead>(vehicleId);
 
             // Highlight selection.
-            if (head->id == self->row_hover)
-                Gfx::drawRect(context, 0, yPos, self->width, self->row_height, Colour::getShade(self->getColour(WindowColour::secondary), 0));
+            if (head->id == self.row_hover)
+                Gfx::drawRect(&context, 0, yPos, self.width, self.row_height, Colour::getShade(self.getColour(WindowColour::secondary), 0));
 
             // Draw vehicle at the bottom of the row.
-            drawVehicle(head, context, yPos + (self->row_height - 28) / 2 + 6);
+            drawVehicle(head, &context, yPos + (self.row_height - 28) / 2 + 6);
 
             // Draw vehicle status
             {
@@ -746,7 +746,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
                 // Draw status
                 yPos += 2;
-                Gfx::drawString_494BBF(*context, 1, yPos, 308, Colour::outline(Colour::black), format, &args);
+                Gfx::drawString_494BBF(context, 1, yPos, 308, Colour::outline(Colour::black), format, &args);
             }
 
             auto vehicle = Vehicles::Vehicle(head);
@@ -762,7 +762,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
                 }
 
                 auto args = FormatArguments::common(profit);
-                Gfx::drawString_494BBF(*context, 310, yPos, 98, Colour::outline(Colour::black), format, &args);
+                Gfx::drawString_494BBF(context, 310, yPos, 98, Colour::outline(Colour::black), format, &args);
             }
 
             // Vehicle age
@@ -773,17 +773,17 @@ namespace OpenLoco::Ui::Windows::VehicleList
                     format = StringIds::vehicle_list_age_year;
 
                 auto args = FormatArguments::common(age);
-                Gfx::drawString_494BBF(*context, 410, yPos, 63, Colour::outline(Colour::black), format, &args);
+                Gfx::drawString_494BBF(context, 410, yPos, 63, Colour::outline(Colour::black), format, &args);
             }
 
             // Vehicle reliability
             {
                 int16_t reliability = vehicle.veh2->reliability;
                 auto args = FormatArguments::common(reliability);
-                Gfx::drawString_494BBF(*context, 475, yPos, 65, Colour::outline(Colour::black), StringIds::vehicle_list_reliability, &args);
+                Gfx::drawString_494BBF(context, 475, yPos, 65, Colour::outline(Colour::black), StringIds::vehicle_list_reliability, &args);
             }
 
-            yPos += self->row_height - 2;
+            yPos += self.row_height - 2;
         }
     }
 


### PR DESCRIPTION
I'd like to see almost everything pass by ref rather than by pointer. Its pretty rare that it should be passing by pointer. Passing by ref makes it clear that it cannot be null and no requirement to check if it is nullptr and prevents reassigning the variable to something else.