### PR TITLE
Make tree clusters cost money outside editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#1035] Incorrect colour selection when building buildings.
 - Fix: [#1070] Crash when naming stations after exhausting natural names.
+- Change: [#298] Planting clusters of trees now costs money and influences ratings outside of editor mode.
 - Change: [#1079] Allow rotating buildings in town list by keyboard shortcut.
 
 21.07 (2021-07-18)

--- a/src/OpenLoco/Windows/TerraForm.cpp
+++ b/src/OpenLoco/Windows/TerraForm.cpp
@@ -681,29 +681,29 @@ namespace OpenLoco::Ui::Windows::Terraform
                         break;
                     case treeCluster::selected:
                     {
-                        // TODO: Lock behind sandbox/editor
                         auto previousId = CompanyManager::updatingCompanyId();
-                        CompanyManager::updatingCompanyId(CompanyId::neutral);
+                        if (isEditorMode())
+                            CompanyManager::updatingCompanyId(CompanyId::neutral);
 
                         auto height = TileManager::getHeight(placementArgs->pos);
                         Audio::playSound(Audio::SoundId::construct, Map::Pos3{ placementArgs->pos.x, placementArgs->pos.y, height.landHeight });
 
                         clusterSelectedTreeToolDown(*placementArgs, 320, 3);
-                        // TODO: Lock behind sandbox/editor
-                        CompanyManager::updatingCompanyId(previousId);
+                        if (isEditorMode())
+                            CompanyManager::updatingCompanyId(previousId);
                         break;
                     }
                     case treeCluster::random:
-                        // TODO: Lock behind sandbox/editor
                         auto previousId = CompanyManager::updatingCompanyId();
-                        CompanyManager::updatingCompanyId(CompanyId::neutral);
+                        if (isEditorMode())
+                            CompanyManager::updatingCompanyId(CompanyId::neutral);
 
                         auto height = TileManager::getHeight(placementArgs->pos);
                         Audio::playSound(Audio::SoundId::construct, Map::Pos3{ placementArgs->pos.x, placementArgs->pos.y, height.landHeight });
 
                         clusterSurfaceTypeTreeToolDown(*placementArgs, 384, 4);
-                        // TODO: Lock behind sandbox/editor
-                        CompanyManager::updatingCompanyId(previousId);
+                        if (isEditorMode())
+                            CompanyManager::updatingCompanyId(previousId);
                         break;
                 }
             }

--- a/src/OpenLoco/Windows/TerraForm.cpp
+++ b/src/OpenLoco/Windows/TerraForm.cpp
@@ -670,10 +670,10 @@ namespace OpenLoco::Ui::Windows::Terraform
             auto placementArgs = getTreePlacementArgsFromCursor(x, y);
             if (placementArgs)
             {
+                GameCommands::setErrorTitle(StringIds::cant_plant_this_here);
                 switch (_treeClusterType)
                 {
                     case treeCluster::none:
-                        GameCommands::setErrorTitle(StringIds::cant_plant_this_here);
                         if (GameCommands::do_23(GameCommands::Flags::apply, *placementArgs) != GameCommands::FAILURE)
                         {
                             Audio::playSound(Audio::SoundId::construct, GameCommands::getPosition());

--- a/src/OpenLoco/Windows/TerraForm.cpp
+++ b/src/OpenLoco/Windows/TerraForm.cpp
@@ -604,6 +604,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void clusterToolDown(const GameCommands::TreePlacementArgs& baseArgs, const uint16_t range, const uint16_t density, TTreeTypeFunc&& getTreeType)
         {
             const auto numPlacements = (range * range * density) / 8192;
+            uint16_t numErrors = 0;
             for (auto i = 0; i < numPlacements; ++i)
             {
                 // Choose a random offset in a circle
@@ -629,8 +630,22 @@ namespace OpenLoco::Ui::Windows::Terraform
                 args.type = *type;
                 args.buildImmediately = true;
                 args.requiresFullClearance = true;
+
+                // First query if we can place a tree at this location; skip if we can't.
+                auto queryRes = do_23(0, args);
+                if (queryRes == GameCommands::FAILURE)
+                {
+                    numErrors++;
+                    continue;
+                }
+
+                // Actually place the tree
                 do_23(GameCommands::Flags::apply, args);
             }
+
+            // Not a single tree placed?
+            if (numErrors == numPlacements)
+                Error::open(StringIds::cant_plant_this_here, StringIds::empty);
         }
 
         // 0x004BBB20


### PR DESCRIPTION
This PR changes the cluster tool such that planting clusters of trees now costs money and influences ratings outside of editor mode.

Potential room for improvement:
- [x] This activates collision detection as well. An error may pop up if another object is in the way of the cluster.
- [x] These errors can stack to a loud sound. Perhaps we should randomise the game command location?