### PR TITLE
Only use red text colour for expenditure sums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 - Fix: [#1035] Incorrect colour selection when building buildings.
 - Fix: [#1070] Crash when naming stations after exhausting natural names.
 - Fix: [#1094] Repeated clicking on construction window not always working.
+- Fix: [#1095] Individual expenses are drawn in red, not just the expenditure sums.
 - Change: [#298] Planting clusters of trees now costs money and influences ratings outside of editor mode.
 - Change: [#1079] Allow rotating buildings in town list by keyboard shortcut.
-- Change: [#1095] Only expenditure sums are now drawn in red, not the individual expenses.
 
 21.07 (2021-07-18)
 ------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: [#1094] Repeated clicking on construction window not always working.
 - Change: [#298] Planting clusters of trees now costs money and influences ratings outside of editor mode.
 - Change: [#1079] Allow rotating buildings in town list by keyboard shortcut.
+- Change: [#1095] Only expenditure sums are now drawn in red, not the individual expenses.
 
 21.07 (2021-07-18)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -1827,24 +1827,16 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 currency48_t expenditures = company.expenditures[columnIndex][j];
                 sum += expenditures;
 
-                string_id mainFormat = StringIds::black_stringid;
-                string_id currFormat = StringIds::plus_currency48;
-                if (expenditures < 0)
-                {
-                    mainFormat = StringIds::red_stringid;
-                    currFormat = StringIds::currency48;
-                }
-
                 if (expenditures != 0)
                 {
-                    auto args = FormatArguments::common(currFormat, expenditures);
+                    auto args = FormatArguments::common(StringIds::currency48, expenditures);
 
                     Gfx::drawString_494C78(
                         *context,
                         x,
                         y,
                         Colour::black,
-                        mainFormat,
+                        StringIds::black_stringid,
                         &args);
                 }
                 y += 10;


### PR DESCRIPTION
In the company window's finances tab, all negative expenses were drawn in a red text colour, rather than just the sums at the bottom. This PR changes it to be in line with vanilla again, which is a little easier on the eyes and more in line with traditional book-keeping practices.

Before:
![Screenshot (7)](https://user-images.githubusercontent.com/604665/128774333-b9f9284c-2bcb-4043-b98e-8a8b296ae6ed.png)

After:
![Screenshot (6)](https://user-images.githubusercontent.com/604665/128774332-b1c3986b-9f3d-407f-b01b-85c4bb031d10.png)
