### PR TITLE
Fix: #366. Implement deliver cargo to nearby stations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 21.07+ (???)
 ------------------------------------------------------------------------
+- Fix: [#366] People and mail cargo incorrectly delivered to far away stations.
 - Fix: [#1035] Incorrect colour selection when building buildings.
 - Fix: [#1070] Crash when naming stations after exhausting natural names.
 - Fix: [#1094] Repeated clicking on construction window not always working.

--- a/src/OpenLoco/Map/BuildingTile.cpp
+++ b/src/OpenLoco/Map/BuildingTile.cpp
@@ -203,7 +203,7 @@ namespace OpenLoco::Map
                 town->var_19C[i][0] += producedAmount;
 
                 const auto size = (buildingObj->flags & BuildingObjectFlags::large_tile) ? Map::TilePos2(2, 2) : Map::TilePos2(1, 1);
-                town->var_19C[i][1] += StationManager::sendProducedCargoToStations(buildingObj->producedCargoType[i], producedAmount, loc, size) & 0xFF;
+                town->var_19C[i][1] += StationManager::deliverCargoToNearbyStations(buildingObj->producedCargoType[i], producedAmount, loc, size) & 0xFF;
             }
         }
         return true;

--- a/src/OpenLoco/Station.cpp
+++ b/src/OpenLoco/Station.cpp
@@ -528,6 +528,16 @@ namespace OpenLoco
         twn->monthly_cargo_delivered[cargoType] = Math::Bound::add(twn->monthly_cargo_delivered[cargoType], cargoQuantity);
     }
 
+    // 0x0042F489
+    void Station::deliverCargoToStation(const uint8_t cargoType, const uint8_t cargoQuantity)
+    {
+        auto& cargoStats = cargo_stats[cargoType];
+        cargoStats.quantity = Math::Bound::add(cargoStats.quantity, cargoQuantity);
+        cargoStats.enroute_age = 0;
+        cargoStats.origin = id();
+        updateCargoDistribution();
+    }
+
     // 0x0048F7D1
     void Station::sub_48F7D1()
     {

--- a/src/OpenLoco/Station.h
+++ b/src/OpenLoco/Station.h
@@ -111,6 +111,7 @@ namespace OpenLoco
         void invalidate();
         void invalidateWindow();
         void setCatchmentDisplay(uint8_t flags);
+        void deliverCargoToStation(const uint8_t cargoType, const uint8_t cargoQuantity);
         void deliverCargoToTown(uint8_t cargoType, uint16_t cargoQuantity);
         void updateCargoDistribution();
 

--- a/src/OpenLoco/StationManager.cpp
+++ b/src/OpenLoco/StationManager.cpp
@@ -416,12 +416,12 @@ namespace OpenLoco::StationManager
     uint16_t deliverCargoToNearbyStations(const uint8_t cargoType, const uint8_t cargoQty, const Map::Pos2& pos, const Map::TilePos2& size)
     {
         const auto initialLoc = TilePos2(pos) - TilePos2(4, 4);
-        const auto searchSize = size + TilePos2(8, 8);
+        const auto catchmentSize = size + TilePos2(8, 8);
         // TODO: Use a fixed size array (max size 15)
         std::vector<std::pair<StationId_t, uint8_t>> foundStations;
-        for (TilePos2 searchOffset{ 0, 0 }; searchOffset.y < searchSize.y; ++searchOffset.y)
+        for (TilePos2 searchOffset{ 0, 0 }; searchOffset.y < catchmentSize.y; ++searchOffset.y)
         {
-            for (; searchOffset.x < searchSize.x; ++searchOffset.x)
+            for (; searchOffset.x < catchmentSize.x; ++searchOffset.x)
             {
                 const auto searchLoc = initialLoc + searchOffset;
                 if (!Map::validCoords(searchLoc))

--- a/src/OpenLoco/StationManager.cpp
+++ b/src/OpenLoco/StationManager.cpp
@@ -417,6 +417,7 @@ namespace OpenLoco::StationManager
     {
         const auto initialLoc = TilePos2(pos) - TilePos2(4, 4);
         const auto searchSize = size + TilePos2(8, 8);
+        // TODO: Use a fixed size array (max size 15)
         std::vector<std::pair<StationId_t, uint8_t>> foundStations;
         for (TilePos2 searchOffset{ 0, 0 }; searchOffset.y < searchSize.y; ++searchOffset.y)
         {
@@ -444,7 +445,7 @@ namespace OpenLoco::StationManager
 
                     if (foundStations.size() > 15)
                     {
-                        continue;
+                        break;
                     }
                     auto res = std::find_if(foundStations.begin(), foundStations.end(), [stationId = elStation->stationId()](const std::pair<StationId_t, uint8_t>& item) { return item.first == stationId; });
                     if (res != foundStations.end())

--- a/src/OpenLoco/StationManager.h
+++ b/src/OpenLoco/StationManager.h
@@ -18,5 +18,5 @@ namespace OpenLoco::StationManager
     string_id generateNewStationName(StationId_t stationId, TownId_t townId, Map::Pos3 position, uint8_t mode);
     void zeroUnused();
     void registerHooks();
-    uint16_t sendProducedCargoToStations(const uint8_t cargoType, const uint8_t cargoQty, const Map::Pos2& pos, const Map::TilePos2& size);
+    uint16_t deliverCargoToNearbyStations(const uint8_t cargoType, const uint8_t cargoQty, const Map::Pos2& pos, const Map::TilePos2& size);
 }


### PR DESCRIPTION
Original game had a bug where it would write to bad memory and end up delivering cargo to stations that it shouldn't.

Note will definitely cause a desync with existing game on some maps.