### PR TITLE
Prevent invalid filename due to off-by-one in file browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: [#1070] Crash when naming stations after exhausting natural names.
 - Fix: [#1094] Repeated clicking on construction window not always working.
 - Fix: [#1095] Individual expenses are drawn in red, not just the expenditure sums.
+- Fix: [#1102] Invalid file error when clicking empty space in file browser.
 - Change: [#298] Planting clusters of trees now costs money and influences ratings outside of editor mode.
 - Change: [#1079] Allow rotating buildings in town list by keyboard shortcut.
 

--- a/src/OpenLoco/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/Windows/PromptBrowseWindow.cpp
@@ -295,7 +295,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     static void onScrollMouseDown(Window* self, int16_t x, int16_t y, uint8_t scrollIndex)
     {
         auto index = y / self->row_height;
-        if (index > _numFiles)
+        if (index >= _numFiles)
             return;
 
         Audio::playSound(Audio::SoundId::clickDown, self->x + (self->width / 2));


### PR DESCRIPTION
The file browser allowed clicking the N+1th filename, for which there is no data. This off-by-one error was not present in the mouseover event; this only affects the mousedown event.