### PR TITLE
Fix road dropdown not remembering selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 21.08+ (???)
 ------------------------------------------------------------------------
+- Fix: [#1108] Road selection not being remembered.
 
 21.08 (2021-08-12)
 ------------------------------------------------------------------------
-- Fix: [#366] People and mail cargo incorrectly delivered to far away stations.
+- Fix: [#366] Original Bug. People and mail cargo incorrectly delivered to far away stations.
 - Fix: [#1035] Incorrect colour selection when building buildings.
 - Fix: [#1070] Crash when naming stations after exhausting natural names.
 - Fix: [#1094] Repeated clicking on construction window not always working.

--- a/src/OpenLoco/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/Windows/ToolbarTop.cpp
@@ -42,7 +42,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     static loco_global<uint8_t, 0x009C870C> last_town_option;
     static loco_global<uint8_t, 0x009C870D> last_port_option;
 
-    static loco_global<int8_t[18], 0x0050A006> available_objects;
+    static loco_global<uint8_t[18], 0x0050A006> available_objects;
 
     namespace Widx
     {
@@ -342,7 +342,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
 
         // Sanity check: any objects available?
         uint32_t i = 0;
-        while (available_objects[i] != -1 && i < std::size(available_objects))
+        while (available_objects[i] != 0xFF && i < std::size(available_objects))
             i++;
         if (i == 0)
             return;
@@ -351,12 +351,12 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
 
         // Add available objects to Dropdown.
         uint16_t highlighted_item = 0;
-        for (i = 0; available_objects[i] != -1 && i < std::size(available_objects); i++)
+        for (i = 0; available_objects[i] != 0xFF && i < std::size(available_objects); i++)
         {
             uint32_t obj_image;
             string_id obj_string_id;
 
-            int objIndex = available_objects[i];
+            auto objIndex = available_objects[i];
             if ((objIndex & (1 << 7)) != 0)
             {
                 auto road = ObjectManager::get<RoadObject>(objIndex & 0x7F);

--- a/src/OpenLoco/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/Windows/ToolbarTopCommon.cpp
@@ -33,7 +33,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
 
     static loco_global<uint8_t, 0x009C870C> last_town_option;
 
-    static loco_global<int8_t[18], 0x0050A006> available_objects;
+    static loco_global<uint8_t[18], 0x0050A006> available_objects;
 
     // 0x00439DE4
     void draw(Window* self, Gfx::Context* context)
@@ -199,7 +199,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
 
         // Sanity check: any objects available?
         uint32_t i = 0;
-        while (available_objects[i] != -1 && i < std::size(available_objects))
+        while (available_objects[i] != 0xFF && i < std::size(available_objects))
             i++;
         if (i == 0)
             return;
@@ -208,12 +208,12 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
 
         // Add available objects to Dropdown.
         uint16_t highlighted_item = 0;
-        for (i = 0; available_objects[i] != -1 && i < std::size(available_objects); i++)
+        for (i = 0; available_objects[i] != 0xFF && i < std::size(available_objects); i++)
         {
             uint32_t obj_image;
             string_id obj_string_id;
 
-            int objIndex = available_objects[i];
+            auto objIndex = available_objects[i];
             if ((objIndex & (1 << 7)) != 0)
             {
                 auto road = ObjectManager::get<RoadObject>(objIndex & 0x7F);


### PR DESCRIPTION
Incorrectly signed type was causing comparisons of equality to fail

This has annoyed me for a while keep accidentally constructing one way road.