### PR TITLE
Fix save game open

### DIFF
--- a/src/OpenLoco/Game.cpp
+++ b/src/OpenLoco/Game.cpp
@@ -85,7 +85,10 @@ namespace OpenLoco::Game
     // 0x00441843
     bool saveSaveGameOpen()
     {
-        strncpy(&_savePath[0], &_path_landscapes[0], std::size(_savePath));
+        if (!isNetworked())
+            strncpy(&_savePath[0], &_path_saves_single_player[0], std::size(_savePath));
+        else
+            strncpy(&_savePath[0], &_path_saves_two_player[0], std::size(_savePath));
 
         return openBrowsePrompt(StringIds::title_prompt_save_game, browse_type::save, S5::filterSV5);
     }

--- a/src/OpenLoco/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/Windows/ToolbarTop.cpp
@@ -2,6 +2,7 @@
 #include "../CompanyManager.h"
 #include "../Config.h"
 #include "../Entities/EntityManager.h"
+#include "../Game.h"
 #include "../GameCommands/GameCommands.h"
 #include "../Graphics/Colour.h"
 #include "../Graphics/Gfx.h"
@@ -131,14 +132,6 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         Dropdown::setHighlightedItem(1);
     }
 
-    // 0x00441843
-    static bool saveGameOpen()
-    {
-        registers regs;
-        call(0x00441843, regs);
-        return regs.eax;
-    }
-
     // 0x0043B1C4
     static void prepareSaveGame()
     {
@@ -154,7 +147,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             return;
         }
 
-        if (!saveGameOpen())
+        if (!OpenLoco::Game::saveSaveGameOpen())
         {
             // Cancelled by user
             Gfx::invalidateScreen();


### PR DESCRIPTION
My previous PR, #1118, removed the hooks to the prompt browse window. This was working fine for all except saving games! Turns out the toolbar menu was still calling the vanilla function, thereby relying on the hook.

Replacing this call revealed a bug in hiding with the save prompt being initialised to the wrong save path. I think this wasn't an issue for users before #1118, however, so a changelog entry won't be needed.