### PR TITLE
Fix caption 22 widget text rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 21.08+ (???)
 ------------------------------------------------------------------------
 - Fix: [#1108] Road selection not being remembered.
+- Fix: [#1124] Confirmation prompt captions are not rendered correctly.
 - Change: [#1104] Exceptions now trigger a message box popup, instead of only being written to the console.
 
 21.08 (2021-08-12)

--- a/src/OpenLoco/Widget.cpp
+++ b/src/OpenLoco/Widget.cpp
@@ -593,8 +593,8 @@ namespace OpenLoco::Ui
         Gfx::fillRect(*context, l + 1, t + 1, r - 1, b - 1, 0x2000000 | 46);
 
         int16_t width = r - l - 4 - 10;
-        int16_t y = t + window->y + 1;
-        int16_t x = l + window->x + 2 + (width / 2);
+        int16_t y = t + 1;
+        int16_t x = l + 2 + (width / 2);
 
         Gfx::drawStringCentredClipped(*context, x, y, width, Colour::white | FormatFlags::textflag_5, text, _commonFormatArgs);
     }


### PR DESCRIPTION
Before:
(Note the caption showing in the lower-right corner of the game canvas, outside the prompt window.)
![Screenshot_20210822_230827](https://user-images.githubusercontent.com/604665/130370203-e348e1ea-b922-4fca-a155-16b298c43eff.png)

After:
![Screenshot_20210822_231149](https://user-images.githubusercontent.com/604665/130370204-875bf104-1064-4347-9ea8-bf8de8e8062c.png)
