### PR TITLE
Fix #1127: Crash during vehicle renewal cheat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#1108] Road selection not being remembered.
 - Fix: [#1124] Confirmation prompt captions are not rendered correctly.
-- Fix: [#1127] Crash during vehicle renewel cheat.
+- Fix: [#1127] Crash during vehicle renewal cheat.
 - Change: [#1104] Exceptions now trigger a message box popup, instead of only being written to the console.
 
 21.08 (2021-08-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#1108] Road selection not being remembered.
 - Fix: [#1124] Confirmation prompt captions are not rendered correctly.
+- Fix: [#1127] Crash during vehicle renewel cheat.
 - Change: [#1104] Exceptions now trigger a message box popup, instead of only being written to the console.
 
 21.08 (2021-08-12)

--- a/src/OpenLoco/GameCommands/Cheat.cpp
+++ b/src/OpenLoco/GameCommands/Cheat.cpp
@@ -165,9 +165,7 @@ namespace OpenLoco::GameCommands
                 train.veh2->reliability = newReliablity;
 
                 // Set reliability for the first car's front bogie component.
-                auto& car = *(train.cars.begin());
-                auto& component = *(car.begin());
-                component.front->reliability = newReliablity * 256;
+                train.cars.firstCar.front->reliability = newReliablity * 256;
             }
             return 0;
         }


### PR DESCRIPTION
Not convinced this will fix #1127 but it does at least make the code slightly cleaner.