### PR TITLE
Implement legacy config read/write

### DIFF
--- a/src/OpenLoco/Config.h
+++ b/src/OpenLoco/Config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Objects/ObjectManager.h"
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -82,7 +83,7 @@ namespace OpenLoco::Config
         MusicPlaylistType music_playlist;             // 0x50AF27, 0x73
         uint16_t height_marker_offset;                // 0x50AF28, 0x74
         NewsType news_settings[newsItemSubTypeCount]; // 0x50AF2A, 0x76
-        uint8_t preferred_currency[16];               // 0x7C
+        ObjectHeader preferred_currency;              // 0x7C
         uint8_t enabled_music[29];                    // 0x50AF40, 0x8C
         uint8_t pad_A9[0xCC - 0xA9];                  // 0xA9
         int32_t volume;                               // 0x50AF80, 0xCC

--- a/src/OpenLoco/Windows/Options.cpp
+++ b/src/OpenLoco/Windows/Options.cpp
@@ -1588,7 +1588,7 @@ namespace OpenLoco::Ui::Windows::Options
                 if (index == ax)
                 {
                     auto& cfg = OpenLoco::Config::get();
-                    memcpy(cfg.preferred_currency, object.second._header, 0x10);
+                    cfg.preferred_currency = *object.second._header;
 
                     sub_4C1519();
                     Config::write();


### PR DESCRIPTION
Should probably add a hook so that #913 is fixed for the config file.