### PR TITLE
Fix: Options window spawns behind title logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: [#1123] Right click interaction of road/tram causing crashes or money.
 - Fix: [#1124] Confirmation prompt captions are not rendered correctly.
 - Fix: [#1127] Crash during vehicle renewal cheat.
+- Fix: [#1144] Options window spawns behind title logo.
 - Change: [#1104] Exceptions now trigger a message box popup, instead of only being written to the console.
 
 21.08 (2021-08-12)

--- a/src/OpenLoco/Windows/Options.cpp
+++ b/src/OpenLoco/Windows/Options.cpp
@@ -2373,7 +2373,7 @@ namespace OpenLoco::Ui::Windows::Options
         window = WindowManager::createWindowCentred(
             WindowType::options,
             Display::_window_size,
-            0,
+            WindowFlags::stick_to_front,
             &Display::_events);
 
         window->widgets = Display::_widgets;


### PR DESCRIPTION
As reported on Discord.

Before:
![Screenshot (1)](https://user-images.githubusercontent.com/604665/132139409-24fd0a87-0fe7-45c6-829a-46e1399ce443.png)

After:
![Screenshot](https://user-images.githubusercontent.com/604665/132139410-1f1fc02f-fbf4-4fd2-988e-c17cebd84a3a.png)
