### PR TITLE
Fix: Options window spawns behind title logo

### DIFF
--- a/src/OpenLoco/Ui/WindowManager.cpp
+++ b/src/OpenLoco/Ui/WindowManager.cpp
@@ -1083,7 +1083,7 @@ namespace OpenLoco::Ui::WindowManager
         bool stickToBack = (flags & WindowFlags::stick_to_back) != 0;
         bool stickToFront = (flags & WindowFlags::stick_to_front) != 0;
         bool hasFlag12 = (flags & WindowFlags::flag_12) != 0;
-        bool hasFlag13 = (flags & WindowFlags::flag_13) != 0;
+        bool shouldOpenQuietly = (flags & WindowFlags::openQuietly) != 0;
 
         // Find right position to insert new window
         size_t dstIndex = 0;
@@ -1116,7 +1116,7 @@ namespace OpenLoco::Ui::WindowManager
         auto window = Ui::Window(origin, size);
         window.type = type;
         window.flags = flags;
-        if (hasFlag12 || (!stickToBack && !stickToFront && !hasFlag13))
+        if (hasFlag12 || (!stickToBack && !stickToFront && !shouldOpenQuietly))
         {
             window.flags |= WindowFlags::white_border_mask;
             Audio::playSound(Audio::SoundId::openWindow, origin.x + size.width / 2);

--- a/src/OpenLoco/Window.h
+++ b/src/OpenLoco/Window.h
@@ -105,7 +105,7 @@ namespace OpenLoco::Ui
         constexpr uint32_t no_auto_close = 1 << 10;
         constexpr uint32_t flag_11 = 1 << 11;
         constexpr uint32_t flag_12 = 1 << 12;
-        constexpr uint32_t flag_13 = 1 << 13;
+        constexpr uint32_t openQuietly = 1 << 13;
         constexpr uint32_t not_scroll_view = 1 << 14;
         constexpr uint32_t flag_15 = 1 << 15;
         constexpr uint32_t flag_16 = 1 << 16;

--- a/src/OpenLoco/Windows/Options.cpp
+++ b/src/OpenLoco/Windows/Options.cpp
@@ -2373,7 +2373,7 @@ namespace OpenLoco::Ui::Windows::Options
         window = WindowManager::createWindowCentred(
             WindowType::options,
             Display::_window_size,
-            WindowFlags::stick_to_front,
+            0,
             &Display::_events);
 
         window->widgets = Display::_widgets;

--- a/src/OpenLoco/Windows/TitleLogo.cpp
+++ b/src/OpenLoco/Windows/TitleLogo.cpp
@@ -38,7 +38,7 @@ namespace OpenLoco::Ui::Windows::TitleLogo
             WindowType::title_logo,
             { 0, 0 },
             window_size,
-            WindowFlags::stick_to_front | WindowFlags::transparent,
+            WindowFlags::openQuietly | WindowFlags::transparent,
             &_events);
 
         window->widgets = _widgets;


### PR DESCRIPTION
The solution from #1144 would open other windows, like the keyboard shortcut window, behind the options window. This PR repurposes the otherwise unused flag 13 to achieve the same effect that the `stick_to_front` flag was likely used for: opening the logo window without a sound effect.