### PR TITLE
Make LoadedObjectHandle trivially copyable

### DIFF
--- a/src/OpenLoco/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/Objects/ObjectManager.cpp
@@ -505,7 +505,7 @@ namespace OpenLoco::ObjectManager
         return object_repository[static_cast<uint8_t>(type)];
     }
 
-    Object* getAny(const LoadedObjectHandle& handle)
+    Object* getAny(const LoadedObjectHandle handle)
     {
         auto obj = _allObjects[getTypeOffset(handle.type) + handle.id];
         if (obj == (void*)-1)
@@ -830,20 +830,20 @@ namespace OpenLoco::ObjectManager
         *ptr += strlen(entry._filename) + 1;
 
         // decoded_chunk_size
-        //ObjectHeader2* h2 = (ObjectHeader2*)ptr;
+        // ObjectHeader2* h2 = (ObjectHeader2*)ptr;
         *ptr += sizeof(ObjectHeader2);
 
         entry._name = (char*)*ptr;
         *ptr += strlen(entry._name) + 1;
 
-        //ObjectHeader3* h3 = (ObjectHeader3*)ptr;
+        // ObjectHeader3* h3 = (ObjectHeader3*)ptr;
         *ptr += sizeof(ObjectHeader3);
 
         uint8_t* countA = (uint8_t*)*ptr;
         *ptr += sizeof(uint8_t);
         for (int n = 0; n < *countA; n++)
         {
-            //header* subh = (header*)ptr;
+            // header* subh = (header*)ptr;
             *ptr += sizeof(ObjectHeader);
         }
 
@@ -851,7 +851,7 @@ namespace OpenLoco::ObjectManager
         *ptr += sizeof(uint8_t);
         for (int n = 0; n < *countB; n++)
         {
-            //header* subh = (header*)ptr;
+            // header* subh = (header*)ptr;
             *ptr += sizeof(ObjectHeader);
         }
 
@@ -901,7 +901,7 @@ namespace OpenLoco::ObjectManager
             auto objectType = header.getType();
             const auto& typedObjectList = getRepositoryItem(objectType);
             auto maxObjectsForType = getMaxObjects(objectType);
-            for (size_t i = 0; i < maxObjectsForType; i++)
+            for (LoadedObjectId i = 0; i < maxObjectsForType; i++)
             {
                 auto obj = typedObjectList.objects[i];
                 if (obj != nullptr && obj != reinterpret_cast<Object*>(-1))
@@ -959,7 +959,7 @@ namespace OpenLoco::ObjectManager
         return (call(objectProc, regs) & X86_FLAG_CARRY) == 0;
     }
 
-    static bool callObjectFunction(const LoadedObjectHandle& handle, ObjectProcedure proc)
+    static bool callObjectFunction(const LoadedObjectHandle handle, ObjectProcedure proc)
     {
         auto* obj = getAny(handle);
         if (obj != nullptr)
@@ -1270,12 +1270,12 @@ namespace OpenLoco::ObjectManager
         call(0x00472031);
     }
 
-    void unload(const LoadedObjectHandle& handle)
+    void unload(const LoadedObjectHandle handle)
     {
         callObjectFunction(handle, ObjectProcedure::unload);
     }
 
-    size_t getByteLength(const LoadedObjectHandle& handle)
+    size_t getByteLength(const LoadedObjectHandle handle)
     {
         return objectEntries[getTypeOffset(handle.type) + handle.id].dataSize;
     }

--- a/src/OpenLoco/Objects/ObjectManager.h
+++ b/src/OpenLoco/Objects/ObjectManager.h
@@ -57,8 +57,6 @@ namespace OpenLoco
     struct CompetitorObject;
     struct ScenarioTextObject;
 
-#pragma pack(push, 1)
-
     /**
      * Represents an index into the entire loaded object array. Not an index for
      * a specific object type. DO NOT USE
@@ -68,13 +66,14 @@ namespace OpenLoco
     /**
      * Represents an index / ID of a specific object type.
      */
-    using LoadedObjectId = size_t;
-#pragma pack(pop)
+    using LoadedObjectId = uint16_t;
+
     struct LoadedObjectHandle
     {
         ObjectType type;
         LoadedObjectId id;
     };
+    static_assert(sizeof(LoadedObjectHandle) == 4);
 }
 
 namespace OpenLoco::ObjectManager
@@ -182,7 +181,7 @@ namespace OpenLoco::ObjectManager
     template<typename T>
     T* get(size_t id);
 
-    Object* getAny(const LoadedObjectHandle& handle);
+    Object* getAny(const LoadedObjectHandle handle);
 
     template<>
     InterfaceSkinObject* get();
@@ -284,9 +283,9 @@ namespace OpenLoco::ObjectManager
     void writePackedObjects(SawyerStreamWriter& fs, const std::vector<ObjectHeader>& packedObjects);
 
     void unloadAll();
-    void unload(const LoadedObjectHandle& handle);
+    void unload(const LoadedObjectHandle handle);
 
-    size_t getByteLength(const LoadedObjectHandle& handle);
+    size_t getByteLength(const LoadedObjectHandle handle);
 
     void drawGenericDescription(Gfx::Context& context, Ui::Point& rowPosition, const uint16_t designed, const uint16_t obsolete);
 }


### PR DESCRIPTION
As for the reason: https://godbolt.org/z/vs86KGKTj