### PR TITLE
Fix #1223. Insert correct null objects into save files

### DIFF
--- a/src/OpenLoco/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/Objects/ObjectManager.cpp
@@ -529,13 +529,21 @@ namespace OpenLoco::ObjectManager
     template<>
     SoundObject* get(size_t id)
     {
-        return _soundObjects[id];
+        if (_soundObjects[id] != reinterpret_cast<SoundObject*>(-1))
+        {
+            return _soundObjects[id];
+        }
+        return nullptr;
     }
 
     template<>
     SteamObject* get(size_t id)
     {
-        return _steamObjects[id];
+        if (_steamObjects[id] != reinterpret_cast<SteamObject*>(-1))
+        {
+            return _steamObjects[id];
+        }
+        return nullptr;
     }
 
     template<>
@@ -622,7 +630,11 @@ namespace OpenLoco::ObjectManager
     template<>
     CurrencyObject* get()
     {
-        return _currencyObjects[0];
+        if (_currencyObjects[0] != reinterpret_cast<CurrencyObject*>(-1))
+        {
+            return _currencyObjects[0];
+        }
+        return nullptr;
     }
 
     template<>
@@ -646,7 +658,11 @@ namespace OpenLoco::ObjectManager
     template<>
     TrackExtraObject* get(size_t id)
     {
-        return _trackExtraObjects[id];
+        if (_trackExtraObjects[id] != reinterpret_cast<TrackExtraObject*>(-1))
+        {
+            return _trackExtraObjects[id];
+        }
+        return nullptr;
     }
 
     template<>
@@ -661,7 +677,11 @@ namespace OpenLoco::ObjectManager
     template<>
     RoadExtraObject* get(size_t id)
     {
-        return _roadExtraObjects[id];
+        if (_roadExtraObjects[id] != reinterpret_cast<RoadExtraObject*>(-1))
+        {
+            return _roadExtraObjects[id];
+        }
+        return nullptr;
     }
 
     template<>
@@ -703,13 +723,21 @@ namespace OpenLoco::ObjectManager
     template<>
     WaterObject* get()
     {
-        return _waterObjects[0];
+        if (_waterObjects[0] != reinterpret_cast<WaterObject*>(-1))
+        {
+            return _waterObjects[0];
+        }
+        return nullptr;
     }
 
     template<>
     CompetitorObject* get(size_t id)
     {
-        return _competitorObjects[id];
+        if (_competitorObjects[id] != reinterpret_cast<CompetitorObject*>(-1))
+        {
+            return _competitorObjects[id];
+        }
+        return nullptr;
     }
 
     template<>


### PR DESCRIPTION
Don't really like the way this works atm but this will do for now.
What should really be done is that these 0xFF entries are inserted in the s5 code but that would need quite a bit of rework to make work so will leave it for the future.