### PR TITLE
Set correct input flag when placing company HQ

### DIFF
--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -872,7 +872,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
                 case widx::build_hq:
                     Input::toolSet(self, widgetIndex, CursorId::placeHQ);
-                    Input::setFlag(Input::Flags::flag5);
+                    Input::setFlag(Input::Flags::flag6);
                     break;
             }
         }


### PR DESCRIPTION
As per #1183, I was looking into naming the input flags, and stumbled across an odd use of flag 5. This flag is mostly used in the context of dragging the viewport, except here:

https://github.com/OpenLoco/OpenLoco/blob/ac901b5aaa2643cbafaf0b279a6cf6e9a65e5ee2/src/OpenLoco/Windows/CompanyWindow.cpp#L873-L876

Going back to IDA, the original game is doing the following (0x00432C3C):
```
bts     input_flags, 6
```

Resolves #1183