### PR TITLE
Implement command line options

### DIFF
--- a/src/OpenLoco/CommandLine.cpp
+++ b/src/OpenLoco/CommandLine.cpp
@@ -1,0 +1,541 @@
+#include "CommandLine.h"
+#include "GameState.h"
+#include "OpenLoco.h"
+#include "S5/S5.h"
+#include "S5/SawyerStream.h"
+#include <iostream>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace OpenLoco
+{
+    static CommandLineOptions _cmdlineOptions;
+
+    static int uncompressFile(const CommandLineOptions& options);
+    static int simulate(const CommandLineOptions& options);
+
+    const CommandLineOptions& getCommandLineOptions()
+    {
+        return _cmdlineOptions;
+    }
+
+    void setCommandLineOptions(const CommandLineOptions& options)
+    {
+        _cmdlineOptions = options;
+    }
+
+    static std::vector<std::string> splitArgs(const char* args)
+    {
+        std::vector<std::string> arguments;
+        arguments.push_back("");
+        auto ch = args;
+        auto arg = ch;
+        auto inQuotes = false;
+        while (*ch != '\0')
+        {
+            if (*ch == ' ' && !inQuotes)
+            {
+                if (ch != arg)
+                {
+                    arguments.emplace_back(arg, ch - arg);
+                }
+                arg = ch + 1;
+            }
+            else if (*ch == '"' && ch == arg)
+            {
+                inQuotes = true;
+                arg = ch + 1;
+            }
+            else if (*ch == '"' && (*(ch + 1) == ' ' || *(ch + 1) == '\0'))
+            {
+                arguments.emplace_back(arg, ch - arg);
+                arg = ch + 1;
+                inQuotes = false;
+            }
+            ch++;
+        }
+        if (*arg != '\0')
+            arguments.emplace_back(arg);
+        return arguments;
+    }
+
+    class CommandLineParser
+    {
+    private:
+        std::vector<std::string_view> _args;
+        std::vector<std::pair<std::string_view, size_t>> _registered;
+        std::vector<std::pair<std::string_view, std::vector<std::string_view>>> _values;
+        std::string _errorMessage;
+
+        static bool isLongOption(std::string_view arg)
+        {
+            if (arg.size() >= 3 && arg[0] == '-' && arg[1] == '-')
+                return true;
+            return false;
+        }
+
+        static bool isShortOption(std::string_view arg)
+        {
+            if (arg.size() >= 2 && arg[0] == '-' && arg[1] != '-')
+                return true;
+            return false;
+        }
+
+        static bool isOptionTerminator(std::string_view arg)
+        {
+            return arg == "--";
+        }
+
+        static bool isArg(std::string_view arg)
+        {
+            return !isLongOption(arg) && !isShortOption(arg) && !isOptionTerminator(arg);
+        }
+
+        std::optional<size_t> getOptionArgCount(std::string_view arg)
+        {
+            for (const auto& r : _registered)
+            {
+                if (std::get<0>(r) == arg)
+                {
+                    return std::get<1>(r);
+                }
+            }
+            return {};
+        }
+
+        void setOption(std::string_view arg)
+        {
+            for (auto& r : _values)
+            {
+                if (std::get<0>(r) == arg)
+                {
+                    return;
+                }
+            }
+            _values.emplace_back(arg, std::vector<std::string_view>());
+        }
+
+        void appendValue(std::string_view arg, std::string_view value)
+        {
+            for (auto& r : _values)
+            {
+                if (std::get<0>(r) == arg)
+                {
+                    auto& v = std::get<1>(r);
+                    v.push_back(value);
+                    return;
+                }
+            }
+            _values.emplace_back(arg, std::vector<std::string_view>{ value });
+        }
+
+        bool appendValues(std::string_view arg, size_t count, size_t& i)
+        {
+            for (size_t j = 0; j < count; j++)
+            {
+                i++;
+                if (i < _args.size())
+                {
+                    auto& nextArg = _args[i];
+                    if (isArg(nextArg))
+                    {
+                        appendValue(arg, nextArg);
+                    }
+                    else
+                    {
+                        setArgumentCountError(arg, count);
+                        return false;
+                    }
+                }
+                else
+                {
+                    setArgumentCountError(arg, count);
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        void setArgumentUnknownError(std::string_view arg)
+        {
+            _errorMessage = std::string("Unknown option: ") + std::string(arg);
+        }
+
+        void setArgumentCountError(std::string_view arg, size_t count)
+        {
+            if (count == 1)
+            {
+                _errorMessage = std::string("Expected ") + "1 argument for " + std::string(arg);
+            }
+            else
+            {
+                _errorMessage = std::string("Expected ") + std::to_string(count) + " arguments for " + std::string(arg);
+            }
+        }
+
+    public:
+        CommandLineParser(int argc, const char** argv)
+        {
+            _args.resize(argc - 1);
+            for (int i = 1; i < argc; i++)
+            {
+                _args[i - 1] = argv[i];
+            }
+        }
+
+        std::string_view getErrorMessage() const
+        {
+            return _errorMessage;
+        }
+
+        CommandLineParser& registerOption(std::string_view option, size_t count = 0)
+        {
+            _registered.emplace_back(option, count);
+            return *this;
+        }
+
+        CommandLineParser& registerOption(std::string_view a, std::string_view b, size_t count = 0)
+        {
+            _registered.emplace_back(a, count);
+            _registered.emplace_back(b, count);
+            return *this;
+        }
+
+        bool parse()
+        {
+            auto noMoreOptions = false;
+            for (size_t i = 0; i < _args.size(); i++)
+            {
+                auto& arg = _args[i];
+                if (!noMoreOptions && isLongOption(arg))
+                {
+                    auto count = getOptionArgCount(arg);
+                    if (count)
+                    {
+                        if (*count == 0)
+                        {
+                            setOption(arg);
+                        }
+                        else if (!appendValues(arg, *count, i))
+                        {
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        setArgumentUnknownError(arg);
+                        return false;
+                    }
+                }
+                else if (!noMoreOptions && isShortOption(arg))
+                {
+                    for (auto c : arg.substr(1))
+                    {
+                        auto count = getOptionArgCount(arg);
+                        if (count)
+                        {
+                            if (*count == 0)
+                            {
+                                setOption(arg);
+                            }
+                            else if (!appendValues(arg, *count, i))
+                            {
+                                return false;
+                            }
+                        }
+                        else
+                        {
+                            setArgumentUnknownError(std::string_view(&c, 1));
+                            return false;
+                        }
+                    }
+                }
+                else if (!noMoreOptions && arg == "--")
+                {
+                    noMoreOptions = true;
+                }
+                else
+                {
+                    appendValue("", arg);
+                }
+            }
+            return true;
+        }
+
+        bool hasOption(std::string_view name)
+        {
+            for (auto& r : _values)
+            {
+                if (std::get<0>(r) == name)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        const std::vector<std::string_view>* getArgs(std::string_view name)
+        {
+            for (auto& r : _values)
+            {
+                if (std::get<0>(r) == name)
+                {
+                    return &std::get<1>(r);
+                }
+            }
+            return nullptr;
+        }
+
+        std::string_view getArg(std::string_view name, size_t index = 0)
+        {
+            const auto* args = getArgs(name);
+            if (args == nullptr || index >= args->size())
+                return {};
+            return (*args)[index];
+        }
+
+        std::string_view getArg(size_t index)
+        {
+            return getArg("", index);
+        }
+
+        template<typename int32_t>
+        std::optional<int32_t> getArg(std::string_view name, size_t index = 0)
+        {
+            auto arg = getArg(name, index);
+            if (arg.size() != 0)
+            {
+                return std::stoi(std::string(arg));
+            }
+            return {};
+        }
+
+        template<typename T>
+        std::optional<T> getArg(size_t index)
+        {
+            return getArg<T>("", index);
+        }
+    };
+
+    std::optional<CommandLineOptions> parseCommandLine(int argc, const char** argv)
+    {
+        auto parser = CommandLineParser(argc, argv)
+                          .registerOption("-o", 1)
+                          .registerOption("--help", "-h")
+                          .registerOption("--version");
+
+        if (!parser.parse())
+        {
+            std::cerr << parser.getErrorMessage() << std::endl;
+            return {};
+        }
+
+        CommandLineOptions options;
+        if (parser.hasOption("--version"))
+        {
+            options.action = CommandLineAction::version;
+        }
+        else if (parser.hasOption("--help") || parser.hasOption("-h"))
+        {
+            options.action = CommandLineAction::help;
+        }
+        else
+        {
+            auto firstArg = parser.getArg(0);
+            if (firstArg == "uncompress")
+            {
+                options.action = CommandLineAction::uncompress;
+                options.path = parser.getArg(1);
+            }
+            else if (firstArg == "simulate")
+            {
+                options.action = CommandLineAction::simulate;
+                options.path = parser.getArg(1);
+                options.ticks = parser.getArg<int32_t>(2);
+            }
+            else
+            {
+                options.path = parser.getArg(0);
+            }
+        }
+
+        options.outputPath = parser.getArg("-o");
+
+        return options;
+    }
+
+    std::optional<CommandLineOptions> parseCommandLine(const char* args)
+    {
+        auto argsV = splitArgs(args);
+        std::vector<const char*> argsC;
+        for (const auto& s : argsV)
+        {
+            argsC.push_back(s.c_str());
+        }
+        return parseCommandLine(argsC.size(), argsC.data());
+    }
+
+    void printVersion()
+    {
+        auto versionInfo = OpenLoco::getVersionInfo();
+        std::cout << versionInfo << std::endl;
+    }
+
+    void printHelp()
+    {
+        std::cout << "usage: openloco [options] [path]" << std::endl;
+        std::cout << "                uncompress [options] <path>" << std::endl;
+        std::cout << "                simulate [options] <path> <ticks>" << std::endl;
+        std::cout << std::endl;
+        std::cout << "options:" << std::endl;
+        std::cout << "           -o     Output path" << std::endl;
+        std::cout << "--help     -h     Print help" << std::endl;
+        std::cout << "--version         Print version" << std::endl;
+    }
+
+    std::optional<int> runCommandLineOnlyCommand(const CommandLineOptions& options)
+    {
+        switch (options.action)
+        {
+            case CommandLineAction::help:
+                printHelp();
+                return 1;
+            case CommandLineAction::version:
+                printVersion();
+                return 1;
+            case CommandLineAction::uncompress:
+                return uncompressFile(options);
+            case CommandLineAction::simulate:
+                return simulate(options);
+            default:
+                return {};
+        }
+    }
+
+    static int uncompressFile(const CommandLineOptions& options)
+    {
+        using namespace S5;
+
+        if (options.path.empty())
+        {
+            std::fprintf(stderr, "No file specified.\n");
+            return 2;
+        }
+
+        try
+        {
+            auto path = fs::u8path(options.path);
+
+            MemoryStream ms;
+            SawyerStreamReader reader(path);
+            SawyerStreamWriter writer(ms);
+
+            if (!reader.validateChecksum())
+            {
+                throw std::runtime_error("Invalid checksum");
+            }
+
+            // Header chunk
+            Header header;
+            reader.readChunk(&header, sizeof(header));
+            writer.writeChunk(SawyerEncoding::uncompressed, header);
+
+            // Optional save details chunk
+            if (header.flags & S5Flags::hasSaveDetails)
+            {
+                auto saveDetails = std::make_unique<SaveDetails>();
+                reader.readChunk(saveDetails.get(), sizeof(SaveDetails));
+                writer.writeChunk(SawyerEncoding::uncompressed, *saveDetails);
+            }
+
+            // Packed objects
+            for (auto i = 0; i < header.numPackedObjects; i++)
+            {
+                auto chunk = reader.readChunk();
+                writer.writeChunk(SawyerEncoding::uncompressed, chunk.data(), chunk.size());
+            }
+
+            if (header.type != S5Type::objects)
+            {
+                // Required objects chunk
+                auto chunk = reader.readChunk();
+                writer.writeChunk(SawyerEncoding::uncompressed, chunk.data(), chunk.size());
+
+                // Game state chunk
+                chunk = reader.readChunk();
+                writer.writeChunk(SawyerEncoding::uncompressed, chunk.data(), chunk.size());
+
+                // Tile elements chunk
+                chunk = reader.readChunk();
+                writer.writeChunk(SawyerEncoding::uncompressed, chunk.data(), chunk.size());
+            }
+
+            writer.writeChecksum();
+            writer.close();
+            reader.close();
+
+            auto outputPath = options.outputPath;
+            if (outputPath.empty())
+            {
+                outputPath = options.path;
+            }
+            FileStream fs(outputPath, StreamFlags::write);
+            fs.write(ms.data(), ms.getLength());
+
+            return 0;
+        }
+        catch (const std::exception& e)
+        {
+            std::fprintf(stderr, "Unable to uncompress S5 file: %s\n", e.what());
+            return 2;
+        }
+    }
+
+    static int simulate(const CommandLineOptions& options)
+    {
+        if (!options.ticks)
+        {
+            std::fprintf(stderr, "Number of ticks to simulate not specified\n");
+            return 2;
+        }
+
+        auto inPath = fs::u8path(options.path);
+        auto outPath = fs::u8path(options.outputPath);
+
+        try
+        {
+            OpenLoco::simulateGame(inPath, *options.ticks);
+        }
+        catch (...)
+        {
+            std::fprintf(stderr, "Unable to load and simulate %s\n", inPath.u8string().c_str());
+        }
+
+        auto& gameState = getGameState();
+        std::printf("--------------------------------\n");
+        std::printf("- Simulate\n");
+        std::printf("--------------------------------\n");
+        std::printf("Input:\n");
+        std::printf("  path:  %s\n", inPath.u8string().c_str());
+        std::printf("  ticks: %d ticks\n", *options.ticks);
+        std::printf("Output:\n");
+        std::printf("  scenario ticks: %u\n", gameState.scenarioTicks);
+        std::printf("  rng:            { 0x%X, 0x%X }\n", gameState.rng.srand_0(), gameState.rng.srand_1());
+
+        if (!outPath.empty())
+        {
+            try
+            {
+                S5::save(outPath, S5::SaveFlags::none);
+                std::printf("  path:           %s\n", outPath.u8string().c_str());
+            }
+            catch (...)
+            {
+                std::fprintf(stderr, "Unable to save game to %s\n", outPath.u8string().c_str());
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/OpenLoco/CommandLine.h
+++ b/src/OpenLoco/CommandLine.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Core/Optional.hpp"
+#include <string>
+
+namespace OpenLoco
+{
+    enum class CommandLineAction
+    {
+        none,
+        uncompress,
+        simulate,
+        help,
+        version
+    };
+
+    struct CommandLineOptions
+    {
+        CommandLineAction action;
+        std::string path;
+        std::optional<int32_t> ticks;
+        std::string outputPath;
+    };
+
+    std::optional<CommandLineOptions> parseCommandLine(int argc, const char** argv);
+    std::optional<CommandLineOptions> parseCommandLine(const char* args);
+    std::optional<int> runCommandLineOnlyCommand(const CommandLineOptions& options);
+    const CommandLineOptions& getCommandLineOptions();
+    void setCommandLineOptions(const CommandLineOptions& options);
+
+    void printVersion();
+    void printHelp();
+}

--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -120,7 +120,10 @@ static Interop::loco_global<set_palette_func, 0x0052524C> set_palette_callback;
 FORCE_ALIGN_ARG_POINTER
 static void CDECL fn_4054a3(const palette_entry_t* palette, int32_t index, int32_t count)
 {
-    (*set_palette_callback)(palette, index, count);
+    if (set_palette_callback != nullptr)
+    {
+        (*set_palette_callback)(palette, index, count);
+    }
 }
 
 FORCE_ALIGN_ARG_POINTER

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -350,7 +350,7 @@ namespace OpenLoco
     {
         if (isAlreadyRunning("Locomotion"))
         {
-            // exitWithError(StringIds::game_init_failure, StringIds::loco_already_running);
+            exitWithError(StringIds::game_init_failure, StringIds::loco_already_running);
         }
 
         // Originally the game would check that all the game
@@ -1201,8 +1201,9 @@ namespace OpenLoco
             initialise();
             loadFile(path);
         }
-        catch (...)
+        catch (const std::exception& e)
         {
+            Console::error("Unable to simulate park: %s", e.what());
         }
         tickLogic(ticks);
     }

--- a/src/OpenLoco/OpenLoco.h
+++ b/src/OpenLoco/OpenLoco.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Core/FileSystem.hpp"
 #include "Utility/Prng.hpp"
 #include <cstdint>
 #include <functional>
@@ -35,8 +36,6 @@ namespace OpenLoco
     std::string getVersionInfo();
 
     void* hInstance();
-    const char* lpCmdLine();
-    void lpCmdLine(const char* path);
     void resetScreenAge();
     uint16_t getScreenAge();
     uint16_t getScreenFlags();
@@ -61,9 +60,11 @@ namespace OpenLoco
     uint32_t scenarioTicks();
     Utility::prng& gPrng();
     void initialiseViewports();
+    void simulateGame(const fs::path& path, int32_t ticks);
 
     void sub_431695(uint16_t var_F253A0);
-    void main();
+    int main(int argc, const char** argv);
+    int main(const char* args);
     void promptTickLoop(std::function<bool()> tickAction);
     [[noreturn]] void exitCleanly();
     [[noreturn]] void exitWithError(OpenLoco::string_id message, uint32_t errorCode);

--- a/src/OpenLoco/Platform/Crash.cpp
+++ b/src/OpenLoco/Platform/Crash.cpp
@@ -6,7 +6,7 @@
 #include <ShlObj.h>
 #include <client/windows/handler/exception_handler.h>
 
-static bool onCrash(
+[[maybe_unused]] static bool onCrash(
     const wchar_t* dumpPath, const wchar_t* miniDumpId, void* context, EXCEPTION_POINTERS* exinfo,
     MDRawAssertionInfo* assertion, bool succeeded)
 {
@@ -69,7 +69,7 @@ static bool onCrash(
     return succeeded;
 }
 
-static std::wstring getDumpDirectory()
+[[maybe_unused]] static std::wstring getDumpDirectory()
 {
     auto user_dir = OpenLoco::Platform::getUserDirectory();
     auto result = OpenLoco::Utility::toUtf16(user_dir.string());
@@ -82,7 +82,7 @@ constexpr const wchar_t* PipeName = L"openloco-bpad";
 
 CExceptionHandler crashInit()
 {
-#if defined(USE_BREAKPAD)
+#if defined(USE_BREAKPAD) && !defined(DEBUG)
     // Path must exist and be RW!
     auto exHandler = new google_breakpad::ExceptionHandler(
         getDumpDirectory(), 0, onCrash, 0, google_breakpad::ExceptionHandler::HANDLER_ALL, MiniDumpWithDataSegs, PipeName, 0);

--- a/src/OpenLoco/Platform/Platform.Posix.cpp
+++ b/src/OpenLoco/Platform/Platform.Posix.cpp
@@ -34,7 +34,7 @@ namespace OpenLoco::Platform
     {
         struct timespec spec;
         clock_gettime(CLOCK_REALTIME, &spec);
-        return spec.tv_nsec / 1000000;
+        return (spec.tv_sec * 1000) + spec.tv_nsec / 1000000;
     }
 
     std::vector<fs::path> getDrives()

--- a/src/OpenLoco/Platform/Platform.Posix.cpp
+++ b/src/OpenLoco/Platform/Platform.Posix.cpp
@@ -23,9 +23,7 @@
 int main(int argc, const char** argv)
 {
     OpenLoco::Interop::loadSections();
-    OpenLoco::lpCmdLine((char*)argv[0]);
-    OpenLoco::main();
-    return 0;
+    return OpenLoco::main(argc, argv);
 }
 
 namespace OpenLoco::Platform

--- a/src/OpenLoco/S5/S5.h
+++ b/src/OpenLoco/S5/S5.h
@@ -7,6 +7,11 @@
 #include <memory>
 #include <vector>
 
+namespace OpenLoco
+{
+    class Stream;
+}
+
 namespace OpenLoco::S5
 {
     enum class S5Type : uint8_t
@@ -390,6 +395,7 @@ namespace OpenLoco::S5
 
     enum SaveFlags : uint32_t
     {
+        none = 0,
         packCustomObjects = 1 << 0,
         scenario = 1 << 1,
         landscape = 1 << 2,
@@ -407,7 +413,9 @@ namespace OpenLoco::S5
     Options& getOptions();
     Options& getPreviewOptions();
     bool save(const fs::path& path, SaveFlags flags);
+    bool save(Stream& stream, SaveFlags flags);
     void registerHooks();
 
     bool load(const fs::path& path, uint32_t flags);
+    bool load(Stream& stream, uint32_t flags);
 }

--- a/src/OpenLoco/S5/SawyerStream.cpp
+++ b/src/OpenLoco/S5/SawyerStream.cpp
@@ -15,8 +15,9 @@
 #endif
 
 using namespace OpenLoco;
-using namespace OpenLoco::Utility;
 
+constexpr const char* exceptionReadError = "Failed to read data from stream";
+constexpr const char* exceptionWriteError = "Failed to write data to stream";
 constexpr const char* exceptionInvalidRLE = "Invalid RLE run";
 constexpr const char* exceptionUnknownEncoding = "Unknown encoding";
 
@@ -124,10 +125,15 @@ stdx::span<uint8_t const> FastBuffer::getSpan() const
     return stdx::span<uint8_t const>(_data, _len);
 }
 
+SawyerStreamReader::SawyerStreamReader(Stream& stream)
+{
+    _stream = &stream;
+}
+
 SawyerStreamReader::SawyerStreamReader(const fs::path& path)
 {
-    _stream.exceptions(std::ifstream::failbit);
-    _stream.open(path, std::ios::in | std::ios::binary);
+    _fstream = std::make_unique<FileStream>(path, StreamFlags::read);
+    _stream = _fstream.get();
 }
 
 stdx::span<uint8_t const> SawyerStreamReader::readChunk()
@@ -153,31 +159,36 @@ size_t SawyerStreamReader::readChunk(void* data, size_t maxDataLen)
 
 void SawyerStreamReader::read(void* data, size_t dataLen)
 {
-    _stream.read(reinterpret_cast<char*>(data), dataLen);
+    try
+    {
+        _stream->read(data, dataLen);
+    }
+    catch (...)
+    {
+        throw std::runtime_error(exceptionReadError);
+    }
 }
 
 bool SawyerStreamReader::validateChecksum()
 {
     auto valid = false;
-    auto backupPos = _stream.tellg();
-
-    _stream.seekg(0, std::ios::end);
-    auto fileLength = static_cast<uint32_t>(_stream.tellg());
+    auto backupPos = _stream->getPosition();
+    auto fileLength = static_cast<uint32_t>(_stream->getLength());
     if (fileLength >= 4)
     {
         // Read checksum
         uint32_t checksum;
-        _stream.seekg(fileLength - 4);
-        _stream.read(reinterpret_cast<char*>(&checksum), sizeof(checksum));
+        _stream->seek(fileLength - 4);
+        _stream->read(&checksum, sizeof(checksum));
 
         // Calculate checksum
         uint32_t actualChecksum = 0;
-        _stream.seekg(0);
+        _stream->setPosition(0);
         uint8_t buffer[2048];
         for (uint32_t i = 0; i < fileLength - 4; i += sizeof(buffer))
         {
             auto readLength = std::min<size_t>(sizeof(buffer), fileLength - 4 - i);
-            _stream.read(reinterpret_cast<char*>(buffer), readLength);
+            _stream->read(buffer, readLength);
             for (size_t j = 0; j < readLength; j++)
             {
                 actualChecksum += buffer[j];
@@ -188,14 +199,15 @@ bool SawyerStreamReader::validateChecksum()
     }
 
     // Restore position
-    _stream.seekg(backupPos);
+    _stream->setPosition(backupPos);
 
     return valid;
 }
 
 void SawyerStreamReader::close()
 {
-    _stream.close();
+    _fstream = {};
+    _stream = nullptr;
 }
 
 stdx::span<uint8_t const> SawyerStreamReader::decode(SawyerEncoding encoding, stdx::span<uint8_t const> data)
@@ -298,15 +310,20 @@ void SawyerStreamReader::decodeRotate(FastBuffer& buffer, stdx::span<uint8_t con
     uint8_t code = 1;
     for (size_t i = 0; i < data.size(); i++)
     {
-        buffer.push_back(ror(data[i], code));
+        buffer.push_back(OpenLoco::Utility::ror(data[i], code));
         code = (code + 2) & 7;
     }
 }
 
+SawyerStreamWriter::SawyerStreamWriter(Stream& stream)
+{
+    _stream = &stream;
+}
+
 SawyerStreamWriter::SawyerStreamWriter(const fs::path& path)
 {
-    _stream.exceptions(std::ifstream::failbit);
-    _stream.open(path, std::ios::out | std::ios::binary);
+    _fstream = std::make_unique<FileStream>(path, StreamFlags::write);
+    _stream = _fstream.get();
 }
 
 void SawyerStreamWriter::writeChunk(SawyerEncoding chunkType, const void* data, size_t dataLen)
@@ -319,7 +336,7 @@ void SawyerStreamWriter::writeChunk(SawyerEncoding chunkType, const void* data, 
 
 void SawyerStreamWriter::write(const void* data, size_t dataLen)
 {
-    _stream.write(reinterpret_cast<const char*>(data), dataLen);
+    writeStream(data, dataLen);
     auto data8 = reinterpret_cast<const uint8_t*>(data);
     for (size_t i = 0; i < dataLen; i++)
     {
@@ -329,12 +346,25 @@ void SawyerStreamWriter::write(const void* data, size_t dataLen)
 
 void SawyerStreamWriter::writeChecksum()
 {
-    _stream.write(reinterpret_cast<const char*>(&_checksum), sizeof(_checksum));
+    writeStream(&_checksum, sizeof(_checksum));
+}
+
+void SawyerStreamWriter::writeStream(const void* data, size_t dataLen)
+{
+    try
+    {
+        _stream->write(data, dataLen);
+    }
+    catch (...)
+    {
+        throw std::runtime_error(exceptionWriteError);
+    }
 }
 
 void SawyerStreamWriter::close()
 {
-    _stream.close();
+    _fstream = {};
+    _stream = nullptr;
 }
 
 stdx::span<uint8_t const> SawyerStreamWriter::encode(SawyerEncoding encoding, stdx::span<uint8_t const> data)
@@ -482,7 +512,7 @@ void SawyerStreamWriter::encodeRotate(FastBuffer& buffer, stdx::span<uint8_t con
     uint8_t code = 1;
     for (size_t i = 0; i < data.size(); i++)
     {
-        buffer.push_back(rol(data[i], code));
+        buffer.push_back(Utility::rol(data[i], code));
         code = (code + 2) & 7;
     }
 }

--- a/src/OpenLoco/S5/SawyerStream.h
+++ b/src/OpenLoco/S5/SawyerStream.h
@@ -2,8 +2,9 @@
 
 #include "../Core/FileSystem.hpp"
 #include "../Core/Span.hpp"
+#include "../Utility/Stream.hpp"
 #include <cstdint>
-#include <fstream>
+#include <memory>
 
 namespace OpenLoco
 {
@@ -51,7 +52,8 @@ namespace OpenLoco
     class SawyerStreamReader
     {
     private:
-        std::ifstream _stream;
+        Stream* _stream;
+        std::unique_ptr<FileStream> _fstream;
         FastBuffer _decodeBuffer;
         FastBuffer _decodeBuffer2;
 
@@ -61,6 +63,7 @@ namespace OpenLoco
         static void decodeRotate(FastBuffer& buffer, stdx::span<uint8_t const> data);
 
     public:
+        SawyerStreamReader(Stream& stream);
         SawyerStreamReader(const fs::path& path);
 
         stdx::span<uint8_t const> readChunk();
@@ -73,17 +76,20 @@ namespace OpenLoco
     class SawyerStreamWriter
     {
     private:
-        std::ofstream _stream;
+        Stream* _stream;
+        std::unique_ptr<FileStream> _fstream;
         uint32_t _checksum{};
         FastBuffer _encodeBuffer;
         FastBuffer _encodeBuffer2;
 
+        void writeStream(const void* data, size_t dataLen);
         stdx::span<uint8_t const> encode(SawyerEncoding encoding, stdx::span<uint8_t const> data);
         static void encodeRunLengthSingle(FastBuffer& buffer, stdx::span<uint8_t const> data);
         static void encodeRunLengthMulti(FastBuffer& buffer, stdx::span<uint8_t const> data);
         static void encodeRotate(FastBuffer& buffer, stdx::span<uint8_t const> data);
 
     public:
+        SawyerStreamWriter(Stream& stream);
         SawyerStreamWriter(const fs::path& path);
 
         void writeChunk(SawyerEncoding chunkType, const void* data, size_t dataLen);

--- a/src/OpenLoco/Utility/Stream.hpp
+++ b/src/OpenLoco/Utility/Stream.hpp
@@ -1,6 +1,13 @@
 #pragma once
 
+#include "../Core/FileSystem.hpp"
+#include "../Core/Span.hpp"
+#include <cstdint>
+#include <cstring>
+#include <fstream>
 #include <istream>
+#include <stdexcept>
+#include <vector>
 
 namespace OpenLoco::Utility
 {
@@ -23,4 +30,255 @@ namespace OpenLoco::Utility
         readData(stream, result);
         return result;
     }
+}
+
+namespace OpenLoco
+{
+    template<typename CharT, typename TraitsT = std::char_traits<CharT>>
+    class SpanStream : public std::istream
+    {
+    private:
+        class SpanStreamBuffer : public std::streambuf
+        {
+        public:
+            SpanStreamBuffer(stdx::span<CharT>& span)
+            {
+                this->setg((char*)span.data(), (char*)span.data(), (char*)(span.data() + span.size()));
+            }
+        };
+
+        std::unique_ptr<SpanStreamBuffer> _buffer;
+
+        SpanStream(std::unique_ptr<SpanStreamBuffer>&& buffer)
+            : std::istream(buffer.get())
+        {
+            _buffer = std::move(buffer);
+        }
+
+    public:
+        SpanStream(stdx::span<CharT> data)
+            : SpanStream(std::make_unique<SpanStreamBuffer>(data))
+        {
+        }
+    };
+}
+
+namespace OpenLoco
+{
+    namespace StreamFlags
+    {
+        constexpr uint8_t read = 1;
+        constexpr uint8_t write = 2;
+    }
+
+    class Stream
+    {
+    public:
+        virtual ~Stream() {}
+        virtual uint64_t getLength() const { throwInvalidOperation(); }
+        virtual uint64_t getPosition() const { throwInvalidOperation(); }
+        virtual void setPosition(uint64_t position) { throwInvalidOperation(); }
+        virtual void read(void* buffer, size_t len) { throwInvalidOperation(); }
+        virtual void write(const void* buffer, size_t len) { throwInvalidOperation(); }
+
+        void seek(int64_t pos)
+        {
+            setPosition(getPosition() + pos);
+        }
+
+    private:
+        [[noreturn]] static void throwInvalidOperation() { throw std::runtime_error("Invalid operation"); }
+    };
+
+    class BinaryStream : public Stream
+    {
+    private:
+        const void* _data{};
+        size_t _index{};
+        size_t _len{};
+
+    public:
+        BinaryStream(const void* data, size_t len)
+            : _data(data)
+            , _len(len)
+        {
+        }
+
+        uint64_t getLength() const override
+        {
+            return _len;
+        }
+
+        uint64_t getPosition() const override
+        {
+            return _index;
+        }
+
+        void setPosition(uint64_t position) override
+        {
+            if (position > _len)
+                throw std::out_of_range("Position too large");
+            _index = static_cast<size_t>(position);
+        }
+
+        void read(void* buffer, size_t len) override
+        {
+            auto maxReadLen = _len - _index;
+            if (len > maxReadLen)
+                throw std::runtime_error("Failed to read data");
+            std::memcpy(buffer, reinterpret_cast<const void*>(reinterpret_cast<size_t>(_data) + _index), len);
+            _index += len;
+        }
+    };
+
+    class MemoryStream : public Stream
+    {
+    private:
+        std::vector<uint8_t> _data{};
+        size_t _index{};
+
+        void ensureLength(size_t len)
+        {
+            if (_data.size() < len)
+            {
+                _data.resize(len);
+            }
+        }
+
+    public:
+        const uint8_t* data() const
+        {
+            return _data.data();
+        }
+
+        uint8_t* data()
+        {
+            return _data.data();
+        }
+
+        uint64_t getLength() const override
+        {
+            return _data.size();
+        }
+
+        uint64_t getPosition() const override
+        {
+            return _index;
+        }
+
+        void setPosition(uint64_t position) override
+        {
+            _index = static_cast<size_t>(position);
+        }
+
+        void read(void* buffer, size_t len) override
+        {
+            auto maxReadLen = _data.size() - _index;
+            if (len > maxReadLen)
+                throw std::runtime_error("Failed to read data");
+            std::memcpy(buffer, reinterpret_cast<const void*>(reinterpret_cast<size_t>(_data.data()) + _index), len);
+            _index += len;
+        }
+
+        void write(const void* buffer, size_t len) override
+        {
+            if (len != 0)
+            {
+                ensureLength(_index + len);
+                std::memcpy(reinterpret_cast<void*>(reinterpret_cast<size_t>(_data.data()) + _index), buffer, len);
+                _index += len;
+            }
+        }
+    };
+
+    class FileStream : public Stream
+    {
+    private:
+        std::fstream _fstream;
+        bool _reading{};
+        bool _writing{};
+
+    public:
+        FileStream(const fs::path path, uint8_t flags)
+        {
+            if (flags & StreamFlags::write)
+            {
+                _fstream.open(path, std::ios::out | std::ios::binary);
+                if (!_fstream.is_open())
+                {
+                    throw std::runtime_error("Failed to open '" + path.u8string() + "' for writing");
+                }
+                _reading = true;
+                _writing = true;
+            }
+            else
+            {
+                _fstream.open(path, std::ios::in | std::ios::binary);
+                if (!_fstream.is_open())
+                {
+                    throw std::runtime_error("Failed to open '" + path.u8string() + "' for reading");
+                }
+                _reading = true;
+            }
+        }
+
+        uint64_t getLength() const override
+        {
+            auto* fs = const_cast<std::fstream*>(&_fstream);
+            if (_writing)
+            {
+                auto backup = fs->tellp();
+                fs->seekp(0, std::ios_base::end);
+                auto len = fs->tellp();
+                fs->seekp(backup);
+                return len;
+            }
+            else
+            {
+                auto backup = fs->tellg();
+                fs->seekg(0, std::ios_base::end);
+                auto len = fs->tellg();
+                fs->seekg(backup);
+                return len;
+            }
+        }
+
+        uint64_t getPosition() const override
+        {
+            auto* fs = const_cast<std::fstream*>(&_fstream);
+            if (_writing)
+            {
+                return static_cast<uint64_t>(fs->tellp());
+            }
+            else
+            {
+                return static_cast<uint64_t>(fs->tellg());
+            }
+        }
+
+        void setPosition(uint64_t position) override
+        {
+            if (_reading)
+                _fstream.seekg(position);
+            if (_writing)
+                _fstream.seekp(position);
+        }
+
+        void read(void* buffer, size_t len) override
+        {
+            _fstream.read(static_cast<char*>(buffer), len);
+            if (_fstream.fail())
+                throw std::runtime_error("Failed to read data");
+        }
+
+        void write(const void* buffer, size_t len) override
+        {
+            if (len != 0)
+            {
+                _fstream.write(static_cast<const char*>(buffer), len);
+                if (_fstream.fail())
+                    throw std::runtime_error("Failed to write data");
+            }
+        }
+    };
 }

--- a/src/OpenLoco/Utility/Stream.hpp
+++ b/src/OpenLoco/Utility/Stream.hpp
@@ -2,6 +2,7 @@
 
 #include "../Core/FileSystem.hpp"
 #include "../Core/Span.hpp"
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
@@ -9,33 +10,36 @@
 #include <stdexcept>
 #include <vector>
 
-namespace OpenLoco::Utility
-{
-    template<typename T1, typename T2, typename T3>
-    std::basic_istream<T1, T2>& readData(std::basic_istream<T1, T2>& stream, T3* dst, size_t count)
-    {
-        return stream.read((char*)dst, static_cast<uint64_t>(count) * sizeof(T3));
-    }
-
-    template<typename T1, typename T2, typename T3>
-    std::basic_istream<T1, T2>& readData(std::basic_istream<T1, T2>& stream, T3& dst)
-    {
-        return readData(stream, &dst, 1);
-    }
-
-    template<typename T3, typename T1, typename T2>
-    T3 readValue(std::basic_istream<T1, T2>& stream)
-    {
-        T3 result{};
-        readData(stream, result);
-        return result;
-    }
-}
-
 namespace OpenLoco
 {
+    namespace Utility
+    {
+        // Obsolete methods, use new Stream APIs
+
+        template<typename T1, typename T2, typename T3>
+        std::basic_istream<T1, T2>& readData(std::basic_istream<T1, T2>& stream, T3* dst, size_t count)
+        {
+            return stream.read((char*)dst, static_cast<uint64_t>(count) * sizeof(T3));
+        }
+
+        template<typename T1, typename T2, typename T3>
+        std::basic_istream<T1, T2>& readData(std::basic_istream<T1, T2>& stream, T3& dst)
+        {
+            return readData(stream, &dst, 1);
+        }
+
+        template<typename T3, typename T1, typename T2>
+        T3 readValue(std::basic_istream<T1, T2>& stream)
+        {
+            T3 result{};
+            readData(stream, result);
+            return result;
+        }
+    }
+
+    // Obsolete class, use new Stream APIs
     template<typename CharT, typename TraitsT = std::char_traits<CharT>>
-    class SpanStream : public std::istream
+    class SpanStream final : public std::istream
     {
     private:
         class SpanStreamBuffer : public std::streambuf
@@ -61,10 +65,7 @@ namespace OpenLoco
         {
         }
     };
-}
 
-namespace OpenLoco
-{
     namespace StreamFlags
     {
         constexpr uint8_t read = 1;
@@ -90,7 +91,7 @@ namespace OpenLoco
         [[noreturn]] static void throwInvalidOperation() { throw std::runtime_error("Invalid operation"); }
     };
 
-    class BinaryStream : public Stream
+    class BinaryStream final : public Stream
     {
     private:
         const void* _data{};
@@ -131,10 +132,10 @@ namespace OpenLoco
         }
     };
 
-    class MemoryStream : public Stream
+    class MemoryStream final : public Stream
     {
     private:
-        std::vector<uint8_t> _data{};
+        std::vector<std::byte> _data{};
         size_t _index{};
 
         void ensureLength(size_t len)
@@ -146,12 +147,12 @@ namespace OpenLoco
         }
 
     public:
-        const uint8_t* data() const
+        const void* data() const
         {
             return _data.data();
         }
 
-        uint8_t* data()
+        void* data()
         {
             return _data.data();
         }
@@ -191,7 +192,7 @@ namespace OpenLoco
         }
     };
 
-    class FileStream : public Stream
+    class FileStream final : public Stream
     {
     private:
         std::fstream _fstream;

--- a/src/OpenLoco/openloco.vcxproj
+++ b/src/OpenLoco/openloco.vcxproj
@@ -19,6 +19,7 @@
     <ClCompile Include="Audio\Channel.cpp" />
     <ClCompile Include="Audio\MusicChannel.cpp" />
     <ClCompile Include="Audio\VehicleChannel.cpp" />
+    <ClCompile Include="CommandLine.cpp" />
     <ClCompile Include="Company.cpp" />
     <ClCompile Include="CompanyManager.cpp" />
     <ClCompile Include="Config.cpp" />
@@ -228,6 +229,7 @@
     <ClInclude Include="Audio\Channel.h" />
     <ClInclude Include="Audio\MusicChannel.h" />
     <ClInclude Include="Audio\VehicleChannel.h" />
+    <ClInclude Include="CommandLine.h" />
     <ClInclude Include="Company.h" />
     <ClInclude Include="CompanyManager.h" />
     <ClInclude Include="ConfigConvert.hpp" />


### PR DESCRIPTION
Add basic command line interface, with uncompress and simulate commands:
```
usage: openloco [options] [path]
                uncompress [options] <path>
                simulate [options] <path> <ticks>

options:
           -o     Output path
--help     -h     Print help
--version         Print version
```

**Note:** about half of the changes are changing S5 code to use new Stream classes. This and a few other things in the command line code were required for the network implementation.