### PR TITLE
Change how the cargo enroute age is calculated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Feature: [#1327] Readd the game intro (use commandline switch --intro to enable)
 - Fix: [#1320] Inability to mark scenario as complete.
 - Fix: [#1325] Crash when saving second loaded scenario of a playthrough.
+- Change: [#1276] Transfering cargo is now viable. The cargo age is calculated as the weighted average of the present and delivered cargo.
 
 22.02 (2022-02-06)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/Station.cpp
+++ b/src/OpenLoco/Station.cpp
@@ -580,7 +580,7 @@ namespace OpenLoco
                 {
                     stationCargo.enrouteAge = std::min(stationCargo.enrouteAge + 1, 255);
                 }
-                else 
+                else
                 {
                     // Change from vanilla to deal with the cargo transfer bug:
                     // Reset enroute age once the station cargo gets cleared

--- a/src/OpenLoco/Station.cpp
+++ b/src/OpenLoco/Station.cpp
@@ -580,6 +580,10 @@ namespace OpenLoco
                 {
                     stationCargo.enrouteAge = std::min(stationCargo.enrouteAge + 1, 255);
                 }
+                else
+                {
+                    stationCargo.enrouteAge = 0;
+                }
                 stationCargo.age = std::min(stationCargo.age + 1, 255);
 
                 auto targetRating = calculateCargoRating(stationCargo);

--- a/src/OpenLoco/Station.cpp
+++ b/src/OpenLoco/Station.cpp
@@ -580,8 +580,11 @@ namespace OpenLoco
                 {
                     stationCargo.enrouteAge = std::min(stationCargo.enrouteAge + 1, 255);
                 }
-                else
+                else 
                 {
+                    // Change from vanilla to deal with the cargo transfer bug:
+                    // Reset enroute age once the station cargo gets cleared
+                    // or else the age keeps increasing
                     stationCargo.enrouteAge = 0;
                 }
                 stationCargo.age = std::min(stationCargo.age + 1, 255);

--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -2678,13 +2678,15 @@ namespace OpenLoco::Vehicles
                 break;
             }
 
-            bool stationHadPreviousCargo = cargoStats.quantity != 0;
+            const bool stationHadPreviousCargo = cargoStats.quantity != 0;
             cargoStats.quantity = Math::Bound::add(cargoStats.quantity, cargo.qty);
             station->updateCargoDistribution();
             cargoStats.enrouteAge = Math::Bound::add(cargoStats.enrouteAge, cargo.numDays);
             if (stationHadPreviousCargo)
             {
-                cargoStats.enrouteAge *= 1 - static_cast<float>(cargo.qty) / cargoStats.quantity;
+                // enrouteAge = enrouteAge * (1 - addedQuantity / summedQuantity)
+                const auto multiplier = (1 << 16) - (cargo.qty << 16) / cargoStats.quantity;
+                cargoStats.enrouteAge = (cargoStats.enrouteAge * multiplier) >> 16;
             }
 
             bool setOrigin = true;

--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -2681,7 +2681,7 @@ namespace OpenLoco::Vehicles
             bool stationHadPreviousCargo = cargoStats.quantity != 0;
             cargoStats.quantity = Math::Bound::add(cargoStats.quantity, cargo.qty);
             station->updateCargoDistribution();
-            cargoStats.enrouteAge += cargo.numDays;
+            cargoStats.enrouteAge = Math::Bound::add(cargoStats.enrouteAge, cargo.numDays);
             if (stationHadPreviousCargo)
             {
                 cargoStats.enrouteAge *= 1 - static_cast<float>(cargo.qty) / cargoStats.quantity;

--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -2682,6 +2682,9 @@ namespace OpenLoco::Vehicles
             cargoStats.quantity = Math::Bound::add(cargoStats.quantity, cargo.qty);
             station->updateCargoDistribution();
             cargoStats.enrouteAge = Math::Bound::add(cargoStats.enrouteAge, cargo.numDays);
+
+            // Change from vanilla to deal with the cargo transfer bug:
+            // Calculate the weighted average of the present and the delivered cargo
             if (stationHadPreviousCargo)
             {
                 // enrouteAge = enrouteAge * (1 - addedQuantity / summedQuantity)

--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -2677,9 +2677,16 @@ namespace OpenLoco::Vehicles
 
                 break;
             }
+
+            bool stationHadPreviousCargo = cargoStats.quantity != 0;
             cargoStats.quantity = Math::Bound::add(cargoStats.quantity, cargo.qty);
             station->updateCargoDistribution();
-            cargoStats.enrouteAge = std::max(cargoStats.enrouteAge, cargo.numDays);
+            cargoStats.enrouteAge += cargo.numDays;
+            if (stationHadPreviousCargo)
+            {
+                cargoStats.enrouteAge *= 1 - static_cast<float>(cargo.qty) / cargoStats.quantity;
+            }
+
             bool setOrigin = true;
             if (cargoStats.origin != StationId::null)
             {


### PR DESCRIPTION
This PR aims to deal with the cargo transfer (original) bug: https://github.com/OpenLoco/OpenLoco/issues/130

An example of how it works:
At a station there are 60 tons of coal (25 days old).
20 tons of coal (5 days old) are added.
The days for the 'enroute' age are added up: 25 + 5 = 30 days
Then, (if there was previous cargo) the result is reduced using the following formula:
`enrouteAge = enrouteAge * (1 - addedQuantity / summedQuantity)`

So the new age would be 30 * (1 - 20 / 80) = 20 days
The new 'enroute' age for the 80 tons is now 20 days.

This should make transferring cargo from, say, a ship to a train which then finishes the delivery, finally viable.