### PR TITLE
Apply codestyle to vehicle.h/.cpp and related code

### DIFF
--- a/src/OpenLoco/Audio/Audio.cpp
+++ b/src/OpenLoco/Audio/Audio.cpp
@@ -844,8 +844,8 @@ namespace OpenLoco::Audio
                 // jump + return
                 _numActiveVehicleSounds += 1;
                 v->var_4A |= 1;
-                v->sound_window_type = main->type;
-                v->sound_window_number = main->number;
+                v->soundWindowType = main->type;
+                v->soundWindowNumber = main->number;
                 return;
             }
         }
@@ -871,8 +871,8 @@ namespace OpenLoco::Audio
             {
                 _numActiveVehicleSounds += 1;
                 v->var_4A |= 1;
-                v->sound_window_type = w->type;
-                v->sound_window_number = w->number;
+                v->soundWindowType = w->type;
+                v->soundWindowNumber = w->number;
                 return;
             }
         }

--- a/src/OpenLoco/Company.cpp
+++ b/src/OpenLoco/Company.cpp
@@ -420,9 +420,9 @@ namespace OpenLoco
                 }
                 for (auto& carComponent : car)
                 {
-                    carComponent.front->colour_scheme = colour;
-                    carComponent.back->colour_scheme = colour;
-                    carComponent.body->colour_scheme = colour;
+                    carComponent.front->colourScheme = colour;
+                    carComponent.back->colourScheme = colour;
+                    carComponent.body->colourScheme = colour;
                 }
             }
         }

--- a/src/OpenLoco/Entities/Misc.cpp
+++ b/src/OpenLoco/Entities/Misc.cpp
@@ -48,7 +48,7 @@ namespace OpenLoco
 
     SteamObject* Exhaust::object() const
     {
-        return ObjectManager::get<SteamObject>(object_id & 0x7F);
+        return ObjectManager::get<SteamObject>(objectId & 0x7F);
     }
 
     // 0x004408C2
@@ -78,7 +78,7 @@ namespace OpenLoco
         {
             _exhaust->base_type = EntityBaseType::misc;
             _exhaust->moveTo(loc);
-            _exhaust->object_id = type;
+            _exhaust->objectId = type;
             auto obj = _exhaust->object();
             _exhaust->var_14 = obj->var_05;
             _exhaust->var_09 = obj->var_06;

--- a/src/OpenLoco/Entities/Misc.h
+++ b/src/OpenLoco/Entities/Misc.h
@@ -64,7 +64,7 @@ namespace OpenLoco
         int16_t var_34;
         int16_t var_36;
         uint8_t pad_38[0x49 - 0x38];
-        uint8_t object_id; // 0x49
+        uint8_t objectId; // 0x49
 
         SteamObject* object() const;
         void update();

--- a/src/OpenLoco/Objects/VehicleObject.h
+++ b/src/OpenLoco/Objects/VehicleObject.h
@@ -88,7 +88,7 @@ namespace OpenLoco
 
     struct simple_animation
     {
-        uint8_t object_id;          // 0x00 (object loader fills this in)
+        uint8_t objectId;           // 0x00 (object loader fills this in)
         uint8_t height;             // 0x01
         simple_animation_type type; // 0x02
     };
@@ -197,7 +197,7 @@ namespace OpenLoco
         TransportMode mode; // 0x02
         VehicleType type;   // 0x03
         uint8_t var_04;
-        uint8_t track_type;               // 0x05
+        uint8_t trackType;                // 0x05
         uint8_t num_mods;                 // 0x06
         uint8_t cost_index;               // 0x07
         int16_t cost_factor;              // 0x08

--- a/src/OpenLoco/Paint/PaintMiscEntity.cpp
+++ b/src/OpenLoco/Paint/PaintMiscEntity.cpp
@@ -50,7 +50,7 @@ namespace OpenLoco::Paint
         }
         SteamObject* steamObject = exhaustEntity->object();
 
-        uint8_t* edi = (exhaustEntity->object_id & 0x80) == 0 ? steamObject->var_16 : steamObject->var_1A;
+        uint8_t* edi = (exhaustEntity->objectId & 0x80) == 0 ? steamObject->var_16 : steamObject->var_1A;
         uint32_t imageId = edi[2 * exhaustEntity->var_26];
         imageId = imageId + steamObject->baseImageId + steamObject->var_0A;
 

--- a/src/OpenLoco/Paint/PaintVehicle.cpp
+++ b/src/OpenLoco/Paint/PaintVehicle.cpp
@@ -37,13 +37,13 @@ namespace OpenLoco::Paint
     // 0x004B0CFC
     static void paintBogie(PaintSession& session, VehicleBogie* bogie)
     {
-        auto* vehObject = ObjectManager::get<VehicleObject>(bogie->object_id);
-        if (bogie->object_sprite_type == SpriteIndex::null)
+        auto* vehObject = ObjectManager::get<VehicleObject>(bogie->objectId);
+        if (bogie->objectSpriteType == SpriteIndex::null)
         {
             return;
         }
 
-        auto& sprite = vehObject->bogie_sprites[bogie->object_sprite_type];
+        auto& sprite = vehObject->bogie_sprites[bogie->objectSpriteType];
         uint8_t yaw = (bogie->sprite_yaw + (session.getRotation() << 4)) & 0x3F;
         auto pitch = bogie->sprite_pitch;
 
@@ -109,7 +109,7 @@ namespace OpenLoco::Paint
                 }
                 else
                 {
-                    imageId = Gfx::recolour2(imageId, bogie->colour_scheme.primary, bogie->colour_scheme.secondary);
+                    imageId = Gfx::recolour2(imageId, bogie->colourScheme.primary, bogie->colourScheme.secondary);
                 }
 
                 if (sprite.flags & BogieSpriteFlags::unk_4)
@@ -137,7 +137,7 @@ namespace OpenLoco::Paint
                 }
                 else
                 {
-                    imageId = Gfx::recolour2(imageId, bogie->colour_scheme.primary, bogie->colour_scheme.secondary);
+                    imageId = Gfx::recolour2(imageId, bogie->colourScheme.primary, bogie->colourScheme.secondary);
                 }
                 if (sprite.flags & BogieSpriteFlags::unk_4)
                 {
@@ -161,7 +161,7 @@ namespace OpenLoco::Paint
                 }
                 else
                 {
-                    imageId = Gfx::recolour2(imageId, bogie->colour_scheme.primary, bogie->colour_scheme.secondary);
+                    imageId = Gfx::recolour2(imageId, bogie->colourScheme.primary, bogie->colourScheme.secondary);
                 }
                 session.addToPlotListAsParent(imageId, { 0, 0, bogie->position.z }, { -6, -6, static_cast<coord_t>(bogie->position.z + 3) }, { 12, 12, 1 });
                 break;
@@ -329,13 +329,13 @@ namespace OpenLoco::Paint
         static loco_global<Map::Pos2[64], 0x00503B6A> _503B6A;  // also used in vehicle.cpp
         static loco_global<int8_t[32 * 4], 0x005001B4> _5001B4; // array of 4 byte structures
 
-        auto* vehObject = ObjectManager::get<VehicleObject>(body->object_id);
-        if (body->object_sprite_type == SpriteIndex::null)
+        auto* vehObject = ObjectManager::get<VehicleObject>(body->objectId);
+        if (body->objectSpriteType == SpriteIndex::null)
         {
             return;
         }
 
-        auto& sprite = vehObject->bodySprites[body->object_sprite_type];
+        auto& sprite = vehObject->bodySprites[body->objectSpriteType];
         uint8_t yaw = (body->sprite_yaw + (session.getRotation() << 4)) & 0x3F;
         auto originalYaw = yaw; // edi
         auto pitch = body->sprite_pitch;
@@ -399,7 +399,7 @@ namespace OpenLoco::Paint
         }
         else
         {
-            auto& unk = vehObject->var_24[body->body_index];
+            auto& unk = vehObject->var_24[body->bodyIndex];
             auto offsetModifier = unk.length - unk.var_01;
             if (body->getFlags38() & Flags38::isReversed)
             {
@@ -436,7 +436,7 @@ namespace OpenLoco::Paint
         }
         else
         {
-            imageId = Gfx::recolour2(bodyImage, body->colour_scheme.primary, body->colour_scheme.secondary);
+            imageId = Gfx::recolour2(bodyImage, body->colourScheme.primary, body->colourScheme.secondary);
         }
         session.addToPlotList4FD200(imageId, offsets, boundBoxOffsets, boundBoxSize);
 

--- a/src/OpenLoco/Vehicles/CloneVehicle.cpp
+++ b/src/OpenLoco/Vehicles/CloneVehicle.cpp
@@ -21,7 +21,7 @@ namespace OpenLoco::Vehicles
             uint32_t totalCost = 0;
             for (auto& car : existingTrain.cars)
             {
-                auto cost = GameCommands::queryDo_5(car.front->object_id);
+                auto cost = GameCommands::queryDo_5(car.front->objectId);
                 if (cost == GameCommands::FAILURE)
                 {
                     totalCost = GameCommands::FAILURE;
@@ -46,7 +46,7 @@ namespace OpenLoco::Vehicles
             uint32_t cost = 0;
             if (newHead == nullptr)
             {
-                cost = GameCommands::do_5(car.front->object_id);
+                cost = GameCommands::do_5(car.front->objectId);
                 auto* newVeh = EntityManager::get<Vehicles::VehicleBase>(_113642A);
                 if (newVeh == nullptr)
                 {
@@ -56,7 +56,7 @@ namespace OpenLoco::Vehicles
             }
             else
             {
-                cost = GameCommands::do_5(car.front->object_id, newHead->head);
+                cost = GameCommands::do_5(car.front->objectId, newHead->head);
             }
             if (cost == GameCommands::FAILURE)
             {

--- a/src/OpenLoco/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/Vehicles/CreateVehicle.cpp
@@ -123,20 +123,20 @@ namespace OpenLoco::Vehicles
         auto newBogie = createVehicleThing<VehicleBogie>();
         newBogie->owner = _updatingCompanyId;
         newBogie->head = head;
-        newBogie->body_index = bodyNumber;
-        newBogie->track_type = lastVeh->getTrackType();
+        newBogie->bodyIndex = bodyNumber;
+        newBogie->trackType = lastVeh->getTrackType();
         newBogie->mode = lastVeh->getTransportMode();
-        newBogie->tile_x = -1;
-        newBogie->tile_y = 0;
-        newBogie->tile_base_z = 0;
+        newBogie->tileX = -1;
+        newBogie->tileY = 0;
+        newBogie->tileBaseZ = 0;
         newBogie->subPosition = 0;
         newBogie->var_2C = TrackAndDirection(0, 0);
         newBogie->routingHandle = lastVeh->getRoutingHandle();
-        newBogie->object_id = vehicleTypeId;
+        newBogie->objectId = vehicleTypeId;
 
         auto& prng = gPrng();
         newBogie->var_44 = prng.randNext();
-        newBogie->creation_day = getCurrentDay();
+        newBogie->creationDay = getCurrentDay();
         newBogie->var_46 = 0;
         newBogie->var_47 = 0;
         newBogie->secondaryCargo.acceptedTypes = 0;
@@ -151,7 +151,7 @@ namespace OpenLoco::Vehicles
         newBogie->var_09 = 1;
         newBogie->var_15 = 1;
 
-        newBogie->colour_scheme = colourScheme;
+        newBogie->colourScheme = colourScheme;
         lastVeh->setNextCar(newBogie->id);
         return newBogie;
     }
@@ -186,7 +186,7 @@ namespace OpenLoco::Vehicles
 
         // Calculate refund cost == 7/8 * cost
         auto cost = Economy::getInflationAdjustedCost(vehObject.cost_factor, vehObject.cost_index, 6);
-        newBogie->refund_cost = cost - cost / 8;
+        newBogie->refundCost = cost - cost / 8;
 
         if (bodyNumber == 0)
         {
@@ -205,12 +205,12 @@ namespace OpenLoco::Vehicles
             }
         }
 
-        newBogie->object_sprite_type = vehObject.var_24[bodyNumber].front_bogie_sprite_ind;
-        if (newBogie->object_sprite_type != SpriteIndex::null)
+        newBogie->objectSpriteType = vehObject.var_24[bodyNumber].front_bogie_sprite_ind;
+        if (newBogie->objectSpriteType != SpriteIndex::null)
         {
-            newBogie->var_14 = vehObject.bogie_sprites[newBogie->object_sprite_type].var_02;
-            newBogie->var_09 = vehObject.bogie_sprites[newBogie->object_sprite_type].var_03;
-            newBogie->var_15 = vehObject.bogie_sprites[newBogie->object_sprite_type].var_04;
+            newBogie->var_14 = vehObject.bogie_sprites[newBogie->objectSpriteType].var_02;
+            newBogie->var_09 = vehObject.bogie_sprites[newBogie->objectSpriteType].var_03;
+            newBogie->var_15 = vehObject.bogie_sprites[newBogie->objectSpriteType].var_04;
         }
         return newBogie;
     }
@@ -224,12 +224,12 @@ namespace OpenLoco::Vehicles
             return nullptr;
         }
         newBogie->var_38 = Flags38::isReversed;
-        newBogie->object_sprite_type = vehObject.var_24[bodyNumber].back_bogie_sprite_ind;
-        if (newBogie->object_sprite_type != SpriteIndex::null)
+        newBogie->objectSpriteType = vehObject.var_24[bodyNumber].back_bogie_sprite_ind;
+        if (newBogie->objectSpriteType != SpriteIndex::null)
         {
-            newBogie->var_14 = vehObject.bogie_sprites[newBogie->object_sprite_type].var_02;
-            newBogie->var_09 = vehObject.bogie_sprites[newBogie->object_sprite_type].var_03;
-            newBogie->var_15 = vehObject.bogie_sprites[newBogie->object_sprite_type].var_04;
+            newBogie->var_14 = vehObject.bogie_sprites[newBogie->objectSpriteType].var_02;
+            newBogie->var_09 = vehObject.bogie_sprites[newBogie->objectSpriteType].var_03;
+            newBogie->var_15 = vehObject.bogie_sprites[newBogie->objectSpriteType].var_04;
         }
         return newBogie;
     }
@@ -242,21 +242,21 @@ namespace OpenLoco::Vehicles
         newBody->setSubType(bodyNumber == 0 ? VehicleThingType::body_start : VehicleThingType::body_continued);
         newBody->owner = _updatingCompanyId;
         newBody->head = head;
-        newBody->body_index = bodyNumber;
-        newBody->track_type = lastVeh->getTrackType();
+        newBody->bodyIndex = bodyNumber;
+        newBody->trackType = lastVeh->getTrackType();
         newBody->mode = lastVeh->getTransportMode();
-        newBody->tile_x = -1;
-        newBody->tile_y = 0;
-        newBody->tile_base_z = 0;
+        newBody->tileX = -1;
+        newBody->tileY = 0;
+        newBody->tileBaseZ = 0;
         newBody->subPosition = 0;
         newBody->var_2C = TrackAndDirection(0, 0);
         newBody->routingHandle = lastVeh->getRoutingHandle();
         newBody->var_38 = Flags38::unk_0; // different to create bogie
-        newBody->object_id = vehicleTypeId;
+        newBody->objectId = vehicleTypeId;
 
         auto& prng = gPrng();
         newBody->var_44 = prng.randNext();
-        newBody->creation_day = getCurrentDay();
+        newBody->creationDay = getCurrentDay();
         newBody->var_46 = 0;
         newBody->var_47 = 0;
         newBody->primaryCargo.acceptedTypes = 0;
@@ -298,16 +298,16 @@ namespace OpenLoco::Vehicles
                 spriteType &= ~SpriteIndex::flag_unk7;
             }
         }
-        newBody->object_sprite_type = spriteType;
+        newBody->objectSpriteType = spriteType;
 
-        if (newBody->object_sprite_type != SpriteIndex::null)
+        if (newBody->objectSpriteType != SpriteIndex::null)
         {
-            newBody->var_14 = vehObject.bodySprites[newBody->object_sprite_type].var_08;
-            newBody->var_09 = vehObject.bodySprites[newBody->object_sprite_type].var_09;
-            newBody->var_15 = vehObject.bodySprites[newBody->object_sprite_type].var_0A;
+            newBody->var_14 = vehObject.bodySprites[newBody->objectSpriteType].var_08;
+            newBody->var_09 = vehObject.bodySprites[newBody->objectSpriteType].var_09;
+            newBody->var_15 = vehObject.bodySprites[newBody->objectSpriteType].var_0A;
         }
 
-        newBody->colour_scheme = colourScheme; // same as create bogie
+        newBody->colourScheme = colourScheme; // same as create bogie
 
         if (bodyNumber == 0 && vehObject.flags & FlagsE0::flag_02)
         {
@@ -428,11 +428,11 @@ namespace OpenLoco::Vehicles
         newHead->owner = _updatingCompanyId;
         newHead->head = newHead->id;
         newHead->var_0C |= Flags0C::commandStop;
-        newHead->track_type = trackType;
+        newHead->trackType = trackType;
         newHead->mode = mode;
-        newHead->tile_x = -1;
-        newHead->tile_y = 0;
-        newHead->tile_base_z = 0;
+        newHead->tileX = -1;
+        newHead->tileY = 0;
+        newHead->tileBaseZ = 0;
         newHead->remainingDistance = 0;
         newHead->subPosition = 0;
         newHead->var_2C = TrackAndDirection(0, 0);
@@ -466,11 +466,11 @@ namespace OpenLoco::Vehicles
         auto* const newVeh1 = createVehicleThing<Vehicle1>();
         newVeh1->owner = _updatingCompanyId;
         newVeh1->head = head;
-        newVeh1->track_type = lastVeh->getTrackType();
+        newVeh1->trackType = lastVeh->getTrackType();
         newVeh1->mode = lastVeh->getTransportMode();
-        newVeh1->tile_x = -1;
-        newVeh1->tile_y = 0;
-        newVeh1->tile_base_z = 0;
+        newVeh1->tileX = -1;
+        newVeh1->tileY = 0;
+        newVeh1->tileBaseZ = 0;
         newVeh1->remainingDistance = 0;
         newVeh1->subPosition = 0;
         newVeh1->var_2C = TrackAndDirection(0, 0);
@@ -497,11 +497,11 @@ namespace OpenLoco::Vehicles
         auto* const newVeh2 = createVehicleThing<Vehicle2>();
         newVeh2->owner = _updatingCompanyId;
         newVeh2->head = head;
-        newVeh2->track_type = lastVeh->getTrackType();
+        newVeh2->trackType = lastVeh->getTrackType();
         newVeh2->mode = lastVeh->getTransportMode();
-        newVeh2->tile_x = -1;
-        newVeh2->tile_y = 0;
-        newVeh2->tile_base_z = 0;
+        newVeh2->tileX = -1;
+        newVeh2->tileY = 0;
+        newVeh2->tileBaseZ = 0;
         newVeh2->remainingDistance = 0;
         newVeh2->subPosition = 0;
         newVeh2->var_2C = TrackAndDirection(0, 0);
@@ -534,11 +534,11 @@ namespace OpenLoco::Vehicles
         auto* const newTail = createVehicleThing<VehicleTail>();
         newTail->owner = _updatingCompanyId;
         newTail->head = head;
-        newTail->track_type = lastVeh->getTrackType();
+        newTail->trackType = lastVeh->getTrackType();
         newTail->mode = lastVeh->getTransportMode();
-        newTail->tile_x = -1;
-        newTail->tile_y = 0;
-        newTail->tile_base_z = 0;
+        newTail->tileX = -1;
+        newTail->tileY = 0;
+        newTail->tileBaseZ = 0;
         newTail->remainingDistance = 0;
         newTail->subPosition = 0;
         newTail->var_2C = TrackAndDirection(0, 0);
@@ -551,7 +551,7 @@ namespace OpenLoco::Vehicles
         newTail->objectId = -1;
         newTail->var_4A = 0;
         lastVeh->setNextCar(newTail->id);
-        newTail->next_car_id = EntityId::null;
+        newTail->nextCarId = EntityId::null;
         return newTail;
     }
 
@@ -701,7 +701,7 @@ namespace OpenLoco::Vehicles
         {
             auto vehObject = ObjectManager::get<VehicleObject>(vehicleTypeId);
 
-            auto head = createBaseVehicle(vehObject->mode, vehObject->type, vehObject->track_type);
+            auto head = createBaseVehicle(vehObject->mode, vehObject->type, vehObject->trackType);
             if (!head)
             {
                 return FAILURE;
@@ -773,11 +773,11 @@ namespace OpenLoco::Vehicles
 
         if (flags & GameCommands::Flags::apply)
         {
-            if (train.head->tile_x != -1)
+            if (train.head->tileX != -1)
             {
-                _backupX = train.head->tile_x;
-                _backupY = train.head->tile_y;
-                _backupZ = train.head->tile_base_z;
+                _backupX = train.head->tileX;
+                _backupY = train.head->tileY;
+                _backupZ = train.head->tileBaseZ;
                 _backup2C = train.head->var_2C;
                 _backup2E = train.head->subPosition;
                 _backupVeh0 = train.head;

--- a/src/OpenLoco/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/Vehicles/Vehicle.cpp
@@ -20,14 +20,14 @@ namespace OpenLoco::Vehicles
         uint32_t remainingDistance;  // 0x28
         TrackAndDirection var_2C;    // 0x2C
         uint16_t subPosition;        // 0x2E
-        int16_t tile_x;              // 0x30
-        int16_t tile_y;              // 0x32
-        uint8_t tile_base_z;         // 0x34
-        uint8_t track_type;          // 0x35 field same in all vehicles
+        int16_t tileX;               // 0x30
+        int16_t tileY;               // 0x32
+        uint8_t tileBaseZ;           // 0x34
+        uint8_t trackType;           // 0x35 field same in all vehicles
         RoutingHandle routingHandle; // 0x36 field same in all vehicles
         uint8_t var_38;              // 0x38
         uint8_t pad_39;
-        EntityId next_car_id; // 0x3A
+        EntityId nextCarId; // 0x3A
         uint8_t pad_3C[0x42 - 0x3C];
         TransportMode mode; // 0x42 field same in all vehicles
     };
@@ -42,7 +42,7 @@ namespace OpenLoco::Vehicles
     VehicleBase* VehicleBase::nextVehicleComponent()
     {
         auto* veh = reinterpret_cast<VehicleCommon*>(this);
-        return EntityManager::get<VehicleBase>(veh->next_car_id);
+        return EntityManager::get<VehicleBase>(veh->nextCarId);
     }
 
     TransportMode VehicleBase::getTransportMode() const
@@ -60,7 +60,7 @@ namespace OpenLoco::Vehicles
     uint8_t VehicleBase::getTrackType() const
     {
         const auto* veh = reinterpret_cast<const VehicleCommon*>(this);
-        return veh->track_type;
+        return veh->trackType;
     }
 
     RoutingHandle VehicleBase::getRoutingHandle() const
@@ -78,7 +78,7 @@ namespace OpenLoco::Vehicles
     void VehicleBase::setNextCar(const EntityId newNextCar)
     {
         auto* veh = reinterpret_cast<VehicleCommon*>(this);
-        veh->next_car_id = newNextCar;
+        veh->nextCarId = newNextCar;
     }
 
     // 0x004AA464
@@ -229,7 +229,7 @@ namespace OpenLoco::Vehicles
     // 0x00426790
     uint16_t VehicleBogie::getPlaneType()
     {
-        auto* vehObj = ObjectManager::get<VehicleObject>(object_id);
+        auto* vehObj = ObjectManager::get<VehicleObject>(objectId);
         if (vehObj->flags & FlagsE0::isHelicopter)
         {
             return 1 << 4;

--- a/src/OpenLoco/Vehicles/Vehicle.h
+++ b/src/OpenLoco/Vehicles/Vehicle.h
@@ -77,8 +77,8 @@ namespace OpenLoco::Vehicles
     namespace Flags5F
     {
         constexpr uint8_t unk_0 = 1 << 0;
-        constexpr uint8_t breakdown_pending = 1 << 1;
-        constexpr uint8_t broken_down = 1 << 2;
+        constexpr uint8_t breakdownPending = 1 << 1;
+        constexpr uint8_t brokenDown = 1 << 2;
         constexpr uint8_t unk_3 = 1 << 3;
     }
 
@@ -234,13 +234,13 @@ namespace OpenLoco::Vehicles
     struct Vehicle2or6 : VehicleBase
     {
         uint8_t pad_24[0x44 - 0x24];
-        SoundObjectId_t drivingSoundId;         // 0x44
-        uint8_t drivingSoundVolume;             // 0x45 channel attribute volume related
-        uint16_t drivingSoundFrequency;         // 0x46 channel attribute frequency
-        uint16_t objectId;                      // 0x48 vehicle object (used for sound)
-        uint16_t var_4A;                        // sound-related flag(s)
-        Ui::WindowNumber_t sound_window_number; // 0x4C
-        Ui::WindowType sound_window_type;       // 0x4E
+        SoundObjectId_t drivingSoundId;       // 0x44
+        uint8_t drivingSoundVolume;           // 0x45 channel attribute volume related
+        uint16_t drivingSoundFrequency;       // 0x46 channel attribute frequency
+        uint16_t objectId;                    // 0x48 vehicle object (used for sound)
+        uint16_t var_4A;                      // sound-related flag(s)
+        Ui::WindowNumber_t soundWindowNumber; // 0x4C
+        Ui::WindowType soundWindowType;       // 0x4E
         uint8_t pad_4F[0x56 - 0x4F];
         uint32_t var_56;
         uint8_t pad_5A[0x73 - 0x5A];
@@ -267,17 +267,17 @@ namespace OpenLoco::Vehicles
         uint32_t remainingDistance; // 0x28
         TrackAndDirection var_2C;
         uint16_t subPosition;        // 0x2E
-        int16_t tile_x;              // 0x30
-        int16_t tile_y;              // 0x32
-        uint8_t tile_base_z;         // 0x34
-        uint8_t track_type;          // 0x35 field same in all vehicles
-        RoutingHandle routingHandle; // 0x36 field same in all vehicles orderId * max_num_routing_steps
+        int16_t tileX;               // 0x30
+        int16_t tileY;               // 0x32
+        uint8_t tileBaseZ;           // 0x34
+        uint8_t trackType;           // 0x35 field same in all vehicles
+        RoutingHandle routingHandle; // 0x36 field same in all vehicles orderId * maxNumRoutingSteps
         uint8_t var_38;
-        uint8_t pad_39;       // 0x39
-        EntityId next_car_id; // 0x3A
-        uint32_t var_3C;      // 0x3C
-        uint8_t pad_40[0x2];  // 0x40
-        TransportMode mode;   // 0x42 field same in all vehicles
+        uint8_t pad_39;      // 0x39
+        EntityId nextCarId;  // 0x3A
+        uint32_t var_3C;     // 0x3C
+        uint8_t pad_40[0x2]; // 0x40
+        TransportMode mode;  // 0x42 field same in all vehicles
         uint8_t pad_43;
         int16_t ordinalNumber;     // 0x44
         uint32_t orderTableOffset; // 0x46 offset into Order Table
@@ -313,7 +313,7 @@ namespace OpenLoco::Vehicles
         bool update();
         VehicleStatus getStatus() const;
         OrderRingView getCurrentOrders() const;
-        bool isPlaced() const { return tile_x != -1 && !(var_38 & Flags38::isGhost); }
+        bool isPlaced() const { return tileX != -1 && !(var_38 & Flags38::isGhost); }
         char* generateCargoTotalString(char* buffer);
         char* generateCargoCapacityString(char* buffer);
         char* cargoLUTToString(CargoTotalArray& cargoTotals, char* buffer);
@@ -412,17 +412,17 @@ namespace OpenLoco::Vehicles
         uint32_t remainingDistance; // 0x28
         TrackAndDirection var_2C;
         uint16_t subPosition;        // 0x2E
-        int16_t tile_x;              // 0x30
-        int16_t tile_y;              // 0x32
-        uint8_t tile_base_z;         // 0x34
-        uint8_t track_type;          // 0x35 field same in all vehicles
+        int16_t tileX;               // 0x30
+        int16_t tileY;               // 0x32
+        uint8_t tileBaseZ;           // 0x34
+        uint8_t trackType;           // 0x35 field same in all vehicles
         RoutingHandle routingHandle; // 0x36 field same in all vehicles
         uint8_t var_38;
-        uint8_t pad_39;       // 0x39
-        EntityId next_car_id; // 0x3A
-        uint32_t var_3C;      // 0x3C
-        uint8_t pad_40[0x2];  // 0x40
-        TransportMode mode;   // 0x42 field same in all vehicles
+        uint8_t pad_39;      // 0x39
+        EntityId nextCarId;  // 0x3A
+        uint32_t var_3C;     // 0x3C
+        uint8_t pad_40[0x2]; // 0x40
+        TransportMode mode;  // 0x42 field same in all vehicles
         uint8_t pad_43;
         Speed16 var_44;
         uint16_t timeAtSignal; // 0x46
@@ -444,24 +444,24 @@ namespace OpenLoco::Vehicles
         uint32_t remainingDistance; // 0x28
         TrackAndDirection var_2C;
         uint16_t subPosition;        // 0x2E
-        int16_t tile_x;              // 0x30
-        int16_t tile_y;              // 0x32
-        uint8_t tile_base_z;         // 0x34
-        uint8_t track_type;          // 0x35 field same in all vehicles
+        int16_t tileX;               // 0x30
+        int16_t tileY;               // 0x32
+        uint8_t tileBaseZ;           // 0x34
+        uint8_t trackType;           // 0x35 field same in all vehicles
         RoutingHandle routingHandle; // 0x36 field same in all vehicles
         uint8_t var_38;
         uint8_t pad_39;              // 0x39
-        EntityId next_car_id;        // 0x3A
+        EntityId nextCarId;          // 0x3A
         uint8_t pad_3C[0x42 - 0x3C]; // 0x3C
         TransportMode mode;          // 0x42 field same in all vehicles
         uint8_t pad_43;
-        SoundObjectId_t drivingSoundId;         // 0x44
-        uint8_t drivingSoundVolume;             // 0x45 channel attribute volume related
-        uint16_t drivingSoundFrequency;         // 0x46 channel attribute frequency
-        uint16_t objectId;                      // 0x48 vehicle object (used for sound)
-        uint16_t var_4A;                        // sound-related flag(s) common with tail
-        Ui::WindowNumber_t sound_window_number; // 0x4C common with tail
-        Ui::WindowType sound_window_type;       // 0x4E common with tail
+        SoundObjectId_t drivingSoundId;       // 0x44
+        uint8_t drivingSoundVolume;           // 0x45 channel attribute volume related
+        uint16_t drivingSoundFrequency;       // 0x46 channel attribute frequency
+        uint16_t objectId;                    // 0x48 vehicle object (used for sound)
+        uint16_t var_4A;                      // sound-related flag(s) common with tail
+        Ui::WindowNumber_t soundWindowNumber; // 0x4C common with tail
+        Ui::WindowType soundWindowType;       // 0x4E common with tail
         uint8_t pad_4F;
         uint16_t totalPower;  // 0x50 maybe not used by aircraft and ship
         uint16_t totalWeight; // 0x52
@@ -485,21 +485,21 @@ namespace OpenLoco::Vehicles
     struct VehicleBody : VehicleBase
     {
         static constexpr auto kVehicleThingType = VehicleThingType::body_continued;
-        ColourScheme colour_scheme; // 0x24
+        ColourScheme colourScheme;  // 0x24
         EntityId head;              // 0x26
         uint32_t remainingDistance; // 0x28
         TrackAndDirection var_2C;
         uint16_t subPosition;        // 0x2E
-        int16_t tile_x;              // 0x30
-        int16_t tile_y;              // 0x32
-        uint8_t tile_base_z;         // 0x34
-        uint8_t track_type;          // 0x35 field same in all vehicles
+        int16_t tileX;               // 0x30
+        int16_t tileY;               // 0x32
+        uint8_t tileBaseZ;           // 0x34
+        uint8_t trackType;           // 0x35 field same in all vehicles
         RoutingHandle routingHandle; // 0x36 field same in all vehicles
         uint8_t var_38;
-        uint8_t object_sprite_type; // 0x39
-        EntityId next_car_id;       // 0x3A
+        uint8_t objectSpriteType; // 0x39
+        EntityId nextCarId;       // 0x3A
         uint8_t pad_3C[0x40 - 0x3C];
-        uint16_t object_id; // 0x40
+        uint16_t objectId;  // 0x40
         TransportMode mode; // 0x42
         uint8_t pad_43;
         int16_t var_44;
@@ -507,9 +507,9 @@ namespace OpenLoco::Vehicles
         uint8_t var_47;            // 0x47 cargo sprite index
         VehicleCargo primaryCargo; // 0x48
         uint8_t pad_52[0x54 - 0x52];
-        uint8_t body_index; // 0x54
+        uint8_t bodyIndex; // 0x54
         int8_t var_55;
-        uint32_t creation_day; // 0x56
+        uint32_t creationDay; // 0x56
         uint8_t pad_5A[0x5E - 0x5A];
         uint8_t var_5E;
         uint8_t var_5F;
@@ -522,39 +522,39 @@ namespace OpenLoco::Vehicles
 
     private:
         void animationUpdate();
-        void sub_4AC255(VehicleBogie* back_bogie, VehicleBogie* front_bogie);
+        void sub_4AC255(VehicleBogie* backBogie, VehicleBogie* frontBogie);
         void steamPuffsAnimationUpdate(uint8_t num, int32_t var_05);
         void dieselExhaust1AnimationUpdate(uint8_t num, int32_t var_05);
         void dieselExhaust2AnimationUpdate(uint8_t num, int32_t var_05);
         void electricSpark1AnimationUpdate(uint8_t num, int32_t var_05);
         void electricSpark2AnimationUpdate(uint8_t num, int32_t var_05);
         void shipWakeAnimationUpdate(uint8_t num, int32_t var_05);
-        Pitch updateSpritePitchSteepSlopes(uint16_t xy_offset, int16_t z_offset);
-        Pitch updateSpritePitch(uint16_t xy_offset, int16_t z_offset);
+        Pitch updateSpritePitchSteepSlopes(uint16_t xyOffset, int16_t zOffset);
+        Pitch updateSpritePitch(uint16_t xyOffset, int16_t zOffset);
     };
     static_assert(sizeof(VehicleBody) == 0x60); // Can't use offset_of change this to last field if more found
 
     uint8_t calculateYaw1FromVectorPlane(int16_t xDiff, int16_t yDiff);
-    uint8_t calculateYaw4FromVector(int16_t x_offset, int16_t y_offset);
+    uint8_t calculateYaw4FromVector(int16_t xOffset, int16_t yOffset);
 
     struct VehicleBogie : VehicleBase
     {
         static constexpr auto kVehicleThingType = VehicleThingType::bogie;
-        ColourScheme colour_scheme; // 0x24
+        ColourScheme colourScheme;  // 0x24
         EntityId head;              // 0x26
         uint32_t remainingDistance; // 0x28
         TrackAndDirection var_2C;
         uint16_t subPosition;        // 0x2E
-        int16_t tile_x;              // 0x30
-        int16_t tile_y;              // 0x32
-        uint8_t tile_base_z;         // 0x34
-        uint8_t track_type;          // 0x35 field same in all vehicles
+        int16_t tileX;               // 0x30
+        int16_t tileY;               // 0x32
+        uint8_t tileBaseZ;           // 0x34
+        uint8_t trackType;           // 0x35 field same in all vehicles
         RoutingHandle routingHandle; // 0x36 field same in all vehicles
         uint8_t var_38;
-        uint8_t object_sprite_type; // 0x39
-        EntityId next_car_id;       // 0x3A
+        uint8_t objectSpriteType; // 0x39
+        EntityId nextCarId;       // 0x3A
         uint8_t pad_3C[0x40 - 0x3C];
-        uint16_t object_id; // 0x40
+        uint16_t objectId;  // 0x40
         TransportMode mode; // 0x42 field same in all vehicles
         uint8_t pad_43;
         uint16_t var_44;
@@ -562,15 +562,15 @@ namespace OpenLoco::Vehicles
         uint8_t var_47;
         VehicleCargo secondaryCargo; // 0x48 Note back bogie cannot carry cargo always check type
         uint8_t pad_52[0x54 - 0x52];
-        uint8_t body_index; // 0x54
+        uint8_t bodyIndex; // 0x54
         uint8_t pad_55;
-        uint32_t creation_day; // 0x56
+        uint32_t creationDay; // 0x56
         uint8_t pad_5A[0x5E - 0x5A];
         uint8_t var_5E;
         uint8_t var_5F;
         uint8_t var_60;
         uint8_t var_61;
-        uint32_t refund_cost; // 0x62 front bogies only
+        uint32_t refundCost;  // 0x62 front bogies only
         uint16_t reliability; // 0x66 front bogies only
         uint16_t var_68;
         uint8_t var_6A;
@@ -588,25 +588,25 @@ namespace OpenLoco::Vehicles
         uint32_t remainingDistance; // 0x28
         TrackAndDirection var_2C;
         uint16_t subPosition;        // 0x2E
-        int16_t tile_x;              // 0x30
-        int16_t tile_y;              // 0x32
-        uint8_t tile_base_z;         // 0x34
-        uint8_t track_type;          // 0x35 field same in all vehicles
+        int16_t tileX;               // 0x30
+        int16_t tileY;               // 0x32
+        uint8_t tileBaseZ;           // 0x34
+        uint8_t trackType;           // 0x35 field same in all vehicles
         RoutingHandle routingHandle; // 0x36 field same in all vehicles
         uint8_t var_38;
         uint8_t pad_39;              // 0x39
-        EntityId next_car_id;        // 0x3A
+        EntityId nextCarId;          // 0x3A
         uint8_t pad_3C[0x42 - 0x3C]; // 0x3C
         TransportMode mode;          // 0x42 field same in all vehicles
         uint8_t pad_43;
-        SoundObjectId_t drivingSoundId;         // 0x44
-        uint8_t drivingSoundVolume;             // 0x45 channel attribute volume related
-        uint16_t drivingSoundFrequency;         // 0x46 channel attribute frequency
-        uint16_t objectId;                      // 0x48 vehicle object (used for sound)
-        uint16_t var_4A;                        // sound-related flag(s) common with veh_2
-        Ui::WindowNumber_t sound_window_number; // 0x4C common with veh_2
-        Ui::WindowType sound_window_type;       // 0x4E common with veh_2
-        uint16_t trainDanglingTimeout;          // 0x4F counts up when no cars on train
+        SoundObjectId_t drivingSoundId;       // 0x44
+        uint8_t drivingSoundVolume;           // 0x45 channel attribute volume related
+        uint16_t drivingSoundFrequency;       // 0x46 channel attribute frequency
+        uint16_t objectId;                    // 0x48 vehicle object (used for sound)
+        uint16_t var_4A;                      // sound-related flag(s) common with veh_2
+        Ui::WindowNumber_t soundWindowNumber; // 0x4C common with veh_2
+        Ui::WindowType soundWindowType;       // 0x4E common with veh_2
+        uint16_t trainDanglingTimeout;        // 0x4F counts up when no cars on train
 
         bool update();
     };

--- a/src/OpenLoco/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/Vehicles/VehicleBody.cpp
@@ -44,7 +44,7 @@ namespace OpenLoco::Vehicles
 
     VehicleObject* VehicleBody::object() const
     {
-        return ObjectManager::get<VehicleObject>(object_id);
+        return ObjectManager::get<VehicleObject>(objectId);
     }
 
     // 0x004AA1D0
@@ -90,7 +90,7 @@ namespace OpenLoco::Vehicles
             return;
 
         auto vehicleObject = object();
-        int32_t var_05 = vehicleObject->var_24[body_index].var_05;
+        int32_t var_05 = vehicleObject->var_24[bodyIndex].var_05;
         if (var_05 == 0)
         {
             return;
@@ -139,18 +139,18 @@ namespace OpenLoco::Vehicles
         }
 
         var_44 += eax & 0xFFFF;
-        if (object_sprite_type == 0xFF)
+        if (objectSpriteType == 0xFF)
             return;
 
         auto vehicleObj = object();
         uint8_t al = 0;
-        if (vehicleObj->bodySprites[object_sprite_type].flags & BodySpriteFlags::hasSpeedAnimation)
+        if (vehicleObj->bodySprites[objectSpriteType].flags & BodySpriteFlags::hasSpeedAnimation)
         {
             Vehicle2* veh3 = vehicleUpdate_2;
-            al = veh3->currentSpeed / (vehicleObj->speed / vehicleObj->bodySprites[object_sprite_type].numAnimationFrames);
-            al = std::min<uint8_t>(al, vehicleObj->bodySprites[object_sprite_type].numAnimationFrames - 1);
+            al = veh3->currentSpeed / (vehicleObj->speed / vehicleObj->bodySprites[objectSpriteType].numAnimationFrames);
+            al = std::min<uint8_t>(al, vehicleObj->bodySprites[objectSpriteType].numAnimationFrames - 1);
         }
-        else if (vehicleObj->bodySprites[object_sprite_type].numRollFrames != 1)
+        else if (vehicleObj->bodySprites[objectSpriteType].numRollFrames != 1)
         {
             VehicleBogie* frontBogie = vehicleUpdate_frontBogie;
             Vehicle2* veh3 = vehicleUpdate_2;
@@ -218,7 +218,7 @@ namespace OpenLoco::Vehicles
         }
         else
         {
-            al = (var_44 >> 12) & (vehicleObj->bodySprites[object_sprite_type].numAnimationFrames - 1);
+            al = (var_44 >> 12) & (vehicleObj->bodySprites[objectSpriteType].numAnimationFrames - 1);
         }
         if (var_46 != al)
         {
@@ -238,13 +238,13 @@ namespace OpenLoco::Vehicles
         auto midPoint = (front_bogie->position + back_bogie->position) / 2;
         moveTo(midPoint);
 
-        if (object_sprite_type == 0xFF)
+        if (objectSpriteType == 0xFF)
             return;
 
         auto bogieDifference = front_bogie->position - back_bogie->position;
         auto distanceBetweenBogies = Math::Vector::distance(front_bogie->position, back_bogie->position);
         auto vehObj = object();
-        if (vehObj->bodySprites[object_sprite_type].flags & BodySpriteFlags::hasSteepSprites)
+        if (vehObj->bodySprites[objectSpriteType].flags & BodySpriteFlags::hasSteepSprites)
         {
             sprite_pitch = updateSpritePitchSteepSlopes(distanceBetweenBogies, bogieDifference.z);
         }
@@ -260,7 +260,7 @@ namespace OpenLoco::Vehicles
         }
         else
         {
-            auto sprite = vehObj->bodySprites[object_sprite_type];
+            auto sprite = vehObj->bodySprites[objectSpriteType];
             uint8_t i = sprite_pitch == Pitch::flat ? sprite.var_0B : sprite.var_0C;
             switch (i)
             {
@@ -860,7 +860,7 @@ namespace OpenLoco::Vehicles
     {
         auto vehicleObject = object();
 
-        uint8_t var_05 = vehicleObject->var_24[body_index].var_05;
+        uint8_t var_05 = vehicleObject->var_24[bodyIndex].var_05;
         if (var_05 == 0)
             return;
 
@@ -902,7 +902,7 @@ namespace OpenLoco::Vehicles
         auto vehicleObject = object();
         VehicleBogie* frontBogie = vehicleUpdate_frontBogie;
         VehicleBogie* backBogie = vehicleUpdate_backBogie;
-        if (frontBogie->var_5F & Flags5F::broken_down)
+        if (frontBogie->var_5F & Flags5F::brokenDown)
             return;
 
         Vehicle2* veh_2 = vehicleUpdate_2;
@@ -946,12 +946,12 @@ namespace OpenLoco::Vehicles
 
         auto smokeLoc = bogieDifference * var_05 / 128 + frontBogie->position + Map::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].height);
 
-        Exhaust::create(smokeLoc, vehicleObject->animation[num].object_id | (soundCode ? 0 : 0x80));
+        Exhaust::create(smokeLoc, vehicleObject->animation[num].objectId | (soundCode ? 0 : 0x80));
         if (soundCode == false)
             return;
 
         var_55++;
-        SteamObject* steam_obj = ObjectManager::get<SteamObject>(vehicleObject->animation[num].object_id);
+        SteamObject* steam_obj = ObjectManager::get<SteamObject>(vehicleObject->animation[num].objectId);
         if (var_55 >= ((uint8_t)vehicleObject->animation[num].type) + 1)
         {
             var_55 = 0;
@@ -962,7 +962,7 @@ namespace OpenLoco::Vehicles
         // Looking for a station
         if (steam_obj->var_08 & (1 << 2))
         {
-            auto tile = Map::TileManager::get(frontBogie->tile_x, frontBogie->tile_y);
+            auto tile = Map::TileManager::get(frontBogie->tileX, frontBogie->tileY);
 
             for (auto& el : tile)
             {
@@ -977,7 +977,7 @@ namespace OpenLoco::Vehicles
                 auto* track = el.as<Map::TrackElement>();
                 if (track == nullptr)
                     continue;
-                if (track->baseZ() != frontBogie->tile_base_z)
+                if (track->baseZ() != frontBogie->tileBaseZ)
                     continue;
                 if (track->trackId() != frontBogie->var_2C.track.id())
                     continue;
@@ -1046,7 +1046,7 @@ namespace OpenLoco::Vehicles
     {
         VehicleBogie* frontBogie = vehicleUpdate_frontBogie;
         VehicleBogie* backBogie = vehicleUpdate_backBogie;
-        if (frontBogie->var_5F & Flags5F::broken_down)
+        if (frontBogie->var_5F & Flags5F::brokenDown)
             return;
 
         VehicleHead* headVeh = vehicleUpdate_head;
@@ -1071,7 +1071,7 @@ namespace OpenLoco::Vehicles
             auto xyFactor = Math::Trigonometry::computeXYVector(positionFactor, invertedDirection) / 2;
 
             Map::Pos3 loc = position + Map::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].height);
-            Exhaust::create(loc, vehicleObject->animation[num].object_id);
+            Exhaust::create(loc, vehicleObject->animation[num].objectId);
         }
         else
         {
@@ -1095,7 +1095,7 @@ namespace OpenLoco::Vehicles
 
             auto loc = bogieDifference * var_05 / 128 + frontBogie->position + Map::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].height);
 
-            Exhaust::create(loc, vehicleObject->animation[num].object_id);
+            Exhaust::create(loc, vehicleObject->animation[num].objectId);
         }
     }
 
@@ -1104,7 +1104,7 @@ namespace OpenLoco::Vehicles
     {
         VehicleBogie* frontBogie = vehicleUpdate_frontBogie;
         VehicleBogie* backBogie = vehicleUpdate_backBogie;
-        if (frontBogie->var_5F & Flags5F::broken_down)
+        if (frontBogie->var_5F & Flags5F::brokenDown)
             return;
 
         Vehicle2* veh_2 = vehicleUpdate_2;
@@ -1144,7 +1144,7 @@ namespace OpenLoco::Vehicles
         loc.x += xyFactor.x;
         loc.y += xyFactor.y;
 
-        Exhaust::create(loc, vehicleObject->animation[num].object_id);
+        Exhaust::create(loc, vehicleObject->animation[num].objectId);
     }
 
     // 0x004ABDAD & 0x004AB3CA
@@ -1152,7 +1152,7 @@ namespace OpenLoco::Vehicles
     {
         VehicleBogie* frontBogie = vehicleUpdate_frontBogie;
         VehicleBogie* backBogie = vehicleUpdate_backBogie;
-        if (frontBogie->var_5F & Flags5F::broken_down)
+        if (frontBogie->var_5F & Flags5F::brokenDown)
             return;
 
         Vehicle2* veh_2 = vehicleUpdate_2;
@@ -1181,7 +1181,7 @@ namespace OpenLoco::Vehicles
 
         auto loc = bogieDifference * var_05 / 128 + frontBogie->position + Map::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].height);
 
-        Exhaust::create(loc, vehicleObject->animation[num].object_id);
+        Exhaust::create(loc, vehicleObject->animation[num].objectId);
     }
 
     // 0x004ABEC3 & 0x004AB4E0
@@ -1189,7 +1189,7 @@ namespace OpenLoco::Vehicles
     {
         VehicleBogie* frontBogie = vehicleUpdate_frontBogie;
         VehicleBogie* backBogie = vehicleUpdate_backBogie;
-        if (frontBogie->var_5F & Flags5F::broken_down)
+        if (frontBogie->var_5F & Flags5F::brokenDown)
             return;
 
         Vehicle2* veh_2 = vehicleUpdate_2;
@@ -1236,7 +1236,7 @@ namespace OpenLoco::Vehicles
         loc.x += xyFactor.x;
         loc.y += xyFactor.y;
 
-        Exhaust::create(loc, vehicleObject->animation[num].object_id);
+        Exhaust::create(loc, vehicleObject->animation[num].objectId);
     }
 
     // 0x004ABC8A & 0x004AB2A7
@@ -1281,7 +1281,7 @@ namespace OpenLoco::Vehicles
         loc.x += xyFactor.x;
         loc.y += xyFactor.y;
 
-        Exhaust::create(loc, vehicleObject->animation[num].object_id);
+        Exhaust::create(loc, vehicleObject->animation[num].objectId);
 
         if (vehicleObject->var_113 == 0)
             return;
@@ -1293,13 +1293,13 @@ namespace OpenLoco::Vehicles
         loc.x += xyFactor.x;
         loc.y += xyFactor.y;
 
-        Exhaust::create(loc, vehicleObject->animation[num].object_id);
+        Exhaust::create(loc, vehicleObject->animation[num].objectId);
     }
 
     // 0x004AC039
     void VehicleBody::updateCargoSprite()
     {
-        if (object_sprite_type == 0xFF)
+        if (objectSpriteType == 0xFF)
         {
             return;
         }
@@ -1309,7 +1309,7 @@ namespace OpenLoco::Vehicles
         }
 
         auto vehicleObj = object();
-        auto& bodySprite = vehicleObj->bodySprites[object_sprite_type];
+        auto& bodySprite = vehicleObj->bodySprites[objectSpriteType];
 
         auto percentageFull = std::min((primaryCargo.qty * 256) / primaryCargo.maxQty, 255);
         auto spriteIndex = (percentageFull * bodySprite.numCargoLoadFrames) / 256;

--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -93,7 +93,7 @@ namespace OpenLoco::Vehicles
             var_5C--;
         }
 
-        if (tile_x == -1)
+        if (tileX == -1)
         {
             if (!train.cars.empty())
             {
@@ -155,7 +155,7 @@ namespace OpenLoco::Vehicles
         Vehicle train(this);
         for (auto& car : train.cars)
         {
-            if (car.front->var_5F & Flags5F::broken_down)
+            if (car.front->var_5F & Flags5F::brokenDown)
             {
                 if ((scenarioTicks() & 3) == 0)
                 {
@@ -165,13 +165,13 @@ namespace OpenLoco::Vehicles
                 }
             }
 
-            if ((car.front->var_5F & Flags5F::breakdown_pending) && !isTitleMode())
+            if ((car.front->var_5F & Flags5F::breakdownPending) && !isTitleMode())
             {
                 auto newConfig = Config::getNew();
                 if (!newConfig.breakdowns_disabled)
                 {
-                    car.front->var_5F &= ~Flags5F::breakdown_pending;
-                    car.front->var_5F |= Flags5F::broken_down;
+                    car.front->var_5F &= ~Flags5F::breakdownPending;
+                    car.front->var_5F |= Flags5F::brokenDown;
                     car.front->var_6A = 5;
                     applyBreakdownToTrain();
 
@@ -191,7 +191,7 @@ namespace OpenLoco::Vehicles
         // Check only the first bogie on each car for breakdown flags
         for (const auto& car : train.cars)
         {
-            auto* vehObj = ObjectManager::get<VehicleObject>(car.front->object_id);
+            auto* vehObj = ObjectManager::get<VehicleObject>(car.front->objectId);
             if (vehObj == nullptr)
             {
                 continue;
@@ -201,7 +201,7 @@ namespace OpenLoco::Vehicles
             {
                 continue;
             }
-            if (car.front->var_5F & Flags5F::broken_down)
+            if (car.front->var_5F & Flags5F::brokenDown)
             {
                 isBrokenDown = true;
             }
@@ -302,7 +302,7 @@ namespace OpenLoco::Vehicles
         Vehicle train(this);
         for (const auto& car : train.cars)
         {
-            totalLength += getVehicleTypeLength(car.body->object_id);
+            totalLength += getVehicleTypeLength(car.body->objectId);
         }
         return totalLength;
     }
@@ -324,7 +324,7 @@ namespace OpenLoco::Vehicles
         }
         else
         {
-            if (newObject->track_type != track_type)
+            if (newObject->trackType != trackType)
             {
                 GameCommands::setErrorText(StringIds::incompatible_vehicle);
                 return false;
@@ -347,8 +347,8 @@ namespace OpenLoco::Vehicles
             Vehicle train(this);
             for (const auto& car : train.cars)
             {
-                // The object_id is the same for all vehicle components and car components of a car
-                if (!sub_4B90F0(vehicleTypeId, car.front->object_id))
+                // The objectId is the same for all vehicle components and car components of a car
+                if (!sub_4B90F0(vehicleTypeId, car.front->objectId))
                 {
                     return false;
                 }
@@ -359,7 +359,7 @@ namespace OpenLoco::Vehicles
             return true;
         }
 
-        if (track_type != 0xFF)
+        if (trackType != 0xFF)
         {
             return true;
         }
@@ -379,7 +379,7 @@ namespace OpenLoco::Vehicles
     {
         VehicleStatus vehStatus = {};
         vehStatus.status2 = StringIds::null;
-        if (tile_x == -1)
+        if (tileX == -1)
         {
             vehStatus.status1 = StringIds::vehicle_status_no_position;
             return vehStatus;
@@ -549,7 +549,7 @@ namespace OpenLoco::Vehicles
     // 0x004A88A6
     void VehicleHead::updateDrivingSound(Vehicle2or6* vehType2or6)
     {
-        if (tile_x == -1 || status == Status::crashed || status == Status::stuck || (var_38 & Flags38::isGhost) || vehType2or6->objectId == 0xFFFF)
+        if (tileX == -1 || status == Status::crashed || status == Status::stuck || (var_38 & Flags38::isGhost) || vehType2or6->objectId == 0xFFFF)
         {
             updateDrivingSoundNone(vehType2or6);
             return;
@@ -613,7 +613,7 @@ namespace OpenLoco::Vehicles
                 {
                     assert(false);
                 }
-                if (train.cars.firstCar.front->var_5F & Flags5F::broken_down)
+                if (train.cars.firstCar.front->var_5F & Flags5F::brokenDown)
                 {
                     updateDrivingSoundNone(vehType2or6);
                     return;
@@ -706,7 +706,7 @@ namespace OpenLoco::Vehicles
                 {
                     assert(false);
                 }
-                if (train.cars.firstCar.front->var_5F & Flags5F::broken_down)
+                if (train.cars.firstCar.front->var_5F & Flags5F::brokenDown)
                 {
                     updateDrivingSoundNone(vehType2or6);
                     return;
@@ -930,7 +930,7 @@ namespace OpenLoco::Vehicles
         auto param1 = 160;
         auto turnaroundAtSignalTimeout = kBusSignalTimeout;
 
-        if (track_type == 0xFF || ObjectManager::get<RoadObject>(track_type)->flags & Flags12::isRoad)
+        if (trackType == 0xFF || ObjectManager::get<RoadObject>(trackType)->flags & Flags12::isRoad)
         {
             if (train.veh1->var_2C.road.isBackToFront())
             {
@@ -1396,7 +1396,7 @@ namespace OpenLoco::Vehicles
         Pitch targetPitch = Pitch::flat;
         if (vehType2->currentSpeed < 50.0_mph)
         {
-            auto vehObject = ObjectManager::get<VehicleObject>(train.cars.firstCar.front->object_id);
+            auto vehObject = ObjectManager::get<VehicleObject>(train.cars.firstCar.front->objectId);
             targetPitch = Pitch::up12deg;
             // Slope sprites for taxiing planes??
             if (!(vehObject->flags & FlagsE0::unk_08))
@@ -1417,7 +1417,7 @@ namespace OpenLoco::Vehicles
         {
             if (vehType2->currentSpeed <= 180.0_mph)
             {
-                auto vehObject = ObjectManager::get<VehicleObject>(train.cars.firstCar.front->object_id);
+                auto vehObject = ObjectManager::get<VehicleObject>(train.cars.firstCar.front->objectId);
 
                 // looks wrong??
                 if (vehObject->flags & FlagsE0::can_couple)
@@ -2057,7 +2057,7 @@ namespace OpenLoco::Vehicles
                 }
                 // 0x4272A5
                 Vehicle train(this);
-                auto vehObject = ObjectManager::get<VehicleObject>(train.cars.firstCar.front->object_id);
+                auto vehObject = ObjectManager::get<VehicleObject>(train.cars.firstCar.front->objectId);
                 if (vehObject->flags & FlagsE0::isHelicopter)
                 {
                     for (uint8_t movementEdge = 0; movementEdge < airportObject->numMovementEdges; movementEdge++)
@@ -2290,13 +2290,13 @@ namespace OpenLoco::Vehicles
     {
         Vehicle train(this);
         moveTo({ newLoc.x, newLoc.y, newLoc.z });
-        tile_x = 0;
+        tileX = 0;
 
         train.veh1->moveTo({ newLoc.x, newLoc.y, newLoc.z });
-        train.veh1->tile_x = 0;
+        train.veh1->tileX = 0;
 
         train.veh2->moveTo({ newLoc.x, newLoc.y, newLoc.z });
-        train.veh2->tile_x = 0;
+        train.veh2->tileX = 0;
 
         // The first bogie of the plane is the shadow of the plane
         auto* shadow = train.cars.firstCar.front;
@@ -2305,7 +2305,7 @@ namespace OpenLoco::Vehicles
         shadow->moveTo({ newLoc.x, newLoc.y, height });
         shadow->sprite_yaw = newYaw;
         shadow->sprite_pitch = Pitch::flat;
-        shadow->tile_x = 0;
+        shadow->tileX = 0;
         shadow->invalidateSprite();
 
         auto* body = train.cars.firstCar.body;
@@ -2313,7 +2313,7 @@ namespace OpenLoco::Vehicles
         body->moveTo({ newLoc.x, newLoc.y, newLoc.z });
         body->sprite_yaw = newYaw;
         body->sprite_pitch = newPitch;
-        body->tile_x = 0;
+        body->tileX = 0;
         body->invalidateSprite();
     }
 
@@ -2425,7 +2425,7 @@ namespace OpenLoco::Vehicles
 
             if (stationId != StationId::null)
             {
-                auto targetTile = TileManager::get(Map::Pos2{ tile_x, tile_y });
+                auto targetTile = TileManager::get(Map::Pos2{ tileX, tileY });
                 StationElement* station = nullptr;
                 for (auto& el : targetTile)
                 {
@@ -2438,7 +2438,7 @@ namespace OpenLoco::Vehicles
                     {
                         continue;
                     }
-                    if (station->baseZ() == tile_base_z)
+                    if (station->baseZ() == tileBaseZ)
                     {
                         station->setFlag6(false);
                         stationId = StationId::null;
@@ -2452,11 +2452,11 @@ namespace OpenLoco::Vehicles
             if (newStationId != StationId::null)
             {
                 stationId = newStationId;
-                tile_x = stationTarget.x;
-                tile_y = stationTarget.y;
-                tile_base_z = stationTarget.z / 4;
+                tileX = stationTarget.x;
+                tileY = stationTarget.y;
+                tileBaseZ = stationTarget.z / 4;
 
-                auto targetTile = TileManager::get(Map::Pos2{ tile_x, tile_y });
+                auto targetTile = TileManager::get(Map::Pos2{ tileX, tileY });
                 StationElement* station = nullptr;
                 for (auto& el : targetTile)
                 {
@@ -2469,7 +2469,7 @@ namespace OpenLoco::Vehicles
                     {
                         continue;
                     }
-                    if (station->baseZ() == tile_base_z)
+                    if (station->baseZ() == tileBaseZ)
                     {
                         station->setFlag6(true);
                         break;
@@ -2509,14 +2509,14 @@ namespace OpenLoco::Vehicles
     {
         Vehicle train(this);
         train.veh1->moveTo({ newLoc.x, newLoc.y, newLoc.z });
-        train.veh1->tile_x = 0;
+        train.veh1->tileX = 0;
         train.veh2->moveTo({ newLoc.x, newLoc.y, newLoc.z });
-        train.veh2->tile_x = 0;
+        train.veh2->tileX = 0;
         train.cars.firstCar.body->invalidateSprite();
         train.cars.firstCar.body->moveTo({ newLoc.x, newLoc.y, newLoc.z });
         train.cars.firstCar.body->sprite_yaw = yaw;
         train.cars.firstCar.body->sprite_pitch = pitch;
-        train.cars.firstCar.body->tile_x = 0;
+        train.cars.firstCar.body->tileX = 0;
         train.cars.firstCar.body->invalidateSprite();
     }
 
@@ -2530,11 +2530,11 @@ namespace OpenLoco::Vehicles
                 return 1;
             case TransportMode::rail:
             {
-                auto tile = Map::TileManager::get(Pos2{ bogie->tile_x, bogie->tile_y });
+                auto tile = Map::TileManager::get(Pos2{ bogie->tileX, bogie->tileY });
                 auto direction = bogie->var_2C.track.cardinalDirection();
                 auto trackId = bogie->var_2C.track.id();
                 auto loadingModifier = 12;
-                auto* elStation = tile.trackStation(trackId, direction, bogie->tile_base_z);
+                auto* elStation = tile.trackStation(trackId, direction, bogie->tileBaseZ);
                 if (elStation != nullptr)
                 {
                     if (elStation->isFlag5() || elStation->isGhost())
@@ -2549,11 +2549,11 @@ namespace OpenLoco::Vehicles
             }
             case TransportMode::road:
             {
-                auto tile = Map::TileManager::get(Pos2{ bogie->tile_x, bogie->tile_y });
+                auto tile = Map::TileManager::get(Pos2{ bogie->tileX, bogie->tileY });
                 auto direction = bogie->var_2C.road.cardinalDirection();
                 auto roadId = bogie->var_2C.road.id();
                 auto loadingModifier = 2;
-                auto* elStation = tile.roadStation(roadId, direction, bogie->tile_base_z);
+                auto* elStation = tile.roadStation(roadId, direction, bogie->tileBaseZ);
                 if (elStation != nullptr)
                 {
                     if (elStation->isFlag5() || elStation->isGhost())
@@ -2942,7 +2942,7 @@ namespace OpenLoco::Vehicles
         station->flags |= StationFlags::flag_7;
         Vehicle train(this);
         auto vehMaxSpeed = train.veh2->maxSpeed;
-        auto carAgeFactor = static_cast<uint8_t>(std::min<uint32_t>(0xFF, (getCurrentDay() - bogie->creation_day) / 256));
+        auto carAgeFactor = static_cast<uint8_t>(std::min<uint32_t>(0xFF, (getCurrentDay() - bogie->creationDay) / 256));
 
         if (stationCargo.flags & (1 << 2))
         {
@@ -3212,8 +3212,8 @@ namespace OpenLoco::Vehicles
         auto direction = bogie->var_2C.track.cardinalDirection();
         auto trackId = bogie->var_2C.track.id();
 
-        auto tile = TileManager::get(Map::Pos2{ bogie->tile_x, bogie->tile_y });
-        auto* elStation = tile.trackStation(trackId, direction, bogie->tile_base_z);
+        auto tile = TileManager::get(Map::Pos2{ bogie->tileX, bogie->tileY });
+        auto* elStation = tile.trackStation(trackId, direction, bogie->tileBaseZ);
         if (elStation == nullptr)
         {
             return StationId::null;
@@ -3344,10 +3344,10 @@ namespace OpenLoco::Vehicles
         Vehicle train(this);
         Vehicle2* veh = train.veh2;
         Pos2 loc = {
-            veh->tile_x,
-            veh->tile_y
+            veh->tileX,
+            veh->tileY
         };
-        auto baseZ = veh->tile_base_z;
+        auto baseZ = veh->tileBaseZ;
 
         auto tile = TileManager::get(loc);
         if (veh->mode == TransportMode::road)
@@ -3497,7 +3497,7 @@ namespace OpenLoco::Vehicles
                         return false;
                     }
 
-                    if (this->tile_x == -1)
+                    if (this->tileX == -1)
                     {
                         return true;
                     }
@@ -3517,7 +3517,7 @@ namespace OpenLoco::Vehicles
                 }
                 else
                 {
-                    if (this->tile_x == -1)
+                    if (this->tileX == -1)
                     {
                         return true;
                     }
@@ -3552,7 +3552,7 @@ namespace OpenLoco::Vehicles
         const Vehicle train(this);
         for (const auto& car : train.cars)
         {
-            auto* vehObj = ObjectManager::get<VehicleObject>(car.front->object_id);
+            auto* vehObj = ObjectManager::get<VehicleObject>(car.front->objectId);
             currency32_t runCost = Economy::getInflationAdjustedCost(vehObj->run_cost_factor, vehObj->run_cost_index, 10);
             totalRunCost += runCost;
         }

--- a/src/OpenLoco/Vehicles/VehicleTail.cpp
+++ b/src/OpenLoco/Vehicles/VehicleTail.cpp
@@ -284,7 +284,7 @@ namespace OpenLoco::Vehicles
         }
 
         const auto _oldRoutingHandle = routingHandle;
-        const Map::Pos3 _oldTilePos = Map::Pos3(tile_x, tile_y, tile_base_z * 4);
+        const Map::Pos3 _oldTilePos = Map::Pos3(tileX, tileY, tileBaseZ * 4);
 
         vehicleUpdate_var_1136114 = 0;
         sub_4B15FF(*vehicleUpdate_var_113612C);
@@ -313,7 +313,7 @@ namespace OpenLoco::Vehicles
             if (ref & (1 << 15))
             {
                 // Update signal state?
-                sub_48963F(_oldTilePos, trackAndDirection.track, track_type, 0);
+                sub_48963F(_oldTilePos, trackAndDirection.track, trackType, 0);
             }
 
             const auto& trackSize = Map::TrackData::getUnkTrack(ref & 0x1FF);
@@ -324,7 +324,7 @@ namespace OpenLoco::Vehicles
             }
             auto trackAndDirection2 = trackAndDirection;
             trackAndDirection2.track.setReversed(!trackAndDirection2.track.isReversed());
-            sub_4A2AD7(nextTile, trackAndDirection2, owner, track_type);
+            sub_4A2AD7(nextTile, trackAndDirection2, owner, trackType);
             leaveLevelCrossing(_oldTilePos, trackAndDirection.track, 9);
         }
         return true;

--- a/src/OpenLoco/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/Windows/BuildVehicle.cpp
@@ -475,7 +475,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                     }
                 }
 
-                if (sanitisedTrackType != vehicleObj->track_type)
+                if (sanitisedTrackType != vehicleObj->trackType)
                 {
                     continue;
                 }
@@ -959,14 +959,14 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
             auto trackName = StringIds::road;
             if (vehicleObj->mode == TransportMode::road)
             {
-                if (vehicleObj->track_type != 0xFF)
+                if (vehicleObj->trackType != 0xFF)
                 {
-                    trackName = ObjectManager::get<RoadObject>(vehicleObj->track_type)->name;
+                    trackName = ObjectManager::get<RoadObject>(vehicleObj->trackType)->name;
                 }
             }
             else
             {
-                trackName = ObjectManager::get<TrackObject>(vehicleObj->track_type)->name;
+                trackName = ObjectManager::get<TrackObject>(vehicleObj->trackType)->name;
             }
 
             buffer = StringManager::formatString(buffer, trackName);
@@ -1159,11 +1159,11 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
             auto vehicleObj = ObjectManager::get<VehicleObject>(_availableVehicles[i]);
             if (vehicleObj && vehicleObj->mode == TransportMode::rail)
             {
-                railTrackTypes |= (1 << vehicleObj->track_type);
+                railTrackTypes |= (1 << vehicleObj->trackType);
             }
             else if (vehicleObj && vehicleObj->mode == TransportMode::road)
             {
-                auto trackType = vehicleObj->track_type;
+                auto trackType = vehicleObj->trackType;
                 if (trackType == 0xFF)
                 {
                     trackType = _525FC5;

--- a/src/OpenLoco/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/Windows/Construction/Common.cpp
@@ -1380,7 +1380,7 @@ namespace OpenLoco::Ui::Windows::Construction
                 if (vehicleObj->mode != transportMode)
                     continue;
 
-                if (trackType != vehicleObj->track_type)
+                if (trackType != vehicleObj->trackType)
                     continue;
 
                 auto company = CompanyManager::get(companyId);

--- a/src/OpenLoco/Windows/News/News.cpp
+++ b/src/OpenLoco/Windows/News/News.cpp
@@ -118,12 +118,12 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                                 window->row_hover = itemId;
                                 if (vehicleObj->mode == TransportMode::rail || vehicleObj->mode == TransportMode::road)
                                 {
-                                    if (vehicleObj->track_type != 0xFF)
+                                    if (vehicleObj->trackType != 0xFF)
                                     {
                                         uint8_t i = 0;
                                         while (i < _numTrackTypeTabs)
                                         {
-                                            if (vehicleObj->track_type == _trackTypesForTab[i])
+                                            if (vehicleObj->trackType == _trackTypesForTab[i])
                                             {
                                                 window->current_secondary_tab = i;
                                                 break;
@@ -229,7 +229,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 case MessageItemArgumentType::vehicle:
                 {
                     Vehicles::Vehicle train(EntityId{ itemId });
-                    if (train.head->tile_x == -1)
+                    if (train.head->tileX == -1)
                         break;
 
                     view.thingId = train.veh2->id;

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -267,7 +267,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             Vehicles::Vehicle train(vehHead);
 
             // If picked up no need for viewport drawn
-            if (vehHead->tile_x == -1)
+            if (vehHead->tileX == -1)
             {
                 self->viewportRemove(0);
                 self->invalidate();
@@ -744,13 +744,13 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             if (head->mode == TransportMode::air || head->mode == TransportMode::water)
             {
-                if (head->status != Vehicles::Status::stopped && head->status != Vehicles::Status::loading && head->tile_x != -1)
+                if (head->status != Vehicles::Status::stopped && head->status != Vehicles::Status::loading && head->tileX != -1)
                 {
                     self->disabled_widgets |= (1 << widx::pickup);
                 }
             }
 
-            if (head->tile_x == -1)
+            if (head->tileX == -1)
             {
                 self->disabled_widgets |= (1 << widx::stopStart) | (1 << widx::passSignal) | (1 << widx::changeDirection) | (1 << widx::centreViewport);
                 if (Input::isToolActive(WindowType::vehicle, self->number))
@@ -1222,7 +1222,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             ToolTip::set_52336E(true);
 
-            auto vehicleObj = ObjectManager::get<VehicleObject>(car->front->object_id);
+            auto vehicleObj = ObjectManager::get<VehicleObject>(car->front->objectId);
             {
                 FormatArguments args{};
                 args.push(vehicleObj->name);
@@ -1231,7 +1231,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             {
                 FormatArguments args{};
-                args.push(car->front->creation_day);
+                args.push(car->front->creationDay);
                 buffer = StringManager::formatString(buffer, StringIds::vehicle_details_tooltip_built, &args);
             }
 
@@ -1265,7 +1265,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             {
                 FormatArguments args{};
-                args.push(car->front->refund_cost);
+                args.push(car->front->refundCost);
                 buffer = StringManager::formatString(buffer, StringIds::vehicle_details_tooltip_value, &args);
             }
 
@@ -1471,7 +1471,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 }
                 auto x = Common::sub_4B743B(al, ah, 0, y, car.front, &context);
 
-                auto vehicleObj = ObjectManager::get<VehicleObject>(car.front->object_id);
+                auto vehicleObj = ObjectManager::get<VehicleObject>(car.front->objectId);
                 FormatArguments args{};
                 args.push(vehicleObj->name);
                 x += 2;
@@ -1641,7 +1641,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 return false;
             }
 
-            auto object = ObjectManager::get<VehicleObject>(train.cars.firstCar.front->object_id);
+            auto object = ObjectManager::get<VehicleObject>(train.cars.firstCar.front->objectId);
             return (object->flags & FlagsE0::refittable);
         }
 
@@ -1831,7 +1831,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void onRefitButton(Window* const self, const WidgetIndex_t wi)
         {
             Vehicles::Vehicle train(Common::getVehicle(self));
-            auto vehicleObject = ObjectManager::get<VehicleObject>(train.cars.firstCar.front->object_id);
+            auto vehicleObject = ObjectManager::get<VehicleObject>(train.cars.firstCar.front->objectId);
             auto maxPrimaryCargo = vehicleObject->max_primary_cargo;
             auto primaryCargoId = Utility::bitScanForward(vehicleObject->primary_cargo_types);
 
@@ -1968,7 +1968,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             ToolTip::set_52336E(true);
 
             {
-                auto vehicleObj = ObjectManager::get<VehicleObject>(car->front->object_id);
+                auto vehicleObj = ObjectManager::get<VehicleObject>(car->front->objectId);
                 FormatArguments args{};
                 args.push(vehicleObj->name);
                 buffer = StringManager::formatString(buffer, StringIds::cargo_capacity_tooltip, &args);
@@ -3232,14 +3232,14 @@ namespace OpenLoco::Ui::Windows::Vehicle
             {
                 case TransportMode::rail:
                 {
-                    auto trackObj = ObjectManager::get<TrackObject>(head.track_type);
+                    auto trackObj = ObjectManager::get<TrackObject>(head.trackType);
                     image = trackObj->image + (isPlaced ? 16 : 17);
                     tooltip = isPlaced ? StringIds::tooltip_remove_from_track : StringIds::tooltip_place_on_track;
                     break;
                 }
                 case TransportMode::road:
                 {
-                    auto roadObjId = head.track_type == 0xFF ? _525FC5 : head.track_type;
+                    auto roadObjId = head.trackType == 0xFF ? _525FC5 : head.trackType;
                     auto roadObj = ObjectManager::get<RoadObject>(roadObjId);
                     image = roadObj->image + (isPlaced ? 32 : 33);
                     tooltip = isPlaced ? StringIds::tooltip_remove_from_track : StringIds::tooltip_place_on_track;
@@ -3373,7 +3373,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         {
             // Note: dont use isPlaced as we need to know if its a ghost
             // consider creating isGhostPlaced
-            if (head.tile_x != -1 && (head.var_38 & Vehicles::Flags38::isGhost))
+            if (head.tileX != -1 && (head.var_38 & Vehicles::Flags38::isGhost))
             {
                 GameCommands::do_63(head.id);
             }
@@ -3565,7 +3565,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         {
             // Note: dont use isPlaced as we need to know if its a ghost
             // consider creating isGhostPlaced
-            if (head.tile_x != -1 && (head.var_38 & Vehicles::Flags38::isGhost))
+            if (head.tileX != -1 && (head.var_38 & Vehicles::Flags38::isGhost))
             {
                 GameCommands::do_59(head.id);
             }
@@ -3809,7 +3809,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         {
             // Note: dont use isPlaced as we need to know if its a ghost
             // consider creating isGhostPlaced
-            if (head.tile_x != -1 && (head.var_38 & Vehicles::Flags38::isGhost))
+            if (head.tileX != -1 && (head.var_38 & Vehicles::Flags38::isGhost))
             {
                 GameCommands::do_2(head.id);
             }
@@ -3886,7 +3886,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             if (*_ghostAirportStationId == placementArgs->stationId && *_ghostAirportNode == placementArgs->airportNode)
             {
-                if (head.tile_x != -1 && (head.var_38 & Vehicles::Flags38::isGhost))
+                if (head.tileX != -1 && (head.var_38 & Vehicles::Flags38::isGhost))
                 {
                     // Will convert inplace vehicle into non ghost
                     placementArgs->convertGhost = true;
@@ -3920,7 +3920,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             if (_1136264 == 0 && *_ghostVehiclePos == placementArgs->pos)
             {
-                if (head.tile_x != -1 && (head.var_38 & Vehicles::Flags38::isGhost))
+                if (head.tileX != -1 && (head.var_38 & Vehicles::Flags38::isGhost))
                 {
                     // Will convert inplace vehicle into non ghost
                     placementArgs->convertGhost = true;
@@ -3955,7 +3955,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             if (*_ghostLandTrackAndDirection == placementArgs->trackAndDirection && *_ghostVehiclePos == placementArgs->pos && *_1136264 == placementArgs->trackProgress)
             {
-                if (head.tile_x != -1 && (head.var_38 & Vehicles::Flags38::isGhost))
+                if (head.tileX != -1 && (head.var_38 & Vehicles::Flags38::isGhost))
                 {
                     // Will convert inplace vehicle into non ghost
                     placementArgs->convertGhost = true;
@@ -4003,7 +4003,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         {
             // TODO: refactor to use removeAirplaneGhost family of functions
             auto head = getVehicle(&self);
-            if (head->tile_x == -1 || !(head->var_38 & Vehicles::Flags38::isGhost))
+            if (head->tileX == -1 || !(head->var_38 & Vehicles::Flags38::isGhost))
             {
                 self.invalidate();
                 return;


### PR DESCRIPTION
This is bigger than I hoped it would be, turns out Vehicle.h has a large number of structures in it and is widely referenced throughout the code. This PR is just the rename to lower camel case, I haven't changed any c-style casts or anything else.