### PR TITLE
Increase stepper speed for loans

### DIFF
--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -1942,7 +1942,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     if (company->currentLoan == 0)
                         return;
 
-                    currency32_t stepSize = 100 * pow(10, (*_clickRepeatTicks / 100));
+                    currency32_t stepSize = 1000 * pow(10, (*_clickRepeatTicks / 100));
                     GameCommands::ChangeLoanArgs args{};
                     args.newLoan = std::max<currency32_t>(0, company->currentLoan - stepSize);
 
@@ -1953,7 +1953,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
                 case widx::loan_increase:
                 {
-                    currency32_t stepSize = 100 * pow(10, (*_clickRepeatTicks / 100));
+                    currency32_t stepSize = 1000 * pow(10, (*_clickRepeatTicks / 100));
                     GameCommands::ChangeLoanArgs args{};
                     args.newLoan = CompanyManager::get(CompanyId(self->number))->currentLoan + stepSize;
 

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -1942,14 +1942,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     if (company->currentLoan == 0)
                         return;
 
-                    currency32_t stepSize{};
-                    if (*_clickRepeatTicks < 100)
-                        stepSize = 1000;
-                    else if (*_clickRepeatTicks >= 100)
-                        stepSize = 10000;
-                    else if (*_clickRepeatTicks >= 200)
-                        stepSize = 100000;
-
+                    currency32_t stepSize = 100 * pow(10, (*_clickRepeatTicks / 100));
                     GameCommands::ChangeLoanArgs args{};
                     args.newLoan = std::max<currency32_t>(0, company->currentLoan - stepSize);
 
@@ -1960,14 +1953,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
                 case widx::loan_increase:
                 {
-                    currency32_t stepSize{};
-                    if (*_clickRepeatTicks < 100)
-                        stepSize = 1000;
-                    else if (*_clickRepeatTicks >= 100)
-                        stepSize = 10000;
-                    else if (*_clickRepeatTicks >= 200)
-                        stepSize = 100000;
-
+                    currency32_t stepSize = 100 * pow(10, (*_clickRepeatTicks / 100));
                     GameCommands::ChangeLoanArgs args{};
                     args.newLoan = CompanyManager::get(CompanyId(self->number))->currentLoan + stepSize;
 

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -25,6 +25,7 @@
 #include "../Vehicles/Vehicle.h"
 #include "../ViewportManager.h"
 #include "../Widget.h"
+#include <cmath>
 
 using namespace OpenLoco::Interop;
 
@@ -1942,9 +1943,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     if (company->currentLoan == 0)
                         return;
 
-                    currency32_t stepSize = 1000 * pow(10, (*_clickRepeatTicks / 100));
                     GameCommands::ChangeLoanArgs args{};
-                    args.newLoan = std::max<currency32_t>(0, company->currentLoan - stepSize);
+                    args.newLoan = std::max<currency32_t>(0, company->currentLoan - calculateStepSize(*_clickRepeatTicks));
 
                     GameCommands::setErrorTitle(StringIds::cant_pay_back_loan);
                     GameCommands::doCommand(args, GameCommands::Flags::apply);
@@ -1953,15 +1953,19 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
                 case widx::loan_increase:
                 {
-                    currency32_t stepSize = 1000 * pow(10, (*_clickRepeatTicks / 100));
                     GameCommands::ChangeLoanArgs args{};
-                    args.newLoan = CompanyManager::get(CompanyId(self->number))->currentLoan + stepSize;
+                    args.newLoan = CompanyManager::get(CompanyId(self->number))->currentLoan + calculateStepSize(*_clickRepeatTicks);
 
                     GameCommands::setErrorTitle(StringIds::cant_borrow_any_more_money);
                     GameCommands::doCommand(args, GameCommands::Flags::apply);
                     break;
                 }
             }
+        }
+
+        static inline currency32_t calculateStepSize(uint16_t repeatTicks)
+        {
+            return 1000 * std::pow(10, repeatTicks / 100);
         }
 
         // 0x0043385D

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -1926,6 +1926,11 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             }
         }
 
+        static inline currency32_t calculateStepSize(uint16_t repeatTicks)
+        {
+            return 1000 * std::pow(10, repeatTicks / 100);
+        }
+
         // 0x0043383E
         static void onMouseDown(Window* self, WidgetIndex_t widgetIndex)
         {
@@ -1961,11 +1966,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     break;
                 }
             }
-        }
-
-        static inline currency32_t calculateStepSize(uint16_t repeatTicks)
-        {
-            return 1000 * std::pow(10, repeatTicks / 100);
         }
 
         // 0x0043385D


### PR DESCRIPTION
Loan stepper size doesn't scale with inflation, so in games that have high inflation (ie year is high, like 2050), trying to alter your loan takes a very long time as the stepper can only do 100k increments at max, and this takes a long time if you need to loan 30 million.
This change removes the upper limit to the stepper size increase already existing in the game, where the longer you hold the button down, the larger the step size becomes.