### PR TITLE
Fix vehicle capacity string having a leading space

### DIFF
--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2293,3 +2293,4 @@ strings:
   2238: "Game speed: Normal"
   2239: "Game speed: Fast forward"
   2240: "Game speed: Extra fast forward"
+  2241: "{COLOUR WINDOW_2}Capacity: {COLOUR BLACK}{STRINGID}"

--- a/src/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/Localisation/StringIds.h
@@ -1768,4 +1768,5 @@ namespace OpenLoco::StringIds
     constexpr string_id shortcut_game_speed_normal = 2238;
     constexpr string_id shortcut_game_speed_fast_forward = 2239;
     constexpr string_id shortcut_game_speed_extra_fast_forward = 2240;
+    constexpr string_id vehicle_capacity = 2241;
 }

--- a/src/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/Localisation/StringIds.h
@@ -1768,5 +1768,5 @@ namespace OpenLoco::StringIds
     constexpr string_id shortcut_game_speed_normal = 2238;
     constexpr string_id shortcut_game_speed_fast_forward = 2239;
     constexpr string_id shortcut_game_speed_extra_fast_forward = 2240;
-    constexpr string_id vehicle_capacity = 2241;
+    constexpr string_id capacity_stringid = 2241;
 }

--- a/src/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/Localisation/StringIds.h
@@ -1768,5 +1768,5 @@ namespace OpenLoco::StringIds
     constexpr string_id shortcut_game_speed_normal = 2238;
     constexpr string_id shortcut_game_speed_fast_forward = 2239;
     constexpr string_id shortcut_game_speed_extra_fast_forward = 2240;
-    constexpr string_id capacity_stringid = 2241;
+    constexpr string_id vehicle_capacity_stringid = 2241;
 }

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -1702,7 +1702,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             head->generateCargoCapacityString(buffer);
             args = {};
             args.push<string_id>(StringIds::buffer_1250);
-            Gfx::drawString_494BBF(*context, self->x + 3, self->y + self->height - 13, self->width - 15, Colour::black, StringIds::vehicle_capacity, &args);
+            Gfx::drawString_494BBF(*context, self->x + 3, self->y + self->height - 13, self->width - 15, Colour::black, StringIds::capacity_stringid, &args);
         }
 
         // based on 0x004B40C7

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -1702,7 +1702,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             head->generateCargoCapacityString(buffer);
             args = {};
             args.push<string_id>(StringIds::buffer_1250);
-            Gfx::drawString_494BBF(*context, self->x + 3, self->y + self->height - 13, self->width - 15, Colour::black, StringIds::object_selection_capacity, &args);
+            Gfx::drawString_494BBF(*context, self->x + 3, self->y + self->height - 13, self->width - 15, Colour::black, StringIds::vehicle_capacity, &args);
         }
 
         // based on 0x004B40C7

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -1702,7 +1702,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             head->generateCargoCapacityString(buffer);
             args = {};
             args.push<string_id>(StringIds::buffer_1250);
-            Gfx::drawString_494BBF(*context, self->x + 3, self->y + self->height - 13, self->width - 15, Colour::black, StringIds::capacity_stringid, &args);
+            Gfx::drawString_494BBF(*context, self->x + 3, self->y + self->height - 13, self->width - 15, Colour::black, StringIds::vehicle_capacity_stringid, &args);
         }
 
         // based on 0x004B40C7


### PR DESCRIPTION
In the new capacity string add in #1271 there is a leading space in the 'capacity' string that shouldn't be there:
![image](https://user-images.githubusercontent.com/7483209/152714112-cae5175d-3392-4af7-baee-b042ac70e5fd.png)
It's now fixed with a new stringid without the leading space
![image](https://user-images.githubusercontent.com/7483209/152714199-112ee449-9661-485b-8e0c-fddc22c4e59c.png)


