### PR TITLE
fixes divide-by-zero audio crash when really far in future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Feature: [#1327] Readd the game intro (use commandline switch --intro to enable)
 - Fix: [#1280] Crash when removing crashed vehicles with news window open.
 - Fix: [#1320] Inability to mark scenario as complete.
+- Fix [#1323] Playlist crash when setting the date really far into the future.
 - Fix: [#1325] Crash when saving second loaded scenario of a playthrough.
 - Fix: [#1328] Various object loading bugs related to custom object files causing crashes on load.
 - Change: [#1276] Transfering cargo is now viable. The cargo age is calculated as the weighted average of the present and delivered cargo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Feature: [#1327] Readd the game intro (use commandline switch --intro to enable)
 - Fix: [#1280] Crash when removing crashed vehicles with news window open.
 - Fix: [#1320] Inability to mark scenario as complete.
-- Fix [#1323] Playlist crash when setting the date really far into the future.
+- Fix: [#1323] Playlist crash when setting the date really far into the future.
 - Fix: [#1325] Crash when saving second loaded scenario of a playthrough.
 - Fix: [#1328] Various object loading bugs related to custom object files causing crashes on load.
 - Change: [#1276] Transfering cargo is now viable. The cargo age is calculated as the weighted average of the present and delivered cargo.

--- a/src/OpenLoco/Audio/Audio.cpp
+++ b/src/OpenLoco/Audio/Audio.cpp
@@ -1004,6 +1004,17 @@ namespace OpenLoco::Audio
         }
     }
 
+    static void addAllSongsToPlaylist(int32_t excludeTrack, std::vector<uint8_t>& playlist)
+    {
+        for (auto i = 0; i < kNumMusicTracks; i++)
+        {
+            if (i != excludeTrack)
+            {
+                playlist.push_back(i);
+            }
+        }
+    }
+
     static int32_t chooseNextMusicTrack(int32_t excludeTrack)
     {
         using MusicPlaylistType = Config::MusicPlaylistType;
@@ -1011,7 +1022,7 @@ namespace OpenLoco::Audio
         static std::vector<uint8_t> playlist;
         playlist.clear();
 
-        auto cfg = Config::get();
+        const auto& cfg = Config::get();
         switch (cfg.music_playlist)
         {
             case MusicPlaylistType::currentEra:
@@ -1031,13 +1042,7 @@ namespace OpenLoco::Audio
                 break;
             }
             case MusicPlaylistType::all:
-                for (auto i = 0; i < kNumMusicTracks; i++)
-                {
-                    if (i != excludeTrack)
-                    {
-                        playlist.push_back(i);
-                    }
-                }
+                addAllSongsToPlaylist(excludeTrack, playlist);
                 break;
             case MusicPlaylistType::custom:
                 for (auto i = 0; i < kNumMusicTracks; i++)
@@ -1052,25 +1057,7 @@ namespace OpenLoco::Audio
 
         if (playlist.size() == 0)
         {
-            if (excludeTrack == kNoSong)
-            {
-                for (auto i = 0; i < kNumMusicTracks; i++)
-                {
-                    if (i != excludeTrack)
-                    {
-                        playlist.push_back(i);
-                    }
-                }
-            }
-            else
-            {
-                const auto& mi = kMusicInfo[excludeTrack];
-                auto currentYear = getCurrentYear();
-                if (currentYear >= mi.startYear && currentYear <= mi.endYear)
-                {
-                    playlist.push_back(excludeTrack);
-                }
-            }
+            addAllSongsToPlaylist(excludeTrack, playlist);
         }
 
         auto r = std::rand() % playlist.size();

--- a/src/OpenLoco/Audio/Audio.cpp
+++ b/src/OpenLoco/Audio/Audio.cpp
@@ -1015,6 +1015,22 @@ namespace OpenLoco::Audio
         }
     }
 
+    static void addCurrentEraSongsToPlaylist(int32_t excludeTrack, std::vector<uint8_t>& playlist)
+    {
+        auto currentYear = getCurrentYear();
+        for (auto i = 0; i < kNumMusicTracks; i++)
+        {
+            const auto& mi = kMusicInfo[i];
+            if (currentYear >= mi.startYear && currentYear <= mi.endYear)
+            {
+                if (i != excludeTrack)
+                {
+                    playlist.push_back(i);
+                }
+            }
+        }
+    }
+
     static int32_t chooseNextMusicTrack(int32_t excludeTrack)
     {
         using MusicPlaylistType = Config::MusicPlaylistType;
@@ -1026,21 +1042,8 @@ namespace OpenLoco::Audio
         switch (cfg.music_playlist)
         {
             case MusicPlaylistType::currentEra:
-            {
-                auto currentYear = getCurrentYear();
-                for (auto i = 0; i < kNumMusicTracks; i++)
-                {
-                    const auto& mi = kMusicInfo[i];
-                    if (currentYear >= mi.startYear && currentYear <= mi.endYear)
-                    {
-                        if (i != excludeTrack)
-                        {
-                            playlist.push_back(i);
-                        }
-                    }
-                }
+                addCurrentEraSongsToPlaylist(excludeTrack, playlist);
                 break;
-            }
             case MusicPlaylistType::all:
                 addAllSongsToPlaylist(excludeTrack, playlist);
                 break;
@@ -1055,7 +1058,12 @@ namespace OpenLoco::Audio
                 break;
         }
 
-        if (playlist.size() == 0)
+        if (playlist.empty() && cfg.music_playlist != MusicPlaylistType::currentEra)
+        {
+            addCurrentEraSongsToPlaylist(excludeTrack, playlist);
+        }
+
+        if (playlist.empty())
         {
             addAllSongsToPlaylist(excludeTrack, playlist);
         }


### PR DESCRIPTION
This happens when the game tries to select a track, but none are available as the current year is out of the range of all music tracks. In this case, we simply default to playing all music tracks.