### PR TITLE
Use uint16_t for 'year' everywhere

### DIFF
--- a/src/OpenLoco/Date.cpp
+++ b/src/OpenLoco/Date.cpp
@@ -37,12 +37,12 @@ namespace OpenLoco
         getGameState().currentMonth = enumValue(month);
     }
 
-    uint16_t getCurrentYear()
+    Year getCurrentYear()
     {
         return getGameState().currentYear;
     }
 
-    void setCurrentYear(const int16_t year)
+    void setCurrentYear(const Year year)
     {
         getGameState().currentYear = year;
     }
@@ -532,7 +532,7 @@ namespace OpenLoco
         return month_table[dayOfYear];
     }
 
-    uint8_t getMonthTotalDay(uint16_t year, MonthId month)
+    uint8_t getMonthTotalDay(Year year, MonthId month)
     {
         static constexpr std::pair<MonthId, uint8_t> month_table[] = {
             { MonthId::january, 31 },

--- a/src/OpenLoco/Date.h
+++ b/src/OpenLoco/Date.h
@@ -4,6 +4,8 @@
 
 namespace OpenLoco
 {
+    using Year = uint16_t;
+
     enum class MonthId : uint8_t
     {
         january,
@@ -24,13 +26,13 @@ namespace OpenLoco
     {
         int32_t day = 0;
         MonthId month;
-        int32_t year = 0;
+        Year year = 0;
 
         // 0x0112C810 originally used as a return argument in calcDate
         int32_t dayOfOlympiad = 0;
 
         Date() = default;
-        Date(int32_t y, MonthId m, int32_t d)
+        Date(Year y, MonthId m, int32_t d)
             : day(d)
             , month(m)
             , year(y)
@@ -43,8 +45,8 @@ namespace OpenLoco
     uint32_t getCurrentDay();
     void setCurrentDay(const uint32_t day);
     MonthId getCurrentMonth();
-    uint16_t getCurrentYear();
-    void setCurrentYear(const int16_t year);
+    Year getCurrentYear();
+    void setCurrentYear(const Year year);
 
     Date getCurrentDate();
     void setDate(const Date& date);
@@ -62,5 +64,5 @@ namespace OpenLoco
     Date calcDate(uint32_t totalDays);
     uint32_t calcDays(Date date);
 
-    uint8_t getMonthTotalDay(uint16_t year, MonthId month);
+    uint8_t getMonthTotalDay(Year year, MonthId month);
 }

--- a/src/OpenLoco/Economy/Economy.cpp
+++ b/src/OpenLoco/Economy/Economy.cpp
@@ -1,5 +1,6 @@
 #include "Economy.h"
 #include "../CompanyManager.h"
+#include "../Date.h"
 #include "../GameState.h"
 #include "../Interop/Interop.hpp"
 #include "../Objects/ObjectManager.h"
@@ -96,7 +97,7 @@ namespace OpenLoco::Economy
     }
 
     // 0x0046E2C0
-    void sub_46E2C0(uint16_t year)
+    void sub_46E2C0(Year year)
     {
         auto& factors = currencyMultiplicationFactors();
         auto& unusedFactors = unusedCurrencyMultiplicationFactors();

--- a/src/OpenLoco/Economy/Economy.h
+++ b/src/OpenLoco/Economy/Economy.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include "../Date.h"
 #include "Currency.h"
 #include <cstdint>
 
 namespace OpenLoco::Economy
 {
     void updateMonthly();
-    void sub_46E2C0(uint16_t year);
+    void sub_46E2C0(Year year);
     currency32_t getInflationAdjustedCost(uint16_t costFactor, uint8_t costIndex, uint8_t divisor);
     void buildDeliveredCargoPaymentsTable();
 }

--- a/src/OpenLoco/Scenario.cpp
+++ b/src/OpenLoco/Scenario.cpp
@@ -236,12 +236,12 @@ namespace OpenLoco::Scenario
     }
 
     // 0x0049685C
-    void initialiseDate(uint16_t year)
+    void initialiseDate(Year year)
     {
         initialiseDate(year, MonthId::january, 1);
     }
 
-    void initialiseDate(uint16_t year, MonthId month, uint8_t day)
+    void initialiseDate(Year year, MonthId month, uint8_t day)
     {
         // NB: this base value was already 1800 in Locomotion.
         auto date = Date(year, month, day);

--- a/src/OpenLoco/Scenario.h
+++ b/src/OpenLoco/Scenario.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Core/FileSystem.hpp"
+#include "Date.h"
 #include "Localisation/FormatArguments.hpp"
 #include <cstdint>
 
@@ -114,9 +115,9 @@ namespace OpenLoco::Scenario
     void sub_4748D4();
     void eraseLandscape();
     void generateLandscape();
-    void initialiseDate(uint16_t year);
+    void initialiseDate(Year year);
 
-    void initialiseDate(uint16_t year, OpenLoco::MonthId month, uint8_t day);
+    void initialiseDate(Year year, OpenLoco::MonthId month, uint8_t day);
 
     /**
      * Loads the given scenario file, but does not initialise any game state.

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -1876,7 +1876,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             const auto company = CompanyManager::get(CompanyId(self.number));
 
-            uint32_t curYear = getCurrentYear();
+            auto curYear = getCurrentYear();
             uint8_t expenditureYears = std::min<uint8_t>(company->numExpenditureMonths, expenditureHistoryCapacity);
 
             // Paint years on top of scroll area.
@@ -2358,7 +2358,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             if ((playerCompany->challengeFlags & CompanyFlags::challengeCompleted) != 0)
             {
-                uint16_t years = objectiveCompletedChallengeInMonths / 12;
+                Year years = objectiveCompletedChallengeInMonths / 12;
                 uint16_t months = objectiveCompletedChallengeInMonths % 12;
 
                 auto args = FormatArguments::common(years, months);
@@ -2374,7 +2374,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             if ((playerCompany->challengeFlags & CompanyFlags::challengeBeatenByOpponent) != 0)
             {
-                uint16_t years = objectiveCompletedChallengeInMonths / 12;
+                Year years = objectiveCompletedChallengeInMonths / 12;
                 uint16_t months = objectiveCompletedChallengeInMonths % 12;
 
                 FormatArguments args{};
@@ -2396,7 +2396,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             {
                 // time limited challenge
                 uint16_t monthsLeft = objectiveTimeLimitYears * 12 - objectiveMonthsInChallenge;
-                uint16_t years = monthsLeft / 12;
+                Year years = monthsLeft / 12;
                 uint16_t months = monthsLeft % 12;
 
                 auto args = FormatArguments::common(years, months);

--- a/src/OpenLoco/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/Windows/IndustryWindow.cpp
@@ -601,7 +601,7 @@ namespace OpenLoco::Ui::Windows::Industry
             }
 
             MonthId month = getCurrentMonth();
-            int16_t year = getCurrentYear();
+            auto year = getCurrentYear();
             int8_t yearSkip = 0;
             // This is either 0 or 1 depending on selected tab
             // used to select the correct history

--- a/src/OpenLoco/Windows/Options.cpp
+++ b/src/OpenLoco/Windows/Options.cpp
@@ -1142,7 +1142,7 @@ namespace OpenLoco::Ui::Windows::Options
 
             if (Config::get().music_playlist == Config::MusicPlaylistType::currentEra)
             {
-                uint16_t year = getCurrentYear();
+                auto year = getCurrentYear();
                 for (int i = 0; i < Audio::kNumMusicTracks; i++)
                 {
                     auto info = Audio::getMusicInfo(i);

--- a/src/OpenLoco/Windows/TimePanel.cpp
+++ b/src/OpenLoco/Windows/TimePanel.cpp
@@ -352,7 +352,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
             if (objectiveFlags & 4)
             {
                 uint16_t monthsLeft = (*objectiveTimeLimitYears * 12 - objectiveMonthsInChallenge);
-                uint16_t yearsLeft = monthsLeft / 12;
+                Year yearsLeft = monthsLeft / 12;
                 monthsLeft = monthsLeft % 12;
                 args.push(StringIds::challenge_time_left);
                 args.push(yearsLeft);

--- a/src/OpenLoco/Windows/TownWindow.cpp
+++ b/src/OpenLoco/Windows/TownWindow.cpp
@@ -179,8 +179,8 @@ namespace OpenLoco::Ui::Windows::Town
                     auto town = TownManager::get(TownId(self->number));
 
                     const uint32_t ebx = (town->var_38 >> 3) + 5;
-                    const int16_t currentYear = getCurrentYear();
-                    int16_t tempYear = currentYear - 51;
+                    const auto currentYear = getCurrentYear();
+                    auto tempYear = currentYear - 51;
                     setCurrentYear(tempYear);
 
                     for (uint8_t i = 8; i > 0; i--)
@@ -418,7 +418,7 @@ namespace OpenLoco::Ui::Windows::Town
             }
 
             int8_t month = static_cast<int8_t>(getCurrentMonth());
-            int16_t year = getCurrentYear();
+            auto year = getCurrentYear();
             int8_t yearSkip = 0;
 
             for (uint8_t i = town->historySize - 1; i > 0; i--)


### PR DESCRIPTION
GameState stores year in `uint16_t` but it's passed around in various formats, some of which are inconsistent with others. This unifies them behind `using Year = uint16_t` to make it easier to rely on the year being the right type/size.