### PR TITLE
Drawing Engine Palette Refactoring

### DIFF
--- a/src/OpenLoco/Drawing/SoftwareDrawingEngine.h
+++ b/src/OpenLoco/Drawing/SoftwareDrawingEngine.h
@@ -5,16 +5,27 @@
 #include <algorithm>
 #include <cstddef>
 
+struct SDL_Palette;
+
 namespace OpenLoco::Drawing
 {
+    struct PaletteEntry;
+
     class SoftwareDrawingEngine
     {
     public:
+        ~SoftwareDrawingEngine();
         void drawDirtyBlocks();
         void drawRect(const Ui::Rect& rect);
         void setDirtyBlocks(int32_t left, int32_t top, int32_t right, int32_t bottom);
 
+        void createPalette();
+        SDL_Palette* getPalette() { return _palette; }
+        void updatePalette(const PaletteEntry* entries, int32_t index, int32_t count);
+
     private:
         void drawDirtyBlocks(size_t x, size_t y, size_t dx, size_t dy);
+
+        SDL_Palette* _palette;
     };
 }

--- a/src/OpenLoco/Graphics/Gfx.cpp
+++ b/src/OpenLoco/Graphics/Gfx.cpp
@@ -1281,7 +1281,16 @@ namespace OpenLoco::Gfx
         setDirtyBlocks(0, 0, Ui::width(), Ui::height());
     }
 
-    Drawing::SoftwareDrawingEngine* engine;
+    static std::unique_ptr<Drawing::SoftwareDrawingEngine> engine;
+
+    static Drawing::SoftwareDrawingEngine& getDrawingEngine()
+    {
+        if (!engine)
+        {
+            engine = std::make_unique<Drawing::SoftwareDrawingEngine>();
+        }
+        return *engine;
+    }
 
     /**
      * 0x004C5C69
@@ -1293,19 +1302,13 @@ namespace OpenLoco::Gfx
      */
     void setDirtyBlocks(int32_t left, int32_t top, int32_t right, int32_t bottom)
     {
-        if (engine == nullptr)
-            engine = new Drawing::SoftwareDrawingEngine();
-
-        engine->setDirtyBlocks(left, top, right, bottom);
+        getDrawingEngine().setDirtyBlocks(left, top, right, bottom);
     }
 
     // 0x004C5CFA
     void drawDirtyBlocks()
     {
-        if (engine == nullptr)
-            engine = new Drawing::SoftwareDrawingEngine();
-
-        engine->drawDirtyBlocks();
+        getDrawingEngine().drawDirtyBlocks();
     }
 
     loco_global<char[512], 0x0112CC04> byte_112CC04;
@@ -1314,9 +1317,6 @@ namespace OpenLoco::Gfx
     // 0x004CF63B
     void render()
     {
-        if (engine == nullptr)
-            engine = new Drawing::SoftwareDrawingEngine();
-
         char backup1[512] = { 0 };
         char backup2[512] = { 0 };
 
@@ -1325,7 +1325,7 @@ namespace OpenLoco::Gfx
 
         if (Ui::dirtyBlocksInitialised())
         {
-            engine->drawDirtyBlocks();
+            getDrawingEngine().drawDirtyBlocks();
         }
 
         if (Input::hasFlag(Input::Flags::flag5))
@@ -1348,7 +1348,7 @@ namespace OpenLoco::Gfx
 
     void redrawScreenRect(Rect rect)
     {
-        engine->drawRect(rect);
+        getDrawingEngine().drawRect(rect);
     }
 
     /**

--- a/src/OpenLoco/Graphics/Gfx.cpp
+++ b/src/OpenLoco/Graphics/Gfx.cpp
@@ -1283,7 +1283,7 @@ namespace OpenLoco::Gfx
 
     static std::unique_ptr<Drawing::SoftwareDrawingEngine> engine;
 
-    static Drawing::SoftwareDrawingEngine& getDrawingEngine()
+    Drawing::SoftwareDrawingEngine& getDrawingEngine()
     {
         if (!engine)
         {

--- a/src/OpenLoco/Graphics/Gfx.h
+++ b/src/OpenLoco/Graphics/Gfx.h
@@ -12,6 +12,11 @@ namespace OpenLoco
     using Colour_t = uint8_t;
 }
 
+namespace OpenLoco::Drawing
+{
+    class SoftwareDrawingEngine;
+}
+
 namespace OpenLoco::Gfx
 {
 #pragma pack(push, 1)
@@ -250,4 +255,6 @@ namespace OpenLoco::Gfx
 
     void setCurrentFontSpriteBase(int16_t value);
     void loadPalette();
+
+    Drawing::SoftwareDrawingEngine& getDrawingEngine();
 }

--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -108,17 +108,17 @@ static int STDCALL getNumDSoundDevices()
 
 #pragma pack(push, 1)
 
-struct palette_entry_t
+struct PaletteEntry
 {
     uint8_t b, g, r, a;
 };
 #pragma pack(pop)
-using set_palette_func = void (*)(const palette_entry_t* palette, int32_t index, int32_t count);
-static Interop::loco_global<set_palette_func, 0x0052524C> set_palette_callback;
+using SetPaletteFunc = void (*)(const PaletteEntry* palette, int32_t index, int32_t count);
+static Interop::loco_global<SetPaletteFunc, 0x0052524C> set_palette_callback;
 
 #ifdef _NO_LOCO_WIN32_
 FORCE_ALIGN_ARG_POINTER
-static void CDECL fn_4054a3(const palette_entry_t* palette, int32_t index, int32_t count)
+static void CDECL fn_4054a3(const PaletteEntry* palette, int32_t index, int32_t count)
 {
     if (set_palette_callback != nullptr)
     {


### PR DESCRIPTION
Moving the SDL_Palette into the SoftwareDrawingEngine to simplify future work. This fixes a few very very minor memory leaks.