### PR TITLE
Fix multiple object loading bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: [#1280] Crash when removing crashed vehicles with news window open.
 - Fix: [#1320] Inability to mark scenario as complete.
 - Fix: [#1325] Crash when saving second loaded scenario of a playthrough.
+- Fix: [#1328] Various object loading bugs related to custom object files causing crashes on load.
 - Change: [#1276] Transfering cargo is now viable. The cargo age is calculated as the weighted average of the present and delivered cargo.
 
 22.02 (2022-02-06)

--- a/src/OpenLoco/Interop/Interop.cpp
+++ b/src/OpenLoco/Interop/Interop.cpp
@@ -256,7 +256,7 @@ namespace OpenLoco::Interop
         OpenLoco::Console::groupEnd();
 #endif
         // lahf only modifies ah, zero out the rest
-        return result & 0xFF00;
+        return (result >> 8) & 0xFF;
     }
 
 #ifdef _ENABLE_CALL_BYVALUE_

--- a/src/OpenLoco/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/Objects/ObjectManager.cpp
@@ -1035,15 +1035,12 @@ namespace OpenLoco::ObjectManager
         for (const auto& header : objects)
         {
             auto id = getObjectId(index);
-            if (!header.isEmpty())
+            if (!header.isEmpty() && !load(header, id))
             {
-                if (!load(header, id))
-                {
-                    result.success = false;
-                    result.problemObject = header;
-                    unloadAll();
-                    break;
-                }
+                result.success = false;
+                result.problemObject = header;
+                unloadAll();
+                break;
             }
             index++;
         }

--- a/src/OpenLoco/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/Objects/ObjectManager.cpp
@@ -985,7 +985,7 @@ namespace OpenLoco::ObjectManager
         registers regs;
         regs.al = static_cast<uint8_t>(proc);
         regs.esi = X86Pointer(&obj);
-        return (call(objectProc, regs) & (X86_FLAG_CARRY << 8)) == 0;
+        return (call(objectProc, regs) & X86_FLAG_CARRY) == 0;
     }
 
     static bool callObjectFunction(const LoadedObjectHandle handle, ObjectProcedure proc)
@@ -1005,7 +1005,7 @@ namespace OpenLoco::ObjectManager
         registers regs;
         regs.ebp = X86Pointer(&header);
         regs.ecx = static_cast<int32_t>(id);
-        return (call(0x00471BC5, regs) & (X86_FLAG_CARRY << 8)) == 0;
+        return (call(0x00471BC5, regs) & X86_FLAG_CARRY) == 0;
     }
 
     static LoadedObjectId getObjectId(LoadedObjectIndex index)

--- a/src/OpenLoco/Scenario.cpp
+++ b/src/OpenLoco/Scenario.cpp
@@ -308,7 +308,7 @@ namespace OpenLoco::Scenario
         static loco_global<char[512], 0x00112CE04> scenarioFilename;
         std::strncpy(&*scenarioFilename, fullPath.u8string().c_str(), std::size(scenarioFilename));
         auto flags = call(0x00442837);
-        return (flags & (Interop::X86_FLAG_CARRY << 8)) == 0;
+        return (flags & Interop::X86_FLAG_CARRY) == 0;
     }
 
     void start()

--- a/src/OpenLoco/Scenario.cpp
+++ b/src/OpenLoco/Scenario.cpp
@@ -308,7 +308,7 @@ namespace OpenLoco::Scenario
         static loco_global<char[512], 0x00112CE04> scenarioFilename;
         std::strncpy(&*scenarioFilename, fullPath.u8string().c_str(), std::size(scenarioFilename));
         auto flags = call(0x00442837);
-        return (flags & Interop::X86_FLAG_CARRY) == 0;
+        return (flags & (Interop::X86_FLAG_CARRY << 8)) == 0;
     }
 
     void start()

--- a/src/OpenLoco/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/Vehicles/Vehicle.cpp
@@ -205,7 +205,7 @@ namespace OpenLoco::Vehicles
             default:
                 break;
         }
-        return (result & (1 << 8)) != 0;
+        return (result & X86_FLAG_CARRY) != 0;
     }
 
     CarComponent::CarComponent(VehicleBase*& component)

--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -3193,7 +3193,7 @@ namespace OpenLoco::Vehicles
     {
         registers regs;
         regs.esi = X86Pointer(this);
-        return call(0x004AC1C2, regs) & (1 << 8);
+        return call(0x004AC1C2, regs) & X86_FLAG_CARRY;
     }
 
     // 0x004AC0A3
@@ -3201,7 +3201,7 @@ namespace OpenLoco::Vehicles
     {
         registers regs;
         regs.esi = X86Pointer(this);
-        return call(0x004AC0A3, regs) & (1 << 8);
+        return call(0x004AC0A3, regs) & X86_FLAG_CARRY;
     }
 
     // 0x004ACCDC
@@ -3209,7 +3209,7 @@ namespace OpenLoco::Vehicles
     {
         registers regs;
         regs.esi = X86Pointer(this);
-        return call(0x004ACCDC, regs) & (1 << 8);
+        return call(0x004ACCDC, regs) & X86_FLAG_CARRY;
     }
 
     // 0x004AD93A

--- a/src/OpenLoco/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/Windows/Construction/ConstructionTab.cpp
@@ -1804,7 +1804,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         regs.bx = y;
         auto flags = call(0x00478361, regs);
 
-        if (flags & (1 << 8))
+        if (flags & X86_FLAG_CARRY)
             return std::nullopt;
 
         return { std::make_pair(regs.di, regs.dl) };
@@ -1818,7 +1818,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         regs.bx = y;
         auto flags = call(0x004A4011, regs);
 
-        if (flags & (1 << 8))
+        if (flags & X86_FLAG_CARRY)
             return std::nullopt;
 
         return { std::make_pair(regs.di, regs.dl) };

--- a/src/OpenLoco/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/Windows/ObjectSelectionWindow.cpp
@@ -789,7 +789,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         regs.bx = bx;
         regs.ebp = X86Pointer(ebp);
 
-        return call(0x00473D1D, regs) & (1 << 8);
+        return call(0x00473D1D, regs) & X86_FLAG_CARRY;
     }
 
     // 0x00473948


### PR DESCRIPTION
One bug meant that object loading would never fail causing unexpected crashes later on. The other bug was that the object count was incorrect when rebuilding an index.