### PR TITLE
Rename object function to getObject

### DIFF
--- a/src/OpenLoco/Company.cpp
+++ b/src/OpenLoco/Company.cpp
@@ -412,7 +412,7 @@ namespace OpenLoco
             Vehicles::Vehicle train(v);
             for (auto& car : train.cars)
             {
-                auto* vehObject = car.body->getObject();
+                const auto* vehObject = car.body->getObject();
                 auto colour = mainColours;
                 if (customVehicleColoursSet & (1 << vehObject->colour_type))
                 {

--- a/src/OpenLoco/Company.cpp
+++ b/src/OpenLoco/Company.cpp
@@ -412,7 +412,7 @@ namespace OpenLoco
             Vehicles::Vehicle train(v);
             for (auto& car : train.cars)
             {
-                auto* vehObject = car.body->object();
+                auto* vehObject = car.body->getObject();
                 auto colour = mainColours;
                 if (customVehicleColoursSet & (1 << vehObject->colour_type))
                 {

--- a/src/OpenLoco/Entities/Misc.cpp
+++ b/src/OpenLoco/Entities/Misc.cpp
@@ -46,7 +46,7 @@ namespace OpenLoco
         }
     }
 
-    SteamObject* Exhaust::object() const
+    const SteamObject* Exhaust::getObject() const
     {
         return ObjectManager::get<SteamObject>(objectId & 0x7F);
     }
@@ -79,7 +79,7 @@ namespace OpenLoco
             _exhaust->base_type = EntityBaseType::misc;
             _exhaust->moveTo(loc);
             _exhaust->objectId = type;
-            auto obj = _exhaust->object();
+            auto obj = _exhaust->getObject();
             _exhaust->var_14 = obj->var_05;
             _exhaust->var_09 = obj->var_06;
             _exhaust->var_15 = obj->var_07;

--- a/src/OpenLoco/Entities/Misc.cpp
+++ b/src/OpenLoco/Entities/Misc.cpp
@@ -79,7 +79,7 @@ namespace OpenLoco
             _exhaust->base_type = EntityBaseType::misc;
             _exhaust->moveTo(loc);
             _exhaust->objectId = type;
-            auto obj = _exhaust->getObject();
+            const auto* obj = _exhaust->getObject();
             _exhaust->var_14 = obj->var_05;
             _exhaust->var_09 = obj->var_06;
             _exhaust->var_15 = obj->var_07;

--- a/src/OpenLoco/Entities/Misc.h
+++ b/src/OpenLoco/Entities/Misc.h
@@ -66,7 +66,7 @@ namespace OpenLoco
         uint8_t pad_38[0x49 - 0x38];
         uint8_t objectId; // 0x49
 
-        SteamObject* object() const;
+        const SteamObject* getObject() const;
         void update();
 
         static Exhaust* create(Map::Pos3 loc, uint8_t type);

--- a/src/OpenLoco/Industry.cpp
+++ b/src/OpenLoco/Industry.cpp
@@ -82,7 +82,7 @@ namespace OpenLoco
     {
         char* ptr = (char*)buffer;
         *ptr = '\0';
-        auto industryObj = getObject();
+        const auto* industryObj = getObject();
 
         // Closing Down
         if (flags & IndustryFlags::closingDown)
@@ -156,7 +156,7 @@ namespace OpenLoco
                 if (surface->industryId() == id())
                 {
                     uint8_t bl = surface->var_6_SLR5();
-                    auto obj = getObject();
+                    const auto* obj = getObject();
                     if (bl == 0 || bl != obj->var_EA)
                     {
                         // loc_4532E5
@@ -179,7 +179,7 @@ namespace OpenLoco
         int16_t tmp_c = var_DB - tmp_b;
         int16_t tmp_d = std::min(tmp_c / 25, 255);
 
-        auto obj = getObject();
+        const auto* obj = getObject();
         if (tmp_d < obj->var_EB)
         {
             var_DF = ((tmp_d * 256) / obj->var_EB) & 0xFF;
@@ -247,7 +247,7 @@ namespace OpenLoco
                 auto tileIndustry = industryEl->industry();
                 if (tileIndustry != nullptr)
                 {
-                    auto industryObject = tileIndustry->getObject();
+                    const auto* industryObject = tileIndustry->getObject();
                     if (industryObject != nullptr)
                     {
                         auto animOffsets = word_4F9274;

--- a/src/OpenLoco/Industry.cpp
+++ b/src/OpenLoco/Industry.cpp
@@ -31,7 +31,7 @@ namespace OpenLoco
         { { Location::null, 0 }, 0 }
     };
 
-    IndustryObject* Industry::object() const
+    const IndustryObject* Industry::getObject() const
     {
         return ObjectManager::get<IndustryObject>(object_id);
     }
@@ -82,7 +82,7 @@ namespace OpenLoco
     {
         char* ptr = (char*)buffer;
         *ptr = '\0';
-        auto industryObj = object();
+        auto industryObj = getObject();
 
         // Closing Down
         if (flags & IndustryFlags::closingDown)
@@ -156,7 +156,7 @@ namespace OpenLoco
                 if (surface->industryId() == id())
                 {
                     uint8_t bl = surface->var_6_SLR5();
-                    auto obj = object();
+                    auto obj = getObject();
                     if (bl == 0 || bl != obj->var_EA)
                     {
                         // loc_4532E5
@@ -179,7 +179,7 @@ namespace OpenLoco
         int16_t tmp_c = var_DB - tmp_b;
         int16_t tmp_d = std::min(tmp_c / 25, 255);
 
-        auto obj = object();
+        auto obj = getObject();
         if (tmp_d < obj->var_EB)
         {
             var_DF = ((tmp_d * 256) / obj->var_EB) & 0xFF;
@@ -247,7 +247,7 @@ namespace OpenLoco
                 auto tileIndustry = industryEl->industry();
                 if (tileIndustry != nullptr)
                 {
-                    auto industryObject = tileIndustry->object();
+                    auto industryObject = tileIndustry->getObject();
                     if (industryObject != nullptr)
                     {
                         auto animOffsets = word_4F9274;

--- a/src/OpenLoco/Industry.h
+++ b/src/OpenLoco/Industry.h
@@ -52,7 +52,7 @@ namespace OpenLoco
         uint8_t pad_393[0x453 - 0x393];
 
         IndustryId id() const;
-        IndustryObject* object() const;
+        const IndustryObject* getObject() const;
         bool empty() const;
         bool canReceiveCargo() const;
         bool canProduceCargo() const;

--- a/src/OpenLoco/IndustryManager.cpp
+++ b/src/OpenLoco/IndustryManager.cpp
@@ -74,7 +74,7 @@ namespace OpenLoco::IndustryManager
     {
         for (auto& industry : industries())
         {
-            auto industryObj = industry.object();
+            auto industryObj = industry.getObject();
             if ((industryObj->flags & flags) == 0)
                 continue;
 

--- a/src/OpenLoco/IndustryManager.cpp
+++ b/src/OpenLoco/IndustryManager.cpp
@@ -74,7 +74,7 @@ namespace OpenLoco::IndustryManager
     {
         for (auto& industry : industries())
         {
-            auto industryObj = industry.getObject();
+            const auto* industryObj = industry.getObject();
             if ((industryObj->flags & flags) == 0)
                 continue;
 

--- a/src/OpenLoco/Map/BuildingTile.cpp
+++ b/src/OpenLoco/Map/BuildingTile.cpp
@@ -35,7 +35,7 @@ namespace OpenLoco::Map
             return true;
         }
 
-        auto* buildingObj = object();
+        auto* buildingObj = getObject();
         if (!isConstructed())
         {
             auto newUnk5u = unk5u();

--- a/src/OpenLoco/Map/BuildingTile.cpp
+++ b/src/OpenLoco/Map/BuildingTile.cpp
@@ -35,7 +35,7 @@ namespace OpenLoco::Map
             return true;
         }
 
-        auto* buildingObj = getObject();
+        const auto* buildingObj = getObject();
         if (!isConstructed())
         {
             auto newUnk5u = unk5u();

--- a/src/OpenLoco/Map/Tile.cpp
+++ b/src/OpenLoco/Map/Tile.cpp
@@ -26,7 +26,7 @@ bool TileElementBase::isLast() const
     return (_flags & ElementFlags::last) != 0;
 }
 
-BuildingObject* BuildingElement::object() const
+const BuildingObject* BuildingElement::getObject() const
 {
     return ObjectManager::get<BuildingObject>(objectId());
 }

--- a/src/OpenLoco/Map/Tile.h
+++ b/src/OpenLoco/Map/Tile.h
@@ -260,7 +260,7 @@ namespace OpenLoco::Map
         uint8_t colour() const { return _6 >> 11; }
         void setColour(Colour_t colour) { _6 = (_6 & 0x7FF) | (colour << 11); }
         uint8_t objectId() const { return _4; }
-        BuildingObject* object() const;
+        const BuildingObject* getObject() const;
         uint8_t multiTileIndex() const { return _5 & 3; }
         uint8_t unk5u() const { return _5 >> 5; } // likely age related as well (higher precision)
         void setUnk5u(uint8_t value)

--- a/src/OpenLoco/Objects/IndustryObject.cpp
+++ b/src/OpenLoco/Objects/IndustryObject.cpp
@@ -39,7 +39,7 @@ namespace OpenLoco
         return produceCargoState;
     }
 
-    char* IndustryObject::getProducedCargoString(const char* buffer)
+    char* IndustryObject::getProducedCargoString(const char* buffer) const
     {
         char* ptr = (char*)buffer;
         auto producedCargoCount = 0;
@@ -60,7 +60,7 @@ namespace OpenLoco
         return ptr;
     }
 
-    char* IndustryObject::getRequiredCargoString(const char* buffer)
+    char* IndustryObject::getRequiredCargoString(const char* buffer) const
     {
         char* ptr = (char*)buffer;
         auto requiredCargoCount = 0;

--- a/src/OpenLoco/Objects/IndustryObject.h
+++ b/src/OpenLoco/Objects/IndustryObject.h
@@ -51,8 +51,8 @@ namespace OpenLoco
 
         bool requiresCargo() const;
         bool producesCargo() const;
-        char* getProducedCargoString(const char* buffer);
-        char* getRequiredCargoString(const char* buffer);
+        char* getProducedCargoString(const char* buffer) const;
+        char* getRequiredCargoString(const char* buffer) const;
         void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
         void drawIndustry(Gfx::Context* clipped, int16_t x, int16_t y) const;
     };

--- a/src/OpenLoco/Paint/PaintMiscEntity.cpp
+++ b/src/OpenLoco/Paint/PaintMiscEntity.cpp
@@ -48,7 +48,7 @@ namespace OpenLoco::Paint
         {
             return;
         }
-        SteamObject* steamObject = exhaustEntity->object();
+        auto* steamObject = exhaustEntity->getObject();
 
         uint8_t* edi = (exhaustEntity->objectId & 0x80) == 0 ? steamObject->var_16 : steamObject->var_1A;
         uint32_t imageId = edi[2 * exhaustEntity->var_26];

--- a/src/OpenLoco/Paint/PaintMiscEntity.cpp
+++ b/src/OpenLoco/Paint/PaintMiscEntity.cpp
@@ -48,7 +48,7 @@ namespace OpenLoco::Paint
         {
             return;
         }
-        auto* steamObject = exhaustEntity->getObject();
+        const auto* steamObject = exhaustEntity->getObject();
 
         uint8_t* edi = (exhaustEntity->objectId & 0x80) == 0 ? steamObject->var_16 : steamObject->var_1A;
         uint32_t imageId = edi[2 * exhaustEntity->var_26];

--- a/src/OpenLoco/Station.cpp
+++ b/src/OpenLoco/Station.cpp
@@ -316,7 +316,7 @@ namespace OpenLoco
                                 {
                                     break;
                                 }
-                                auto obj = industry->getObject();
+                                const auto* obj = industry->getObject();
 
                                 if (obj == nullptr)
                                 {
@@ -351,7 +351,7 @@ namespace OpenLoco
                                     break;
                                 }
 
-                                auto* obj = buildingEl.getObject();
+                                const auto* obj = buildingEl.getObject();
 
                                 if (obj == nullptr)
                                 {

--- a/src/OpenLoco/Station.cpp
+++ b/src/OpenLoco/Station.cpp
@@ -316,7 +316,7 @@ namespace OpenLoco
                                 {
                                     break;
                                 }
-                                auto obj = industry->object();
+                                auto obj = industry->getObject();
 
                                 if (obj == nullptr)
                                 {
@@ -351,7 +351,7 @@ namespace OpenLoco
                                     break;
                                 }
 
-                                auto* obj = buildingEl.object();
+                                auto* obj = buildingEl.getObject();
 
                                 if (obj == nullptr)
                                 {

--- a/src/OpenLoco/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/Ui/ViewportInteraction.cpp
@@ -742,7 +742,7 @@ namespace OpenLoco::Ui::ViewportInteraction
             return false;
         }
 
-        auto* buildingObj = building->getObject();
+        const auto* buildingObj = building->getObject();
         auto args = FormatArguments::mapToolTip();
         if (isEditorMode() || !(buildingObj->flags & BuildingObjectFlags::undestructible))
         {
@@ -802,7 +802,7 @@ namespace OpenLoco::Ui::ViewportInteraction
             return false;
         }
 
-        auto* buildingObj = building->getObject();
+        const auto* buildingObj = building->getObject();
         auto* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_338));
         buffer = StringManager::formatString(buffer, buildingObj->name);
         if (!building->isConstructed())

--- a/src/OpenLoco/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/Ui/ViewportInteraction.cpp
@@ -742,7 +742,7 @@ namespace OpenLoco::Ui::ViewportInteraction
             return false;
         }
 
-        auto* buildingObj = building->object();
+        auto* buildingObj = building->getObject();
         auto args = FormatArguments::mapToolTip();
         if (isEditorMode() || !(buildingObj->flags & BuildingObjectFlags::undestructible))
         {
@@ -802,7 +802,7 @@ namespace OpenLoco::Ui::ViewportInteraction
             return false;
         }
 
-        auto* buildingObj = building->object();
+        auto* buildingObj = building->getObject();
         auto* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_338));
         buffer = StringManager::formatString(buffer, buildingObj->name);
         if (!building->isConstructed())

--- a/src/OpenLoco/Vehicles/Vehicle.h
+++ b/src/OpenLoco/Vehicles/Vehicle.h
@@ -514,7 +514,7 @@ namespace OpenLoco::Vehicles
         uint8_t var_5E;
         uint8_t var_5F;
 
-        VehicleObject* object() const;
+        const VehicleObject* getObject() const;
         bool update();
         void secondaryAnimationUpdate();
         void sub_4AAB0B();

--- a/src/OpenLoco/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/Vehicles/VehicleBody.cpp
@@ -89,7 +89,7 @@ namespace OpenLoco::Vehicles
         if ((headVeh->status == Status::crashed) || (headVeh->status == Status::stuck))
             return;
 
-        auto vehicleObject = getObject();
+        const auto* vehicleObject = getObject();
         int32_t var_05 = vehicleObject->var_24[bodyIndex].var_05;
         if (var_05 == 0)
         {
@@ -142,7 +142,7 @@ namespace OpenLoco::Vehicles
         if (objectSpriteType == 0xFF)
             return;
 
-        auto vehicleObj = getObject();
+        const auto* vehicleObj = getObject();
         uint8_t al = 0;
         if (vehicleObj->bodySprites[objectSpriteType].flags & BodySpriteFlags::hasSpeedAnimation)
         {
@@ -243,7 +243,7 @@ namespace OpenLoco::Vehicles
 
         auto bogieDifference = front_bogie->position - back_bogie->position;
         auto distanceBetweenBogies = Math::Vector::distance(front_bogie->position, back_bogie->position);
-        auto vehObj = getObject();
+        const auto* vehObj = getObject();
         if (vehObj->bodySprites[objectSpriteType].flags & BodySpriteFlags::hasSteepSprites)
         {
             sprite_pitch = updateSpritePitchSteepSlopes(distanceBetweenBogies, bogieDifference.z);
@@ -858,7 +858,7 @@ namespace OpenLoco::Vehicles
     // 0x004AB655
     void VehicleBody::secondaryAnimationUpdate()
     {
-        auto vehicleObject = getObject();
+        const auto* vehicleObject = getObject();
 
         uint8_t var_05 = vehicleObject->var_24[bodyIndex].var_05;
         if (var_05 == 0)
@@ -899,7 +899,7 @@ namespace OpenLoco::Vehicles
     // 0x004AB688, 0x004AACA5
     void VehicleBody::steamPuffsAnimationUpdate(uint8_t num, int32_t var_05)
     {
-        auto vehicleObject = getObject();
+        const auto* vehicleObject = getObject();
         VehicleBogie* frontBogie = vehicleUpdate_frontBogie;
         VehicleBogie* backBogie = vehicleUpdate_backBogie;
         if (frontBogie->var_5F & Flags5F::brokenDown)
@@ -1051,7 +1051,7 @@ namespace OpenLoco::Vehicles
 
         VehicleHead* headVeh = vehicleUpdate_head;
         Vehicle2* veh_2 = vehicleUpdate_2;
-        auto vehicleObject = getObject();
+        const auto* vehicleObject = getObject();
 
         if (headVeh->vehicleType == VehicleType::ship)
         {
@@ -1108,7 +1108,7 @@ namespace OpenLoco::Vehicles
             return;
 
         Vehicle2* veh_2 = vehicleUpdate_2;
-        auto vehicleObject = getObject();
+        const auto* vehicleObject = getObject();
 
         if (veh_2->var_5A != 1)
             return;
@@ -1156,7 +1156,7 @@ namespace OpenLoco::Vehicles
             return;
 
         Vehicle2* veh_2 = vehicleUpdate_2;
-        auto vehicleObject = getObject();
+        const auto* vehicleObject = getObject();
 
         if (veh_2->var_5A != 2 && veh_2->var_5A != 1)
             return;
@@ -1193,7 +1193,7 @@ namespace OpenLoco::Vehicles
             return;
 
         Vehicle2* veh_2 = vehicleUpdate_2;
-        auto vehicleObject = getObject();
+        const auto* vehicleObject = getObject();
 
         if (veh_2->var_5A != 2 && veh_2->var_5A != 1)
             return;
@@ -1243,7 +1243,7 @@ namespace OpenLoco::Vehicles
     void VehicleBody::shipWakeAnimationUpdate(uint8_t num, int32_t)
     {
         Vehicle2* veh_2 = vehicleUpdate_2;
-        auto vehicleObject = getObject();
+        const auto* vehicleObject = getObject();
 
         if (veh_2->var_5A == 0)
             return;
@@ -1308,7 +1308,7 @@ namespace OpenLoco::Vehicles
             return;
         }
 
-        auto vehicleObj = getObject();
+        const auto* vehicleObj = getObject();
         auto& bodySprite = vehicleObj->bodySprites[objectSpriteType];
 
         auto percentageFull = std::min((primaryCargo.qty * 256) / primaryCargo.maxQty, 255);

--- a/src/OpenLoco/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/Vehicles/VehicleBody.cpp
@@ -42,7 +42,7 @@ namespace OpenLoco::Vehicles
         Pitch::down25deg,
     };
 
-    VehicleObject* VehicleBody::object() const
+    const VehicleObject* VehicleBody::getObject() const
     {
         return ObjectManager::get<VehicleObject>(objectId);
     }
@@ -89,7 +89,7 @@ namespace OpenLoco::Vehicles
         if ((headVeh->status == Status::crashed) || (headVeh->status == Status::stuck))
             return;
 
-        auto vehicleObject = object();
+        auto vehicleObject = getObject();
         int32_t var_05 = vehicleObject->var_24[bodyIndex].var_05;
         if (var_05 == 0)
         {
@@ -142,7 +142,7 @@ namespace OpenLoco::Vehicles
         if (objectSpriteType == 0xFF)
             return;
 
-        auto vehicleObj = object();
+        auto vehicleObj = getObject();
         uint8_t al = 0;
         if (vehicleObj->bodySprites[objectSpriteType].flags & BodySpriteFlags::hasSpeedAnimation)
         {
@@ -243,7 +243,7 @@ namespace OpenLoco::Vehicles
 
         auto bogieDifference = front_bogie->position - back_bogie->position;
         auto distanceBetweenBogies = Math::Vector::distance(front_bogie->position, back_bogie->position);
-        auto vehObj = object();
+        auto vehObj = getObject();
         if (vehObj->bodySprites[objectSpriteType].flags & BodySpriteFlags::hasSteepSprites)
         {
             sprite_pitch = updateSpritePitchSteepSlopes(distanceBetweenBogies, bogieDifference.z);
@@ -858,7 +858,7 @@ namespace OpenLoco::Vehicles
     // 0x004AB655
     void VehicleBody::secondaryAnimationUpdate()
     {
-        auto vehicleObject = object();
+        auto vehicleObject = getObject();
 
         uint8_t var_05 = vehicleObject->var_24[bodyIndex].var_05;
         if (var_05 == 0)
@@ -899,7 +899,7 @@ namespace OpenLoco::Vehicles
     // 0x004AB688, 0x004AACA5
     void VehicleBody::steamPuffsAnimationUpdate(uint8_t num, int32_t var_05)
     {
-        auto vehicleObject = object();
+        auto vehicleObject = getObject();
         VehicleBogie* frontBogie = vehicleUpdate_frontBogie;
         VehicleBogie* backBogie = vehicleUpdate_backBogie;
         if (frontBogie->var_5F & Flags5F::brokenDown)
@@ -1051,7 +1051,7 @@ namespace OpenLoco::Vehicles
 
         VehicleHead* headVeh = vehicleUpdate_head;
         Vehicle2* veh_2 = vehicleUpdate_2;
-        auto vehicleObject = object();
+        auto vehicleObject = getObject();
 
         if (headVeh->vehicleType == VehicleType::ship)
         {
@@ -1108,7 +1108,7 @@ namespace OpenLoco::Vehicles
             return;
 
         Vehicle2* veh_2 = vehicleUpdate_2;
-        auto vehicleObject = object();
+        auto vehicleObject = getObject();
 
         if (veh_2->var_5A != 1)
             return;
@@ -1156,7 +1156,7 @@ namespace OpenLoco::Vehicles
             return;
 
         Vehicle2* veh_2 = vehicleUpdate_2;
-        auto vehicleObject = object();
+        auto vehicleObject = getObject();
 
         if (veh_2->var_5A != 2 && veh_2->var_5A != 1)
             return;
@@ -1193,7 +1193,7 @@ namespace OpenLoco::Vehicles
             return;
 
         Vehicle2* veh_2 = vehicleUpdate_2;
-        auto vehicleObject = object();
+        auto vehicleObject = getObject();
 
         if (veh_2->var_5A != 2 && veh_2->var_5A != 1)
             return;
@@ -1243,7 +1243,7 @@ namespace OpenLoco::Vehicles
     void VehicleBody::shipWakeAnimationUpdate(uint8_t num, int32_t)
     {
         Vehicle2* veh_2 = vehicleUpdate_2;
-        auto vehicleObject = object();
+        auto vehicleObject = getObject();
 
         if (veh_2->var_5A == 0)
             return;
@@ -1308,7 +1308,7 @@ namespace OpenLoco::Vehicles
             return;
         }
 
-        auto vehicleObj = object();
+        auto vehicleObj = getObject();
         auto& bodySprite = vehicleObj->bodySprites[objectSpriteType];
 
         auto percentageFull = std::min((primaryCargo.qty * 256) / primaryCargo.maxQty, 255);

--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -2208,7 +2208,7 @@ namespace OpenLoco::Vehicles
         }
 
         Vehicle train(this);
-        auto* vehObj = train.cars.firstCar.body->object();
+        auto* vehObj = train.cars.firstCar.body->getObject();
         if (vehObj != nullptr && vehObj->numStartSounds != 0)
         {
             auto numSounds = vehObj->numStartSounds & NumStartSounds::mask;
@@ -2618,7 +2618,7 @@ namespace OpenLoco::Vehicles
             if (cargoStats.industryId != IndustryId::null)
             {
                 auto* industry = IndustryManager::get(cargoStats.industryId);
-                auto* industryObj = industry->object();
+                auto* industryObj = industry->getObject();
 
                 for (auto i = 0; i < 3; ++i)
                 {
@@ -3123,7 +3123,7 @@ namespace OpenLoco::Vehicles
     void VehicleHead::produceLeavingDockSound()
     {
         Vehicle train(this);
-        auto* vehObj = train.cars.firstCar.body->object();
+        auto* vehObj = train.cars.firstCar.body->getObject();
         if (vehObj != nullptr && vehObj->numStartSounds != 0)
         {
             auto randSoundIndex = gPrng().randNext((vehObj->numStartSounds & NumStartSounds::mask) - 1);
@@ -3148,7 +3148,7 @@ namespace OpenLoco::Vehicles
     void VehicleHead::produceTouchdownAirportSound()
     {
         Vehicle train(this);
-        auto* vehObj = train.cars.firstCar.body->object();
+        auto* vehObj = train.cars.firstCar.body->getObject();
         if (vehObj != nullptr && vehObj->numStartSounds != 0)
         {
 

--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -2208,7 +2208,7 @@ namespace OpenLoco::Vehicles
         }
 
         Vehicle train(this);
-        auto* vehObj = train.cars.firstCar.body->getObject();
+        const auto* vehObj = train.cars.firstCar.body->getObject();
         if (vehObj != nullptr && vehObj->numStartSounds != 0)
         {
             auto numSounds = vehObj->numStartSounds & NumStartSounds::mask;
@@ -2618,7 +2618,7 @@ namespace OpenLoco::Vehicles
             if (cargoStats.industryId != IndustryId::null)
             {
                 auto* industry = IndustryManager::get(cargoStats.industryId);
-                auto* industryObj = industry->getObject();
+                const auto* industryObj = industry->getObject();
 
                 for (auto i = 0; i < 3; ++i)
                 {
@@ -3123,7 +3123,7 @@ namespace OpenLoco::Vehicles
     void VehicleHead::produceLeavingDockSound()
     {
         Vehicle train(this);
-        auto* vehObj = train.cars.firstCar.body->getObject();
+        const auto* vehObj = train.cars.firstCar.body->getObject();
         if (vehObj != nullptr && vehObj->numStartSounds != 0)
         {
             auto randSoundIndex = gPrng().randNext((vehObj->numStartSounds & NumStartSounds::mask) - 1);
@@ -3148,7 +3148,7 @@ namespace OpenLoco::Vehicles
     void VehicleHead::produceTouchdownAirportSound()
     {
         Vehicle train(this);
-        auto* vehObj = train.cars.firstCar.body->getObject();
+        const auto* vehObj = train.cars.firstCar.body->getObject();
         if (vehObj != nullptr && vehObj->numStartSounds != 0)
         {
 

--- a/src/OpenLoco/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/Windows/Construction/StationTab.cpp
@@ -348,7 +348,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                         }
 
                         auto* industry = elIndustry->industry();
-                        auto* industryObj = industry->getObject();
+                        const auto* industryObj = industry->getObject();
                         if (!(industryObj->flags & IndustryObjectFlags::built_on_water))
                         {
                             continue;

--- a/src/OpenLoco/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/Windows/Construction/StationTab.cpp
@@ -348,7 +348,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                         }
 
                         auto* industry = elIndustry->industry();
-                        auto* industryObj = industry->object();
+                        auto* industryObj = industry->getObject();
                         if (!(industryObj->flags & IndustryObjectFlags::built_on_water))
                         {
                             continue;

--- a/src/OpenLoco/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/Windows/IndustryWindow.cpp
@@ -443,7 +443,7 @@ namespace OpenLoco::Ui::Windows::Industry
             Common::drawTabs(self, context);
 
             auto industry = IndustryManager::get(IndustryId(self->number));
-            auto industryObj = industry->object();
+            auto industryObj = industry->getObject();
             int16_t xPos = self->x + 3;
             int16_t yPos = self->y + 45;
             Ui::Point origin = { xPos, yPos };

--- a/src/OpenLoco/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/Windows/IndustryWindow.cpp
@@ -443,7 +443,7 @@ namespace OpenLoco::Ui::Windows::Industry
             Common::drawTabs(self, context);
 
             auto industry = IndustryManager::get(IndustryId(self->number));
-            auto industryObj = industry->getObject();
+            const auto* industryObj = industry->getObject();
             int16_t xPos = self->x + 3;
             int16_t yPos = self->y + 45;
             Ui::Point origin = { xPos, yPos };


### PR DESCRIPTION
It was suggested that `object` for a function name is perhaps a bit unclear. This changes it to getObject and ensures the result is const as nothing should be using a non const object except for ObjectManager functions.