### PR TITLE
Fix Remove Crash Vehicle Crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 22.02+ (???)
 ------------------------------------------------------------------------
 - Feature: [#1327] Readd the game intro (use commandline switch --intro to enable)
+- Fix: [#1280] Crash when removing crashed vehicles with news window open.
 - Fix: [#1320] Inability to mark scenario as complete.
 - Fix: [#1325] Crash when saving second loaded scenario of a playthrough.
 - Change: [#1276] Transfering cargo is now viable. The cargo age is calculated as the weighted average of the present and delivered cargo.

--- a/src/OpenLoco/Windows/News/News.cpp
+++ b/src/OpenLoco/Windows/News/News.cpp
@@ -328,9 +328,10 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             {
                 _dword_525CD0 = ecx;
                 _dword_525CD4 = edx;
-                auto viewport = self->viewports[0];
+                auto& viewport = self->viewports[0];
                 if (viewport != nullptr)
                 {
+                    viewport->width = 0;
                     viewport = nullptr;
                     self->invalidate();
                 }
@@ -428,9 +429,10 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             {
                 _dword_525CD8 = ecx;
                 _dword_525CDC = edx;
-                auto viewport = self->viewports[0];
+                auto& viewport = self->viewports[0];
                 if (viewport != nullptr)
                 {
+                    viewport->width = 0;
                     viewport = nullptr;
                     self->invalidate();
                 }

--- a/src/OpenLoco/Windows/News/News.cpp
+++ b/src/OpenLoco/Windows/News/News.cpp
@@ -331,8 +331,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 auto& viewport = self->viewports[0];
                 if (viewport != nullptr)
                 {
-                    viewport->width = 0;
-                    viewport = nullptr;
+                    self->viewportRemove(0);
                     self->invalidate();
                 }
 
@@ -429,11 +428,10 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             {
                 _dword_525CD8 = ecx;
                 _dword_525CDC = edx;
-                auto& viewport = self->viewports[0];
+                auto& viewport = self->viewports[1];
                 if (viewport != nullptr)
                 {
-                    viewport->width = 0;
-                    viewport = nullptr;
+                    self->viewportRemove(1);
                     self->invalidate();
                 }
 

--- a/src/OpenLoco/Windows/News/News.cpp
+++ b/src/OpenLoco/Windows/News/News.cpp
@@ -328,12 +328,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             {
                 _dword_525CD0 = ecx;
                 _dword_525CD4 = edx;
-                auto& viewport = self->viewports[0];
-                if (viewport != nullptr)
-                {
-                    self->viewportRemove(0);
-                    self->invalidate();
-                }
+                self->viewportRemove(0);
+                self->invalidate();
 
                 self->widgets[Common::widx::viewport1].left = 6;
                 self->widgets[Common::widx::viewport1].right = 353;
@@ -428,12 +424,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             {
                 _dword_525CD8 = ecx;
                 _dword_525CDC = edx;
-                auto& viewport = self->viewports[1];
-                if (viewport != nullptr)
-                {
-                    self->viewportRemove(1);
-                    self->invalidate();
-                }
+                self->viewportRemove(1);
+                self->invalidate();
 
                 self->widgets[Common::widx::viewport2].left = 186;
                 self->widgets[Common::widx::viewport2].right = 353;


### PR DESCRIPTION
This fixes the crash that happens when you remove a crashed vehicle that has a news article window open that references it.
We should probably check every single viewport init function to make sure it is correctly deleteing viewports (setting the width to 0). 

Edit. I checked all other users and they used the correct viewportRemove function so all is fine.