### PR TITLE
renames updatingCompanyId() into get/set variants

### DIFF
--- a/src/OpenLoco/Company.cpp
+++ b/src/OpenLoco/Company.cpp
@@ -175,7 +175,7 @@ namespace OpenLoco
     // 0x00430762
     void Company::aiThink()
     {
-        const auto updatingCompanyId = CompanyManager::updatingCompanyId();
+        const auto updatingCompanyId = CompanyManager::getUpdatingCompanyId();
 
         // Ensure this is only used for Non-Player controlled companies.
         if (CompanyManager::isPlayerCompany(updatingCompanyId))

--- a/src/OpenLoco/CompanyManager.cpp
+++ b/src/OpenLoco/CompanyManager.cpp
@@ -78,12 +78,12 @@ namespace OpenLoco::CompanyManager
         updateColours();
     }
 
-    CompanyId updatingCompanyId()
+    CompanyId getUpdatingCompanyId()
     {
         return _updatingCompanyId;
     }
 
-    void updatingCompanyId(CompanyId id)
+    void setUpdatingCompanyId(CompanyId id)
     {
         _updatingCompanyId = id;
     }
@@ -156,7 +156,7 @@ namespace OpenLoco::CompanyManager
             auto company = get(id);
             if (company != nullptr && !isPlayerCompany(id) && !company->empty())
             {
-                updatingCompanyId(id);
+                setUpdatingCompanyId(id);
                 company->aiThink();
             }
 

--- a/src/OpenLoco/CompanyManager.h
+++ b/src/OpenLoco/CompanyManager.h
@@ -11,8 +11,8 @@
 namespace OpenLoco::CompanyManager
 {
     void reset();
-    CompanyId updatingCompanyId();
-    void updatingCompanyId(CompanyId id);
+    CompanyId getUpdatingCompanyId();
+    void setUpdatingCompanyId(CompanyId id);
 
     FixedVector<Company, Limits::maxCompanies> companies();
     Company* get(CompanyId id);

--- a/src/OpenLoco/Game.cpp
+++ b/src/OpenLoco/Game.cpp
@@ -161,7 +161,7 @@ namespace OpenLoco::Game
         else if (isNetworked())
         {
             // 0x0043C0DB
-            if (CompanyManager::getControllingId() == CompanyManager::updatingCompanyId())
+            if (CompanyManager::getControllingId() == CompanyManager::getUpdatingCompanyId())
             {
                 MultiPlayer::setFlag(MultiPlayer::flags::flag_4);
                 MultiPlayer::setFlag(MultiPlayer::flags::flag_3);
@@ -182,12 +182,12 @@ namespace OpenLoco::Game
         {
             clearScreenFlag(ScreenFlags::networked);
             auto playerCompanyId = CompanyManager::getControllingId();
-            auto previousUpdatingId = CompanyManager::updatingCompanyId();
-            CompanyManager::updatingCompanyId(playerCompanyId);
+            auto previousUpdatingId = CompanyManager::getUpdatingCompanyId();
+            CompanyManager::setUpdatingCompanyId(playerCompanyId);
 
             Ui::WindowManager::closeAllFloatingWindows();
 
-            CompanyManager::updatingCompanyId(previousUpdatingId);
+            CompanyManager::setUpdatingCompanyId(previousUpdatingId);
             setScreenFlag(ScreenFlags::networked);
 
             // If the other party is leaving the game, go back to the title screen.

--- a/src/OpenLoco/GameCommands/Cheat.cpp
+++ b/src/OpenLoco/GameCommands/Cheat.cpp
@@ -25,7 +25,7 @@ namespace OpenLoco::GameCommands
     {
         static uint32_t acquireAssets(CompanyId targetCompanyId)
         {
-            auto ourCompanyId = CompanyManager::updatingCompanyId();
+            auto ourCompanyId = CompanyManager::getUpdatingCompanyId();
 
             // First phase: change ownership of all tile elements that currently belong to the target company.
             for (auto& element : TileManager::getElements())
@@ -161,7 +161,7 @@ namespace OpenLoco::GameCommands
 
         static uint32_t vehicleReliability(int32_t newReliablity)
         {
-            auto ourCompanyId = CompanyManager::updatingCompanyId();
+            auto ourCompanyId = CompanyManager::getUpdatingCompanyId();
 
             for (auto vehicle : EntityManager::VehicleList())
             {

--- a/src/OpenLoco/GameCommands/GameCommands.cpp
+++ b/src/OpenLoco/GameCommands/GameCommands.cpp
@@ -303,7 +303,7 @@ namespace OpenLoco::GameCommands
             return ebx;
 
         // Apply to company money
-        CompanyManager::applyPaymentToCompany(CompanyManager::updatingCompanyId(), ebx, getExpenditureType());
+        CompanyManager::applyPaymentToCompany(CompanyManager::getUpdatingCompanyId(), ebx, getExpenditureType());
 
         if (ebx != 0 && _updatingCompanyId == _player_company[0])
         {

--- a/src/OpenLoco/IndustryManager.cpp
+++ b/src/OpenLoco/IndustryManager.cpp
@@ -43,7 +43,7 @@ namespace OpenLoco::IndustryManager
     {
         if (Game::hasFlags(1u << 0) && !isEditorMode())
         {
-            CompanyManager::updatingCompanyId(CompanyId::neutral);
+            CompanyManager::setUpdatingCompanyId(CompanyId::neutral);
             for (auto& industry : industries())
             {
                 industry.update();

--- a/src/OpenLoco/Map/RoadTile.cpp
+++ b/src/OpenLoco/Map/RoadTile.cpp
@@ -63,8 +63,8 @@ namespace OpenLoco::Map
                 return true;
         }
 
-        CompanyId backup = CompanyManager::updatingCompanyId();
-        CompanyManager::updatingCompanyId(owner());
+        CompanyId backup = CompanyManager::getUpdatingCompanyId();
+        CompanyManager::setUpdatingCompanyId(owner());
 
         GameCommands::RoadRemovalArgs args;
         args.pos = Map::Pos3(loc.x, loc.y, baseZ() * 4);
@@ -74,7 +74,7 @@ namespace OpenLoco::Map
         args.objectId = roadObjectId();
         GameCommands::doCommand(args, GameCommands::Flags::apply);
 
-        CompanyManager::updatingCompanyId(backup);
+        CompanyManager::setUpdatingCompanyId(backup);
 
         return false;
     }

--- a/src/OpenLoco/Map/TileManager.cpp
+++ b/src/OpenLoco/Map/TileManager.cpp
@@ -635,7 +635,7 @@ namespace OpenLoco::Map::TileManager
             return;
         }
 
-        CompanyManager::updatingCompanyId(CompanyId::neutral);
+        CompanyManager::setUpdatingCompanyId(CompanyId::neutral);
         auto pos = *_startUpdateLocation;
         for (; pos.y < Map::map_height; pos.y += 16 * Map::tile_size)
         {

--- a/src/OpenLoco/Scenario.cpp
+++ b/src/OpenLoco/Scenario.cpp
@@ -183,7 +183,7 @@ namespace OpenLoco::Scenario
     {
         WindowManager::closeConstructionWindows();
 
-        CompanyManager::updatingCompanyId(CompanyId::neutral);
+        CompanyManager::setUpdatingCompanyId(CompanyId::neutral);
         WindowManager::setCurrentRotation(0);
 
         CompanyManager::reset();

--- a/src/OpenLoco/Title.cpp
+++ b/src/OpenLoco/Title.cpp
@@ -52,7 +52,7 @@ namespace OpenLoco::Title
 
     // Explicit deduction guide (not needed as of C++20)
     template<class... Ts>
-    overloaded(Ts...) -> overloaded<Ts...>;
+    overloaded(Ts...)->overloaded<Ts...>;
 
     static const TitleSequence _titleSequence = {
         MoveStep{ 231, 160 },

--- a/src/OpenLoco/Title.cpp
+++ b/src/OpenLoco/Title.cpp
@@ -52,7 +52,7 @@ namespace OpenLoco::Title
 
     // Explicit deduction guide (not needed as of C++20)
     template<class... Ts>
-    overloaded(Ts...)->overloaded<Ts...>;
+    overloaded(Ts...) -> overloaded<Ts...>;
 
     static const TitleSequence _titleSequence = {
         MoveStep{ 231, 160 },
@@ -157,7 +157,7 @@ namespace OpenLoco::Title
     // 0x0046AD7D
     void start()
     {
-        CompanyManager::updatingCompanyId(CompanyManager::getControllingId());
+        CompanyManager::setUpdatingCompanyId(CompanyManager::getControllingId());
         if (isPaused())
         {
             GameCommands::togglePause(1);

--- a/src/OpenLoco/TownManager.cpp
+++ b/src/OpenLoco/TownManager.cpp
@@ -49,7 +49,7 @@ namespace OpenLoco::TownManager
                 auto town = get(id);
                 if (town != nullptr && !town->empty())
                 {
-                    CompanyManager::updatingCompanyId(CompanyId::neutral);
+                    CompanyManager::setUpdatingCompanyId(CompanyId::neutral);
                     town->update();
                 }
             }

--- a/src/OpenLoco/Ui/WindowManager.cpp
+++ b/src/OpenLoco/Ui/WindowManager.cpp
@@ -1217,7 +1217,7 @@ namespace OpenLoco::Ui::WindowManager
     void dispatchUpdateAll()
     {
         _523508++;
-        CompanyManager::updatingCompanyId(CompanyManager::getControllingId());
+        CompanyManager::setUpdatingCompanyId(CompanyManager::getControllingId());
 
         for (Ui::Window* w = _windowsEnd - 1; w >= _windows; w--)
         {

--- a/src/OpenLoco/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/Windows/Construction/Common.cpp
@@ -1362,7 +1362,7 @@ namespace OpenLoco::Ui::Windows::Construction
                 trackType &= ~(1 << 7);
             }
 
-            auto companyId = CompanyManager::updatingCompanyId();
+            auto companyId = CompanyManager::getUpdatingCompanyId();
 
             modList[0] = 0xFF;
             modList[1] = 0xFF;

--- a/src/OpenLoco/Windows/TerraForm.cpp
+++ b/src/OpenLoco/Windows/TerraForm.cpp
@@ -671,9 +671,9 @@ namespace OpenLoco::Ui::Windows::Terraform
                         break;
                     case treeCluster::selected:
                     {
-                        auto previousId = CompanyManager::updatingCompanyId();
+                        auto previousId = CompanyManager::getUpdatingCompanyId();
                         if (isEditorMode())
-                            CompanyManager::updatingCompanyId(CompanyId::neutral);
+                            CompanyManager::setUpdatingCompanyId(CompanyId::neutral);
 
                         if (clusterToolDown(*placementArgs, 320, 3, [type = placementArgs->type](const Map::TilePos2&, bool) { return std::optional<uint8_t>(type); }))
                         {
@@ -682,13 +682,13 @@ namespace OpenLoco::Ui::Windows::Terraform
                         }
 
                         if (isEditorMode())
-                            CompanyManager::updatingCompanyId(previousId);
+                            CompanyManager::setUpdatingCompanyId(previousId);
                         break;
                     }
                     case treeCluster::random:
-                        auto previousId = CompanyManager::updatingCompanyId();
+                        auto previousId = CompanyManager::getUpdatingCompanyId();
                         if (isEditorMode())
-                            CompanyManager::updatingCompanyId(CompanyId::neutral);
+                            CompanyManager::setUpdatingCompanyId(CompanyId::neutral);
 
                         if (clusterToolDown(*placementArgs, 384, 4, getRandomTreeTypeFromSurface))
                         {
@@ -697,7 +697,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                         }
 
                         if (isEditorMode())
-                            CompanyManager::updatingCompanyId(previousId);
+                            CompanyManager::setUpdatingCompanyId(previousId);
                         break;
                 }
             }

--- a/src/OpenLoco/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/Windows/ToolbarTop.cpp
@@ -139,7 +139,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
 
         if (isNetworked())
         {
-            if (CompanyManager::updatingCompanyId() == CompanyManager::getControllingId())
+            if (CompanyManager::getUpdatingCompanyId() == CompanyManager::getControllingId())
             {
                 GameCommands::do_72();
                 MultiPlayer::setFlag(MultiPlayer::flags::flag_2);


### PR DESCRIPTION
When dealing with the `_updatingCompanyId` loco_global, `CompanayManager::updatingCompanyId()` is the function to both set and get the value. This PR changes it so the function isn't overloaded and has the getter/setter named appropriately