### PR TITLE
Remove redundant if statement

### DIFF
--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -2885,10 +2885,7 @@ namespace OpenLoco::Vehicles
             }
             if (highestQty != 0)
             {
-                if (cargo.type != chosenCargo)
-                {
-                    cargo.type = chosenCargo;
-                }
+                cargo.type = chosenCargo;
             }
         }
 


### PR DESCRIPTION
I found a redundant `if` statement and simplified it. I tried to find any others existing in openloco with this regex in VS

`if \((.*) != (.*)\)\r\n\s+{\r\n\s+\1 = \2;\r\n\s+}`

but this line was the only match.