### PR TITLE
Implement sub_497348

### DIFF
--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -28,6 +28,7 @@
 #include "../Station.h"
 #include "../StationManager.h"
 #include "../Title.h"
+#include "../TownManager.h"
 #include "../Tutorial.h"
 #include "../Ui.h"
 #include "../Ui/ProgressBar.h"
@@ -782,6 +783,7 @@ void OpenLoco::Interop::registerHooks()
     GameCommands::registerHooks();
     Scenario::registerHooks();
     StationManager::registerHooks();
+    TownManager::registerHooks();
     S5::registerHooks();
     Title::registerHooks();
     OpenLoco::Tutorial::registerHooks();

--- a/src/OpenLoco/Objects/BuildingObject.h
+++ b/src/OpenLoco/Objects/BuildingObject.h
@@ -40,7 +40,8 @@ namespace OpenLoco
         uint8_t var_A4[2];
         uint8_t var_A6[2];
         uint8_t var_A8[2];
-        uint8_t pad_AA[0xAD - 0xAA];
+        uint8_t pad_AA[0xAC - 0xAA];
+        uint8_t var_AC;
         uint8_t var_AD;
 
         void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;

--- a/src/OpenLoco/Town.cpp
+++ b/src/OpenLoco/Town.cpp
@@ -151,11 +151,11 @@ namespace OpenLoco
     {
         auto newSize = enumValue(size);
         if (size < TownSize::metropolis
-            && var_34 >= _populations[enumValue(size) + 1])
+            && populationCapacity >= _populations[enumValue(size) + 1])
         {
             newSize++;
         }
-        else if (size != TownSize::hamlet && var_34 + 100 < _populations[enumValue(size)])
+        else if (size != TownSize::hamlet && populationCapacity + 100 < _populations[enumValue(size)])
         {
             newSize--;
         }

--- a/src/OpenLoco/Town.h
+++ b/src/OpenLoco/Town.h
@@ -43,7 +43,7 @@ namespace OpenLoco
         uint8_t historySize;            // 0x5B (<= 20 * 12)
         uint8_t history[20 * 12];       // 0x5C (20 years, 12 months)
         int32_t history_min_population; // 0x14C
-        uint8_t pad_150[0x158 - 0x150];
+        uint8_t var_150[8];
         uint16_t monthly_cargo_delivered[32];
         uint32_t cargo_influence_flags;
         uint16_t var_19C[2][2];

--- a/src/OpenLoco/Town.h
+++ b/src/OpenLoco/Town.h
@@ -28,14 +28,14 @@ namespace OpenLoco
 #pragma pack(push, 1)
     struct Town
     {
-        string_id name;        // 0x00
-        coord_t x;             // 0x02
-        coord_t y;             // 0x04
-        uint16_t flags;        // 0x06
-        LabelFrame labelFrame; // 0x08
-        Utility::prng prng;    // 0x28
-        uint32_t population;   // 0x30
-        uint32_t var_34;
+        string_id name;              // 0x00
+        coord_t x;                   // 0x02
+        coord_t y;                   // 0x04
+        uint16_t flags;              // 0x06
+        LabelFrame labelFrame;       // 0x08
+        Utility::prng prng;          // 0x28
+        uint32_t population;         // 0x30
+        uint32_t populationCapacity; // 0x34
         uint16_t var_38;
         int16_t company_ratings[15];    // 0x3A
         uint16_t companies_with_rating; // 0x58

--- a/src/OpenLoco/Town.h
+++ b/src/OpenLoco/Town.h
@@ -28,15 +28,15 @@ namespace OpenLoco
 #pragma pack(push, 1)
     struct Town
     {
-        string_id name;              // 0x00
-        coord_t x;                   // 0x02
-        coord_t y;                   // 0x04
-        uint16_t flags;              // 0x06
-        LabelFrame labelFrame;       // 0x08
-        Utility::prng prng;          // 0x28
-        uint32_t population;         // 0x30
-        uint32_t populationCapacity; // 0x34
-        uint16_t var_38;
+        string_id name;                 // 0x00
+        coord_t x;                      // 0x02
+        coord_t y;                      // 0x04
+        uint16_t flags;                 // 0x06
+        LabelFrame labelFrame;          // 0x08
+        Utility::prng prng;             // 0x28
+        uint32_t population;            // 0x30
+        uint32_t populationCapacity;    // 0x34
+        int16_t numBuildings;           // 0x38
         int16_t company_ratings[15];    // 0x3A
         uint16_t companies_with_rating; // 0x58
         TownSize size;                  // 0x5A

--- a/src/OpenLoco/TownManager.cpp
+++ b/src/OpenLoco/TownManager.cpp
@@ -212,6 +212,15 @@ namespace OpenLoco::TownManager
         return { std::make_pair(town->id(), invUnk) };
     }
 
+    void registerHooks()
+    {
+        registerHook(
+            0x00497348,
+            [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                sub_497348();
+                return 0;
+            });
+    }
 }
 
 OpenLoco::TownId OpenLoco::Town::id() const

--- a/src/OpenLoco/TownManager.cpp
+++ b/src/OpenLoco/TownManager.cpp
@@ -19,7 +19,7 @@ namespace OpenLoco::TownManager
 
     // 0x00497DC1
     // The return value of this function is also being returned via dword_1135C38.
-    Town* sub_497DC1(const Map::Pos2& loc, uint32_t population, uint32_t unk1, int16_t rating, uint16_t unk3)
+    Town* sub_497DC1(const Map::Pos2& loc, uint32_t population, uint32_t populationCapacity, int16_t rating, int16_t numBuildings)
     {
         auto res = getClosestTownAndUnk(loc);
         if (res == std::nullopt)
@@ -32,7 +32,7 @@ namespace OpenLoco::TownManager
         dword_1135C38 = town;
         if (town != nullptr)
         {
-            town->populationCapacity += unk1;
+            town->populationCapacity += populationCapacity;
         }
         if (population != 0)
         {
@@ -53,9 +53,9 @@ namespace OpenLoco::TownManager
             }
         }
 
-        if (town->var_38 + unk3 <= std::numeric_limits<uint16_t>::max())
+        if (town->numBuildings + numBuildings <= std::numeric_limits<int16_t>::max())
         {
-            town->var_38 += unk3;
+            town->numBuildings += numBuildings;
         }
 
         return town;
@@ -68,7 +68,7 @@ namespace OpenLoco::TownManager
     {
         for (auto& town : towns())
         {
-            town.var_38 = 0;
+            town.numBuildings = 0;
             town.population = 0;
             town.populationCapacity = 0;
             std::fill(std::begin(town.var_150), std::end(town.var_150), 0);
@@ -207,7 +207,7 @@ namespace OpenLoco::TownManager
             return std::nullopt;
         }
         const int32_t realDistance = Math::Vector::distance(Map::Pos2(town->x, town->y), loc);
-        const auto unk = std::clamp((realDistance - town->var_38 * 4 + 512) / 128, 0, 4);
+        const auto unk = std::clamp((realDistance - town->numBuildings * 4 + 512) / 128, 0, 4);
         const uint8_t invUnk = std::min(4 - unk, 3); //edx
         return { std::make_pair(town->id(), invUnk) };
     }

--- a/src/OpenLoco/TownManager.cpp
+++ b/src/OpenLoco/TownManager.cpp
@@ -64,7 +64,7 @@ namespace OpenLoco::TownManager
     static auto& rawTowns() { return getGameState().towns; }
 
     // 0x00497348
-    void sub_497348()
+    void resetBuildingsInfluence()
     {
         for (auto& town : towns())
         {
@@ -217,7 +217,7 @@ namespace OpenLoco::TownManager
         registerHook(
             0x00497348,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                sub_497348();
+                resetBuildingsInfluence();
                 return 0;
             });
     }

--- a/src/OpenLoco/TownManager.cpp
+++ b/src/OpenLoco/TownManager.cpp
@@ -32,7 +32,7 @@ namespace OpenLoco::TownManager
         dword_1135C38 = town;
         if (town != nullptr)
         {
-            town->var_34 += unk1;
+            town->populationCapacity += unk1;
         }
         if (population != 0)
         {
@@ -70,7 +70,7 @@ namespace OpenLoco::TownManager
         {
             town.var_38 = 0;
             town.population = 0;
-            town.var_34 = 0;
+            town.populationCapacity = 0;
             std::fill(std::begin(town.var_150), std::end(town.var_150), 0);
         }
 

--- a/src/OpenLoco/TownManager.h
+++ b/src/OpenLoco/TownManager.h
@@ -16,4 +16,5 @@ namespace OpenLoco::TownManager
     void updateMonthly();
     Town* sub_497DC1(const Map::Pos2& loc, uint32_t population, uint32_t unk1, int16_t rating, uint16_t unk3);
     void sub_497348();
+    void registerHooks();
 }

--- a/src/OpenLoco/TownManager.h
+++ b/src/OpenLoco/TownManager.h
@@ -14,7 +14,7 @@ namespace OpenLoco::TownManager
     void update();
     void updateLabels();
     void updateMonthly();
-    Town* sub_497DC1(const Map::Pos2& loc, uint32_t population, uint32_t unk1, int16_t rating, uint16_t unk3);
+    Town* sub_497DC1(const Map::Pos2& loc, uint32_t population, uint32_t populationCapacity, int16_t rating, int16_t numBuildings);
     void resetBuildingsInfluence();
     void registerHooks();
 }

--- a/src/OpenLoco/TownManager.h
+++ b/src/OpenLoco/TownManager.h
@@ -15,6 +15,6 @@ namespace OpenLoco::TownManager
     void updateLabels();
     void updateMonthly();
     Town* sub_497DC1(const Map::Pos2& loc, uint32_t population, uint32_t unk1, int16_t rating, uint16_t unk3);
-    void sub_497348();
+    void resetBuildingsInfluence();
     void registerHooks();
 }

--- a/src/OpenLoco/TownManager.h
+++ b/src/OpenLoco/TownManager.h
@@ -15,4 +15,5 @@ namespace OpenLoco::TownManager
     void updateLabels();
     void updateMonthly();
     Town* sub_497DC1(const Map::Pos2& loc, uint32_t population, uint32_t unk1, int16_t rating, uint16_t unk3);
+    void sub_497348();
 }

--- a/src/OpenLoco/Windows/TownWindow.cpp
+++ b/src/OpenLoco/Windows/TownWindow.cpp
@@ -178,7 +178,7 @@ namespace OpenLoco::Ui::Windows::Town
                 {
                     auto town = TownManager::get(TownId(self->number));
 
-                    const uint32_t ebx = (town->var_38 >> 3) + 5;
+                    const uint32_t ebx = (town->numBuildings >> 3) + 5;
                     const int16_t currentYear = getCurrentYear();
                     int16_t tempYear = currentYear - 51;
                     setCurrentYear(tempYear);


### PR DESCRIPTION
This is an implementation of `sub_497348`.
There is a weird behavior here where `producedQuantity[0]` is being sent to `sub_497DC1` as `population` when `building->isConstructed()` is `false`. I think I understood that correctly from the assembly code, but another set of eyes on this is a good idea.
I couldn't test this code on a busy save because my game can't seem to be able to run it currently (not related to this branch. It won't open the save on `master` as well), so please test this code.
I added a hook to this function in a separate commit so that it can be easily removed if we choose to remove it.