### PR TITLE
use correct id for vehicle unlock check

### DIFF
--- a/src/OpenLoco/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/Vehicles/CreateVehicle.cpp
@@ -819,7 +819,7 @@ namespace OpenLoco::Vehicles
         _backupVeh0 = reinterpret_cast<VehicleHead*>(-1);
 
         const auto* company = CompanyManager::get(CompanyManager::getUpdatingCompanyId());
-        if (!company->isVehicleIndexUnlocked(static_cast<uint16_t>(vehicleThingId)))
+        if (!company->isVehicleIndexUnlocked(static_cast<uint16_t>(vehicleTypeId)))
         {
             GameCommands::setErrorText(StringIds::vehicle_is_locked);
             return GameCommands::FAILURE;


### PR DESCRIPTION
I somehow used the wrong variable when implementing #1371 and I really don't know how, because I absolutely tested this multiple times as a game command, so I've no idea how this has happened. *Maybe* a base rebase or merge on my part, but I don't think that's it. Oh well, this is the fix.