### PR TITLE
Try out TileManager visitor

### DIFF
--- a/src/OpenLoco/Map/BuildingTile.cpp
+++ b/src/OpenLoco/Map/BuildingTile.cpp
@@ -100,11 +100,8 @@ namespace OpenLoco::Map
                 for (auto i = 1; i < 4; ++i)
                 {
                     const auto pos = loc + Map::offsets[i];
-                    TileManager::visit<BuildingElement>(TilePos2{ pos }, [=](BuildingElement& elBuilding2) {
-                        if (elBuilding2.baseZ() != baseZ())
-                        {
-                            return;
-                        }
+                    auto func = std::bind(TileManager::atHeight<BuildingElement>, std::placeholders::_1, baseZ());
+                    TileManager::visit<BuildingElement>(TilePos2{ pos }, func, [=](BuildingElement& elBuilding2) {
                         elBuilding2.setConstructed(isConstructed);
                         elBuilding2.setUnk5u(newUnk5u);
                         elBuilding2.setAge(newAge);

--- a/src/OpenLoco/Map/BuildingTile.cpp
+++ b/src/OpenLoco/Map/BuildingTile.cpp
@@ -100,23 +100,16 @@ namespace OpenLoco::Map
                 for (auto i = 1; i < 4; ++i)
                 {
                     const auto pos = loc + Map::offsets[i];
-                    auto tile = TileManager::get(pos);
-                    for (auto& el : tile)
-                    {
-                        auto* elBuilding2 = el.as<BuildingElement>();
-                        if (elBuilding2 == nullptr)
+                    TileManager::visitAll<BuildingElement>(TilePos2{ pos }, [this, isConstructed, newUnk5u, newAge, pos](BuildingElement& elBuilding2) {
+                        if (elBuilding2.baseZ() != baseZ())
                         {
-                            continue;
+                            return;
                         }
-                        if (elBuilding2->baseZ() != baseZ())
-                        {
-                            continue;
-                        }
-                        elBuilding2->setConstructed(isConstructed);
-                        elBuilding2->setUnk5u(newUnk5u);
-                        elBuilding2->setAge(newAge);
-                        Ui::ViewportManager::invalidate(pos, elBuilding2->baseZ() * 4, elBuilding2->clearZ() * 4, ZoomLevel::quarter);
-                    }
+                        elBuilding2.setConstructed(isConstructed);
+                        elBuilding2.setUnk5u(newUnk5u);
+                        elBuilding2.setAge(newAge);
+                        Ui::ViewportManager::invalidate(pos, elBuilding2.baseZ() * 4, elBuilding2.clearZ() * 4, ZoomLevel::quarter);
+                    });
                 }
             }
         }

--- a/src/OpenLoco/Map/BuildingTile.cpp
+++ b/src/OpenLoco/Map/BuildingTile.cpp
@@ -100,7 +100,7 @@ namespace OpenLoco::Map
                 for (auto i = 1; i < 4; ++i)
                 {
                     const auto pos = loc + Map::offsets[i];
-                    TileManager::visitAll<BuildingElement>(TilePos2{ pos }, [this, isConstructed, newUnk5u, newAge, pos](BuildingElement& elBuilding2) {
+                    TileManager::visitAll<BuildingElement>(TilePos2{ pos }, [=](BuildingElement& elBuilding2) {
                         if (elBuilding2.baseZ() != baseZ())
                         {
                             return;

--- a/src/OpenLoco/Map/BuildingTile.cpp
+++ b/src/OpenLoco/Map/BuildingTile.cpp
@@ -100,8 +100,11 @@ namespace OpenLoco::Map
                 for (auto i = 1; i < 4; ++i)
                 {
                     const auto pos = loc + Map::offsets[i];
-                    auto func = std::bind(TileManager::atHeight<BuildingElement>, std::placeholders::_1, baseZ());
-                    TileManager::visit<BuildingElement>(TilePos2{ pos }, func, [=](BuildingElement& elBuilding2) {
+                    TileManager::visit<BuildingElement>(TilePos2{ pos }, [=](BuildingElement& elBuilding2) {
+                        if (TileManager::atHeight(elBuilding2, baseZ()))
+                        {
+                            return;
+                        }
                         elBuilding2.setConstructed(isConstructed);
                         elBuilding2.setUnk5u(newUnk5u);
                         elBuilding2.setAge(newAge);

--- a/src/OpenLoco/Map/BuildingTile.cpp
+++ b/src/OpenLoco/Map/BuildingTile.cpp
@@ -100,7 +100,7 @@ namespace OpenLoco::Map
                 for (auto i = 1; i < 4; ++i)
                 {
                     const auto pos = loc + Map::offsets[i];
-                    TileManager::visitAll<BuildingElement>(TilePos2{ pos }, [=](BuildingElement& elBuilding2) {
+                    TileManager::visit<BuildingElement>(TilePos2{ pos }, [=](BuildingElement& elBuilding2) {
                         if (elBuilding2.baseZ() != baseZ())
                         {
                             return;

--- a/src/OpenLoco/Map/TileManager.cpp
+++ b/src/OpenLoco/Map/TileManager.cpp
@@ -154,7 +154,7 @@ namespace OpenLoco::Map::TileManager
         return _tiles.get();
     }
 
-    Tile get(TilePos2 pos)
+    Tile get(const TilePos2& pos)
     {
         size_t index = (pos.y << 9) | pos.x;
         auto data = _tiles[index];
@@ -165,7 +165,7 @@ namespace OpenLoco::Map::TileManager
         return Tile(pos, data);
     }
 
-    Tile get(Pos2 pos)
+    Tile get(const Pos2& pos)
     {
         return get(pos.x, pos.y);
     }

--- a/src/OpenLoco/Map/TileManager.h
+++ b/src/OpenLoco/Map/TileManager.h
@@ -40,8 +40,27 @@ namespace OpenLoco::Map::TileManager
     void createDestructExplosion(const Map::Pos3& pos);
     void removeBuildingElement(BuildingElement& element, const Map::Pos2& pos);
 
+    template<typename T, typename Predicate, typename Visitor>
+    void visit(const TilePos2& pos, Predicate&& pred, Visitor&& vis)
+    {
+        auto tile = get(pos);
+        for (auto& el : tile)
+        {
+            auto* elT = el.as<T>();
+            if (elT == nullptr)
+            {
+                continue;
+            }
+            if (!pred(*elT))
+            {
+                continue;
+            }
+            vis(*elT);
+        }
+    }
+
     template<typename T, typename Visitor>
-    void visitAll(const TilePos2& pos, Visitor&& vis)
+    void visit(const TilePos2& pos, Visitor&& vis)
     {
         auto tile = get(pos);
         for (auto& el : tile)
@@ -54,8 +73,8 @@ namespace OpenLoco::Map::TileManager
             vis(*elT);
         }
     }
-    template<typename T, typename Visitor>
-    T* visitFirst(const TilePos2& pos, Visitor&& vis)
+    template<typename T, typename Predicate>
+    T* find(const TilePos2& pos, Predicate&& pred)
     {
         auto tile = get(pos);
         for (auto& el : tile)
@@ -65,7 +84,7 @@ namespace OpenLoco::Map::TileManager
             {
                 continue;
             }
-            if (!vis(*elT))
+            if (!pred(*elT))
             {
                 continue;
             }

--- a/src/OpenLoco/Map/TileManager.h
+++ b/src/OpenLoco/Map/TileManager.h
@@ -13,8 +13,8 @@ namespace OpenLoco::Map::TileManager
     stdx::span<TileElement> getElements();
     TileElement* getElementsEnd();
     TileElement** getElementIndex();
-    Tile get(TilePos2 pos);
-    Tile get(Pos2 pos);
+    Tile get(const TilePos2& pos);
+    Tile get(const Pos2& pos);
     Tile get(coord_t x, coord_t y);
     void setElements(stdx::span<TileElement> elements);
     void removeElement(TileElement& element);
@@ -39,4 +39,34 @@ namespace OpenLoco::Map::TileManager
     void removeSurfaceIndustry(const Pos2& pos);
     void createDestructExplosion(const Map::Pos3& pos);
     void removeBuildingElement(BuildingElement& element, const Map::Pos2& pos);
+
+    template<typename T, typename Visitor>
+    void visitAll(const TilePos2& pos, Visitor&& vis)
+    {
+        auto tile = get(pos);
+        for (auto& el : tile)
+        {
+            auto* elT = el.as<T>();
+            if (elT == nullptr)
+            {
+                continue;
+            }
+            vis(*elT);
+        }
+    }
+    template<typename T, typename Visitor>
+    T* visitFirst(const TilePos2& pos, Visitor&& vis)
+    {
+        auto tile = get(pos);
+        for (auto& el : tile)
+        {
+            auto* elT = el.as<T>();
+            if (elT == nullptr)
+            {
+                continue;
+            }
+            vis(*elT);
+            return elT;
+        }
+    }
 }

--- a/src/OpenLoco/Map/TileManager.h
+++ b/src/OpenLoco/Map/TileManager.h
@@ -40,6 +40,11 @@ namespace OpenLoco::Map::TileManager
     void createDestructExplosion(const Map::Pos3& pos);
     void removeBuildingElement(BuildingElement& element, const Map::Pos2& pos);
 
+    template<typename T>
+    bool atHeight(T& el, uint8_t baseZ) {
+        return el.baseZ() == baseZ;
+    }
+
     template<typename T, typename Predicate, typename Visitor>
     void visit(const TilePos2& pos, Predicate&& pred, Visitor&& vis)
     {

--- a/src/OpenLoco/Map/TileManager.h
+++ b/src/OpenLoco/Map/TileManager.h
@@ -65,7 +65,10 @@ namespace OpenLoco::Map::TileManager
             {
                 continue;
             }
-            vis(*elT);
+            if (!vis(*elT))
+            {
+                continue;
+            }
             return elT;
         }
     }


### PR DESCRIPTION
Just trying to simiplify the code we use for accessing tile elements what about the below:
```cpp
TileManager::visitAll<BuildingElement>(pos, [=](BuildingElement& elBuilding) {
    if (elBuilding.baseZ() != baseZ())
    {
        return;
    }
    elBuilding.setConstructed(isConstructed);
    elBuilding.setUnk5u(newUnk5u);
    elBuilding.setAge(newAge);
    Ui::ViewportManager::invalidate(pos, elBuilding.baseZ() * 4, elBuilding.clearZ() * 4, ZoomLevel::quarter);
});
```
```cpp
TileManager::visitFirst<BuildingElement>(pos, [=](BuildingElement& elBuilding) {
    if (elBuilding.baseZ() != baseZ())
    {
        return false;
    }
    elBuilding.setConstructed(isConstructed);
    elBuilding.setUnk5u(newUnk5u);
    elBuilding.setAge(newAge);
    Ui::ViewportManager::invalidate(pos, elBuilding.baseZ() * 4, elBuilding.clearZ() * 4, ZoomLevel::quarter);
    return true;
});
```

Advantages: 

- No need to deal with `Tile`.
- You only ever have a reference not a pointer.
- Reduces LOC a small amount
- Expresses intent better `visitAll`, `visitFirst`

Disadvantages:

- passing parameters into lambdas isn't always great
- You still need to write BuildingElement twice if you want syntax highlighting.
- `visitFirst` needs the return true/false whilst `visitAll` does not.
- No sharing of search parameters (baseZ in above). Could be made into a `Visitor` and a `UnaryPredicate` search function (this might also solve the no sharing between `visitFirst` `visitAll`
- Lambda's sometimes format weird in clangformat.