### PR TITLE
Fix crash when opening build window on certain scenarios

### DIFF
--- a/src/OpenLoco/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/Windows/BuildVehicle.cpp
@@ -1206,6 +1206,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
             {
                 // Reset the tabs
                 _TrackTypesForTab[0] = -1;
+                _numTrackTypeTabs = 1;
                 window->widgets[tab_track_type_0].type = WidgetType::tab;
                 for (WidgetIndex_t j = tab_track_type_1; j <= tab_track_type_7; ++j)
                 {


### PR DESCRIPTION
Vaguely related to one of #1376 issues.
None rail track only has one track type.