### PR TITLE
Tidy up audio allow caching of music samples

### DIFF
--- a/src/OpenLoco/Audio/Audio.cpp
+++ b/src/OpenLoco/Audio/Audio.cpp
@@ -130,11 +130,6 @@ namespace OpenLoco::Audio
         { PathId::music_20s6, StringIds::music_sandy_track_blues, 1921, 1929 }
     };
 
-    static constexpr bool isMusicChannel(ChannelId id)
-    {
-        return (id == ChannelId::bgm || id == ChannelId::title);
-    }
-
     static Channel* getChannel(ChannelId id)
     {
         auto index = static_cast<size_t>(id);

--- a/src/OpenLoco/Audio/Audio.cpp
+++ b/src/OpenLoco/Audio/Audio.cpp
@@ -645,7 +645,6 @@ namespace OpenLoco::Audio
         {
             return res->second;
         }
-        // TODO: This is leaking memory as it doesn't lookup already loaded results
         const auto path = Environment::getPath(asset);
         std::ifstream fs(path, std::ios::in | std::ios::binary);
 

--- a/src/OpenLoco/Audio/Audio.h
+++ b/src/OpenLoco/Audio/Audio.h
@@ -92,8 +92,11 @@ namespace OpenLoco::Audio
     void unpauseSound();
     void playSound(Vehicles::Vehicle2or6* t);
     void playSound(SoundId id, const Map::Pos3& loc);
-    // FOR HOOKS ONLY DO NOT USE FOR OPENLOCO CODE
+
+    // FOR HOOKS ONLY DO NOT USE THIS FUNCTION FOR OPENLOCO CODE
+    // INSTEAD USE playSound(SoundId id, const Map::Pos3& loc) OR playSound(SoundId id, int32_t pan)
     void playSound(SoundId id, const Map::Pos3& loc, int32_t pan);
+
     void playSound(SoundId id, int32_t pan);
     void playSound(SoundId id, const Map::Pos3& loc, int32_t volume, int32_t frequency);
     void updateSounds();

--- a/src/OpenLoco/Audio/Audio.h
+++ b/src/OpenLoco/Audio/Audio.h
@@ -97,11 +97,6 @@ namespace OpenLoco::Audio
     void playSound(SoundId id, const Map::Pos3& loc, int32_t volume, int32_t frequency);
     void updateSounds();
 
-    bool loadChannel(ChannelId id, const char* path, int32_t c);
-    bool playChannel(ChannelId id, int32_t loop, int32_t volume, int32_t d, int32_t freq);
-    void stopChannel(ChannelId id);
-    void setChannelVolume(ChannelId id, int32_t volume);
-    bool isChannelPlaying(ChannelId id);
     void setBgmVolume(int32_t volume);
 
     void updateVehicleNoise();

--- a/src/OpenLoco/Audio/Audio.h
+++ b/src/OpenLoco/Audio/Audio.h
@@ -92,6 +92,7 @@ namespace OpenLoco::Audio
     void unpauseSound();
     void playSound(Vehicles::Vehicle2or6* t);
     void playSound(SoundId id, const Map::Pos3& loc);
+    // FOR HOOKS ONLY DO NOT USE FOR OPENLOCO CODE
     void playSound(SoundId id, const Map::Pos3& loc, int32_t pan);
     void playSound(SoundId id, int32_t pan);
     void playSound(SoundId id, const Map::Pos3& loc, int32_t volume, int32_t frequency);

--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -57,33 +57,6 @@ using namespace OpenLoco;
 // MSVC ignores C++17's [[maybe_unused]] attribute on functions, so just disable the warning
 #pragma warning(disable : 4505) // unreferenced local function has been removed.
 
-FORCE_ALIGN_ARG_POINTER
-static int32_t CDECL audioLoadChannel(int a0, const char* a1, int a2, int a3, int a4)
-{
-    return 0;
-}
-
-FORCE_ALIGN_ARG_POINTER
-static int32_t CDECL audioPlayChannel(int a0, int a1, int a2, int a3, int a4)
-{
-    return 0;
-}
-
-FORCE_ALIGN_ARG_POINTER
-static void CDECL audioStopChannel(int a0, int a1, int a2, int a3, int a4)
-{
-}
-
-FORCE_ALIGN_ARG_POINTER
-static void CDECL audioSetChannelVolume(int a0, int a1)
-{
-}
-
-FORCE_ALIGN_ARG_POINTER
-static int32_t CDECL audioIsChannelPlaying(int a0)
-{
-}
-
 #ifdef _NO_LOCO_WIN32_
 static void STDCALL fn_40447f()
 {
@@ -587,12 +560,6 @@ void OpenLoco::Interop::loadSections()
 static void registerAudioHooks()
 {
     using namespace OpenLoco::Interop;
-
-    writeJmp(0x0040194E, (void*)&audioLoadChannel);
-    writeJmp(0x00401999, (void*)&audioPlayChannel);
-    writeJmp(0x00401A05, (void*)&audioStopChannel);
-    writeJmp(0x00401AD3, (void*)&audioSetChannelVolume);
-    writeJmp(0x00401B10, (void*)&audioIsChannelPlaying);
 
     writeRet(0x0048AB36);
     writeRet(0x00404B40);

--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -60,31 +60,28 @@ using namespace OpenLoco;
 FORCE_ALIGN_ARG_POINTER
 static int32_t CDECL audioLoadChannel(int a0, const char* a1, int a2, int a3, int a4)
 {
-    return Audio::loadChannel((Audio::ChannelId)a0, a1, a2) ? 1 : 0;
+    return 0;
 }
 
 FORCE_ALIGN_ARG_POINTER
 static int32_t CDECL audioPlayChannel(int a0, int a1, int a2, int a3, int a4)
 {
-    return Audio::playChannel((Audio::ChannelId)a0, a1, a2, a3, a4) ? 1 : 0;
+    return 0;
 }
 
 FORCE_ALIGN_ARG_POINTER
 static void CDECL audioStopChannel(int a0, int a1, int a2, int a3, int a4)
 {
-    Audio::stopChannel((Audio::ChannelId)a0);
 }
 
 FORCE_ALIGN_ARG_POINTER
 static void CDECL audioSetChannelVolume(int a0, int a1)
 {
-    Audio::setChannelVolume((Audio::ChannelId)a0, a1);
 }
 
 FORCE_ALIGN_ARG_POINTER
 static int32_t CDECL audioIsChannelPlaying(int a0)
 {
-    return Audio::isChannelPlaying((Audio::ChannelId)a0) ? 1 : 0;
 }
 
 #ifdef _NO_LOCO_WIN32_


### PR DESCRIPTION
This prevents the multiple reloads of music samples which was a memory leak (although very slow). Also refactored to remove some of the old code that was designed around the hooks.