### PR TITLE
Exit cleanly when an exception occurs

### DIFF
--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -1274,6 +1274,7 @@ namespace OpenLoco
         {
             std::cerr << e.what() << std::endl;
             Ui::showMessageBox("Exception", e.what());
+            exitCleanly();
             return 2;
         }
     }


### PR DESCRIPTION
OpenAL was crashing / hanging when an exception occurs during the game. Possibly because the sources were not deleted before the context?

This was output to the console:
```
[ALSOFT] (WW) Error generated on context 03464E40, code 0xa004, "Deleting in-use buffer 33"
```