### PR TITLE
reduce loco_globals with S5::getOptions()

### DIFF
--- a/src/OpenLoco/EditorController.cpp
+++ b/src/OpenLoco/EditorController.cpp
@@ -1,5 +1,6 @@
 #include "EditorController.h"
 #include "Game.h"
+#include "S5/S5.h"
 #include "Ui/WindowManager.h"
 
 using namespace OpenLoco::Interop;
@@ -8,8 +9,6 @@ using namespace OpenLoco::Ui::Windows;
 
 namespace OpenLoco::EditorController
 {
-    static loco_global<Step, 0x009C8714> _editorStep;
-
     // 0x0043D7DC
     void init()
     {
@@ -18,17 +17,17 @@ namespace OpenLoco::EditorController
 
     Step getCurrentStep()
     {
-        return _editorStep;
+        return (Step)S5::getOptions().editorStep;
     }
 
     Step getPreviousStep()
     {
-        return Step(static_cast<uint8_t>(*_editorStep) - 1);
+        return Step(static_cast<uint8_t>(S5::getOptions().editorStep) - 1);
     }
 
     Step getNextStep()
     {
-        return Step(static_cast<uint8_t>(*_editorStep) + 1);
+        return Step(static_cast<uint8_t>(S5::getOptions().editorStep) + 1);
     }
 
     bool canGoBack()

--- a/src/OpenLoco/Game.cpp
+++ b/src/OpenLoco/Game.cpp
@@ -29,8 +29,6 @@ namespace OpenLoco::Game
 
     static loco_global<char[256], 0x0050B745> _currentScenarioFilename;
 
-    static loco_global<uint16_t, 0x009C871A> _scenarioFlags;
-
     static loco_global<char[512], 0x0112CE04> _savePath;
 
     // 0x0046DB4C
@@ -99,10 +97,10 @@ namespace OpenLoco::Game
     // 0x00441993
     bool saveLandscapeOpen()
     {
-        *_scenarioFlags &= ~(1 << 0);
+        S5::getOptions().scenarioFlags &= ~(1 << 0);
         if (hasFlags(1u << 0))
         {
-            *_scenarioFlags |= (1 << 0);
+            S5::getOptions().scenarioFlags |= (1 << 0);
             sub_46DB4C();
         }
 

--- a/src/OpenLoco/Game.cpp
+++ b/src/OpenLoco/Game.cpp
@@ -30,7 +30,6 @@ namespace OpenLoco::Game
     static loco_global<char[256], 0x0050B745> _currentScenarioFilename;
 
     static loco_global<uint16_t, 0x009C871A> _scenarioFlags;
-    static loco_global<char[64], 0x009C873E> _scenarioTitle;
 
     static loco_global<char[512], 0x0112CE04> _savePath;
 
@@ -90,7 +89,7 @@ namespace OpenLoco::Game
     // 0x004418DB
     bool saveScenarioOpen()
     {
-        auto path = fs::u8path(&_pathScenarios[0]).parent_path() / &_scenarioTitle[0];
+        auto path = fs::u8path(&_pathScenarios[0]).parent_path() / S5::getOptions().scenarioName;
         strncpy(&_savePath[0], path.u8string().c_str(), std::size(_savePath));
         strncat(&_savePath[0], S5::extensionSC5, std::size(_savePath));
 
@@ -107,7 +106,7 @@ namespace OpenLoco::Game
             sub_46DB4C();
         }
 
-        auto path = fs::u8path(&_pathLandscapes[0]).parent_path() / &_scenarioTitle[0];
+        auto path = fs::u8path(&_pathLandscapes[0]).parent_path() / S5::getOptions().scenarioName;
         strncpy(&_savePath[0], path.u8string().c_str(), std::size(_savePath));
         strncat(&_savePath[0], S5::extensionSC5, std::size(_savePath));
 

--- a/src/OpenLoco/Scenario.cpp
+++ b/src/OpenLoco/Scenario.cpp
@@ -59,7 +59,6 @@ namespace OpenLoco::Scenario
     static loco_global<S5::Options, 0x009C8714> _activeOptions;
 
     static loco_global<char[256], 0x0050B745> _currentScenarioFilename;
-    static loco_global<char[64], 0x009C873E> _scenarioTitle;
     static loco_global<uint16_t, 0x0050C19A> _50C19A;
 
     // 0x0046115C
@@ -360,7 +359,7 @@ namespace OpenLoco::Scenario
         }
 
         auto savePath = Environment::getPath(Environment::PathId::save);
-        savePath /= std::string(_scenarioTitle) + S5::extensionSV5;
+        savePath /= std::string(S5::getOptions().scenarioName) + S5::extensionSV5;
         std::strncpy(_currentScenarioFilename, savePath.u8string().c_str(), std::size(_currentScenarioFilename));
 
         call(0x004C159C);

--- a/src/OpenLoco/Scenario.cpp
+++ b/src/OpenLoco/Scenario.cpp
@@ -56,8 +56,6 @@ namespace OpenLoco::Scenario
     static loco_global<uint8_t, 0x00526240> objectiveTimeLimitYears;
     static loco_global<uint16_t, 0x00526241> objectiveTimeLimitUntilYear;
 
-    static loco_global<S5::Options, 0x009C8714> _activeOptions;
-
     static loco_global<char[256], 0x0050B745> _currentScenarioFilename;
     static loco_global<uint16_t, 0x0050C19A> _50C19A;
 
@@ -347,8 +345,8 @@ namespace OpenLoco::Scenario
         sub_4BAEC4();
         Title::sub_4284C8();
 
-        std::memcpy(gameState.scenarioDetails, _activeOptions->scenarioDetails, sizeof(gameState.scenarioDetails));
-        std::memcpy(gameState.scenarioName, _activeOptions->scenarioName, sizeof(gameState.scenarioName));
+        std::memcpy(gameState.scenarioDetails, S5::getOptions().scenarioDetails, sizeof(gameState.scenarioDetails));
+        std::memcpy(gameState.scenarioName, S5::getOptions().scenarioName, sizeof(gameState.scenarioName));
 
         const auto* stexObj = ObjectManager::get<ScenarioTextObject>();
         if (stexObj != nullptr)
@@ -366,7 +364,7 @@ namespace OpenLoco::Scenario
         call(0x0046E07B); // load currency gfx
         CompanyManager::reset();
         CompanyManager::createPlayerCompany();
-        initialiseDate(_activeOptions->scenarioStartYear);
+        initialiseDate(S5::getOptions().scenarioStartYear);
         initialiseSnowLine();
         sub_4748D4();
         std::fill(std::begin(gameState.recordSpeed), std::end(gameState.recordSpeed), 0_mph);

--- a/src/OpenLoco/Tutorial.cpp
+++ b/src/OpenLoco/Tutorial.cpp
@@ -19,8 +19,8 @@ namespace OpenLoco::Tutorial
     static loco_global<State, 0x00508F19> _state;
 
     // The following two globals are unused, but left here for documentation purposes.
-    static loco_global<uint16_t*, 0x009C86FC> _tutorialOffset;
-    static loco_global<uint16_t*, 0x009C8704> _tutorialEnd;
+    // static loco_global<uint16_t*, 0x009C86FC> _tutorialOffset;
+    // static loco_global<uint16_t*, 0x009C8704> _tutorialEnd;
 
     static loco_global<string_id, 0x009C8708> _tutorialString;
     static loco_global<uint8_t, 0x009C870A> _tutorialNumber;


### PR DESCRIPTION
Reduces `loco_global` usage by replacing with calls to `S5.getOptions()`.
Will be easiest to code-review this by commit as I've done 1 `loco_global` per commit