### PR TITLE
Fix #1424 crash when loading scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix: [#1379] Year formatted correctly in date cheat window.
 - Fix: [#1393] Vehicles not sorted correctly in build vehicle window.
 - Fix: [#1400] Imperial-to-metric power conversion didn't match vanilla.
+- Fix: [#1424] Crash when loading a scenario after waiting on title screen.
 - Fix: [#1434] Can set 0 or more than 80 towns in scenario editor.
 
 22.03.1 (2022-03-08)

--- a/src/OpenLoco/Scenario.cpp
+++ b/src/OpenLoco/Scenario.cpp
@@ -306,6 +306,7 @@ namespace OpenLoco::Scenario
             fullPath = scenarioPath / path;
         }
 
+        Audio::pauseSound();
         static loco_global<char[512], 0x00112CE04> scenarioFilename;
         std::strncpy(&*scenarioFilename, fullPath.u8string().c_str(), std::size(scenarioFilename));
         auto flags = call(0x00442837);


### PR DESCRIPTION
Issue was caused by the sound not being unloaded(paused) when loading a scenario from the main scenario select screen. All other ways of loading would not be affected as sound is disabled when the load save screen is visible.

#1279 is similar but would really be best to handle by implementing vehicle sell.