### PR TITLE
correctly format autopay tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix: [#1400] Imperial-to-metric power conversion didn't match vanilla.
 - Fix: [#1424] Crash when loading a scenario after waiting on title screen.
 - Fix: [#1434] Can set 0 or more than 80 towns in scenario editor.
+- Fix: [#1449] Autopay tooltip was formatted poorly.
 
 22.03.1 (2022-03-08)
 ------------------------------------------------------------------------

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2281,7 +2281,7 @@ strings:
   2226: "Construction: Select position"
   2227: "Trains reverse at signals"
   2228: Autopay
-  2229: "Once per day, any current funds you have will be used to pay off your loan, if you have one."
+  2229: "{SMALLFONT}{COLOUR BLACK}Once per day, any current funds you have will be used to pay off your loan, if you have one."
   2230: "{COLOUR WINDOW_2}Year:"
   2231: "{COLOUR WINDOW_2}Month:"
   2232: "{COLOUR WINDOW_2}Day:"


### PR DESCRIPTION
Autopay tooltip on finances window is not formatted correctly. I swear I fixed this a while ago, but apparently not