### PR TITLE
renames var_2C to trackAndDirection where applicable

### DIFF
--- a/src/OpenLoco/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/Vehicles/CreateVehicle.cpp
@@ -132,7 +132,7 @@ namespace OpenLoco::Vehicles
         newBogie->tileY = 0;
         newBogie->tileBaseZ = 0;
         newBogie->subPosition = 0;
-        newBogie->var_2C = TrackAndDirection(0, 0);
+        newBogie->trackAndDirection = TrackAndDirection(0, 0);
         newBogie->routingHandle = lastVeh->getRoutingHandle();
         newBogie->objectId = vehicleTypeId;
 
@@ -251,7 +251,7 @@ namespace OpenLoco::Vehicles
         newBody->tileY = 0;
         newBody->tileBaseZ = 0;
         newBody->subPosition = 0;
-        newBody->var_2C = TrackAndDirection(0, 0);
+        newBody->trackAndDirection = TrackAndDirection(0, 0);
         newBody->routingHandle = lastVeh->getRoutingHandle();
         newBody->var_38 = Flags38::unk_0; // different to create bogie
         newBody->objectId = vehicleTypeId;
@@ -437,7 +437,7 @@ namespace OpenLoco::Vehicles
         newHead->tileBaseZ = 0;
         newHead->remainingDistance = 0;
         newHead->subPosition = 0;
-        newHead->var_2C = TrackAndDirection(0, 0);
+        newHead->trackAndDirection = TrackAndDirection(0, 0);
         newHead->routingHandle = routingHandle;
         newHead->var_14 = 0;
         newHead->var_09 = 0;
@@ -475,7 +475,7 @@ namespace OpenLoco::Vehicles
         newVeh1->tileBaseZ = 0;
         newVeh1->remainingDistance = 0;
         newVeh1->subPosition = 0;
-        newVeh1->var_2C = TrackAndDirection(0, 0);
+        newVeh1->trackAndDirection = TrackAndDirection(0, 0);
         newVeh1->routingHandle = lastVeh->getRoutingHandle();
         newVeh1->var_14 = 0;
         newVeh1->var_09 = 0;
@@ -506,7 +506,7 @@ namespace OpenLoco::Vehicles
         newVeh2->tileBaseZ = 0;
         newVeh2->remainingDistance = 0;
         newVeh2->subPosition = 0;
-        newVeh2->var_2C = TrackAndDirection(0, 0);
+        newVeh2->trackAndDirection = TrackAndDirection(0, 0);
         newVeh2->routingHandle = lastVeh->getRoutingHandle();
         newVeh2->var_14 = 0;
         newVeh2->var_09 = 0;
@@ -543,7 +543,7 @@ namespace OpenLoco::Vehicles
         newTail->tileBaseZ = 0;
         newTail->remainingDistance = 0;
         newTail->subPosition = 0;
-        newTail->var_2C = TrackAndDirection(0, 0);
+        newTail->trackAndDirection = TrackAndDirection(0, 0);
         newTail->routingHandle = lastVeh->getRoutingHandle();
         newTail->var_14 = 0;
         newTail->var_09 = 0;
@@ -749,7 +749,7 @@ namespace OpenLoco::Vehicles
                 _backupX = train.head->tileX;
                 _backupY = train.head->tileY;
                 _backupZ = train.head->tileBaseZ;
-                _backup2C = train.head->var_2C;
+                _backup2C = train.head->trackAndDirection;
                 _backup2E = train.head->subPosition;
                 _backupVeh0 = train.head;
                 train.head->liftUpVehicle();

--- a/src/OpenLoco/Vehicles/Routing.cpp
+++ b/src/OpenLoco/Vehicles/Routing.cpp
@@ -448,13 +448,13 @@ namespace OpenLoco::Vehicles
                     continue;
                 }
 
-                if (vehicle->getTrackLoc() == interest.loc && vehicle->getVar2C().track == tad)
+                if (vehicle->getTrackLoc() == interest.loc && vehicle->getTrackAndDirection().track == tad)
                 {
                     _routingTransformData = 1;
                     break;
                 }
 
-                if (vehicle->getTrackLoc() == nextLoc && vehicle->getVar2C().track == backwardTaD)
+                if (vehicle->getTrackLoc() == nextLoc && vehicle->getTrackAndDirection().track == backwardTaD)
                 {
                     _routingTransformData = 1;
                     break;

--- a/src/OpenLoco/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/Vehicles/Vehicle.cpp
@@ -16,16 +16,16 @@ namespace OpenLoco::Vehicles
     struct VehicleCommon : VehicleBase
     {
         uint8_t pad_24[0x24 - 0x22];
-        EntityId head;               // 0x26
-        uint32_t remainingDistance;  // 0x28
-        TrackAndDirection var_2C;    // 0x2C
-        uint16_t subPosition;        // 0x2E
-        int16_t tileX;               // 0x30
-        int16_t tileY;               // 0x32
-        uint8_t tileBaseZ;           // 0x34
-        uint8_t trackType;           // 0x35 field same in all vehicles
-        RoutingHandle routingHandle; // 0x36 field same in all vehicles
-        uint8_t var_38;              // 0x38
+        EntityId head;                       // 0x26
+        uint32_t remainingDistance;          // 0x28
+        TrackAndDirection trackAndDirection; // 0x2C
+        uint16_t subPosition;                // 0x2E
+        int16_t tileX;                       // 0x30
+        int16_t tileY;                       // 0x32
+        uint8_t tileBaseZ;                   // 0x34
+        uint8_t trackType;                   // 0x35 field same in all vehicles
+        RoutingHandle routingHandle;         // 0x36 field same in all vehicles
+        uint8_t var_38;                      // 0x38
         uint8_t pad_39;
         EntityId nextCarId; // 0x3A
         uint8_t pad_3C[0x42 - 0x3C];
@@ -69,10 +69,10 @@ namespace OpenLoco::Vehicles
         return Map::Pos3(veh->tileX, veh->tileY, veh->tileBaseZ * Map::kSmallZStep);
     }
 
-    TrackAndDirection VehicleBase::getVar2C() const
+    TrackAndDirection VehicleBase::getTrackAndDirection() const
     {
         const auto* veh = reinterpret_cast<const VehicleCommon*>(this);
-        return veh->var_2C;
+        return veh->trackAndDirection;
     }
 
     RoutingHandle VehicleBase::getRoutingHandle() const

--- a/src/OpenLoco/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/Vehicles/Vehicle.cpp
@@ -22,7 +22,7 @@ namespace OpenLoco::Vehicles
         uint16_t subPosition;                // 0x2E
         int16_t tileX;                       // 0x30
         int16_t tileY;                       // 0x32
-        uint8_t tileBaseZ;                   // 0x34
+        Map::SmallZ tileBaseZ;               // 0x34
         uint8_t trackType;                   // 0x35 field same in all vehicles
         RoutingHandle routingHandle;         // 0x36 field same in all vehicles
         uint8_t var_38;                      // 0x38

--- a/src/OpenLoco/Vehicles/Vehicle.h
+++ b/src/OpenLoco/Vehicles/Vehicle.h
@@ -229,7 +229,7 @@ namespace OpenLoco::Vehicles
         uint8_t getFlags38() const;
         uint8_t getTrackType() const;
         Map::Pos3 getTrackLoc() const;
-        TrackAndDirection getVar2C() const;
+        TrackAndDirection getTrackAndDirection() const;
         RoutingHandle getRoutingHandle() const;
         EntityId getHead() const;
         void setNextCar(const EntityId newNextCar);
@@ -275,15 +275,15 @@ namespace OpenLoco::Vehicles
     {
         static constexpr auto kVehicleThingType = VehicleThingType::head;
         uint8_t pad_24[0x26 - 0x24];
-        EntityId head;              // 0x26
-        uint32_t remainingDistance; // 0x28
-        TrackAndDirection var_2C;
-        uint16_t subPosition;        // 0x2E
-        int16_t tileX;               // 0x30
-        int16_t tileY;               // 0x32
-        Map::SmallZ tileBaseZ;       // 0x34
-        uint8_t trackType;           // 0x35 field same in all vehicles
-        RoutingHandle routingHandle; // 0x36 field same in all vehicles orderId * maxNumRoutingSteps
+        EntityId head;                       // 0x26
+        uint32_t remainingDistance;          // 0x28
+        TrackAndDirection trackAndDirection; // 0x2C
+        uint16_t subPosition;                // 0x2E
+        int16_t tileX;                       // 0x30
+        int16_t tileY;                       // 0x32
+        Map::SmallZ tileBaseZ;               // 0x34
+        uint8_t trackType;                   // 0x35 field same in all vehicles
+        RoutingHandle routingHandle;         // 0x36 field same in all vehicles orderId * maxNumRoutingSteps
         uint8_t var_38;
         uint8_t pad_39;      // 0x39
         EntityId nextCarId;  // 0x3A
@@ -421,15 +421,15 @@ namespace OpenLoco::Vehicles
     {
         static constexpr auto kVehicleThingType = VehicleThingType::vehicle_1;
         uint8_t pad_24[0x26 - 0x24];
-        EntityId head;              // 0x26
-        uint32_t remainingDistance; // 0x28
-        TrackAndDirection var_2C;
-        uint16_t subPosition;        // 0x2E
-        int16_t tileX;               // 0x30
-        int16_t tileY;               // 0x32
-        Map::SmallZ tileBaseZ;       // 0x34
-        uint8_t trackType;           // 0x35 field same in all vehicles
-        RoutingHandle routingHandle; // 0x36 field same in all vehicles
+        EntityId head;                       // 0x26
+        uint32_t remainingDistance;          // 0x28
+        TrackAndDirection trackAndDirection; // 0x2C
+        uint16_t subPosition;                // 0x2E
+        int16_t tileX;                       // 0x30
+        int16_t tileY;                       // 0x32
+        uint8_t tileBaseZ;                   // 0x34
+        uint8_t trackType;                   // 0x35 field same in all vehicles
+        RoutingHandle routingHandle;         // 0x36 field same in all vehicles
         uint8_t var_38;
         uint8_t pad_39;      // 0x39
         EntityId nextCarId;  // 0x3A
@@ -458,15 +458,15 @@ namespace OpenLoco::Vehicles
     {
         static constexpr auto kVehicleThingType = VehicleThingType::vehicle_2;
         uint8_t pad_24[0x26 - 0x24];
-        EntityId head;              // 0x26
-        uint32_t remainingDistance; // 0x28
-        TrackAndDirection var_2C;
-        uint16_t subPosition;        // 0x2E
-        int16_t tileX;               // 0x30
-        int16_t tileY;               // 0x32
-        Map::SmallZ tileBaseZ;       // 0x34
-        uint8_t trackType;           // 0x35 field same in all vehicles
-        RoutingHandle routingHandle; // 0x36 field same in all vehicles
+        EntityId head;                       // 0x26
+        uint32_t remainingDistance;          // 0x28
+        TrackAndDirection trackAndDirection; // 0x2C
+        uint16_t subPosition;                // 0x2E
+        int16_t tileX;                       // 0x30
+        int16_t tileY;                       // 0x32
+        uint8_t tileBaseZ;                   // 0x34
+        uint8_t trackType;                   // 0x35 field same in all vehicles
+        RoutingHandle routingHandle;         // 0x36 field same in all vehicles
         uint8_t var_38;
         uint8_t pad_39;              // 0x39
         EntityId nextCarId;          // 0x3A
@@ -504,16 +504,16 @@ namespace OpenLoco::Vehicles
     struct VehicleBody : VehicleBase
     {
         static constexpr auto kVehicleThingType = VehicleThingType::body_continued;
-        ColourScheme colourScheme;  // 0x24
-        EntityId head;              // 0x26
-        uint32_t remainingDistance; // 0x28
-        TrackAndDirection var_2C;
-        uint16_t subPosition;        // 0x2E
-        int16_t tileX;               // 0x30
-        int16_t tileY;               // 0x32
-        Map::SmallZ tileBaseZ;       // 0x34
-        uint8_t trackType;           // 0x35 field same in all vehicles
-        RoutingHandle routingHandle; // 0x36 field same in all vehicles
+        ColourScheme colourScheme;           // 0x24
+        EntityId head;                       // 0x26
+        uint32_t remainingDistance;          // 0x28
+        TrackAndDirection trackAndDirection; // 0x2C
+        uint16_t subPosition;                // 0x2E
+        int16_t tileX;                       // 0x30
+        int16_t tileY;                       // 0x32
+        uint8_t tileBaseZ;                   // 0x34
+        uint8_t trackType;                   // 0x35 field same in all vehicles
+        RoutingHandle routingHandle;         // 0x36 field same in all vehicles
         uint8_t var_38;
         uint8_t objectSpriteType; // 0x39
         EntityId nextCarId;       // 0x3A
@@ -559,16 +559,16 @@ namespace OpenLoco::Vehicles
     struct VehicleBogie : VehicleBase
     {
         static constexpr auto kVehicleThingType = VehicleThingType::bogie;
-        ColourScheme colourScheme;  // 0x24
-        EntityId head;              // 0x26
-        uint32_t remainingDistance; // 0x28
-        TrackAndDirection var_2C;
-        uint16_t subPosition;        // 0x2E
-        int16_t tileX;               // 0x30
-        int16_t tileY;               // 0x32
-        Map::SmallZ tileBaseZ;       // 0x34
-        uint8_t trackType;           // 0x35 field same in all vehicles
-        RoutingHandle routingHandle; // 0x36 field same in all vehicles
+        ColourScheme colourScheme;           // 0x24
+        EntityId head;                       // 0x26
+        uint32_t remainingDistance;          // 0x28
+        TrackAndDirection trackAndDirection; // 0x2C
+        uint16_t subPosition;                // 0x2E
+        int16_t tileX;                       // 0x30
+        int16_t tileY;                       // 0x32
+        uint8_t tileBaseZ;                   // 0x34
+        uint8_t trackType;                   // 0x35 field same in all vehicles
+        RoutingHandle routingHandle;         // 0x36 field same in all vehicles
         uint8_t var_38;
         uint8_t objectSpriteType; // 0x39
         EntityId nextCarId;       // 0x3A
@@ -608,15 +608,15 @@ namespace OpenLoco::Vehicles
     {
         static constexpr auto kVehicleThingType = VehicleThingType::tail;
         uint8_t pad_24[0x26 - 0x24];
-        EntityId head;              // 0x26
-        uint32_t remainingDistance; // 0x28
-        TrackAndDirection var_2C;
-        uint16_t subPosition;        // 0x2E
-        int16_t tileX;               // 0x30
-        int16_t tileY;               // 0x32
-        Map::SmallZ tileBaseZ;       // 0x34
-        uint8_t trackType;           // 0x35 field same in all vehicles
-        RoutingHandle routingHandle; // 0x36 field same in all vehicles
+        EntityId head;                       // 0x26
+        uint32_t remainingDistance;          // 0x28
+        TrackAndDirection trackAndDirection; // 0x2C
+        uint16_t subPosition;                // 0x2E
+        int16_t tileX;                       // 0x30
+        int16_t tileY;                       // 0x32
+        uint8_t tileBaseZ;                   // 0x34
+        uint8_t trackType;                   // 0x35 field same in all vehicles
+        RoutingHandle routingHandle;         // 0x36 field same in all vehicles
         uint8_t var_38;
         uint8_t pad_39;              // 0x39
         EntityId nextCarId;          // 0x3A

--- a/src/OpenLoco/Vehicles/Vehicle.h
+++ b/src/OpenLoco/Vehicles/Vehicle.h
@@ -614,7 +614,7 @@ namespace OpenLoco::Vehicles
         uint16_t subPosition;                // 0x2E
         int16_t tileX;                       // 0x30
         int16_t tileY;                       // 0x32
-        uint8_t tileBaseZ;                   // 0x34
+        Map::SmallZ tileBaseZ;               // 0x34
         uint8_t trackType;                   // 0x35 field same in all vehicles
         RoutingHandle routingHandle;         // 0x36 field same in all vehicles
         uint8_t var_38;

--- a/src/OpenLoco/Vehicles/Vehicle.h
+++ b/src/OpenLoco/Vehicles/Vehicle.h
@@ -427,7 +427,7 @@ namespace OpenLoco::Vehicles
         uint16_t subPosition;                // 0x2E
         int16_t tileX;                       // 0x30
         int16_t tileY;                       // 0x32
-        uint8_t tileBaseZ;                   // 0x34
+        Map::SmallZ tileBaseZ;               // 0x34
         uint8_t trackType;                   // 0x35 field same in all vehicles
         RoutingHandle routingHandle;         // 0x36 field same in all vehicles
         uint8_t var_38;
@@ -464,7 +464,7 @@ namespace OpenLoco::Vehicles
         uint16_t subPosition;                // 0x2E
         int16_t tileX;                       // 0x30
         int16_t tileY;                       // 0x32
-        uint8_t tileBaseZ;                   // 0x34
+        Map::SmallZ tileBaseZ;               // 0x34
         uint8_t trackType;                   // 0x35 field same in all vehicles
         RoutingHandle routingHandle;         // 0x36 field same in all vehicles
         uint8_t var_38;
@@ -511,7 +511,7 @@ namespace OpenLoco::Vehicles
         uint16_t subPosition;                // 0x2E
         int16_t tileX;                       // 0x30
         int16_t tileY;                       // 0x32
-        uint8_t tileBaseZ;                   // 0x34
+        Map::SmallZ tileBaseZ;               // 0x34
         uint8_t trackType;                   // 0x35 field same in all vehicles
         RoutingHandle routingHandle;         // 0x36 field same in all vehicles
         uint8_t var_38;
@@ -566,7 +566,7 @@ namespace OpenLoco::Vehicles
         uint16_t subPosition;                // 0x2E
         int16_t tileX;                       // 0x30
         int16_t tileY;                       // 0x32
-        uint8_t tileBaseZ;                   // 0x34
+        Map::SmallZ tileBaseZ;               // 0x34
         uint8_t trackType;                   // 0x35 field same in all vehicles
         RoutingHandle routingHandle;         // 0x36 field same in all vehicles
         uint8_t var_38;

--- a/src/OpenLoco/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/Vehicles/VehicleBody.cpp
@@ -163,8 +163,8 @@ namespace OpenLoco::Vehicles
             }
             else
             {
-                ah = vehicle_arr_4F865C[frontBogie->var_2C.track._data >> 2];
-                if ((frontBogie->var_2C.track.id() == 12) || (frontBogie->var_2C.track.id() == 13))
+                ah = vehicle_arr_4F865C[frontBogie->trackAndDirection.track._data >> 2];
+                if ((frontBogie->trackAndDirection.track.id() == 12) || (frontBogie->trackAndDirection.track.id() == 13))
                 {
                     if (frontBogie->subPosition >= 48)
                     {
@@ -980,9 +980,9 @@ namespace OpenLoco::Vehicles
                     continue;
                 if (track->baseZ() != frontBogie->tileBaseZ)
                     continue;
-                if (track->trackId() != frontBogie->var_2C.track.id())
+                if (track->trackId() != frontBogie->trackAndDirection.track.id())
                     continue;
-                if (track->unkDirection() != frontBogie->var_2C.track.cardinalDirection())
+                if (track->unkDirection() != frontBogie->trackAndDirection.track.cardinalDirection())
                     continue;
                 if (!track->hasStationElement())
                     continue;
@@ -1223,12 +1223,12 @@ namespace OpenLoco::Vehicles
         auto yaw = (sprite_yaw + 16) & 0x3F;
         auto firstBogie = var_38 & Flags38::isReversed ? backBogie : frontBogie;
         auto unkFactor = 5;
-        if (!trackIdToSparkDirection[(firstBogie->var_2C.road._data >> 3)])
+        if (!trackIdToSparkDirection[(firstBogie->trackAndDirection.road._data >> 3)])
         {
             unkFactor = -5;
         }
 
-        if (firstBogie->var_2C.road.isReversed())
+        if (firstBogie->trackAndDirection.road.isReversed())
         {
             unkFactor = -unkFactor;
         }

--- a/src/OpenLoco/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/Vehicles/VehicleHead.cpp
@@ -962,7 +962,7 @@ namespace OpenLoco::Vehicles
 
         if (trackType == 0xFF || ObjectManager::get<RoadObject>(trackType)->flags & Flags12::isRoad)
         {
-            if (train.veh1->var_2C.road.isBackToFront())
+            if (train.veh1->trackAndDirection.road.isBackToFront())
             {
                 param1 = 128;
                 turnaroundAtSignalTimeout = 544;
@@ -972,7 +972,7 @@ namespace OpenLoco::Vehicles
         {
             // Tram
             turnaroundAtSignalTimeout = kTramSignalTimeout;
-            if (train.veh1->var_2C.road.isBackToFront())
+            if (train.veh1->trackAndDirection.road.isBackToFront())
             {
                 param1 = 64;
                 turnaroundAtSignalTimeout = 128;
@@ -2561,8 +2561,8 @@ namespace OpenLoco::Vehicles
             case TransportMode::rail:
             {
                 auto tile = Map::TileManager::get(Pos2{ bogie->tileX, bogie->tileY });
-                auto direction = bogie->var_2C.track.cardinalDirection();
-                auto trackId = bogie->var_2C.track.id();
+                auto direction = bogie->trackAndDirection.track.cardinalDirection();
+                auto trackId = bogie->trackAndDirection.track.id();
                 auto loadingModifier = 12;
                 auto* elStation = tile.trackStation(trackId, direction, bogie->tileBaseZ);
                 if (elStation != nullptr)
@@ -2580,8 +2580,8 @@ namespace OpenLoco::Vehicles
             case TransportMode::road:
             {
                 auto tile = Map::TileManager::get(Pos2{ bogie->tileX, bogie->tileY });
-                auto direction = bogie->var_2C.road.cardinalDirection();
-                auto roadId = bogie->var_2C.road.id();
+                auto direction = bogie->trackAndDirection.road.cardinalDirection();
+                auto roadId = bogie->trackAndDirection.road.id();
                 auto loadingModifier = 2;
                 auto* elStation = tile.roadStation(roadId, direction, bogie->tileBaseZ);
                 if (elStation != nullptr)
@@ -3248,8 +3248,8 @@ namespace OpenLoco::Vehicles
 
     static StationId tryFindStationAt(VehicleBogie* bogie)
     {
-        auto direction = bogie->var_2C.track.cardinalDirection();
-        auto trackId = bogie->var_2C.track.id();
+        auto direction = bogie->trackAndDirection.track.cardinalDirection();
+        auto trackId = bogie->trackAndDirection.track.id();
 
         auto tile = TileManager::get(Map::Pos2{ bogie->tileX, bogie->tileY });
         auto* elStation = tile.trackStation(trackId, direction, bogie->tileBaseZ);
@@ -3404,7 +3404,7 @@ namespace OpenLoco::Vehicles
                 if (elRoad->isGhost() || elRoad->isFlag5())
                     continue;
 
-                if (elRoad->roadId() != veh->var_2C.road.id())
+                if (elRoad->roadId() != veh->trackAndDirection.road.id())
                     continue;
 
                 return true;
@@ -3426,10 +3426,10 @@ namespace OpenLoco::Vehicles
                 if (elTrack->isGhost() || elTrack->isFlag5())
                     continue;
 
-                if (elTrack->unkDirection() != veh->var_2C.track.cardinalDirection())
+                if (elTrack->unkDirection() != veh->trackAndDirection.track.cardinalDirection())
                     continue;
 
-                if (elTrack->trackId() != veh->var_2C.track.id())
+                if (elTrack->trackId() != veh->trackAndDirection.track.id())
                     continue;
 
                 return true;

--- a/src/OpenLoco/Vehicles/VehicleTail.cpp
+++ b/src/OpenLoco/Vehicles/VehicleTail.cpp
@@ -92,18 +92,18 @@ namespace OpenLoco::Vehicles
         }
 
         const auto ref = RoutingManager::getRouting(_oldRoutingHandle);
-        TrackAndDirection trackAndDirection((ref & 0x1F8) >> 3, ref & 0x7);
+        TrackAndDirection trackAndDir((ref & 0x1F8) >> 3, ref & 0x7);
         RoutingManager::freeRouting(_oldRoutingHandle);
 
         if (mode == TransportMode::road)
         {
-            sub_47D959(_oldTilePos, trackAndDirection.road, false);
+            sub_47D959(_oldTilePos, trackAndDir.road, false);
         }
         else
         {
             if (ref & (1 << 15))
             {
-                setSignalState(_oldTilePos, trackAndDirection.track, trackType, 0);
+                setSignalState(_oldTilePos, trackAndDir.track, trackType, 0);
             }
 
             const auto& trackSize = Map::TrackData::getUnkTrack(ref & 0x1FF);
@@ -112,10 +112,10 @@ namespace OpenLoco::Vehicles
             {
                 nextTile -= Map::Pos3{ _503C6C[trackSize.rotationEnd], 0 };
             }
-            auto trackAndDirection2 = trackAndDirection;
+            auto trackAndDirection2 = trackAndDir;
             trackAndDirection2.track.setReversed(!trackAndDirection2.track.isReversed());
             sub_4A2AD7(nextTile, trackAndDirection2.track, owner, trackType);
-            leaveLevelCrossing(_oldTilePos, trackAndDirection.track, 9);
+            leaveLevelCrossing(_oldTilePos, trackAndDir.track, 9);
         }
         return true;
     }


### PR DESCRIPTION
Just a bulk rename from `Vehicle*::var_2C` to `trackAndDirection`, since that's what var_2C is.