### PR TITLE
Hold shift when placing a vehicle to start it immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 22.04+ (???)
 ------------------------------------------------------------------------
 - Feature: [#1457] Added option to invert right-mouse panning the game view.
+- Feature: [#1484] Hold shift when placing a vehicle to start it immediately.
 - Fix: [#293] Menu screen and other window corruption when many objects loaded.
 - Fix: [#1463] Crash when opening the build window under certain situations.
 

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -4125,10 +4125,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
             args.push(head.name);
             args.push(head.ordinalNumber);
             GameCommands::setErrorTitle(StringIds::cant_place_string_id_here);
-            if (GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply) != GameCommands::FAILURE)
-            {
-                pickupToolPlacementCommandCallback(self, head.head);
-            }
+
+            auto result = GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply);
+            pickupToolPlacementCommandCallback(result, self, head.head);
         }
 
         // 0x004B2C95
@@ -4159,10 +4158,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
             args.push(head.name);
             args.push(head.ordinalNumber);
             GameCommands::setErrorTitle(StringIds::cant_place_string_id_here);
-            if (GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply) != GameCommands::FAILURE)
-            {
-                pickupToolPlacementCommandCallback(self, head.head);
-            }
+
+            auto result = GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply);
+            pickupToolPlacementCommandCallback(result, self, head.head);
         }
 
         // 0x004B2C74

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -4094,6 +4094,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             args.push(head.name);
             args.push(head.ordinalNumber);
             GameCommands::setErrorTitle(StringIds::cant_place_string_id_here);
+
             auto result = GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply);
             pickupToolPlacementCommandCallback(result, self, head.head);
         }

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -4051,6 +4051,16 @@ namespace OpenLoco::Ui::Windows::Vehicle
             Error::open(StringIds::cant_place_string_id_here, StringIds::null);
         }
 
+        static void pickupToolPlacementSuccess(Window& self, EntityId vehicleHead)
+        {
+            if (Input::hasKeyModifier(Input::KeyModifier::shift))
+            {
+                GameCommands::do12(vehicleHead, 1);
+            }
+            Input::toolCancel();
+            self.callOnMouseUp(Common::widx::tabMain);
+        }
+
         // 0x004B2E18
         static void pickupToolDownAir(Window& self, const Vehicles::VehicleHead& head, const int16_t x, const int16_t y)
         {
@@ -4080,13 +4090,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             GameCommands::setErrorTitle(StringIds::cant_place_string_id_here);
             if (GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply) != GameCommands::FAILURE)
             {
-                if (Input::hasKeyModifier(Input::KeyModifier::shift))
-                {
-                    GameCommands::do12(head.head, 1);
-                }
-
-                Input::toolCancel();
-                self.callOnMouseUp(Common::widx::tabMain);
+                pickupToolPlacementSuccess(self, head.head);
             }
         }
 
@@ -4119,13 +4123,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             GameCommands::setErrorTitle(StringIds::cant_place_string_id_here);
             if (GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply) != GameCommands::FAILURE)
             {
-                if (Input::hasKeyModifier(Input::KeyModifier::shift))
-                {
-                    GameCommands::do12(head.head, 1);
-                }
-
-                Input::toolCancel();
-                self.callOnMouseUp(Common::widx::tabMain);
+                pickupToolPlacementSuccess(self, head.head);
             }
         }
 
@@ -4159,13 +4157,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             GameCommands::setErrorTitle(StringIds::cant_place_string_id_here);
             if (GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply) != GameCommands::FAILURE)
             {
-                if (Input::hasKeyModifier(Input::KeyModifier::shift))
-                {
-                    GameCommands::do12(head.head, 1);
-                }
-
-                Input::toolCancel();
-                self.callOnMouseUp(Common::widx::tabMain);
+                pickupToolPlacementSuccess(self, head.head);
             }
         }
 

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -4080,6 +4080,11 @@ namespace OpenLoco::Ui::Windows::Vehicle
             GameCommands::setErrorTitle(StringIds::cant_place_string_id_here);
             if (GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply) != GameCommands::FAILURE)
             {
+                if (Input::hasKeyModifier(Input::KeyModifier::shift))
+                {
+                    GameCommands::do12(head.head, 1);
+                }
+
                 Input::toolCancel();
                 self.callOnMouseUp(Common::widx::tabMain);
             }
@@ -4114,6 +4119,11 @@ namespace OpenLoco::Ui::Windows::Vehicle
             GameCommands::setErrorTitle(StringIds::cant_place_string_id_here);
             if (GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply) != GameCommands::FAILURE)
             {
+                if (Input::hasKeyModifier(Input::KeyModifier::shift))
+                {
+                    GameCommands::do12(head.head, 1);
+                }
+
                 Input::toolCancel();
                 self.callOnMouseUp(Common::widx::tabMain);
             }

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -4149,6 +4149,11 @@ namespace OpenLoco::Ui::Windows::Vehicle
             GameCommands::setErrorTitle(StringIds::cant_place_string_id_here);
             if (GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply) != GameCommands::FAILURE)
             {
+                if (Input::hasKeyModifier(Input::KeyModifier::shift))
+                {
+                    GameCommands::do12(head.head, 1);
+                }
+
                 Input::toolCancel();
                 self.callOnMouseUp(Common::widx::tabMain);
             }

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -4051,12 +4051,18 @@ namespace OpenLoco::Ui::Windows::Vehicle
             Error::open(StringIds::cant_place_string_id_here, StringIds::null);
         }
 
-        static void pickupToolPlacementSuccess(Window& self, EntityId vehicleHead)
+        static void pickupToolPlacementCommandCallback(uint32_t gameCommandResult, Window& self, EntityId vehicleHead)
         {
+            if (gameCommandResult == GameCommands::FAILURE)
+            {
+                return;
+            }
+
             if (Input::hasKeyModifier(Input::KeyModifier::shift))
             {
                 GameCommands::do12(vehicleHead, 1);
             }
+
             Input::toolCancel();
             self.callOnMouseUp(Common::widx::tabMain);
         }
@@ -4088,10 +4094,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             args.push(head.name);
             args.push(head.ordinalNumber);
             GameCommands::setErrorTitle(StringIds::cant_place_string_id_here);
-            if (GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply) != GameCommands::FAILURE)
-            {
-                pickupToolPlacementSuccess(self, head.head);
-            }
+            auto result = GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply);
+            pickupToolPlacementCommandCallback(result, self, head.head);
         }
 
         // 0x004B2F1C
@@ -4123,7 +4127,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             GameCommands::setErrorTitle(StringIds::cant_place_string_id_here);
             if (GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply) != GameCommands::FAILURE)
             {
-                pickupToolPlacementSuccess(self, head.head);
+                pickupToolPlacementCommandCallback(self, head.head);
             }
         }
 
@@ -4157,7 +4161,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             GameCommands::setErrorTitle(StringIds::cant_place_string_id_here);
             if (GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply) != GameCommands::FAILURE)
             {
-                pickupToolPlacementSuccess(self, head.head);
+                pickupToolPlacementCommandCallback(self, head.head);
             }
         }
 


### PR DESCRIPTION
As title says, this feature is simple - if you hold the shift key when placing a vehicle, when the vehicle is placed it will automatically be toggled to 'On'. 