### PR TITLE
Reduce locoglobals snowandseason

### DIFF
--- a/src/OpenLoco/GameCommands/CreateTree.cpp
+++ b/src/OpenLoco/GameCommands/CreateTree.cpp
@@ -113,7 +113,7 @@ namespace OpenLoco::GameCommands
             {
                 elTree->setUnk5l(treeObj->growth - 1);
                 elTree->setClearZ(treeObj->height / Map::kSmallZStep + elTree->baseZ());
-                if (elTree->baseZ() - 4 > Scenario::getSnowLine() && (treeObj->flags & TreeObjectFlags::hasSnowVariation))
+                if (elTree->baseZ() - 4 > Scenario::getCurrentSnowLine() && (treeObj->flags & TreeObjectFlags::hasSnowVariation))
                 {
                     elTree->setSnow(true);
                 }

--- a/src/OpenLoco/GameState.h
+++ b/src/OpenLoco/GameState.h
@@ -55,7 +55,7 @@ namespace OpenLoco
         uint8_t pickupDirection;                                                 // 0x000198 (0x00525FB0)
         uint8_t lastTreeOption;                                                  // 0x000199 (0x00525FB1)
         uint16_t seaLevel;                                                       // 0x00019A (0x00525FB2)
-        uint8_t currentSnowLine;                                                 // 0x00019C (0x00525FB4)
+        Map::SmallZ currentSnowLine;                                             // 0x00019C (0x00525FB4)
         Scenario::Season currentSeason;                                          // 0x00019D (0x00525FB5)
         uint8_t lastLandOption;                                                  // 0x00019E (0x00525FB6)
         uint8_t maxCompetingCompanies;                                           // 0x00019F (0x00525FB7)

--- a/src/OpenLoco/GameState.h
+++ b/src/OpenLoco/GameState.h
@@ -6,6 +6,7 @@
 #include "Map/Animation.h"
 #include "Map/Wave.h"
 #include "Message.h"
+#include "Scenario.h"
 #include "Station.h"
 #include "Town.h"
 
@@ -55,7 +56,7 @@ namespace OpenLoco
         uint8_t lastTreeOption;                                                  // 0x000199 (0x00525FB1)
         uint16_t seaLevel;                                                       // 0x00019A (0x00525FB2)
         uint8_t currentSnowLine;                                                 // 0x00019C (0x00525FB4)
-        uint8_t currentSeason;                                                   // 0x00019D (0x00525FB5)
+        Scenario::Season currentSeason;                                          // 0x00019D (0x00525FB5)
         uint8_t lastLandOption;                                                  // 0x00019E (0x00525FB6)
         uint8_t maxCompetingCompanies;                                           // 0x00019F (0x00525FB7)
         uint32_t numOrders;                                                      // 0x0001A0 (0x00525FB8)

--- a/src/OpenLoco/Scenario.cpp
+++ b/src/OpenLoco/Scenario.cpp
@@ -41,9 +41,6 @@ namespace OpenLoco::Scenario
 
     static loco_global<uint32_t, 0x00525F5E> _scenario_ticks;
 
-    static loco_global<uint8_t, 0x00525FB4> _currentSnowLine;
-    static loco_global<Season, 0x00525FB5> _currentSeason;
-
     static loco_global<uint16_t, 0x0052622E> _52622E; // tick-related?
 
     static loco_global<ObjectiveType, 0x00526230> objectiveType;
@@ -98,7 +95,7 @@ namespace OpenLoco::Scenario
             season = nextSeason(season);
         }
 
-        _currentSeason = season;
+        setCurrentSeason(season);
     }
 
     // 0x00496A18
@@ -113,13 +110,13 @@ namespace OpenLoco::Scenario
 
         updateSeason(currentDayOfYear, climateObj);
 
-        if (_currentSeason == Season::winter)
+        if (getCurrentSeason() == Season::winter)
         {
-            _currentSnowLine = climateObj->winterSnowLine;
+            setCurrentSnowLine(climateObj->winterSnowLine);
         }
         else
         {
-            _currentSnowLine = climateObj->summerSnowLine;
+            setCurrentSnowLine(climateObj->summerSnowLine);
         }
     }
 
@@ -132,21 +129,36 @@ namespace OpenLoco::Scenario
 
         updateSeason(currentDayOfYear, climateObj);
 
-        if (_currentSeason == Season::winter)
+        if (getCurrentSeason() == Season::winter)
         {
-            if (_currentSnowLine != climateObj->winterSnowLine)
-                _currentSnowLine--;
+            if (getCurrentSnowLine() != climateObj->winterSnowLine)
+                setCurrentSnowLine(getCurrentSnowLine() - 1);
         }
         else
         {
-            if (_currentSnowLine != climateObj->summerSnowLine)
-                _currentSnowLine++;
+            if (getCurrentSnowLine() != climateObj->summerSnowLine)
+                setCurrentSnowLine(getCurrentSnowLine() + 1);
         }
     }
 
-    uint8_t getSnowLine()
+    // 0x00525FB4
+    uint8_t getCurrentSnowLine()
     {
-        return _currentSnowLine;
+        return getGameState().currentSnowLine;
+    }
+    void setCurrentSnowLine(uint8_t snowline)
+    {
+        getGameState().currentSnowLine = snowline;
+    }
+
+    // 0x00525FB5
+    Season getCurrentSeason()
+    {
+        return getGameState().currentSeason;
+    }
+    void setCurrentSeason(Season season)
+    {
+        getGameState().currentSeason = season;
     }
 
     // 0x00475988
@@ -257,7 +269,7 @@ namespace OpenLoco::Scenario
 
         _scenario_ticks = 0;
         _52622E = 0;
-        _currentSeason = Season::winter;
+        setCurrentSeason(Season::winter);
 
         CompanyManager::determineAvailableVehicles();
 

--- a/src/OpenLoco/Scenario.cpp
+++ b/src/OpenLoco/Scenario.cpp
@@ -142,11 +142,11 @@ namespace OpenLoco::Scenario
     }
 
     // 0x00525FB4
-    uint8_t getCurrentSnowLine()
+    Map::SmallZ getCurrentSnowLine()
     {
         return getGameState().currentSnowLine;
     }
-    void setCurrentSnowLine(uint8_t snowline)
+    void setCurrentSnowLine(Map::SmallZ snowline)
     {
         getGameState().currentSnowLine = snowline;
     }

--- a/src/OpenLoco/Scenario.h
+++ b/src/OpenLoco/Scenario.h
@@ -110,7 +110,14 @@ namespace OpenLoco::Scenario
     Season nextSeason(Season season);
     void initialiseSnowLine();
     void updateSnowLine(int32_t currentDayOfYear);
-    uint8_t getSnowLine();
+
+    // 0x00525FB4
+    uint8_t getCurrentSnowLine();
+    void setCurrentSnowLine(uint8_t snowline);
+
+    // 0x00525FB5
+    Season getCurrentSeason();
+    void setCurrentSeason(Season season);
 
     void reset();
     void sub_4748D4();

--- a/src/OpenLoco/Scenario.h
+++ b/src/OpenLoco/Scenario.h
@@ -2,6 +2,7 @@
 
 #include "Core/FileSystem.hpp"
 #include "Localisation/FormatArguments.hpp"
+#include "Map/Map.hpp"
 #include <cstdint>
 
 namespace OpenLoco
@@ -112,8 +113,8 @@ namespace OpenLoco::Scenario
     void updateSnowLine(int32_t currentDayOfYear);
 
     // 0x00525FB4
-    uint8_t getCurrentSnowLine();
-    void setCurrentSnowLine(uint8_t snowline);
+    Map::SmallZ getCurrentSnowLine();
+    void setCurrentSnowLine(Map::SmallZ snowline);
 
     // 0x00525FB5
     Season getCurrentSeason();

--- a/src/OpenLoco/Windows/TerraForm.cpp
+++ b/src/OpenLoco/Windows/TerraForm.cpp
@@ -19,6 +19,7 @@
 #include "../Objects/TreeObject.h"
 #include "../Objects/WallObject.h"
 #include "../Objects/WaterObject.h"
+#include "../Scenario.h"
 #include "../Ui/Dropdown.h"
 #include "../Ui/ScrollView.h"
 #include "../Ui/WindowManager.h"
@@ -509,8 +510,6 @@ namespace OpenLoco::Ui::Windows::Terraform
             _lastTreeCost = placeTreeGhost(*placementArgs);
         }
 
-        static loco_global<uint8_t, 0x00525FB4> _currentSnowLine;
-
         // 0x004BDF19
         static std::optional<uint8_t> getRandomTreeTypeFromSurface(const Map::TilePos2& loc, bool unk)
         {
@@ -532,7 +531,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             }
 
             uint16_t mustTreeFlags = 0;
-            if (surface->baseZ() - 4 > _currentSnowLine)
+            if (surface->baseZ() - 4 > Scenario::getCurrentSnowLine())
             {
                 mustTreeFlags |= TreeObjectFlags::hasSnowVariation;
             }


### PR DESCRIPTION
removes

```
static loco_global<uint8_t, 0x00525FB4> _currentSnowLine;
static loco_global<Season, 0x00525FB5> _currentSeason;
```