### PR TITLE
split ScenarioObjective::Objective into 2 parts, so part of it can be reused in S5::Options

### DIFF
--- a/src/OpenLoco/EditorController.cpp
+++ b/src/OpenLoco/EditorController.cpp
@@ -87,17 +87,17 @@ namespace OpenLoco::EditorController
         options.maxCompetingCompanies = CompanyManager::getMaxCompetingCompanies();
         options.competitorStartDelay = CompanyManager::getCompetitorStartDelay();
         gameState.numberOfIndustries = options.numberOfIndustries;
-        options.objectiveType = enumValue(Scenario::getObjective().type);
-        options.objectiveFlags = Scenario::getObjective().flags;
-        options.objectiveCompanyValue = Scenario::getObjective().companyValue;
-        options.objectiveMonthlyVehicleProfit = Scenario::getObjective().monthlyVehicleProfit;
-        options.objectivePerformanceIndex = Scenario::getObjective().performanceIndex;
-        options.objectiveDeliveredCargoType = Scenario::getObjective().deliveredCargoType;
-        options.objectiveDeliveredCargoAmount = Scenario::getObjective().deliveredCargoAmount;
-        options.objectiveTimeLimitYears = Scenario::getObjective().timeLimitYears;
+        options.objective.type = Scenario::getObjective().type;
+        options.objective.flags = Scenario::getObjective().flags;
+        options.objective.companyValue = Scenario::getObjective().companyValue;
+        options.objective.monthlyVehicleProfit = Scenario::getObjective().monthlyVehicleProfit;
+        options.objective.performanceIndex = Scenario::getObjective().performanceIndex;
+        options.objective.deliveredCargoType = Scenario::getObjective().deliveredCargoType;
+        options.objective.deliveredCargoAmount = Scenario::getObjective().deliveredCargoAmount;
+        options.objective.timeLimitYears = Scenario::getObjective().timeLimitYears;
 
-        options.objectiveDeliveredCargo = ObjectManager::getHeader(LoadedObjectHandle{ ObjectType::cargo, options.objectiveDeliveredCargoType });
-        options.currency = ObjectManager::getHeader(LoadedObjectHandle{ ObjectType::currency, options.objectiveDeliveredCargoType });
+        options.objectiveDeliveredCargo = ObjectManager::getHeader(LoadedObjectHandle{ ObjectType::cargo, options.objective.deliveredCargoType });
+        options.currency = ObjectManager::getHeader(LoadedObjectHandle{ ObjectType::currency, options.objective.deliveredCargoType });
     }
 
     // 0x0043EE25
@@ -180,14 +180,14 @@ namespace OpenLoco::EditorController
                     break;
                 }
 
-                const auto cargoId = S5::getOptions().objectiveDeliveredCargoType;
+                const auto cargoId = S5::getOptions().objective.deliveredCargoType;
                 if (ObjectManager::get<CargoObject>(cargoId) == nullptr)
                 {
                     for (size_t i = 0; i < ObjectManager::getMaxObjects(ObjectType::cargo); i++)
                     {
                         if (ObjectManager::get<CargoObject>(i) != nullptr)
                         {
-                            S5::getOptions().objectiveDeliveredCargoType = static_cast<uint8_t>(i);
+                            S5::getOptions().objective.deliveredCargoType = static_cast<uint8_t>(i);
                             break;
                         }
                     }

--- a/src/OpenLoco/EditorController.cpp
+++ b/src/OpenLoco/EditorController.cpp
@@ -87,15 +87,7 @@ namespace OpenLoco::EditorController
         options.maxCompetingCompanies = CompanyManager::getMaxCompetingCompanies();
         options.competitorStartDelay = CompanyManager::getCompetitorStartDelay();
         gameState.numberOfIndustries = options.numberOfIndustries;
-        options.objective.type = Scenario::getObjective().type;
-        options.objective.flags = Scenario::getObjective().flags;
-        options.objective.companyValue = Scenario::getObjective().companyValue;
-        options.objective.monthlyVehicleProfit = Scenario::getObjective().monthlyVehicleProfit;
-        options.objective.performanceIndex = Scenario::getObjective().performanceIndex;
-        options.objective.deliveredCargoType = Scenario::getObjective().deliveredCargoType;
-        options.objective.deliveredCargoAmount = Scenario::getObjective().deliveredCargoAmount;
-        options.objective.timeLimitYears = Scenario::getObjective().timeLimitYears;
-
+        options.objective = Scenario::getObjective();
         options.objectiveDeliveredCargo = ObjectManager::getHeader(LoadedObjectHandle{ ObjectType::cargo, options.objective.deliveredCargoType });
         options.currency = ObjectManager::getHeader(LoadedObjectHandle{ ObjectType::currency, options.objective.deliveredCargoType });
     }

--- a/src/OpenLoco/GameState.h
+++ b/src/OpenLoco/GameState.h
@@ -89,6 +89,7 @@ namespace OpenLoco
         uint8_t numberOfIndustries;                                              // 0x000415 (0x0052622D)
         uint16_t var_416;                                                        // 0x000416 (0x0052622E)
         Scenario::Objective scenarioObjective;                                   // 0x000418 (0x00526230)
+        Scenario::Objective2 scenarioObjective2;                                 // 0x000429 (0x00526241)
         uint8_t industryFlags;                                                   // 0x00042F (0x00526247)
         uint16_t forbiddenVehiclesPlayers;                                       // 0x000430 (0x00526248)
         uint16_t forbiddenVehiclesCompetitors;                                   // 0x000432 (0x0052624A)

--- a/src/OpenLoco/GameState.h
+++ b/src/OpenLoco/GameState.h
@@ -89,7 +89,7 @@ namespace OpenLoco
         uint8_t numberOfIndustries;                                              // 0x000415 (0x0052622D)
         uint16_t var_416;                                                        // 0x000416 (0x0052622E)
         Scenario::Objective scenarioObjective;                                   // 0x000418 (0x00526230)
-        Scenario::Objective2 scenarioObjective2;                                 // 0x000429 (0x00526241)
+        Scenario::ObjectiveProgress scenarioObjectiveProgress;                   // 0x000429 (0x00526241)
         uint8_t industryFlags;                                                   // 0x00042F (0x00526247)
         uint16_t forbiddenVehiclesPlayers;                                       // 0x000430 (0x00526248)
         uint16_t forbiddenVehiclesCompetitors;                                   // 0x000432 (0x0052624A)

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -1008,7 +1008,7 @@ namespace OpenLoco
                 if (today.month != yesterday.month)
                 {
                     // End of every month
-                    Scenario::getObjective2().monthsInChallenge++;
+                    Scenario::getObjectiveProgress().monthsInChallenge++;
                     TownManager::updateMonthly();
                     IndustryManager::updateMonthly();
                     CompanyManager::updateMonthly1();

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -1008,7 +1008,7 @@ namespace OpenLoco
                 if (today.month != yesterday.month)
                 {
                     // End of every month
-                    Scenario::getObjective().monthsInChallenge++;
+                    Scenario::getObjective2().monthsInChallenge++;
                     TownManager::updateMonthly();
                     IndustryManager::updateMonthly();
                     CompanyManager::updateMonthly1();

--- a/src/OpenLoco/S5/S5.h
+++ b/src/OpenLoco/S5/S5.h
@@ -3,6 +3,7 @@
 #include "../Core/FileSystem.hpp"
 #include "../EditorController.h"
 #include "../Objects/Object.h"
+#include "../ScenarioObjective.h"
 #include "Limits.h"
 #include <cstdint>
 #include <memory>
@@ -103,14 +104,7 @@ namespace OpenLoco::S5
         uint8_t preview[128][128];                            // 0x18A
         uint8_t maxCompetingCompanies;                        // 0x418A
         uint8_t competitorStartDelay;                         // 0x418B
-        uint8_t objectiveType;                                // 0x418C
-        uint8_t objectiveFlags;                               // 0x418D
-        uint32_t objectiveCompanyValue;                       // 0x418E
-        uint32_t objectiveMonthlyVehicleProfit;               // 0x4192
-        uint8_t objectivePerformanceIndex;                    // 0x4196
-        uint8_t objectiveDeliveredCargoType;                  // 0x4197
-        uint32_t objectiveDeliveredCargoAmount;               // 0x4198
-        uint8_t objectiveTimeLimitYears;                      // 0x419C
+        Scenario::Objective objective;                        // 0x418C
         ObjectHeader objectiveDeliveredCargo;                 // 0x419D
         ObjectHeader currency;                                // 0x41AD
 
@@ -144,14 +138,16 @@ namespace OpenLoco::S5
     static_assert(0x009C8714 + offsetof(Options, numberOfIndustries) == 0x009C889D);
     static_assert(0x009C8714 + offsetof(Options, scenarioName) == 0x009C873E);
     static_assert(0x009C8714 + offsetof(Options, scenarioDetails) == 0x009C877E);
-    static_assert(0x009C8714 + offsetof(Options, objectiveType) == 0x009CC8A0);
-    static_assert(0x009C8714 + offsetof(Options, objectiveFlags) == 0x009CC8A1);
-    static_assert(0x009C8714 + offsetof(Options, objectiveCompanyValue) == 0x009CC8A2);
-    static_assert(0x009C8714 + offsetof(Options, objectiveMonthlyVehicleProfit) == 0x009CC8A6);
-    static_assert(0x009C8714 + offsetof(Options, objectivePerformanceIndex) == 0x009CC8AA);
-    static_assert(0x009C8714 + offsetof(Options, objectiveDeliveredCargoType) == 0x009CC8AB);
-    static_assert(0x009C8714 + offsetof(Options, objectiveDeliveredCargoAmount) == 0x009CC8AC);
-    static_assert(0x009C8714 + offsetof(Options, objectiveTimeLimitYears) == 0x009CC8B0);
+
+    static_assert(0x009C8714 + offsetof(Options, objective.type) == 0x009CC8A0);
+    static_assert(0x009C8714 + offsetof(Options, objective.flags) == 0x009CC8A1);
+    static_assert(0x009C8714 + offsetof(Options, objective.companyValue) == 0x009CC8A2);
+    static_assert(0x009C8714 + offsetof(Options, objective.monthlyVehicleProfit) == 0x009CC8A6);
+    static_assert(0x009C8714 + offsetof(Options, objective.performanceIndex) == 0x009CC8AA);
+    static_assert(0x009C8714 + offsetof(Options, objective.deliveredCargoType) == 0x009CC8AB);
+    static_assert(0x009C8714 + offsetof(Options, objective.deliveredCargoAmount) == 0x009CC8AC);
+    static_assert(0x009C8714 + offsetof(Options, objective.timeLimitYears) == 0x009CC8B0);
+
     static_assert(0x009C8714 + offsetof(Options, objectiveDeliveredCargo) == 0x009CC8B1);
     static_assert(0x009C8714 + offsetof(Options, currency) == 0x009CC8C1);
 

--- a/src/OpenLoco/Scenario.cpp
+++ b/src/OpenLoco/Scenario.cpp
@@ -376,8 +376,8 @@ namespace OpenLoco::Scenario
         initialiseSnowLine();
         sub_4748D4();
         std::fill(std::begin(gameState.recordSpeed), std::end(gameState.recordSpeed), 0_mph);
-        getObjective().timeLimitUntilYear = getObjective().timeLimitUntilYear - 1 + gameState.currentYear;
-        getObjective().monthsInChallenge = 0;
+        getObjective2().timeLimitUntilYear = getObjective2().timeLimitUntilYear - 1 + gameState.currentYear;
+        getObjective2().monthsInChallenge = 0;
         call(0x0049B546);
         gameState.lastMapWindowFlags = 0;
 
@@ -466,7 +466,7 @@ namespace OpenLoco::Scenario
             else
             {
                 args.push(StringIds::by_the_end_of);
-                args.push(Scenario::getObjective().timeLimitUntilYear);
+                args.push(Scenario::getObjective2().timeLimitUntilYear);
             }
         }
 

--- a/src/OpenLoco/Scenario.cpp
+++ b/src/OpenLoco/Scenario.cpp
@@ -376,8 +376,8 @@ namespace OpenLoco::Scenario
         initialiseSnowLine();
         sub_4748D4();
         std::fill(std::begin(gameState.recordSpeed), std::end(gameState.recordSpeed), 0_mph);
-        getObjective2().timeLimitUntilYear = getObjective2().timeLimitUntilYear - 1 + gameState.currentYear;
-        getObjective2().monthsInChallenge = 0;
+        getObjectiveProgress().timeLimitUntilYear = getObjectiveProgress().timeLimitUntilYear - 1 + gameState.currentYear;
+        getObjectiveProgress().monthsInChallenge = 0;
         call(0x0049B546);
         gameState.lastMapWindowFlags = 0;
 
@@ -466,7 +466,7 @@ namespace OpenLoco::Scenario
             else
             {
                 args.push(StringIds::by_the_end_of);
-                args.push(Scenario::getObjective2().timeLimitUntilYear);
+                args.push(Scenario::getObjectiveProgress().timeLimitUntilYear);
             }
         }
 

--- a/src/OpenLoco/ScenarioObjective.cpp
+++ b/src/OpenLoco/ScenarioObjective.cpp
@@ -8,8 +8,8 @@ namespace OpenLoco::Scenario
         return getGameState().scenarioObjective;
     }
 
-    Objective2& getObjective2()
+    ObjectiveProgress& getObjectiveProgress()
     {
-        return getGameState().scenarioObjective2;
+        return getGameState().scenarioObjectiveProgress;
     }
 }

--- a/src/OpenLoco/ScenarioObjective.cpp
+++ b/src/OpenLoco/ScenarioObjective.cpp
@@ -7,4 +7,9 @@ namespace OpenLoco::Scenario
     {
         return getGameState().scenarioObjective;
     }
+
+    Objective2& getObjective2()
+    {
+        return getGameState().scenarioObjective2;
+    }
 }

--- a/src/OpenLoco/ScenarioObjective.h
+++ b/src/OpenLoco/ScenarioObjective.h
@@ -22,13 +22,13 @@ namespace OpenLoco::Scenario
     Objective& getObjective();
 
 #pragma pack(push, 1)
-    struct Objective2
+    struct ObjectiveProgress
     {
         uint16_t timeLimitUntilYear;         // 0x000429 (0x00526241)
         uint16_t monthsInChallenge;          // 0x00042B (0x00526243)
         uint16_t completedChallengeInMonths; // 0x00042D (0x00526245)
     };
 #pragma pack(pop)
-    static_assert(sizeof(Objective2) == 0x6);
-    Objective2& getObjective2();
+    static_assert(sizeof(ObjectiveProgress) == 0x6);
+    ObjectiveProgress& getObjectiveProgress();
 }

--- a/src/OpenLoco/ScenarioObjective.h
+++ b/src/OpenLoco/ScenarioObjective.h
@@ -8,19 +8,27 @@ namespace OpenLoco::Scenario
 #pragma pack(push, 1)
     struct Objective
     {
-        Scenario::ObjectiveType type;        // 0x000418 (0x00526230)
-        uint8_t flags;                       // 0x000419 (0x00526231)
-        uint32_t companyValue;               // 0x00041A (0x00526232)
-        uint32_t monthlyVehicleProfit;       // 0x00041E (0x00526236)
-        uint8_t performanceIndex;            // 0x000422 (0x0052623A)
-        uint8_t deliveredCargoType;          // 0x000423 (0x0052623B)
-        uint32_t deliveredCargoAmount;       // 0x000424 (0x0052623C)
-        uint8_t timeLimitYears;              // 0x000428 (0x00526240)
+        Scenario::ObjectiveType type;  // 0x000418 (0x00526230)
+        uint8_t flags;                 // 0x000419 (0x00526231)
+        uint32_t companyValue;         // 0x00041A (0x00526232)
+        uint32_t monthlyVehicleProfit; // 0x00041E (0x00526236)
+        uint8_t performanceIndex;      // 0x000422 (0x0052623A)
+        uint8_t deliveredCargoType;    // 0x000423 (0x0052623B)
+        uint32_t deliveredCargoAmount; // 0x000424 (0x0052623C)
+        uint8_t timeLimitYears;        // 0x000428 (0x00526240)
+    };
+#pragma pack(pop)
+    static_assert(sizeof(Objective) == 0x11);
+    Objective& getObjective();
+
+#pragma pack(push, 1)
+    struct Objective2
+    {
         uint16_t timeLimitUntilYear;         // 0x000429 (0x00526241)
         uint16_t monthsInChallenge;          // 0x00042B (0x00526243)
         uint16_t completedChallengeInMonths; // 0x00042D (0x00526245)
     };
 #pragma pack(pop)
-    static_assert(sizeof(Objective) == 0x17);
-    Objective& getObjective();
+    static_assert(sizeof(Objective2) == 0x6);
+    Objective2& getObjective2();
 }

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -2353,8 +2353,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             if ((playerCompany->challengeFlags & CompanyFlags::challengeCompleted) != 0)
             {
-                uint16_t years = Scenario::getObjective2().completedChallengeInMonths / 12;
-                uint16_t months = Scenario::getObjective2().completedChallengeInMonths % 12;
+                uint16_t years = Scenario::getObjectiveProgress().completedChallengeInMonths / 12;
+                uint16_t months = Scenario::getObjectiveProgress().completedChallengeInMonths % 12;
 
                 auto args = FormatArguments::common(years, months);
                 Gfx::drawString_495224(*context, self->x + 5, y, self->width - 10, Colour::black, StringIds::success_you_completed_the_challenge_in_years_months, &args);
@@ -2369,8 +2369,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             if ((playerCompany->challengeFlags & CompanyFlags::challengeBeatenByOpponent) != 0)
             {
-                uint16_t years = Scenario::getObjective2().completedChallengeInMonths / 12;
-                uint16_t months = Scenario::getObjective2().completedChallengeInMonths % 12;
+                uint16_t years = Scenario::getObjectiveProgress().completedChallengeInMonths / 12;
+                uint16_t months = Scenario::getObjectiveProgress().completedChallengeInMonths % 12;
 
                 FormatArguments args{};
                 args.push(CompanyManager::getOpponent()->ownerName);
@@ -2390,7 +2390,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             if ((Scenario::getObjective().flags & Scenario::ObjectiveFlags::withinTimeLimit) != 0)
             {
                 // time limited challenge
-                uint16_t monthsLeft = Scenario::getObjective().timeLimitYears * 12 - Scenario::getObjective2().monthsInChallenge;
+                uint16_t monthsLeft = Scenario::getObjective().timeLimitYears * 12 - Scenario::getObjectiveProgress().monthsInChallenge;
                 uint16_t years = monthsLeft / 12;
                 uint16_t months = monthsLeft % 12;
 

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -2353,8 +2353,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             if ((playerCompany->challengeFlags & CompanyFlags::challengeCompleted) != 0)
             {
-                uint16_t years = Scenario::getObjective().completedChallengeInMonths / 12;
-                uint16_t months = Scenario::getObjective().completedChallengeInMonths % 12;
+                uint16_t years = Scenario::getObjective2().completedChallengeInMonths / 12;
+                uint16_t months = Scenario::getObjective2().completedChallengeInMonths % 12;
 
                 auto args = FormatArguments::common(years, months);
                 Gfx::drawString_495224(*context, self->x + 5, y, self->width - 10, Colour::black, StringIds::success_you_completed_the_challenge_in_years_months, &args);
@@ -2369,8 +2369,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             if ((playerCompany->challengeFlags & CompanyFlags::challengeBeatenByOpponent) != 0)
             {
-                uint16_t years = Scenario::getObjective().completedChallengeInMonths / 12;
-                uint16_t months = Scenario::getObjective().completedChallengeInMonths % 12;
+                uint16_t years = Scenario::getObjective2().completedChallengeInMonths / 12;
+                uint16_t months = Scenario::getObjective2().completedChallengeInMonths % 12;
 
                 FormatArguments args{};
                 args.push(CompanyManager::getOpponent()->ownerName);
@@ -2390,7 +2390,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             if ((Scenario::getObjective().flags & Scenario::ObjectiveFlags::withinTimeLimit) != 0)
             {
                 // time limited challenge
-                uint16_t monthsLeft = Scenario::getObjective().timeLimitYears * 12 - Scenario::getObjective().monthsInChallenge;
+                uint16_t monthsLeft = Scenario::getObjective().timeLimitYears * 12 - Scenario::getObjective2().monthsInChallenge;
                 uint16_t years = monthsLeft / 12;
                 uint16_t months = monthsLeft % 12;
 

--- a/src/OpenLoco/Windows/TimePanel.cpp
+++ b/src/OpenLoco/Windows/TimePanel.cpp
@@ -348,7 +348,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
 
             if (Scenario::getObjective().flags & Scenario::ObjectiveFlags::withinTimeLimit)
             {
-                uint16_t monthsLeft = (Scenario::getObjective().timeLimitYears * 12 - Scenario::getObjective().monthsInChallenge);
+                uint16_t monthsLeft = (Scenario::getObjective().timeLimitYears * 12 - Scenario::getObjective2().monthsInChallenge);
                 uint16_t yearsLeft = monthsLeft / 12;
                 monthsLeft = monthsLeft % 12;
                 args.push(StringIds::challenge_time_left);

--- a/src/OpenLoco/Windows/TimePanel.cpp
+++ b/src/OpenLoco/Windows/TimePanel.cpp
@@ -348,7 +348,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
 
             if (Scenario::getObjective().flags & Scenario::ObjectiveFlags::withinTimeLimit)
             {
-                uint16_t monthsLeft = (Scenario::getObjective().timeLimitYears * 12 - Scenario::getObjective2().monthsInChallenge);
+                uint16_t monthsLeft = (Scenario::getObjective().timeLimitYears * 12 - Scenario::getObjectiveProgress().monthsInChallenge);
                 uint16_t yearsLeft = monthsLeft / 12;
                 monthsLeft = monthsLeft % 12;
                 args.push(StringIds::challenge_time_left);


### PR DESCRIPTION
Suggested here:
_Originally posted by @duncanspumpkin in https://github.com/OpenLoco/OpenLoco/pull/1487#discussion_r861452305_