### PR TITLE
Reenable Tree wilt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Feature: [#1484] Hold shift when placing a vehicle to start it immediately.
 - Fix: [#293] Menu screen and other window corruption when many objects loaded.
 - Fix: [#1463] Crash when opening the build window under certain situations.
+- Fix: [#1499] Trees have a subtle wilt effect that was missing. Certain trees displayed the wrong image for certain seasons.
 
 22.04 (2022-04-12)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/Graphics/Gfx.cpp
+++ b/src/OpenLoco/Graphics/Gfx.cpp
@@ -281,6 +281,12 @@ namespace OpenLoco::Gfx
         // Vanilla setup scrolling text related globals here (unused)
     }
 
+    // 0x00452336
+    void initialiseTreeWiltPaletteMap()
+    {
+        call(0x00452336);
+    }
+
     // 0x00447485
     // edi: context
     // ebp: fill

--- a/src/OpenLoco/Graphics/Gfx.h
+++ b/src/OpenLoco/Graphics/Gfx.h
@@ -145,6 +145,7 @@ namespace OpenLoco::Gfx
 
     void loadG1();
     void initialiseCharacterWidths();
+    void initialiseTreeWiltPaletteMap();
     void clear(Context& context, uint32_t fill);
     void clearSingle(Context& context, uint8_t paletteId);
 

--- a/src/OpenLoco/Graphics/ImageId.h
+++ b/src/OpenLoco/Graphics/ImageId.h
@@ -1,4 +1,5 @@
 #include "Colour.h"
+#include <cassert>
 
 namespace OpenLoco
 {
@@ -162,6 +163,7 @@ namespace OpenLoco
         constexpr ImageId withRemap(ExtColour paletteId) const
         {
             ImageId result = *this;
+            assert(enumValue(paletteId) <= 0x7F); // If larger then it eats into treeWilt
             result._index &= ~(kMaskRemap | kFlagSecondary | kFlagBlend);
             result._index |= enumValue(paletteId) << kShiftRemap;
             result._index |= kFlagPrimary;

--- a/src/OpenLoco/Graphics/ImageId.h
+++ b/src/OpenLoco/Graphics/ImageId.h
@@ -120,7 +120,7 @@ namespace OpenLoco
             return _index & kMaskIndex;
         }
 
-        constexpr ExtColour getTransluceny() const
+        constexpr ExtColour getTranslucency() const
         {
             return static_cast<ExtColour>((_index & kMaskTranslucent) >> kShiftTranslucent);
         }

--- a/src/OpenLoco/Graphics/ImageIds.h
+++ b/src/OpenLoco/Graphics/ImageIds.h
@@ -1313,6 +1313,14 @@ namespace OpenLoco::ImageIds
     constexpr uint32_t smoke_10 = 3475;
     constexpr uint32_t smoke_11 = 3476;
 
+    constexpr uint32_t tree_wilt_palette_map_1 = 3479; // Map zero is use no wilting
+    constexpr uint32_t tree_wilt_palette_map_2 = 3480;
+    constexpr uint32_t tree_wilt_palette_map_3 = 3481;
+    constexpr uint32_t tree_wilt_palette_map_4 = 3482;
+    constexpr uint32_t tree_wilt_palette_map_5 = 3483;
+    constexpr uint32_t tree_wilt_palette_map_6 = 3484;
+    constexpr uint32_t tree_wilt_palette_map_7 = 3485;
+
     constexpr uint32_t tab_object_settings = 3505;
     constexpr uint32_t tab_object_audio = 3506;
     constexpr uint32_t tab_object_currency = 3507;

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -403,6 +403,7 @@ namespace OpenLoco
         Gfx::loadG1();
         Ui::ProgressBar::setProgress(220);
         Gfx::initialiseCharacterWidths();
+        Gfx::initialiseTreeWiltPaletteMap();
         Ui::ProgressBar::setProgress(235);
         Ui::ProgressBar::setProgress(250);
         Ui::initialiseCursors();

--- a/src/OpenLoco/Paint/PaintTree.cpp
+++ b/src/OpenLoco/Paint/PaintTree.cpp
@@ -24,6 +24,11 @@ namespace OpenLoco::Paint
     // 0x004BAEDA
     void paintTree(PaintSession& session, const Map::TreeElement& elTree)
     {
+        //registers regs;
+        //regs.esi = X86Pointer(&elTree);
+        //regs.ecx = (session.getRotation() + elTree.data()[0]) & 0x3;
+        //regs.dx = elTree.baseHeight();
+        //call(0x004BAEDA, regs);
         session.setItemType(InteractionItem::tree);
 
         const auto* treeObj = ObjectManager::get<TreeObject>(elTree.treeObjectId());
@@ -48,7 +53,7 @@ namespace OpenLoco::Paint
             {
                 image2Season = season;
                 season = elTree.season();
-                edx = (~edx) & 0b111;
+                edx = 8 - edx;
             }
             // Unlikely to do anything as no remap flag set
             edx = edx << 26;

--- a/src/OpenLoco/Paint/PaintTree.cpp
+++ b/src/OpenLoco/Paint/PaintTree.cpp
@@ -13,7 +13,7 @@ using namespace OpenLoco::Ui::ViewportInteraction;
 namespace OpenLoco::Paint
 {
     constexpr std::array<uint8_t, 6> _50076A = { 3, 0, 1, 2, 1, 4 };
-    constexpr std::array<bool, 5> _500770 = { true, true, false, false, true };
+    constexpr std::array<bool, 6> _500770 = { true, true, false, false, true, true };
     constexpr std::array<Map::Pos2, 4> kTreeQuadrantOffset = {
         Map::Pos2{ 7, 7 },
         Map::Pos2{ 7, 23 },
@@ -44,7 +44,7 @@ namespace OpenLoco::Paint
 
             auto image2Season = elTree.season();
 
-            if (!_500770[season])
+            if (_500770[image2Season])
             {
                 image2Season = season;
                 season = elTree.season();


### PR DESCRIPTION
The init function was originally in initDisplay a function we implemented very early on and replaced with an SDL2 call. I've moved the init up into the main init function. Annoyingly this breaks a few assumptions we made in the ImageId class. It turns out there are 3 states for primary colours: normal, extended (remap), translucent (remap). Extended and translucent had been rolled into one (remap) but that needs to be undone as extended can be used with tree wilt but translucent cannot be used with treewilt!