### PR TITLE
Disable copy construction of loco globals

### DIFF
--- a/src/OpenLoco/Audio/Audio.cpp
+++ b/src/OpenLoco/Audio/Audio.cpp
@@ -1103,7 +1103,7 @@ namespace OpenLoco::Audio
             // Choose a track to play, unless we have requested one track in particular.
             if (_currentSong == kNoSong || !requestedSong)
             {
-                auto trackToExclude = _lastSong;
+                uint8_t trackToExclude = _lastSong;
                 _lastSong = _currentSong;
                 _currentSong = chooseNextMusicTrack(trackToExclude);
             }

--- a/src/OpenLoco/Input/Keyboard.cpp
+++ b/src/OpenLoco/Input/Keyboard.cpp
@@ -161,7 +161,7 @@ namespace OpenLoco::Input
     {
         if (text != nullptr && text[0] != '\0')
         {
-            auto index = _keyQueueLastWrite;
+            uint32_t index = _keyQueueLastWrite;
             _keyQueue[index].charCode = text[0];
         }
     }

--- a/src/OpenLoco/Interop/Interop.hpp
+++ b/src/OpenLoco/Interop/Interop.hpp
@@ -53,8 +53,8 @@ namespace OpenLoco::Interop
 
 #pragma pack(push, 1)
     /**
-    * x86 register structure, only used for easy interop to Locomotion code.
-    */
+     * x86 register structure, only used for easy interop to Locomotion code.
+     */
     struct registers
     {
         union
@@ -140,17 +140,17 @@ namespace OpenLoco::Interop
     }
 
     /**
-    * Returns the flags register
-    *
-    * Flags register is as follows:
-    * 0bSZ0A_0P0C_0000_0000
-    * S = Signed flag
-    * Z = Zero flag
-    * C = Carry flag
-    * A = Adjust flag
-    * P = Parity flag
-    * All other bits are undefined.
-    */
+     * Returns the flags register
+     *
+     * Flags register is as follows:
+     * 0bSZ0A_0P0C_0000_0000
+     * S = Signed flag
+     * Z = Zero flag
+     * C = Carry flag
+     * A = Adjust flag
+     * P = Parity flag
+     * All other bits are undefined.
+     */
     int32_t call(int32_t address);
     int32_t call(int32_t address, registers& registers);
 
@@ -171,6 +171,8 @@ namespace OpenLoco::Interop
         {
             _Myptr = &(addr<TAddress, T>());
         }
+
+        loco_global(const loco_global<T, TAddress>&) = delete; // Do not copy construct a loco global
 
         operator reference()
         {

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -876,7 +876,7 @@ namespace OpenLoco
         if (_50C197 != 0)
         {
             auto title = StringIds::error_unable_to_load_saved_game;
-            auto message = _50C198;
+            string_id message = _50C198;
             if (_50C197 == -2)
             {
                 title = _50C198;

--- a/src/OpenLoco/Title.cpp
+++ b/src/OpenLoco/Title.cpp
@@ -117,7 +117,7 @@ namespace OpenLoco::Title
         Scenario::sub_46115C();
         if (Intro::state() == Intro::State::none)
         {
-            auto backupWord = _525F62;
+            uint16_t backupWord = _525F62;
             auto titlePath = Environment::getPath(Environment::PathId::title);
             clearScreenFlag(ScreenFlags::networked);
             S5::load(titlePath, S5::LoadFlags::titleSequence);

--- a/src/OpenLoco/Vehicles/VehicleBogie.cpp
+++ b/src/OpenLoco/Vehicles/VehicleBogie.cpp
@@ -43,7 +43,7 @@ namespace OpenLoco::Vehicles
         vehicleUpdate_backBogieHasMoved = vehicleUpdate_frontBogieHasMoved;
         vehicleUpdate_frontBogieHasMoved = hasMoved;
 
-        const auto stash1136130 = vehicleUpdate_var_1136130;
+        const int32_t stash1136130 = vehicleUpdate_var_1136130;
         if (var_5E != 0)
         {
             auto unk = var_5E;

--- a/src/OpenLoco/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/Windows/Construction/ConstructionTab.cpp
@@ -654,8 +654,8 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         uint8_t rotation;
         uint8_t roadId;
 
-        auto x = _x;
-        auto y = _y;
+        const uint16_t x = _x;
+        const uint16_t y = _y;
 
         if (!road)
         {
@@ -829,8 +829,8 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
         uint8_t rotation;
         uint8_t trackId;
-        auto x = _x;
-        auto y = _y;
+        const uint16_t x = _x;
+        const uint16_t y = _y;
 
         if (!track)
         {


### PR DESCRIPTION
This was the source of a few bugs as its not copying the value its copying the reference which is almost never what you meant