### PR TITLE
Refactor for window left-align tabs (issue 495)

### DIFF
--- a/src/OpenLoco/Widget.cpp
+++ b/src/OpenLoco/Widget.cpp
@@ -1004,6 +1004,7 @@ namespace OpenLoco::Ui
         {
             if (window.isDisabled(i) == false)
             {
+                window.widgets[i].type = WidgetType::tab;
                 window.widgets[i].left = xPos;
                 window.widgets[i].right = xPos + tabWidth;
                 xPos = window.widgets[i].right + 1;

--- a/src/OpenLoco/Widget.cpp
+++ b/src/OpenLoco/Widget.cpp
@@ -996,4 +996,25 @@ namespace OpenLoco::Ui
             Gfx::drawRect(*ctx, pos.x, pos.y + 26, 31, 1, Colours::getShade(w->getColour(WindowColour::secondary).c(), 7));
         }
     }
+
+    void Widget::leftAlignTabs(Window* const window, uint8_t firstTabIndex, uint8_t lastTabIndex, uint16_t tabWidth)
+    {
+        int16_t xPos = window->widgets[firstTabIndex].left;
+        for (uint8_t i = firstTabIndex; i <= lastTabIndex; i++)
+        {
+            if (window->isDisabled(i))
+            {
+                window->widgets[i].type = WidgetType::none;
+            }
+
+            else
+            {
+                window->widgets[i].type = WidgetType::tab;
+                window->widgets[i].left = xPos;
+                window->widgets[i].right = xPos + tabWidth;
+                xPos = window->widgets[i].right + 1;
+
+            }
+        }
+    }
 }

--- a/src/OpenLoco/Widget.cpp
+++ b/src/OpenLoco/Widget.cpp
@@ -1007,7 +1007,6 @@ namespace OpenLoco::Ui
                 window.widgets[i].left = xPos;
                 window.widgets[i].right = xPos + tabWidth;
                 xPos = window.widgets[i].right + 1;
-
             }
         }
     }

--- a/src/OpenLoco/Widget.cpp
+++ b/src/OpenLoco/Widget.cpp
@@ -1002,7 +1002,12 @@ namespace OpenLoco::Ui
         int16_t xPos = window.widgets[firstTabIndex].left;
         for (uint8_t i = firstTabIndex; i <= lastTabIndex; i++)
         {
-            if (window.isDisabled(i) == false)
+            if (window.isDisabled(i))
+            {
+                window.widgets[i].type = WidgetType::none;
+            }
+
+            else
             {
                 window.widgets[i].type = WidgetType::tab;
                 window.widgets[i].left = xPos;

--- a/src/OpenLoco/Widget.cpp
+++ b/src/OpenLoco/Widget.cpp
@@ -997,22 +997,16 @@ namespace OpenLoco::Ui
         }
     }
 
-    void Widget::leftAlignTabs(Window* const window, uint8_t firstTabIndex, uint8_t lastTabIndex, uint16_t tabWidth)
+    void Widget::leftAlignTabs(Window& window, uint8_t firstTabIndex, uint8_t lastTabIndex, uint16_t tabWidth)
     {
-        int16_t xPos = window->widgets[firstTabIndex].left;
+        int16_t xPos = window.widgets[firstTabIndex].left;
         for (uint8_t i = firstTabIndex; i <= lastTabIndex; i++)
         {
-            if (window->isDisabled(i))
+            if (window.isDisabled(i) == false)
             {
-                window->widgets[i].type = WidgetType::none;
-            }
-
-            else
-            {
-                window->widgets[i].type = WidgetType::tab;
-                window->widgets[i].left = xPos;
-                window->widgets[i].right = xPos + tabWidth;
-                xPos = window->widgets[i].right + 1;
+                window.widgets[i].left = xPos;
+                window.widgets[i].right = xPos + tabWidth;
+                xPos = window.widgets[i].right + 1;
 
             }
         }

--- a/src/OpenLoco/Widget.cpp
+++ b/src/OpenLoco/Widget.cpp
@@ -999,8 +999,8 @@ namespace OpenLoco::Ui
 
     void Widget::leftAlignTabs(Window& window, uint8_t firstTabIndex, uint8_t lastTabIndex, uint16_t tabWidth)
     {
-        int16_t xPos = window.widgets[firstTabIndex].left;
-        for (uint8_t i = firstTabIndex; i <= lastTabIndex; i++)
+        auto xPos = window.widgets[firstTabIndex].left;
+        for (auto i = firstTabIndex; i <= lastTabIndex; i++)
         {
             if (window.isDisabled(i))
             {

--- a/src/OpenLoco/Widget.h
+++ b/src/OpenLoco/Widget.h
@@ -40,7 +40,7 @@ namespace OpenLoco::Ui
         static void drawViewportCentreButton(Gfx::Context* context, const Window* window, const WidgetIndex_t widgetIndex);
         static void drawTab(Window* w, Gfx::Context* ctx, int32_t imageId, WidgetIndex_t index);
 
-        //typical tab width, to be used in most (all?) cases
+        // typical tab width, to be used in most (all?) cases
         static constexpr uint16_t kDefaultTabWidth = 30;
         static void leftAlignTabs(Window& window, uint8_t firstTabIndex, uint8_t lastTabIndex, uint16_t tabWidth);
 

--- a/src/OpenLoco/Widget.h
+++ b/src/OpenLoco/Widget.h
@@ -42,7 +42,7 @@ namespace OpenLoco::Ui
 
         // typical tab width, to be used in most (all?) cases
         static constexpr uint16_t kDefaultTabWidth = 30;
-        static void leftAlignTabs(Window& window, uint8_t firstTabIndex, uint8_t lastTabIndex, uint16_t tabWidth);
+        static void leftAlignTabs(Window& window, uint8_t firstTabIndex, uint8_t lastTabIndex, uint16_t tabWidth = kDefaultTabWidth);
 
         void draw(Gfx::Context* context, Window* window, const uint64_t pressedWidgets, const uint64_t toolWidgets, const uint64_t hoveredWidgets, uint8_t& scrollviewIndex);
 

--- a/src/OpenLoco/Widget.h
+++ b/src/OpenLoco/Widget.h
@@ -41,8 +41,8 @@ namespace OpenLoco::Ui
         static void drawTab(Window* w, Gfx::Context* ctx, int32_t imageId, WidgetIndex_t index);
 
         //typical tab width, to be used in most (all?) cases
-        static const uint16_t defaultTabWidth = 30;
-        static void leftAlignTabs(Window* const window, uint8_t firstTabIndex, uint8_t lastTabIndex, uint16_t tabWidth);
+        static constexpr uint16_t kDefaultTabWidth = 30;
+        static void leftAlignTabs(Window& window, uint8_t firstTabIndex, uint8_t lastTabIndex, uint16_t tabWidth);
 
         void draw(Gfx::Context* context, Window* window, const uint64_t pressedWidgets, const uint64_t toolWidgets, const uint64_t hoveredWidgets, uint8_t& scrollviewIndex);
 

--- a/src/OpenLoco/Widget.h
+++ b/src/OpenLoco/Widget.h
@@ -40,6 +40,10 @@ namespace OpenLoco::Ui
         static void drawViewportCentreButton(Gfx::Context* context, const Window* window, const WidgetIndex_t widgetIndex);
         static void drawTab(Window* w, Gfx::Context* ctx, int32_t imageId, WidgetIndex_t index);
 
+        //typical tab width, to be used in most (all?) cases
+        static const uint16_t defaultTabWidth = 30;
+        static void leftAlignTabs(Window* const window, uint8_t firstTabIndex, uint8_t lastTabIndex, uint16_t tabWidth);
+
         void draw(Gfx::Context* context, Window* window, const uint64_t pressedWidgets, const uint64_t toolWidgets, const uint64_t hoveredWidgets, uint8_t& scrollviewIndex);
 
     private:

--- a/src/OpenLoco/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/Windows/BuildVehicle.cpp
@@ -909,7 +909,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         window->widgets[widx::scrollview_vehicle_selection].right = width - 187;
         window->widgets[widx::scrollview_vehicle_selection].bottom = height - 14;
 
-        Widget::leftAlignTabs(*window, widx::tab_build_new_trains, widx::tab_build_new_ships, Widget::kDefaultTabWidth);
+        Widget::leftAlignTabs(*window, widx::tab_build_new_trains, widx::tab_build_new_ships);
     }
 
     // 0x4C2F23

--- a/src/OpenLoco/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/Windows/BuildVehicle.cpp
@@ -909,7 +909,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         window->widgets[widx::scrollview_vehicle_selection].right = width - 187;
         window->widgets[widx::scrollview_vehicle_selection].bottom = height - 14;
 
-        Widget::leftAlignTabs(window, widx::tab_build_new_trains, widx::tab_build_new_ships, Widget::defaultTabWidth);
+        Widget::leftAlignTabs(*window, widx::tab_build_new_trains, widx::tab_build_new_ships, Widget::kDefaultTabWidth);
     }
 
     // 0x4C2F23

--- a/src/OpenLoco/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/Windows/BuildVehicle.cpp
@@ -239,7 +239,6 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     static void setTrackTypeTabs(Ui::Window* window);
     static void resetTrackTypeTabSelection(Ui::Window* window);
     static void setTopToolbarLastTrack(uint8_t trackType, bool isRoad);
-    static void setTransportTypeTabs(Ui::Window* window);
     static void drawVehicleOverview(Gfx::Context* context, int16_t vehicleTypeIdx, CompanyId company, uint8_t eax, uint8_t esi, Ui::Point offset);
     static int16_t drawVehicleInline(Gfx::Context* context, int16_t vehicleTypeIdx, uint8_t unk_1, CompanyId company, Ui::Point loc);
     static void drawTransportTypeTabs(Ui::Window* window, Gfx::Context* context);
@@ -910,7 +909,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         window->widgets[widx::scrollview_vehicle_selection].right = width - 187;
         window->widgets[widx::scrollview_vehicle_selection].bottom = height - 14;
 
-        setTransportTypeTabs(window);
+        Widget::leftAlignTabs(window, widx::tab_build_new_trains, widx::tab_build_new_ships, Widget::defaultTabWidth);
     }
 
     // 0x4C2F23
@@ -1337,29 +1336,6 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
 
         // The window number doesn't really matter as there is only one top toolbar
         WindowManager::invalidate(WindowType::topToolbar, 0);
-    }
-
-    // 0x4C2865 common for build vehicle window and vehicle list
-    static void setTransportTypeTabs(Ui::Window* window)
-    {
-        auto disabledWidgets = window->disabledWidgets >> widx::tab_build_new_trains;
-        auto widget = window->widgets + widx::tab_build_new_trains;
-        auto tabWidth = widget->right - widget->left;
-        auto tabX = widget->left;
-        for (auto i = 0; i <= widx::tab_build_new_ships - widx::tab_build_new_trains; ++i, ++widget)
-        {
-            if (disabledWidgets & (1ULL << i))
-            {
-                widget->type = WidgetType::none;
-            }
-            else
-            {
-                widget->type = WidgetType::tab;
-                widget->left = tabX;
-                widget->right = tabX + tabWidth;
-                tabX += tabWidth + 1;
-            }
-        }
     }
 
     // 0x4C2BFD

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -180,7 +180,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge);
         }
 
         // 0x00432055
@@ -711,7 +711,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge);
         }
 
         static void drawAIdetails(Gfx::Context& context, const int32_t x, int32_t& y, const OpenLoco::Company& company)
@@ -1280,7 +1280,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[Common::widx::company_select].right = self->width - 3;
             self->widgets[Common::widx::company_select].left = self->width - 28;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge);
 
             // Set company's main colour
             self->widgets[widx::main_colour_scheme].image = Widget::imageIdColourSet | Gfx::recolour(ImageIds::colour_swatch_recolourable, company->mainColours.primary);
@@ -1655,7 +1655,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 self->widgets[widx::loan_autopay].type = WidgetType::none;
             }
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge);
         }
 
         // 0x004333D0
@@ -2132,7 +2132,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[Common::widx::close_button].left = self->width - 15;
             self->widgets[Common::widx::close_button].right = self->width - 3;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge);
         }
 
         // 0x00433ACD
@@ -2320,7 +2320,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[Common::widx::company_select].left = self->width - 28;
             self->widgets[Common::widx::company_select].type = WidgetType::none;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge);
         }
 
         // 0x00433DEB

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -180,7 +180,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::kDefaultTabWidth);
         }
 
         // 0x00432055
@@ -711,7 +711,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::kDefaultTabWidth);
         }
 
         static void drawAIdetails(Gfx::Context& context, const int32_t x, int32_t& y, const OpenLoco::Company& company)
@@ -1280,7 +1280,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[Common::widx::company_select].right = self->width - 3;
             self->widgets[Common::widx::company_select].left = self->width - 28;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::kDefaultTabWidth);
 
             // Set company's main colour
             self->widgets[widx::main_colour_scheme].image = Widget::imageIdColourSet | Gfx::recolour(ImageIds::colour_swatch_recolourable, company->mainColours.primary);
@@ -1655,7 +1655,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 self->widgets[widx::loan_autopay].type = WidgetType::none;
             }
 
-            Widget::leftAlignTabs(self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::kDefaultTabWidth);
         }
 
         // 0x004333D0
@@ -2132,7 +2132,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[Common::widx::close_button].left = self->width - 15;
             self->widgets[Common::widx::close_button].right = self->width - 3;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::kDefaultTabWidth);
         }
 
         // 0x00433ACD
@@ -2320,7 +2320,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[Common::widx::company_select].left = self->width - 28;
             self->widgets[Common::widx::company_select].type = WidgetType::none;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::kDefaultTabWidth);
         }
 
         // 0x00433DEB

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -94,7 +94,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void switchTabWidgets(Window* self);
         static void drawCompanySelect(const Window* const self, Gfx::Context* const context);
         static void drawTabs(Window* self, Gfx::Context* context);
-        static void repositionTabs(Window* self);
     }
 
     namespace Status
@@ -181,7 +180,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::defaultTabWidth);
         }
 
         // 0x00432055
@@ -712,7 +711,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::defaultTabWidth);
         }
 
         static void drawAIdetails(Gfx::Context& context, const int32_t x, int32_t& y, const OpenLoco::Company& company)
@@ -1281,7 +1280,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[Common::widx::company_select].right = self->width - 3;
             self->widgets[Common::widx::company_select].left = self->width - 28;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::defaultTabWidth);
 
             // Set company's main colour
             self->widgets[widx::main_colour_scheme].image = Widget::imageIdColourSet | Gfx::recolour(ImageIds::colour_swatch_recolourable, company->mainColours.primary);
@@ -1656,7 +1655,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 self->widgets[widx::loan_autopay].type = WidgetType::none;
             }
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::defaultTabWidth);
         }
 
         // 0x004333D0
@@ -2133,7 +2132,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[Common::widx::close_button].left = self->width - 15;
             self->widgets[Common::widx::close_button].right = self->width - 3;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::defaultTabWidth);
         }
 
         // 0x00433ACD
@@ -2321,7 +2320,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->widgets[Common::widx::company_select].left = self->width - 28;
             self->widgets[Common::widx::company_select].type = WidgetType::none;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_status, Common::widx::tab_challenge, Widget::defaultTabWidth);
         }
 
         // 0x00433DEB
@@ -2771,23 +2770,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     imageId += challengeTabImageIds[0];
 
                 Widget::drawTab(self, context, imageId, widx::tab_challenge);
-            }
-        }
-
-        // 0x004343BC
-        static void repositionTabs(Window* self)
-        {
-            int16_t xPos = self->widgets[widx::tab_status].left;
-            const int16_t tabWidth = self->widgets[widx::tab_status].right - xPos;
-
-            for (uint8_t i = widx::tab_status; i <= widx::tab_challenge; i++)
-            {
-                if (self->isDisabled(i))
-                    continue;
-
-                self->widgets[i].left = xPos;
-                self->widgets[i].right = xPos + tabWidth;
-                xPos = self->widgets[i].right + 1;
             }
         }
     }

--- a/src/OpenLoco/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/Windows/IndustryWindow.cpp
@@ -758,7 +758,6 @@ namespace OpenLoco::Ui::Windows::Industry
             TextInput::openTextInput(self, StringIds::title_industry_name, StringIds::prompt_enter_new_industry_name, industry->name, widgetIndex, &industry->town);
         }
 
-
         // 0x00455CC7
         static void switchTab(Window* self, WidgetIndex_t widgetIndex)
         {

--- a/src/OpenLoco/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/Windows/IndustryWindow.cpp
@@ -57,7 +57,6 @@ namespace OpenLoco::Ui::Windows::Industry
         static void textInput(Window* self, WidgetIndex_t callingWidget, const char* input);
         static void update(Window* self);
         static void renameIndustryPrompt(Window* self, WidgetIndex_t widgetIndex);
-        static void repositionTabs(Window* self);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
         static void drawTabs(Window* self, Gfx::Context* context);
         static void setDisabledWidgets(Window* self);
@@ -125,7 +124,7 @@ namespace OpenLoco::Ui::Windows::Industry
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::defaultTabWidth);
         }
 
         // 0x00455C22
@@ -355,7 +354,7 @@ namespace OpenLoco::Ui::Windows::Industry
         {
             Common::prepareDraw(self);
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::defaultTabWidth);
         }
 
         // 0x0045654F
@@ -395,7 +394,7 @@ namespace OpenLoco::Ui::Windows::Industry
         {
             Common::prepareDraw(self);
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::defaultTabWidth);
         }
 
         // 0x004565FF
@@ -433,7 +432,7 @@ namespace OpenLoco::Ui::Windows::Industry
         {
             Common::prepareDraw(self);
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::defaultTabWidth);
         }
 
         // 0x00456705
@@ -759,22 +758,6 @@ namespace OpenLoco::Ui::Windows::Industry
             TextInput::openTextInput(self, StringIds::title_industry_name, StringIds::prompt_enter_new_industry_name, industry->name, widgetIndex, &industry->town);
         }
 
-        // 0x00456A5E, 0x00456A64
-        static void repositionTabs(Window* self)
-        {
-            int16_t xPos = self->widgets[widx::tab_industry].left;
-            const int16_t tabWidth = self->widgets[widx::tab_industry].right - xPos;
-
-            for (uint8_t i = widx::tab_industry; i <= widx::tab_transported; i++)
-            {
-                if (self->isDisabled(i))
-                    continue;
-
-                self->widgets[i].left = xPos;
-                self->widgets[i].right = xPos + tabWidth;
-                xPos = self->widgets[i].right + 1;
-            }
-        }
 
         // 0x00455CC7
         static void switchTab(Window* self, WidgetIndex_t widgetIndex)

--- a/src/OpenLoco/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/Windows/IndustryWindow.cpp
@@ -124,7 +124,7 @@ namespace OpenLoco::Ui::Windows::Industry
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_industry, Common::widx::tab_transported);
         }
 
         // 0x00455C22
@@ -354,7 +354,7 @@ namespace OpenLoco::Ui::Windows::Industry
         {
             Common::prepareDraw(self);
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_industry, Common::widx::tab_transported);
         }
 
         // 0x0045654F
@@ -394,7 +394,7 @@ namespace OpenLoco::Ui::Windows::Industry
         {
             Common::prepareDraw(self);
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_industry, Common::widx::tab_transported);
         }
 
         // 0x004565FF
@@ -432,7 +432,7 @@ namespace OpenLoco::Ui::Windows::Industry
         {
             Common::prepareDraw(self);
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_industry, Common::widx::tab_transported);
         }
 
         // 0x00456705

--- a/src/OpenLoco/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/Windows/IndustryWindow.cpp
@@ -124,7 +124,7 @@ namespace OpenLoco::Ui::Windows::Industry
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::kDefaultTabWidth);
         }
 
         // 0x00455C22
@@ -354,7 +354,7 @@ namespace OpenLoco::Ui::Windows::Industry
         {
             Common::prepareDraw(self);
 
-            Widget::leftAlignTabs(self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::kDefaultTabWidth);
         }
 
         // 0x0045654F
@@ -394,7 +394,7 @@ namespace OpenLoco::Ui::Windows::Industry
         {
             Common::prepareDraw(self);
 
-            Widget::leftAlignTabs(self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::kDefaultTabWidth);
         }
 
         // 0x004565FF
@@ -432,7 +432,7 @@ namespace OpenLoco::Ui::Windows::Industry
         {
             Common::prepareDraw(self);
 
-            Widget::leftAlignTabs(self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_industry, Common::widx::tab_transported, Widget::kDefaultTabWidth);
         }
 
         // 0x00456705

--- a/src/OpenLoco/Windows/MapWindow.cpp
+++ b/src/OpenLoco/Windows/MapWindow.cpp
@@ -406,30 +406,6 @@ namespace OpenLoco::Ui::Windows::MapWindow
         return args;
     }
 
-    // 0x0046D223
-    static void leftAlignTabs(Window* self, uint8_t firstTabIndex, uint8_t lastTabIndex)
-    {
-        auto disabledWidgets = self->disabledWidgets;
-        auto pos = self->widgets[firstTabIndex].left;
-        auto tabWidth = self->widgets[firstTabIndex].right - pos;
-
-        for (auto index = firstTabIndex; index <= lastTabIndex; index++)
-        {
-            self->widgets[index].type = WidgetType::none;
-
-            if (!(disabledWidgets & (1ULL << index)))
-            {
-                self->widgets[index].type = WidgetType::tab;
-
-                self->widgets[index].left = pos;
-                pos += tabWidth;
-
-                self->widgets[index].right = pos;
-                pos++;
-            }
-        }
-    }
-
     // 0x0046B6BF
     static void prepareDraw(Window* self)
     {
@@ -473,7 +449,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
         self->disabledWidgets = disabledWidgets;
 
-        leftAlignTabs(self, widx::tabOverall, widx::tabOwnership);
+        Widget::leftAlignTabs(self, widx::tabOverall, widx::tabOwnership, Widget::defaultTabWidth);
     }
 
     // 0x0046D0E0

--- a/src/OpenLoco/Windows/MapWindow.cpp
+++ b/src/OpenLoco/Windows/MapWindow.cpp
@@ -449,7 +449,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
         self->disabledWidgets = disabledWidgets;
 
-        Widget::leftAlignTabs(self, widx::tabOverall, widx::tabOwnership, Widget::defaultTabWidth);
+        Widget::leftAlignTabs(*self, widx::tabOverall, widx::tabOwnership, Widget::kDefaultTabWidth);
     }
 
     // 0x0046D0E0

--- a/src/OpenLoco/Windows/MapWindow.cpp
+++ b/src/OpenLoco/Windows/MapWindow.cpp
@@ -449,7 +449,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
         self->disabledWidgets = disabledWidgets;
 
-        Widget::leftAlignTabs(*self, widx::tabOverall, widx::tabOwnership, Widget::kDefaultTabWidth);
+        Widget::leftAlignTabs(*self, widx::tabOverall, widx::tabOwnership);
     }
 
     // 0x0046D0E0

--- a/src/OpenLoco/Windows/Options.cpp
+++ b/src/OpenLoco/Windows/Options.cpp
@@ -2377,7 +2377,7 @@ namespace OpenLoco::Ui::Windows::Options
             w->disabledWidgets |= 1 << Common::Widx::tab_regional;
         }
 
-        Widget::leftAlignTabs(*w, Common::Widx::tab_display, Common::Widx::tab_miscellaneous, Widget::kDefaultTabWidth);
+        Widget::leftAlignTabs(*w, Common::Widx::tab_display, Common::Widx::tab_miscellaneous);
     }
 
     static void sub_4C1519()

--- a/src/OpenLoco/Windows/Options.cpp
+++ b/src/OpenLoco/Windows/Options.cpp
@@ -2377,16 +2377,7 @@ namespace OpenLoco::Ui::Windows::Options
             w->disabledWidgets |= 1 << Common::Widx::tab_regional;
         }
 
-        int x = w->widgets[Common::Widx::tab_display].left;
-        for (int i = Common::Widx::tab_display; i <= Common::Widx::tab_miscellaneous; i++)
-        {
-            if (!w->isDisabled(i))
-            {
-                w->widgets[i].left = x;
-                w->widgets[i].right = x + 30;
-                x += 31;
-            }
-        }
+        Widget::leftAlignTabs(w, Common::Widx::tab_display, Common::Widx::tab_miscellaneous, Widget::defaultTabWidth);
     }
 
     static void sub_4C1519()

--- a/src/OpenLoco/Windows/Options.cpp
+++ b/src/OpenLoco/Windows/Options.cpp
@@ -2377,7 +2377,7 @@ namespace OpenLoco::Ui::Windows::Options
             w->disabledWidgets |= 1 << Common::Widx::tab_regional;
         }
 
-        Widget::leftAlignTabs(w, Common::Widx::tab_display, Common::Widx::tab_miscellaneous, Widget::defaultTabWidth);
+        Widget::leftAlignTabs(*w, Common::Widx::tab_display, Common::Widx::tab_miscellaneous, Widget::kDefaultTabWidth);
     }
 
     static void sub_4C1519()

--- a/src/OpenLoco/Windows/StationList.cpp
+++ b/src/OpenLoco/Windows/StationList.cpp
@@ -443,7 +443,7 @@ namespace OpenLoco::Ui::Windows::StationList
         window->widgets[widx::sort_accepts].text = window->sortMode == SortMode::CargoAccepted ? StringIds::table_header_accepts_desc : StringIds::table_header_accepts;
 
        // Reposition tabs
-        Widget::leftAlignTabs(window, widx::tab_all_stations, widx::tab_ship_ports, Widget::defaultTabWidth);
+        Widget::leftAlignTabs(*window, widx::tab_all_stations, widx::tab_ship_ports, Widget::kDefaultTabWidth);
     }
 
     // 0x0049157F

--- a/src/OpenLoco/Windows/StationList.cpp
+++ b/src/OpenLoco/Windows/StationList.cpp
@@ -442,21 +442,8 @@ namespace OpenLoco::Ui::Windows::StationList
         window->widgets[widx::sort_total_waiting].text = window->sortMode == SortMode::TotalUnitsWaiting ? StringIds::table_header_total_waiting_desc : StringIds::table_header_total_waiting;
         window->widgets[widx::sort_accepts].text = window->sortMode == SortMode::CargoAccepted ? StringIds::table_header_accepts_desc : StringIds::table_header_accepts;
 
-        // Reposition tabs (0x00491A39 / 0x00491A3F)
-        int16_t new_tab_x = window->widgets[widx::tab_all_stations].left;
-        int16_t tab_width = window->widgets[widx::tab_all_stations].right - new_tab_x;
-
-        for (auto& tabInfo : tabInformationByType)
-        {
-            if (window->isDisabled(tabInfo.widgetIndex))
-                continue;
-
-            Widget& tab = window->widgets[tabInfo.widgetIndex];
-
-            tab.left = new_tab_x;
-            new_tab_x += tab_width;
-            tab.right = new_tab_x++;
-        }
+       // Reposition tabs
+        Widget::leftAlignTabs(window, widx::tab_all_stations, widx::tab_ship_ports, Widget::defaultTabWidth);
     }
 
     // 0x0049157F

--- a/src/OpenLoco/Windows/StationList.cpp
+++ b/src/OpenLoco/Windows/StationList.cpp
@@ -443,7 +443,7 @@ namespace OpenLoco::Ui::Windows::StationList
         window->widgets[widx::sort_accepts].text = window->sortMode == SortMode::CargoAccepted ? StringIds::table_header_accepts_desc : StringIds::table_header_accepts;
 
         // Reposition tabs
-        Widget::leftAlignTabs(*window, widx::tab_all_stations, widx::tab_ship_ports, Widget::kDefaultTabWidth);
+        Widget::leftAlignTabs(*window, widx::tab_all_stations, widx::tab_ship_ports);
     }
 
     // 0x0049157F

--- a/src/OpenLoco/Windows/StationList.cpp
+++ b/src/OpenLoco/Windows/StationList.cpp
@@ -442,7 +442,7 @@ namespace OpenLoco::Ui::Windows::StationList
         window->widgets[widx::sort_total_waiting].text = window->sortMode == SortMode::TotalUnitsWaiting ? StringIds::table_header_total_waiting_desc : StringIds::table_header_total_waiting;
         window->widgets[widx::sort_accepts].text = window->sortMode == SortMode::CargoAccepted ? StringIds::table_header_accepts_desc : StringIds::table_header_accepts;
 
-       // Reposition tabs
+        // Reposition tabs
         Widget::leftAlignTabs(*window, widx::tab_all_stations, widx::tab_ship_ports, Widget::kDefaultTabWidth);
     }
 

--- a/src/OpenLoco/Windows/StationWindow.cpp
+++ b/src/OpenLoco/Windows/StationWindow.cpp
@@ -107,7 +107,7 @@ namespace OpenLoco::Ui::Windows::Station
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_station, Common::widx::tab_cargo_ratings, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_station, Common::widx::tab_cargo_ratings);
         }
 
         // 0x0048E470
@@ -350,7 +350,7 @@ namespace OpenLoco::Ui::Windows::Station
             self->widgets[widx::station_catchment].right = self->width - 2;
             self->widgets[widx::station_catchment].left = self->width - 25;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_station, Common::widx::tab_cargo_ratings, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_station, Common::widx::tab_cargo_ratings);
 
             self->activatedWidgets &= ~(1 << widx::station_catchment);
             if (StationId(self->number) == _lastSelectedStation)
@@ -597,7 +597,7 @@ namespace OpenLoco::Ui::Windows::Station
             self->widgets[widx::status_bar].bottom = self->height - 3;
             self->widgets[widx::status_bar].right = self->width - 14;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_station, Common::widx::tab_cargo_ratings, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_station, Common::widx::tab_cargo_ratings);
         }
 
         // 0x0048ED24

--- a/src/OpenLoco/Windows/StationWindow.cpp
+++ b/src/OpenLoco/Windows/StationWindow.cpp
@@ -878,7 +878,6 @@ namespace OpenLoco::Ui::Windows::Station
             TextInput::openTextInput(self, StringIds::title_station_name, StringIds::prompt_type_new_station_name, station->name, widgetIndex, &station->town);
         }
 
-
         // 0x0048E520
         static void switchTab(Window* self, WidgetIndex_t widgetIndex)
         {

--- a/src/OpenLoco/Windows/StationWindow.cpp
+++ b/src/OpenLoco/Windows/StationWindow.cpp
@@ -60,7 +60,6 @@ namespace OpenLoco::Ui::Windows::Station
         static void textInput(Window* self, WidgetIndex_t callingWidget, const char* input);
         static void update(Window* self);
         static void renameStationPrompt(Window* self, WidgetIndex_t widgetIndex);
-        static void repositionTabs(Window* self);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
         static void drawTabs(Window* self, Gfx::Context* context);
         static void enableRenameByCaption(Window* self);
@@ -108,7 +107,7 @@ namespace OpenLoco::Ui::Windows::Station
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_station, Common::widx::tab_cargo_ratings, Widget::defaultTabWidth);
         }
 
         // 0x0048E470
@@ -351,7 +350,7 @@ namespace OpenLoco::Ui::Windows::Station
             self->widgets[widx::station_catchment].right = self->width - 2;
             self->widgets[widx::station_catchment].left = self->width - 25;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_station, Common::widx::tab_cargo_ratings, Widget::defaultTabWidth);
 
             self->activatedWidgets &= ~(1 << widx::station_catchment);
             if (StationId(self->number) == _lastSelectedStation)
@@ -598,7 +597,7 @@ namespace OpenLoco::Ui::Windows::Station
             self->widgets[widx::status_bar].bottom = self->height - 3;
             self->widgets[widx::status_bar].right = self->width - 14;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_station, Common::widx::tab_cargo_ratings, Widget::defaultTabWidth);
         }
 
         // 0x0048ED24
@@ -879,22 +878,6 @@ namespace OpenLoco::Ui::Windows::Station
             TextInput::openTextInput(self, StringIds::title_station_name, StringIds::prompt_type_new_station_name, station->name, widgetIndex, &station->town);
         }
 
-        // 0x0048EF82, 0x0048EF88
-        static void repositionTabs(Window* self)
-        {
-            int16_t xPos = self->widgets[widx::tab_station].left;
-            const int16_t tabWidth = self->widgets[widx::tab_station].right - xPos;
-
-            for (uint8_t i = widx::tab_station; i <= widx::tab_cargo_ratings; i++)
-            {
-                if (self->isDisabled(i))
-                    continue;
-
-                self->widgets[i].left = xPos;
-                self->widgets[i].right = xPos + tabWidth;
-                xPos = self->widgets[i].right + 1;
-            }
-        }
 
         // 0x0048E520
         static void switchTab(Window* self, WidgetIndex_t widgetIndex)

--- a/src/OpenLoco/Windows/StationWindow.cpp
+++ b/src/OpenLoco/Windows/StationWindow.cpp
@@ -107,7 +107,7 @@ namespace OpenLoco::Ui::Windows::Station
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_station, Common::widx::tab_cargo_ratings, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_station, Common::widx::tab_cargo_ratings, Widget::kDefaultTabWidth);
         }
 
         // 0x0048E470
@@ -350,7 +350,7 @@ namespace OpenLoco::Ui::Windows::Station
             self->widgets[widx::station_catchment].right = self->width - 2;
             self->widgets[widx::station_catchment].left = self->width - 25;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_station, Common::widx::tab_cargo_ratings, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_station, Common::widx::tab_cargo_ratings, Widget::kDefaultTabWidth);
 
             self->activatedWidgets &= ~(1 << widx::station_catchment);
             if (StationId(self->number) == _lastSelectedStation)
@@ -597,7 +597,7 @@ namespace OpenLoco::Ui::Windows::Station
             self->widgets[widx::status_bar].bottom = self->height - 3;
             self->widgets[widx::status_bar].right = self->width - 14;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_station, Common::widx::tab_cargo_ratings, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_station, Common::widx::tab_cargo_ratings, Widget::kDefaultTabWidth);
         }
 
         // 0x0048ED24

--- a/src/OpenLoco/Windows/TerraForm.cpp
+++ b/src/OpenLoco/Windows/TerraForm.cpp
@@ -687,7 +687,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             self->widgets[widx::plant_cluster_selected].right = self->width - 2;
             self->widgets[widx::plant_cluster_random].right = self->width - 2;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::kDefaultTabWidth);
         }
 
         // 0x004BB8C9
@@ -1038,7 +1038,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             self->widgets[widx::tool_area].image = _adjustToolSize + ImageIds::tool_area;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::kDefaultTabWidth);
         }
 
         // 0x004BC5E7
@@ -1540,7 +1540,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 self->widgets[widx::land_material].image = landObj->var_16 + OpenLoco::Land::ImageIds::landscape_generator_tile_icon;
             }
 
-            Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::kDefaultTabWidth);
         }
 
         // 0x004BC909
@@ -1825,7 +1825,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             self->widgets[widx::tool_area].image = _adjustToolSize + ImageIds::tool_area;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::kDefaultTabWidth);
         }
 
         // 0x004BCCFF
@@ -2266,7 +2266,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             self->widgets[widx::scrollview].right = self->width - 4;
             self->widgets[widx::scrollview].bottom = self->height - 14;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::kDefaultTabWidth);
         }
 
         // 0x004BC0C2

--- a/src/OpenLoco/Windows/TerraForm.cpp
+++ b/src/OpenLoco/Windows/TerraForm.cpp
@@ -687,7 +687,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             self->widgets[widx::plant_cluster_selected].right = self->width - 2;
             self->widgets[widx::plant_cluster_random].right = self->width - 2;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls);
         }
 
         // 0x004BB8C9
@@ -1038,7 +1038,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             self->widgets[widx::tool_area].image = _adjustToolSize + ImageIds::tool_area;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls);
         }
 
         // 0x004BC5E7
@@ -1540,7 +1540,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 self->widgets[widx::land_material].image = landObj->var_16 + OpenLoco::Land::ImageIds::landscape_generator_tile_icon;
             }
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls);
         }
 
         // 0x004BC909
@@ -1825,7 +1825,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             self->widgets[widx::tool_area].image = _adjustToolSize + ImageIds::tool_area;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls);
         }
 
         // 0x004BCCFF
@@ -2266,7 +2266,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             self->widgets[widx::scrollview].right = self->width - 4;
             self->widgets[widx::scrollview].bottom = self->height - 14;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_clear_area, Common::widx::tab_build_walls);
         }
 
         // 0x004BC0C2

--- a/src/OpenLoco/Windows/TerraForm.cpp
+++ b/src/OpenLoco/Windows/TerraForm.cpp
@@ -92,7 +92,6 @@ namespace OpenLoco::Ui::Windows::Terraform
 
         static void initEvents();
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
-        static void repositionTabs(Window* self);
         static void drawTabs(Window* self, Gfx::Context* context);
         static void prepareDraw(Window* self);
         static void onUpdate(Window* self);
@@ -688,7 +687,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             self->widgets[widx::plant_cluster_selected].right = self->width - 2;
             self->widgets[widx::plant_cluster_random].right = self->width - 2;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::defaultTabWidth);
         }
 
         // 0x004BB8C9
@@ -1039,7 +1038,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             self->widgets[widx::tool_area].image = _adjustToolSize + ImageIds::tool_area;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::defaultTabWidth);
         }
 
         // 0x004BC5E7
@@ -1541,7 +1540,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 self->widgets[widx::land_material].image = landObj->var_16 + OpenLoco::Land::ImageIds::landscape_generator_tile_icon;
             }
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::defaultTabWidth);
         }
 
         // 0x004BC909
@@ -1826,7 +1825,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             self->widgets[widx::tool_area].image = _adjustToolSize + ImageIds::tool_area;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::defaultTabWidth);
         }
 
         // 0x004BCCFF
@@ -2267,7 +2266,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             self->widgets[widx::scrollview].right = self->width - 4;
             self->widgets[widx::scrollview].bottom = self->height - 14;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls, Widget::defaultTabWidth);
         }
 
         // 0x004BC0C2
@@ -2412,27 +2411,6 @@ namespace OpenLoco::Ui::Windows::Terraform
                 case Common::widx::tab_plant_trees:
                     Common::switchTab(self, widgetIndex);
                     break;
-            }
-        }
-
-        // 0x004BCF29, 0x004BCF2F
-        static void repositionTabs(Window* self)
-        {
-            int16_t xPos = self->widgets[widx::tab_clear_area].left;
-            const int16_t tabWidth = self->widgets[widx::tab_clear_area].right - xPos;
-
-            for (uint8_t i = widx::tab_clear_area; i <= widx::tab_build_walls; i++)
-            {
-                if (self->isDisabled(i))
-                {
-                    self->widgets[i].type = WidgetType::none;
-                    continue;
-                }
-
-                self->widgets[i].type = WidgetType::tab;
-                self->widgets[i].left = xPos;
-                self->widgets[i].right = xPos + tabWidth;
-                xPos = self->widgets[i].right + 1;
             }
         }
 

--- a/src/OpenLoco/Windows/TownList.cpp
+++ b/src/OpenLoco/Windows/TownList.cpp
@@ -136,7 +136,7 @@ namespace OpenLoco::Ui::Windows::TownList
             self->widgets[widx::sort_town_population].text = self->sortMode == SortMode::Population ? StringIds::table_header_population_desc : StringIds::table_header_population;
             self->widgets[widx::sort_town_stations].text = self->sortMode == SortMode::Stations ? StringIds::table_header_stations_desc : StringIds::table_header_stations;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings, Widget::kDefaultTabWidth);
         }
 
         // 0x0049A0F8
@@ -623,7 +623,7 @@ namespace OpenLoco::Ui::Windows::TownList
         {
             Common::prepareDraw(self);
 
-            Widget::leftAlignTabs(self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings, Widget::kDefaultTabWidth);
 
             self->widgets[widx::current_size].text = townSizeNames[_townSize - 1];
         }
@@ -840,7 +840,7 @@ namespace OpenLoco::Ui::Windows::TownList
             if (self->currentTab == Common::widx::tab_build_misc_buildings - Common::widx::tab_town_list)
                 self->widgets[Common::widx::caption].text = StringIds::title_build_new_misc_buildings;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings, Widget::kDefaultTabWidth);
         }
 
         // 0x0049A9C2

--- a/src/OpenLoco/Windows/TownList.cpp
+++ b/src/OpenLoco/Windows/TownList.cpp
@@ -64,7 +64,6 @@ namespace OpenLoco::Ui::Windows::TownList
         makeRemapWidget({ 96, 15 }, { 31, 27 }, WidgetType::tab, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_misc_buildings)
 
         static void prepareDraw(Window* self);
-        static void repositionTabs(Window* self);
         static void drawTabs(Window* self, Gfx::Context* context);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
         static void initEvents();
@@ -137,7 +136,7 @@ namespace OpenLoco::Ui::Windows::TownList
             self->widgets[widx::sort_town_population].text = self->sortMode == SortMode::Population ? StringIds::table_header_population_desc : StringIds::table_header_population;
             self->widgets[widx::sort_town_stations].text = self->sortMode == SortMode::Stations ? StringIds::table_header_stations_desc : StringIds::table_header_stations;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings, Widget::defaultTabWidth);
         }
 
         // 0x0049A0F8
@@ -624,7 +623,7 @@ namespace OpenLoco::Ui::Windows::TownList
         {
             Common::prepareDraw(self);
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings, Widget::defaultTabWidth);
 
             self->widgets[widx::current_size].text = townSizeNames[_townSize - 1];
         }
@@ -841,7 +840,7 @@ namespace OpenLoco::Ui::Windows::TownList
             if (self->currentTab == Common::widx::tab_build_misc_buildings - Common::widx::tab_town_list)
                 self->widgets[Common::widx::caption].text = StringIds::title_build_new_misc_buildings;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings, Widget::defaultTabWidth);
         }
 
         // 0x0049A9C2
@@ -1480,25 +1479,6 @@ namespace OpenLoco::Ui::Windows::TownList
 
             self->widgets[Common::widx::close_button].left = self->width - 15;
             self->widgets[Common::widx::close_button].right = self->width - 3;
-        }
-
-        // 0x0049B004 and 0x0049B00A
-        static void repositionTabs(Window* self)
-        {
-            int16_t new_tab_x = self->widgets[widx::tab_town_list].left;
-            int16_t tab_width = self->widgets[widx::tab_town_list].right - new_tab_x;
-
-            for (auto& tabInfo : tabInformationByTabOffset)
-            {
-                if (self->isDisabled(tabInfo.widgetIndex))
-                    continue;
-
-                Widget& tab = self->widgets[tabInfo.widgetIndex];
-
-                tab.left = new_tab_x;
-                new_tab_x += tab_width;
-                tab.right = new_tab_x++;
-            }
         }
 
         // 0x0049B054

--- a/src/OpenLoco/Windows/TownList.cpp
+++ b/src/OpenLoco/Windows/TownList.cpp
@@ -136,7 +136,7 @@ namespace OpenLoco::Ui::Windows::TownList
             self->widgets[widx::sort_town_population].text = self->sortMode == SortMode::Population ? StringIds::table_header_population_desc : StringIds::table_header_population;
             self->widgets[widx::sort_town_stations].text = self->sortMode == SortMode::Stations ? StringIds::table_header_stations_desc : StringIds::table_header_stations;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings);
         }
 
         // 0x0049A0F8
@@ -623,7 +623,7 @@ namespace OpenLoco::Ui::Windows::TownList
         {
             Common::prepareDraw(self);
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings);
 
             self->widgets[widx::current_size].text = townSizeNames[_townSize - 1];
         }
@@ -840,7 +840,7 @@ namespace OpenLoco::Ui::Windows::TownList
             if (self->currentTab == Common::widx::tab_build_misc_buildings - Common::widx::tab_town_list)
                 self->widgets[Common::widx::caption].text = StringIds::title_build_new_misc_buildings;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_town_list, Common::widx::tab_build_misc_buildings);
         }
 
         // 0x0049A9C2

--- a/src/OpenLoco/Windows/TownWindow.cpp
+++ b/src/OpenLoco/Windows/TownWindow.cpp
@@ -124,7 +124,7 @@ namespace OpenLoco::Ui::Windows::Town
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Widget::leftAlignTabs(self, Common::widx::tab_town, Common::widx::tab_company_ratings, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_town, Common::widx::tab_company_ratings, Widget::kDefaultTabWidth);
         }
 
         // 0x00498FFE

--- a/src/OpenLoco/Windows/TownWindow.cpp
+++ b/src/OpenLoco/Windows/TownWindow.cpp
@@ -124,7 +124,7 @@ namespace OpenLoco::Ui::Windows::Town
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Widget::leftAlignTabs(*self, Common::widx::tab_town, Common::widx::tab_company_ratings, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tab_town, Common::widx::tab_company_ratings);
         }
 
         // 0x00498FFE

--- a/src/OpenLoco/Windows/TownWindow.cpp
+++ b/src/OpenLoco/Windows/TownWindow.cpp
@@ -59,7 +59,6 @@ namespace OpenLoco::Ui::Windows::Town
         static void textInput(Window* self, WidgetIndex_t callingWidget, const char* input);
         static void update(Window* self);
         static void renameTownPrompt(Window* self, WidgetIndex_t widgetIndex);
-        static void repositionTabs(Window* self);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
         static void drawTabs(Window* self, Gfx::Context* context);
         static void initEvents();
@@ -125,7 +124,7 @@ namespace OpenLoco::Ui::Windows::Town
             self->widgets[widx::centre_on_viewport].left = self->widgets[widx::viewport].right - 24;
             self->widgets[widx::centre_on_viewport].top = self->widgets[widx::viewport].bottom - 24;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tab_town, Common::widx::tab_company_ratings, Widget::defaultTabWidth);
         }
 
         // 0x00498FFE
@@ -677,23 +676,6 @@ namespace OpenLoco::Ui::Windows::Town
             commonFormatArgs[8] = town->name;
 
             TextInput::openTextInput(self, StringIds::title_town_name, StringIds::prompt_type_new_town_name, town->name, widgetIndex, &commonFormatArgs);
-        }
-
-        // 0x004999A7, 0x004999AD
-        static void repositionTabs(Window* self)
-        {
-            int16_t xPos = self->widgets[widx::tab_town].left;
-            const int16_t tabWidth = self->widgets[widx::tab_town].right - xPos;
-
-            for (uint8_t i = widx::tab_town; i <= widx::tab_company_ratings; i++)
-            {
-                if (self->isDisabled(i))
-                    continue;
-
-                self->widgets[i].left = xPos;
-                self->widgets[i].right = xPos + tabWidth;
-                xPos = self->widgets[i].right + 1;
-            }
         }
 
         // 0x004991BC

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -903,7 +903,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self->widgets[widx::centreViewport].bottom = self->widgets[widx::viewport].bottom - 1;
             self->widgets[widx::centreViewport].left = self->widgets[widx::viewport].right - 1 - 23;
             self->widgets[widx::centreViewport].top = self->widgets[widx::viewport].bottom - 1 - 23;
-            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute);
         }
 
         // 0x004B226D
@@ -1429,7 +1429,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self->widgets[Common::widx::caption].right = self->width - 2;
             self->widgets[Common::widx::closeButton].left = self->width - 15;
             self->widgets[Common::widx::closeButton].right = self->width - 3;
-            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute);
 
             self->widgets[widx::carList].right = self->width - 26;
             self->widgets[widx::carList].bottom = self->height - 24;
@@ -1784,7 +1784,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 widgets[widx::cargoList].right = self->width - 26 + 22;
             }
 
-            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute);
         }
 
         // 004B3F0D
@@ -2168,7 +2168,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self->widgets[Common::widx::closeButton].left = self->width - 15;
             self->widgets[Common::widx::closeButton].right = self->width - 3;
 
-            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute);
         }
 
         // 0x004B576C
@@ -3202,7 +3202,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             {
                 self->disabledWidgets &= ~((1 << widx::orderUp) | (1 << widx::orderDown));
             }
-            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute, Widget::kDefaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute);
         }
 
         // 0x004B4866

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -84,7 +84,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void textInput(Window* const self, const WidgetIndex_t callingWidget, const char* const input);
         static void renameVehicle(Window* const self, const WidgetIndex_t widgetIndex);
         static void switchTab(Window* const self, const WidgetIndex_t widgetIndex);
-        static void repositionTabs(Window* const self);
         static void setCaptionEnableState(Window* const self);
         static void onPickup(Window* const self, const WidgetIndex_t pickupWidx);
         static void event8(Window* const self);
@@ -904,7 +903,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self->widgets[widx::centreViewport].bottom = self->widgets[widx::viewport].bottom - 1;
             self->widgets[widx::centreViewport].left = self->widgets[widx::viewport].right - 1 - 23;
             self->widgets[widx::centreViewport].top = self->widgets[widx::viewport].bottom - 1 - 23;
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tabMain, Common::widx::tabRoute, Widget::defaultTabWidth);
         }
 
         // 0x004B226D
@@ -1430,7 +1429,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self->widgets[Common::widx::caption].right = self->width - 2;
             self->widgets[Common::widx::closeButton].left = self->width - 15;
             self->widgets[Common::widx::closeButton].right = self->width - 3;
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tabMain, Common::widx::tabRoute, Widget::defaultTabWidth);
 
             self->widgets[widx::carList].right = self->width - 26;
             self->widgets[widx::carList].bottom = self->height - 24;
@@ -1785,7 +1784,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 widgets[widx::cargoList].right = self->width - 26 + 22;
             }
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tabMain, Common::widx::tabRoute, Widget::defaultTabWidth);
         }
 
         // 004B3F0D
@@ -2169,7 +2168,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self->widgets[Common::widx::closeButton].left = self->width - 15;
             self->widgets[Common::widx::closeButton].right = self->width - 3;
 
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tabMain, Common::widx::tabRoute, Widget::defaultTabWidth);
         }
 
         // 0x004B576C
@@ -3203,7 +3202,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             {
                 self->disabledWidgets &= ~((1 << widx::orderUp) | (1 << widx::orderDown));
             }
-            Common::repositionTabs(self);
+            Widget::leftAlignTabs(self, Common::widx::tabMain, Common::widx::tabRoute, Widget::defaultTabWidth);
         }
 
         // 0x004B4866
@@ -4306,23 +4305,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self->initScrollWidgets();
             self->invalidate();
             self->moveInsideScreenEdges();
-        }
-
-        // 0x004B5ECD
-        static void repositionTabs(Window* const self)
-        {
-            int16_t xPos = self->widgets[widx::tabMain].left;
-            const int16_t tabWidth = self->widgets[widx::tabMain].right - xPos;
-
-            for (uint8_t i = widx::tabMain; i <= widx::tabRoute; i++)
-            {
-                if (self->isDisabled(i))
-                    continue;
-
-                self->widgets[i].left = xPos;
-                self->widgets[i].right = xPos + tabWidth;
-                xPos = self->widgets[i].right + 1;
-            }
         }
 
         // 0x004B1E94

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -903,7 +903,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self->widgets[widx::centreViewport].bottom = self->widgets[widx::viewport].bottom - 1;
             self->widgets[widx::centreViewport].left = self->widgets[widx::viewport].right - 1 - 23;
             self->widgets[widx::centreViewport].top = self->widgets[widx::viewport].bottom - 1 - 23;
-            Widget::leftAlignTabs(self, Common::widx::tabMain, Common::widx::tabRoute, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute, Widget::kDefaultTabWidth);
         }
 
         // 0x004B226D
@@ -1429,7 +1429,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self->widgets[Common::widx::caption].right = self->width - 2;
             self->widgets[Common::widx::closeButton].left = self->width - 15;
             self->widgets[Common::widx::closeButton].right = self->width - 3;
-            Widget::leftAlignTabs(self, Common::widx::tabMain, Common::widx::tabRoute, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute, Widget::kDefaultTabWidth);
 
             self->widgets[widx::carList].right = self->width - 26;
             self->widgets[widx::carList].bottom = self->height - 24;
@@ -1784,7 +1784,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 widgets[widx::cargoList].right = self->width - 26 + 22;
             }
 
-            Widget::leftAlignTabs(self, Common::widx::tabMain, Common::widx::tabRoute, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute, Widget::kDefaultTabWidth);
         }
 
         // 004B3F0D
@@ -2168,7 +2168,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self->widgets[Common::widx::closeButton].left = self->width - 15;
             self->widgets[Common::widx::closeButton].right = self->width - 3;
 
-            Widget::leftAlignTabs(self, Common::widx::tabMain, Common::widx::tabRoute, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute, Widget::kDefaultTabWidth);
         }
 
         // 0x004B576C
@@ -3202,7 +3202,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             {
                 self->disabledWidgets &= ~((1 << widx::orderUp) | (1 << widx::orderDown));
             }
-            Widget::leftAlignTabs(self, Common::widx::tabMain, Common::widx::tabRoute, Widget::defaultTabWidth);
+            Widget::leftAlignTabs(*self, Common::widx::tabMain, Common::widx::tabRoute, Widget::kDefaultTabWidth);
         }
 
         // 0x004B4866

--- a/src/OpenLoco/Windows/VehicleList.cpp
+++ b/src/OpenLoco/Windows/VehicleList.cpp
@@ -512,29 +512,6 @@ namespace OpenLoco::Ui::Windows::VehicleList
         return type_to_widx[tabIndex];
     }
 
-    // 0x4C2865
-    static void setTransportTypeTabs(Window* self)
-    {
-        auto disabledWidgets = self->disabledWidgets >> Widx::tab_trains;
-        auto widget = self->widgets + Widx::tab_trains;
-        auto tabWidth = widget->right - widget->left;
-        auto tabX = widget->left;
-        for (auto i = 0; i <= Widx::tab_ships - Widx::tab_trains; ++i, ++widget)
-        {
-            if (disabledWidgets & (1ULL << i))
-            {
-                widget->type = WidgetType::none;
-            }
-            else
-            {
-                widget->type = WidgetType::tab;
-                widget->left = tabX;
-                widget->right = tabX + tabWidth;
-                tabX += tabWidth + 1;
-            }
-        }
-    }
-
     // 0x004C1F88
     static void prepareDraw(Window* self)
     {
@@ -619,7 +596,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         };
         self->widgets[Widx::cargo_type_btn].tooltip = filterTooltipByType[self->var_88A];
 
-        setTransportTypeTabs(self);
+        Widget::leftAlignTabs(self, Widx::tab_trains, Widx::tab_ships, Widget::defaultTabWidth);
     }
 
     // 0x004C211C

--- a/src/OpenLoco/Windows/VehicleList.cpp
+++ b/src/OpenLoco/Windows/VehicleList.cpp
@@ -596,7 +596,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         };
         self->widgets[Widx::cargo_type_btn].tooltip = filterTooltipByType[self->var_88A];
 
-        Widget::leftAlignTabs(*self, Widx::tab_trains, Widx::tab_ships, Widget::kDefaultTabWidth);
+        Widget::leftAlignTabs(*self, Widx::tab_trains, Widx::tab_ships);
     }
 
     // 0x004C211C

--- a/src/OpenLoco/Windows/VehicleList.cpp
+++ b/src/OpenLoco/Windows/VehicleList.cpp
@@ -596,7 +596,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         };
         self->widgets[Widx::cargo_type_btn].tooltip = filterTooltipByType[self->var_88A];
 
-        Widget::leftAlignTabs(self, Widx::tab_trains, Widx::tab_ships, Widget::defaultTabWidth);
+        Widget::leftAlignTabs(*self, Widx::tab_trains, Widx::tab_ships, Widget::kDefaultTabWidth);
     }
 
     // 0x004C211C


### PR DESCRIPTION
Changes to BuildVehicle file (or any other widget) can be omitted from merge as desired, per the notes on issue 495 suggesting BuildVehicle requires special consideration.