### PR TITLE
Disable arg alignment on platforms without SSE2 on by default

### DIFF
--- a/src/OpenLoco/Interop/Interop.hpp
+++ b/src/OpenLoco/Interop/Interop.hpp
@@ -13,7 +13,7 @@
 #define assert_struct_size(x, y)
 #endif
 
-#if defined(__clang__) || (defined(__GNUC__) && !defined(__MINGW32__))
+#if (defined(__clang__) || (defined(__GNUC__) && !defined(__MINGW32__))) && defined(__SSE2__)
 #define FORCE_ALIGN_ARG_POINTER __attribute__((force_align_arg_pointer))
 #else
 #define FORCE_ALIGN_ARG_POINTER


### PR DESCRIPTION
This is to overcome a bug in GCC
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90333
which means we cannot force argument alignment. Luckily, the attribute
is only required on machines with SSE2 by default (where in particular
libx11 is compiled with SSE2) such as Arch. On the other hand, platforms
that target i386 *only*, such as Ubuntu, won't hit this (#986) and the
attribute is not necessary