### PR TITLE
Remove game state modifications from load file

### DIFF
--- a/src/OpenLoco/S5/S5.h
+++ b/src/OpenLoco/S5/S5.h
@@ -405,6 +405,7 @@ namespace OpenLoco::S5
         ObjectHeader requiredObjects[859];
         GameState gameState;
         std::vector<TileElement> tileElements;
+        std::vector<std::pair<ObjectHeader, std::vector<uint8_t>>> packedObjects;
     };
 
     namespace LoadFlags


### PR DESCRIPTION
Moves them into the higher level part of the function. This is important for the scenario list as we need to load a save without modifying state to list its properties.