### PR TITLE
Hook malloc and free a bit higher up in the call stack. Fixes running on Apple M1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: [#1578] Clang-compiled openloco does not list scenarios.
 - Fix: [#1583] Newspaper text line height is wrong.
 - Technical: [#1565] Any missing objects are now listed in the dev console when encountered.
+- Technical: [#1600] Allow running OpenLoco through Wine on Apple Silicon Macs
 
 22.06.1 (2022-07-01)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -500,6 +500,7 @@ static void registerMemoryHooks()
     writeJmp(0x4d1401, (void*)&fn_malloc);
     writeJmp(0x406bf7, (void*)&fn_malloc);
     writeJmp(0x4D1B28, (void*)&fn_realloc);
+    writeJmp(0x406C02, (void*)&fn_realloc);
     writeJmp(0x4D1355, (void*)&fn_free);
     writeJmp(0x406c12, (void*)&fn_free);
 }

--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -498,8 +498,10 @@ static void registerMemoryHooks()
     // Hook Locomotion's alloc / free routines so that we don't
     // allocate a block in one module and freeing it in another.
     writeJmp(0x4d1401, (void*)&fn_malloc);
+    writeJmp(0x406bf7, (void*)&fn_malloc);
     writeJmp(0x4D1B28, (void*)&fn_realloc);
     writeJmp(0x4D1355, (void*)&fn_free);
+    writeJmp(0x406c12, (void*)&fn_free);
 }
 
 #ifdef _NO_LOCO_WIN32_

--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -497,12 +497,12 @@ static void registerMemoryHooks()
 
     // Hook Locomotion's alloc / free routines so that we don't
     // allocate a block in one module and freeing it in another.
-    writeJmp(0x4d1401, (void*)&fn_malloc);
-    writeJmp(0x406bf7, (void*)&fn_malloc);
+    writeJmp(0x4D1401, (void*)&fn_malloc);
+    writeJmp(0x406BF7, (void*)&fn_malloc);
     writeJmp(0x4D1B28, (void*)&fn_realloc);
     writeJmp(0x406C02, (void*)&fn_realloc);
     writeJmp(0x4D1355, (void*)&fn_free);
-    writeJmp(0x406c12, (void*)&fn_free);
+    writeJmp(0x406C12, (void*)&fn_free);
 }
 
 #ifdef _NO_LOCO_WIN32_


### PR DESCRIPTION
On Apple M1, we can run OpenLoco in Wine32on64 within Rosetta 2.  However, it
seems that for some reason, these malloc and free hooks don't seem to work.
The realloc hook does work, therefore our implementation of realloc() receives
a block of memory that was never allocated by our implementation of malloc();
this causes realloc() to return a nullptr which causes a segfault.

By hooking these malloc and free wrappers, which simply call the malloc and free
implementations we were already hooking, our implementation of malloc and free
is properly called and OpenLoco runs on M1.
