### PR TITLE
Add <array> include for gcc 12

### DIFF
--- a/src/OpenLoco/Graphics/Gfx.h
+++ b/src/OpenLoco/Graphics/Gfx.h
@@ -5,6 +5,7 @@
 #include "../Ui/Rect.h"
 #include "../Ui/Types.hpp"
 #include "ImageId.h"
+#include <array>
 #include <cstdint>
 
 namespace OpenLoco


### PR DESCRIPTION
This PR addresses the following compiler error. Not sure why GCC 12 has decided to start complaining about this. To add to this, `<array>` doesn't seem quite right, considering we're not using `std::array` containers in this header. Other suggestions are welcome.

```
/home/aaron/Repositories/OpenLoco/OpenLoco/src/OpenLoco/Drawing/../Graphics/Gfx.h: In constructor ‘OpenLoco::Gfx::PaletteMap::PaletteMap(uint8_t (&)[TSize])’:
/home/aaron/Repositories/OpenLoco/OpenLoco/src/OpenLoco/Drawing/../Graphics/Gfx.h:137:54: error: ‘size’ is not a member of ‘std’; did you mean ‘size_t’?
  137 |             , _dataLength(static_cast<uint32_t>(std::size(map)))
      |                                                      ^~~~
      |                                                      size_t
/home/aaron/Repositories/OpenLoco/OpenLoco/src/OpenLoco/Drawing/../Graphics/Gfx.h:139:53: error: ‘size’ is not a member of ‘std’; did you mean ‘size_t’?
  139 |             , _mapLength(static_cast<uint16_t>(std::size(map)))
      |                                                     ^~~~
      |                                                     size_t
```