### PR TITLE
Undo change in Gfx::drawStringLeftWrapped

### DIFF
--- a/src/OpenLoco/Graphics/Gfx.cpp
+++ b/src/OpenLoco/Graphics/Gfx.cpp
@@ -1025,7 +1025,6 @@ namespace OpenLoco::Gfx
 
         _currentFontFlags = 0;
         Ui::Point point = { x, y };
-        point.y -= (lineHeight / 2) * (breakCount - 1);
 
         const char* ptr = buffer;
 


### PR DESCRIPTION
Overgeneralisation from bba9607df2e0d11c8e5875fa56c5b387e75867e3

Before:
![Screenshot](https://user-images.githubusercontent.com/604665/185510408-ecba873a-0580-43bb-a4a1-ba7f38f5a4d0.png)

After:
![Screenshot (2)](https://user-images.githubusercontent.com/604665/185510407-300385e1-c76e-4931-ad0d-7e4c00355852.png)