### PR TITLE
Some cleanup around rendering code

### DIFF
--- a/src/OpenLoco/Drawing/DrawSprite.cpp
+++ b/src/OpenLoco/Drawing/DrawSprite.cpp
@@ -1,5 +1,6 @@
 #include "DrawSprite.h"
 #include "../Graphics/Gfx.h"
+#include "../Graphics/RenderTarget.h"
 #include "DrawSpriteBMP.hpp"
 #include "DrawSpriteRLE.hpp"
 
@@ -48,35 +49,35 @@ namespace OpenLoco::Drawing
     }
 
     template<uint8_t TZoomLevel, bool TIsRLE>
-    inline void drawSpriteToBufferHelper(Gfx::Context& context, const DrawSpriteArgs& args, const DrawBlendOp op)
+    inline void drawSpriteToBufferHelper(Gfx::RenderTarget& rt, const DrawSpriteArgs& args, const DrawBlendOp op)
     {
         if constexpr (!TIsRLE)
         {
             switch (op)
             {
                 case BlendOp::transparent | BlendOp::src | BlendOp::dst:
-                    drawBMPSprite<BlendOp::transparent | BlendOp::src | BlendOp::dst, TZoomLevel>(context, args);
+                    drawBMPSprite<BlendOp::transparent | BlendOp::src | BlendOp::dst, TZoomLevel>(rt, args);
                     break;
                 case BlendOp::transparent | BlendOp::src:
-                    drawBMPSprite<BlendOp::transparent | BlendOp::src, TZoomLevel>(context, args);
+                    drawBMPSprite<BlendOp::transparent | BlendOp::src, TZoomLevel>(rt, args);
                     break;
                 case BlendOp::transparent | BlendOp::dst:
-                    drawBMPSprite<BlendOp::transparent | BlendOp::dst, TZoomLevel>(context, args);
+                    drawBMPSprite<BlendOp::transparent | BlendOp::dst, TZoomLevel>(rt, args);
                     break;
                 case BlendOp::none:
-                    drawBMPSprite<BlendOp::none, TZoomLevel>(context, args);
+                    drawBMPSprite<BlendOp::none, TZoomLevel>(rt, args);
                     break;
                 case BlendOp::transparent:
-                    drawBMPSprite<BlendOp::transparent, TZoomLevel>(context, args);
+                    drawBMPSprite<BlendOp::transparent, TZoomLevel>(rt, args);
                     break;
                 case BlendOp::transparent | BlendOp::src | BlendOp::noiseMask:
-                    drawBMPSprite<BlendOp::transparent | BlendOp::src | BlendOp::noiseMask, TZoomLevel>(context, args);
+                    drawBMPSprite<BlendOp::transparent | BlendOp::src | BlendOp::noiseMask, TZoomLevel>(rt, args);
                     break;
                 case BlendOp::none | BlendOp::noiseMask:
-                    drawBMPSprite<BlendOp::none | BlendOp::noiseMask, TZoomLevel>(context, args);
+                    drawBMPSprite<BlendOp::none | BlendOp::noiseMask, TZoomLevel>(rt, args);
                     break;
                 case BlendOp::transparent | BlendOp::noiseMask:
-                    drawBMPSprite<BlendOp::transparent | BlendOp::noiseMask, TZoomLevel>(context, args);
+                    drawBMPSprite<BlendOp::transparent | BlendOp::noiseMask, TZoomLevel>(rt, args);
                     break;
                 default:
                     assert(false);
@@ -88,19 +89,19 @@ namespace OpenLoco::Drawing
             switch (op)
             {
                 case BlendOp::transparent | BlendOp::src | BlendOp::dst:
-                    drawRLESprite<BlendOp::transparent | BlendOp::src | BlendOp::dst, TZoomLevel>(context, args);
+                    drawRLESprite<BlendOp::transparent | BlendOp::src | BlendOp::dst, TZoomLevel>(rt, args);
                     break;
                 case BlendOp::transparent | BlendOp::src:
-                    drawRLESprite<BlendOp::transparent | BlendOp::src, TZoomLevel>(context, args);
+                    drawRLESprite<BlendOp::transparent | BlendOp::src, TZoomLevel>(rt, args);
                     break;
                 case BlendOp::transparent | BlendOp::dst:
-                    drawRLESprite<BlendOp::transparent | BlendOp::dst, TZoomLevel>(context, args);
+                    drawRLESprite<BlendOp::transparent | BlendOp::dst, TZoomLevel>(rt, args);
                     break;
                 case BlendOp::none:
-                    drawRLESprite<BlendOp::none, TZoomLevel>(context, args);
+                    drawRLESprite<BlendOp::none, TZoomLevel>(rt, args);
                     break;
                 case BlendOp::transparent:
-                    drawRLESprite<BlendOp::transparent, TZoomLevel>(context, args);
+                    drawRLESprite<BlendOp::transparent, TZoomLevel>(rt, args);
                     break;
                 default:
                     assert(false);
@@ -110,43 +111,43 @@ namespace OpenLoco::Drawing
     }
 
     template<>
-    void drawSpriteToBuffer<0, false>(Gfx::Context& context, const DrawSpriteArgs& args, const DrawBlendOp op)
+    void drawSpriteToBuffer<0, false>(Gfx::RenderTarget& rt, const DrawSpriteArgs& args, const DrawBlendOp op)
     {
-        drawSpriteToBufferHelper<0, false>(context, args, op);
+        drawSpriteToBufferHelper<0, false>(rt, args, op);
     }
     template<>
-    void drawSpriteToBuffer<1, false>(Gfx::Context& context, const DrawSpriteArgs& args, const DrawBlendOp op)
+    void drawSpriteToBuffer<1, false>(Gfx::RenderTarget& rt, const DrawSpriteArgs& args, const DrawBlendOp op)
     {
-        drawSpriteToBufferHelper<1, false>(context, args, op);
+        drawSpriteToBufferHelper<1, false>(rt, args, op);
     }
     template<>
-    void drawSpriteToBuffer<2, false>(Gfx::Context& context, const DrawSpriteArgs& args, const DrawBlendOp op)
+    void drawSpriteToBuffer<2, false>(Gfx::RenderTarget& rt, const DrawSpriteArgs& args, const DrawBlendOp op)
     {
-        drawSpriteToBufferHelper<2, false>(context, args, op);
+        drawSpriteToBufferHelper<2, false>(rt, args, op);
     }
     template<>
-    void drawSpriteToBuffer<3, false>(Gfx::Context& context, const DrawSpriteArgs& args, const DrawBlendOp op)
+    void drawSpriteToBuffer<3, false>(Gfx::RenderTarget& rt, const DrawSpriteArgs& args, const DrawBlendOp op)
     {
-        drawSpriteToBufferHelper<3, false>(context, args, op);
+        drawSpriteToBufferHelper<3, false>(rt, args, op);
     }
     template<>
-    void drawSpriteToBuffer<0, true>(Gfx::Context& context, const DrawSpriteArgs& args, const DrawBlendOp op)
+    void drawSpriteToBuffer<0, true>(Gfx::RenderTarget& rt, const DrawSpriteArgs& args, const DrawBlendOp op)
     {
-        drawSpriteToBufferHelper<0, true>(context, args, op);
+        drawSpriteToBufferHelper<0, true>(rt, args, op);
     }
     template<>
-    void drawSpriteToBuffer<1, true>(Gfx::Context& context, const DrawSpriteArgs& args, const DrawBlendOp op)
+    void drawSpriteToBuffer<1, true>(Gfx::RenderTarget& rt, const DrawSpriteArgs& args, const DrawBlendOp op)
     {
-        drawSpriteToBufferHelper<1, true>(context, args, op);
+        drawSpriteToBufferHelper<1, true>(rt, args, op);
     }
     template<>
-    void drawSpriteToBuffer<2, true>(Gfx::Context& context, const DrawSpriteArgs& args, const DrawBlendOp op)
+    void drawSpriteToBuffer<2, true>(Gfx::RenderTarget& rt, const DrawSpriteArgs& args, const DrawBlendOp op)
     {
-        drawSpriteToBufferHelper<2, true>(context, args, op);
+        drawSpriteToBufferHelper<2, true>(rt, args, op);
     }
     template<>
-    void drawSpriteToBuffer<3, true>(Gfx::Context& context, const DrawSpriteArgs& args, const DrawBlendOp op)
+    void drawSpriteToBuffer<3, true>(Gfx::RenderTarget& rt, const DrawSpriteArgs& args, const DrawBlendOp op)
     {
-        drawSpriteToBufferHelper<3, true>(context, args, op);
+        drawSpriteToBufferHelper<3, true>(rt, args, op);
     }
 }

--- a/src/OpenLoco/Drawing/DrawSprite.h
+++ b/src/OpenLoco/Drawing/DrawSprite.h
@@ -6,7 +6,7 @@ namespace OpenLoco::Gfx
 {
     struct PaletteMap;
     struct G1Element;
-    struct Context;
+    struct RenderTarget;
 }
 
 namespace OpenLoco::Drawing
@@ -70,5 +70,5 @@ namespace OpenLoco::Drawing
     DrawBlendOp getDrawBlendOp(const ImageId image, const DrawSpriteArgs& args);
 
     template<uint8_t TZoomLevel, bool TIsRLE>
-    void drawSpriteToBuffer(Gfx::Context& context, const DrawSpriteArgs& args, const DrawBlendOp op);
+    void drawSpriteToBuffer(Gfx::RenderTarget& rt, const DrawSpriteArgs& args, const DrawBlendOp op);
 }

--- a/src/OpenLoco/Drawing/DrawSpriteBMP.hpp
+++ b/src/OpenLoco/Drawing/DrawSpriteBMP.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "../Graphics/Gfx.h"
+#include "../Graphics/RenderTarget.h"
 #include "DrawSprite.h"
 #include "DrawSpriteHelper.hpp"
 
 namespace OpenLoco::Drawing
 {
     template<DrawBlendOp TBlendOp, uint8_t TZoomLevel>
-    inline void drawBMPSprite(Gfx::Context& context, const DrawSpriteArgs& args)
+    inline void drawBMPSprite(Gfx::RenderTarget& rt, const DrawSpriteArgs& args)
     {
         const auto& g1 = args.sourceImage;
         const auto* src = g1.offset + ((static_cast<size_t>(g1.width) * args.srcPos.y) + args.srcPos.x);
@@ -15,8 +16,8 @@ namespace OpenLoco::Drawing
         const int32_t width = args.size.width;
         int32_t height = args.size.height;
         const size_t srcLineWidth = g1.width << TZoomLevel;
-        const size_t dstLineWidth = (static_cast<size_t>(context.width) >> TZoomLevel) + context.pitch;
-        auto* dst = context.bits;
+        const size_t dstLineWidth = (static_cast<size_t>(rt.width) >> TZoomLevel) + rt.pitch;
+        auto* dst = rt.bits;
         // Move the pointer to the start point of the destination
         dst += dstLineWidth * args.dstPos.y + args.dstPos.x;
 

--- a/src/OpenLoco/Drawing/DrawSpriteRLE.hpp
+++ b/src/OpenLoco/Drawing/DrawSpriteRLE.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "../Graphics/Gfx.h"
+#include "../Graphics/RenderTarget.h"
 #include "DrawSprite.h"
 #include "DrawSpriteHelper.hpp"
 
 namespace OpenLoco::Drawing
 {
     template<DrawBlendOp TBlendOp, uint8_t TZoomLevel>
-    inline void drawRLESprite(Gfx::Context& context, const DrawSpriteArgs& args)
+    inline void drawRLESprite(Gfx::RenderTarget& rt, const DrawSpriteArgs& args)
     {
         auto src0 = args.sourceImage.offset;
         const auto srcX = args.srcPos.x;
@@ -15,8 +16,8 @@ namespace OpenLoco::Drawing
         const int32_t width = args.size.width;
         int32_t height = args.size.height;
         constexpr auto zoom = 1 << TZoomLevel;
-        auto dstLineWidth = (static_cast<size_t>(context.width) >> TZoomLevel) + context.pitch;
-        auto* dst0 = context.bits;
+        auto dstLineWidth = (static_cast<size_t>(rt.width) >> TZoomLevel) + rt.pitch;
+        auto* dst0 = rt.bits;
         // Move the pointer to the start point of the destination
         dst0 += dstLineWidth * args.dstPos.y + args.dstPos.x;
 

--- a/src/OpenLoco/Drawing/FPSCounter.cpp
+++ b/src/OpenLoco/Drawing/FPSCounter.cpp
@@ -47,13 +47,13 @@ namespace OpenLoco::Drawing
         const char* formatString = (_currentFPS >= 10.0f ? "%.0f" : "%.1f");
         snprintf(&buffer[3], std::size(buffer) - 3, formatString, fps);
 
-        auto& context = Gfx::screenContext();
+        auto& rt = Gfx::getScreenRT();
 
         // Draw text
         const int stringWidth = Gfx::getStringWidth(buffer);
         const auto x = Ui::width() / 2 - (stringWidth / 2);
         const auto y = 2;
-        Gfx::drawString(context, x, y, Colour::black, buffer);
+        Gfx::drawString(rt, x, y, Colour::black, buffer);
 
         // Make area dirty so the text doesn't get drawn over the last
         Gfx::setDirtyBlocks(x - 16, y - 4, x + 16, 16);

--- a/src/OpenLoco/Drawing/SoftwareDrawingEngine.cpp
+++ b/src/OpenLoco/Drawing/SoftwareDrawingEngine.cpp
@@ -17,9 +17,9 @@ namespace OpenLoco::Drawing
     static loco_global<uint8_t[1], 0x00E025C4> _E025C4;
     loco_global<SetPaletteFunc, 0x0052524C> set_palette_callback;
 
-    static void windowDraw(Context* context, Ui::Window* w, Rect rect);
-    static void windowDraw(Context* context, Ui::Window* w, int16_t left, int16_t top, int16_t right, int16_t bottom);
-    static bool windowDrawSplit(Gfx::Context* context, Ui::Window* w, int16_t left, int16_t top, int16_t right, int16_t bottom);
+    static void windowDraw(RenderTarget* rt, Ui::Window* w, Rect rect);
+    static void windowDraw(RenderTarget* rt, Ui::Window* w, int16_t left, int16_t top, int16_t right, int16_t bottom);
+    static bool windowDrawSplit(Gfx::RenderTarget* rt, Ui::Window* w, int16_t left, int16_t top, int16_t right, int16_t bottom);
 
     SoftwareDrawingEngine::~SoftwareDrawingEngine()
     {
@@ -203,14 +203,14 @@ namespace OpenLoco::Drawing
         regs.dx = rect.bottom() - 1;
         call(0x00451D98, regs);
 
-        Context windowContext;
-        windowContext.width = rect.width();
-        windowContext.height = rect.height();
-        windowContext.x = rect.left();
-        windowContext.y = rect.top();
-        windowContext.bits = screen_info->context.bits + rect.left() + ((screen_info->context.width + screen_info->context.pitch) * rect.top());
-        windowContext.pitch = screen_info->context.width + screen_info->context.pitch - rect.width();
-        windowContext.zoom_level = 0;
+        RenderTarget rt;
+        rt.width = rect.width();
+        rt.height = rect.height();
+        rt.x = rect.left();
+        rt.y = rect.top();
+        rt.bits = screen_info->renderTarget.bits + rect.left() + ((screen_info->renderTarget.width + screen_info->renderTarget.pitch) * rect.top());
+        rt.pitch = screen_info->renderTarget.width + screen_info->renderTarget.pitch - rect.width();
+        rt.zoom_level = 0;
 
         for (size_t i = 0; i < Ui::WindowManager::count(); i++)
         {
@@ -225,13 +225,13 @@ namespace OpenLoco::Drawing
             if (rect.left() >= w->x + w->width || rect.top() >= w->y + w->height)
                 continue;
 
-            windowDraw(&windowContext, w, rect);
+            windowDraw(&rt, w, rect);
         }
     }
 
-    static void windowDraw(Context* context, Ui::Window* w, Rect rect)
+    static void windowDraw(RenderTarget* rt, Ui::Window* w, Rect rect)
     {
-        windowDraw(context, w, rect.left(), rect.top(), rect.right(), rect.bottom());
+        windowDraw(rt, w, rect.left(), rect.top(), rect.right(), rect.bottom());
     }
 
     /**
@@ -243,13 +243,13 @@ namespace OpenLoco::Drawing
      * @param right @<dx>
      * @param bottom @<bp>
      */
-    static void windowDraw(Context* context, Ui::Window* w, int16_t left, int16_t top, int16_t right, int16_t bottom)
+    static void windowDraw(RenderTarget* rt, Ui::Window* w, int16_t left, int16_t top, int16_t right, int16_t bottom)
     {
         if (!w->isVisible())
             return;
 
         // Split window into only the regions that require drawing
-        if (windowDrawSplit(context, w, left, top, right, bottom))
+        if (windowDrawSplit(rt, w, left, top, right, bottom))
             return;
 
         // Clamp region
@@ -263,7 +263,7 @@ namespace OpenLoco::Drawing
             return;
 
         // Draw the window in this region
-        Ui::WindowManager::drawSingle(context, w, left, top, right, bottom);
+        Ui::WindowManager::drawSingle(rt, w, left, top, right, bottom);
 
         for (uint32_t index = Ui::WindowManager::indexOf(w) + 1; index < Ui::WindowManager::count(); index++)
         {
@@ -273,14 +273,14 @@ namespace OpenLoco::Drawing
             if ((v->flags & Ui::WindowFlags::transparent) == 0)
                 continue;
 
-            Ui::WindowManager::drawSingle(context, v, left, top, right, bottom);
+            Ui::WindowManager::drawSingle(rt, v, left, top, right, bottom);
         }
     }
 
     /**
      * 0x004C5EA9
      *
-     * @param context
+     * @param rt
      * @param w @<esi>
      * @param left @<ax>
      * @param top @<bx>
@@ -288,7 +288,7 @@ namespace OpenLoco::Drawing
      * @param bottom @<bp>
      * @return
      */
-    static bool windowDrawSplit(Gfx::Context* context, Ui::Window* w, int16_t left, int16_t top, int16_t right, int16_t bottom)
+    static bool windowDrawSplit(Gfx::RenderTarget* rt, Ui::Window* w, int16_t left, int16_t top, int16_t right, int16_t bottom)
     {
         // Divide the draws up for only the visible regions of the window recursively
         for (uint32_t index = Ui::WindowManager::indexOf(w) + 1; index < Ui::WindowManager::count(); index++)
@@ -307,26 +307,26 @@ namespace OpenLoco::Drawing
             if (topwindow->x > left)
             {
                 // Split draw at topwindow.left
-                windowDraw(context, w, left, top, topwindow->x, bottom);
-                windowDraw(context, w, topwindow->x, top, right, bottom);
+                windowDraw(rt, w, left, top, topwindow->x, bottom);
+                windowDraw(rt, w, topwindow->x, top, right, bottom);
             }
             else if (topwindow->x + topwindow->width < right)
             {
                 // Split draw at topwindow.right
-                windowDraw(context, w, left, top, topwindow->x + topwindow->width, bottom);
-                windowDraw(context, w, topwindow->x + topwindow->width, top, right, bottom);
+                windowDraw(rt, w, left, top, topwindow->x + topwindow->width, bottom);
+                windowDraw(rt, w, topwindow->x + topwindow->width, top, right, bottom);
             }
             else if (topwindow->y > top)
             {
                 // Split draw at topwindow.top
-                windowDraw(context, w, left, top, right, topwindow->y);
-                windowDraw(context, w, left, topwindow->y, right, bottom);
+                windowDraw(rt, w, left, top, right, topwindow->y);
+                windowDraw(rt, w, left, topwindow->y, right, bottom);
             }
             else if (topwindow->y + topwindow->height < bottom)
             {
                 // Split draw at topwindow.bottom
-                windowDraw(context, w, left, top, right, topwindow->y + topwindow->height);
-                windowDraw(context, w, left, topwindow->y + topwindow->height, right, bottom);
+                windowDraw(rt, w, left, top, right, topwindow->y + topwindow->height);
+                windowDraw(rt, w, left, topwindow->y + topwindow->height, right, bottom);
             }
 
             // Drawing for this region should be done now, exit

--- a/src/OpenLoco/Graphics/Gfx.h
+++ b/src/OpenLoco/Graphics/Gfx.h
@@ -22,6 +22,8 @@ namespace OpenLoco::Drawing
 
 namespace OpenLoco::Gfx
 {
+    struct RenderTarget;
+
     namespace G1ExpectedCount
     {
         constexpr uint32_t kDisc = 0x101A; // And GOG
@@ -29,22 +31,6 @@ namespace OpenLoco::Gfx
         constexpr uint32_t kObjects = 0x40000;
     }
 #pragma pack(push, 1)
-
-    struct Context
-    {
-        uint8_t* bits;       // 0x00
-        int16_t x;           // 0x04
-        int16_t y;           // 0x06
-        int16_t width;       // 0x08
-        int16_t height;      // 0x0A
-        int16_t pitch;       // 0x0C note: this is actually (pitch - width)
-        uint16_t zoom_level; // 0x0E
-
-        Ui::Rect getUiRect() const;
-        Ui::Rect getDrawableRect() const;
-    };
-
-    Context& screenContext();
 
     struct G1Header
     {
@@ -151,22 +137,20 @@ namespace OpenLoco::Gfx
     std::optional<uint32_t> getPaletteG1Index(ExtColour paletteId);
     std::optional<PaletteMap> getPaletteMapForColour(ExtColour paletteId);
 
-    Context& screenContext();
-
     void loadG1();
     void initialiseCharacterWidths();
     void initialiseNoiseMaskMap();
-    void clear(Context& context, uint32_t fill);
-    void clearSingle(Context& context, uint8_t paletteId);
+    void clear(RenderTarget& rt, uint32_t fill);
+    void clearSingle(RenderTarget& rt, uint8_t paletteId);
 
     int16_t clipString(int16_t width, char* string);
     uint16_t getStringWidth(const char* buffer);
     uint16_t getMaxStringWidth(const char* buffer);
 
-    Ui::Point drawString(Context& context, int16_t x, int16_t y, AdvancedColour colour, void* str);
+    Ui::Point drawString(RenderTarget& rt, int16_t x, int16_t y, AdvancedColour colour, void* str);
 
     int16_t drawStringLeftWrapped(
-        Context& context,
+        RenderTarget& rt,
         int16_t x,
         int16_t y,
         int16_t width,
@@ -174,20 +158,20 @@ namespace OpenLoco::Gfx
         string_id stringId,
         const void* args = nullptr);
     void drawStringLeft(
-        Context& context,
+        RenderTarget& rt,
         int16_t x,
         int16_t y,
         AdvancedColour colour,
         string_id stringId,
         const void* args = nullptr);
     void drawStringLeft(
-        Context& context,
+        RenderTarget& rt,
         Ui::Point* origin,
         AdvancedColour colour,
         string_id stringId,
         const void* args = nullptr);
     void drawStringLeftClipped(
-        Context& context,
+        RenderTarget& rt,
         int16_t x,
         int16_t y,
         int16_t width,
@@ -195,35 +179,35 @@ namespace OpenLoco::Gfx
         string_id stringId,
         const void* args = nullptr);
     void drawStringRight(
-        Context& context,
+        RenderTarget& rt,
         int16_t x,
         int16_t y,
         AdvancedColour colour,
         string_id stringId,
         const void* args = nullptr);
     void drawStringRightUnderline(
-        Context& context,
+        RenderTarget& rt,
         int16_t x,
         int16_t y,
         AdvancedColour colour,
         string_id stringId,
         const void* args);
     void drawStringLeftUnderline(
-        Context& context,
+        RenderTarget& rt,
         int16_t x,
         int16_t y,
         AdvancedColour colour,
         string_id stringId,
         const void* args = nullptr);
     void drawStringCentred(
-        Context& context,
+        RenderTarget& rt,
         int16_t x,
         int16_t y,
         AdvancedColour colour,
         string_id stringId,
         const void* args = nullptr);
     void drawStringCentredClipped(
-        Context& context,
+        RenderTarget& rt,
         int16_t x,
         int16_t y,
         int16_t width,
@@ -231,14 +215,14 @@ namespace OpenLoco::Gfx
         string_id stringId,
         const void* args = nullptr);
     uint16_t drawStringCentredWrapped(
-        Context& context,
+        RenderTarget& rt,
         Ui::Point& origin,
         uint16_t width,
         AdvancedColour colour,
         string_id stringId,
         const void* args = nullptr);
     void drawStringCentredRaw(
-        Context& context,
+        RenderTarget& rt,
         int16_t x,
         int16_t y,
         int16_t width,
@@ -247,15 +231,15 @@ namespace OpenLoco::Gfx
     uint16_t getStringWidthNewLined(const char* buffer);
     std::pair<uint16_t, uint16_t> wrapString(char* buffer, uint16_t stringWidth);
 
-    void fillRect(Gfx::Context& context, int16_t left, int16_t top, int16_t right, int16_t bottom, uint32_t colour);
-    void drawRect(Gfx::Context& context, int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint32_t colour);
-    void fillRectInset(Gfx::Context& context, int16_t left, int16_t top, int16_t right, int16_t bottom, uint32_t colour, uint8_t flags);
-    void drawRectInset(Gfx::Context& context, int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint32_t colour, uint8_t flags);
-    void drawLine(Gfx::Context& context, int16_t left, int16_t top, int16_t right, int16_t bottom, uint32_t colour);
-    void drawImage(Gfx::Context* context, int16_t x, int16_t y, uint32_t image);
-    void drawImage(Gfx::Context& context, const Ui::Point& pos, const ImageId& image);
-    void drawImageSolid(Gfx::Context& context, const Ui::Point& pos, const ImageId& image, PaletteIndex_t paletteIndex);
-    void drawImagePaletteSet(Gfx::Context& context, const Ui::Point& pos, const ImageId& image, const PaletteMap& palette, const G1Element* noiseImage);
+    void fillRect(Gfx::RenderTarget& rt, int16_t left, int16_t top, int16_t right, int16_t bottom, uint32_t colour);
+    void drawRect(Gfx::RenderTarget& rt, int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint32_t colour);
+    void fillRectInset(Gfx::RenderTarget& rt, int16_t left, int16_t top, int16_t right, int16_t bottom, uint32_t colour, uint8_t flags);
+    void drawRectInset(Gfx::RenderTarget& rt, int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint32_t colour, uint8_t flags);
+    void drawLine(Gfx::RenderTarget& rt, int16_t left, int16_t top, int16_t right, int16_t bottom, uint32_t colour);
+    void drawImage(Gfx::RenderTarget* rt, int16_t x, int16_t y, uint32_t image);
+    void drawImage(Gfx::RenderTarget& rt, const Ui::Point& pos, const ImageId& image);
+    void drawImageSolid(Gfx::RenderTarget& rt, const Ui::Point& pos, const ImageId& image, PaletteIndex_t paletteIndex);
+    void drawImagePaletteSet(Gfx::RenderTarget& rt, const Ui::Point& pos, const ImageId& image, const PaletteMap& palette, const G1Element* noiseImage);
     [[nodiscard]] uint32_t recolour(uint32_t image);
     [[nodiscard]] uint32_t recolour(uint32_t image, Colour colour);
     [[nodiscard]] uint32_t recolour(uint32_t image, ExtColour colour);
@@ -272,8 +256,6 @@ namespace OpenLoco::Gfx
 
     void redrawScreenRect(Ui::Rect rect);
     void redrawScreenRect(int16_t left, int16_t top, int16_t right, int16_t bottom);
-
-    std::optional<Gfx::Context> clipContext(const Gfx::Context& src, const Ui::Rect& newRect);
 
     G1Element* getG1Element(uint32_t id);
 

--- a/src/OpenLoco/Graphics/RenderTarget.cpp
+++ b/src/OpenLoco/Graphics/RenderTarget.cpp
@@ -1,0 +1,48 @@
+#include "RenderTarget.h"
+#include "../Interop/Interop.hpp"
+
+using namespace OpenLoco::Interop;
+
+namespace OpenLoco::Gfx
+{
+    static loco_global<RenderTarget, 0x0050B884> _screenRT;
+
+    Ui::Rect RenderTarget::getDrawableRect() const
+    {
+        auto zoom = zoom_level;
+        auto left = x >> zoom;
+        auto top = y >> zoom;
+        auto right = (width >> zoom) + left;
+        auto bottom = (height >> zoom) + top;
+        return Ui::Rect::fromLTRB(left, top, right, bottom);
+    }
+
+    Ui::Rect RenderTarget::getUiRect() const
+    {
+        return Ui::Rect::fromLTRB(x, y, x + width, y + height);
+    }
+
+    RenderTarget& getScreenRT()
+    {
+        return _screenRT;
+    }
+
+    // 0x004CEC50
+    std::optional<Gfx::RenderTarget> clipRenderTarget(const Gfx::RenderTarget& src, const Ui::Rect& newRect)
+    {
+        const Ui::Rect oldRect = src.getUiRect();
+        Ui::Rect intersect = oldRect.intersection(newRect);
+        const auto stride = oldRect.size.width + src.pitch;
+        const int16_t newPitch = stride - intersect.size.width;
+        auto* newBits = src.bits + (stride * (intersect.origin.y - oldRect.origin.y) + (intersect.origin.x - oldRect.origin.x));
+        intersect.origin.x = std::max(0, oldRect.origin.x - newRect.origin.x);
+        intersect.origin.y = std::max(0, oldRect.origin.y - newRect.origin.y);
+        Gfx::RenderTarget newRT{ newBits, static_cast<int16_t>(intersect.origin.x), static_cast<int16_t>(intersect.origin.y), static_cast<int16_t>(intersect.size.width), static_cast<int16_t>(intersect.size.height), newPitch, 0 };
+
+        if (newRT.width <= 0 || newRT.height <= 0)
+        {
+            return {};
+        }
+        return { newRT };
+    }
+}

--- a/src/OpenLoco/Graphics/RenderTarget.h
+++ b/src/OpenLoco/Graphics/RenderTarget.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "../Ui/Rect.h"
+#include <cstdint>
+#include <optional>
+
+namespace OpenLoco::Gfx
+{
+#pragma pack(push, 1)
+
+    // TODO: Convert this to a handle once everything is implemented.
+    // Depending on the rendering engine this could be a buffer on GPU or RAM.
+    struct RenderTarget
+    {
+        uint8_t* bits;       // 0x00
+        int16_t x;           // 0x04
+        int16_t y;           // 0x06
+        int16_t width;       // 0x08
+        int16_t height;      // 0x0A
+        int16_t pitch;       // 0x0C note: this is actually (pitch - width)
+        uint16_t zoom_level; // 0x0E
+
+        Ui::Rect getUiRect() const;
+        Ui::Rect getDrawableRect() const;
+    };
+
+#pragma pack(pop)
+
+    RenderTarget& getScreenRT();
+
+    std::optional<Gfx::RenderTarget> clipRenderTarget(const Gfx::RenderTarget& src, const Ui::Rect& newRect);
+
+}

--- a/src/OpenLoco/Interop/Hooks.cpp
+++ b/src/OpenLoco/Interop/Hooks.cpp
@@ -679,7 +679,7 @@ void OpenLoco::Interop::registerHooks()
         0x00451025,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             registers backup = regs;
-            auto pos = Gfx::drawString(*X86Pointer<Gfx::Context>(regs.edi), regs.cx, regs.dx, static_cast<Colour>(regs.al), X86Pointer<uint8_t>(regs.esi));
+            auto pos = Gfx::drawString(*X86Pointer<Gfx::RenderTarget>(regs.edi), regs.cx, regs.dx, static_cast<Colour>(regs.al), X86Pointer<uint8_t>(regs.esi));
             regs = backup;
             regs.cx = pos.x;
             regs.dx = pos.y;
@@ -737,8 +737,8 @@ void OpenLoco::Interop::registerHooks()
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             registers backup = regs;
             Ui::Window* window = X86Pointer<Ui::Window>(regs.esi);
-            auto context = X86Pointer<Gfx::Context>(regs.edi);
-            window->draw(context);
+            auto rt = X86Pointer<Gfx::RenderTarget>(regs.edi);
+            window->draw(rt);
             regs = backup;
             return 0;
         });
@@ -900,8 +900,8 @@ void OpenLoco::Interop::registerHooks()
         0x00448C79,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             registers backup = regs;
-            Gfx::Context* context = X86Pointer<Gfx::Context>(regs.edi);
-            Gfx::drawImage(*context, { regs.cx, regs.dx }, ImageId::fromUInt32(regs.ebx));
+            Gfx::RenderTarget* rt = X86Pointer<Gfx::RenderTarget>(regs.edi);
+            Gfx::drawImage(*rt, { regs.cx, regs.dx }, ImageId::fromUInt32(regs.ebx));
 
             regs = backup;
             return 0;

--- a/src/OpenLoco/Objects/AirportObject.cpp
+++ b/src/OpenLoco/Objects/AirportObject.cpp
@@ -7,18 +7,18 @@
 namespace OpenLoco
 {
     // 0x00490DCF
-    void AirportObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void AirportObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
 
-        Gfx::drawImage(&context, x - 34, y - 34, colourImage);
+        Gfx::drawImage(&rt, x - 34, y - 34, colourImage);
     }
 
     // 0x00490DE7
-    void AirportObject::drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
+    void AirportObject::drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
     {
         Ui::Point rowPosition = { x, y };
-        ObjectManager::drawGenericDescription(context, rowPosition, designed_year, obsolete_year);
+        ObjectManager::drawGenericDescription(rt, rowPosition, designed_year, obsolete_year);
     }
 
     // 0x00490DA8

--- a/src/OpenLoco/Objects/AirportObject.h
+++ b/src/OpenLoco/Objects/AirportObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -73,8 +73,8 @@ namespace OpenLoco
         MovementEdge* movementEdges; // 0xB2
         uint8_t pad_B6[0xBA - 0xB6];
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
-        void drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
+        void drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();

--- a/src/OpenLoco/Objects/BridgeObject.cpp
+++ b/src/OpenLoco/Objects/BridgeObject.cpp
@@ -6,11 +6,11 @@
 namespace OpenLoco
 {
     // 0x0042C6A8
-    void BridgeObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void BridgeObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
 
-        Gfx::drawImage(&context, x - 21, y - 9, colourImage);
+        Gfx::drawImage(&rt, x - 21, y - 9, colourImage);
     }
 
     // 0x0042C651

--- a/src/OpenLoco/Objects/BridgeObject.h
+++ b/src/OpenLoco/Objects/BridgeObject.h
@@ -9,7 +9,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -37,7 +37,7 @@ namespace OpenLoco
         uint8_t road_mods[7];         // 0x23
         uint16_t designed_year;       // 0x2A
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();

--- a/src/OpenLoco/Objects/BuildingObject.cpp
+++ b/src/OpenLoco/Objects/BuildingObject.cpp
@@ -10,17 +10,17 @@ using namespace OpenLoco::Interop;
 namespace OpenLoco
 {
     // 0x0042DE40
-    void BuildingObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void BuildingObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto bit = Utility::bitScanReverse(colours);
 
         const auto colour = (bit == -1) ? Colour::black : static_cast<Colour>(bit);
 
-        drawBuilding(&context, 1, x, y + 40, colour);
+        drawBuilding(&rt, 1, x, y + 40, colour);
     }
 
     // 0x0042DB95
-    void BuildingObject::drawBuilding(Gfx::Context* clipped, uint8_t buildingRotation, int16_t x, int16_t y, Colour colour) const
+    void BuildingObject::drawBuilding(Gfx::RenderTarget* clipped, uint8_t buildingRotation, int16_t x, int16_t y, Colour colour) const
     {
         registers regs;
         regs.cx = x;
@@ -33,10 +33,10 @@ namespace OpenLoco
     }
 
     // 0x0042DE82
-    void BuildingObject::drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
+    void BuildingObject::drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
     {
         Ui::Point rowPosition = { x, y };
-        ObjectManager::drawGenericDescription(context, rowPosition, designedYear, obsoleteYear);
+        ObjectManager::drawGenericDescription(rt, rowPosition, designedYear, obsoleteYear);
     }
 
     // 0x0042DE1E

--- a/src/OpenLoco/Objects/BuildingObject.h
+++ b/src/OpenLoco/Objects/BuildingObject.h
@@ -9,7 +9,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
     namespace BuildingObjectFlags
@@ -49,9 +49,9 @@ namespace OpenLoco
         uint8_t var_AD;
         uint32_t var_AE[4];
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
-        void drawBuilding(Gfx::Context* clipped, uint8_t buildingRotation, int16_t x, int16_t y, Colour colour) const;
-        void drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
+        void drawBuilding(Gfx::RenderTarget* clipped, uint8_t buildingRotation, int16_t x, int16_t y, Colour colour) const;
+        void drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();

--- a/src/OpenLoco/Objects/CompetitorObject.cpp
+++ b/src/OpenLoco/Objects/CompetitorObject.cpp
@@ -12,16 +12,16 @@ namespace OpenLoco
     static const Ui::Size objectPreviewSize = { 112, 112 };
 
     // 0x00434D5B
-    void CompetitorObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void CompetitorObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
-        Gfx::drawRect(context, 0, 0, objectPreviewSize.width, objectPreviewSize.height, AdvancedColour(Colour::mutedOrange).inset().u8());
+        Gfx::drawRect(rt, 0, 0, objectPreviewSize.width, objectPreviewSize.height, AdvancedColour(Colour::mutedOrange).inset().u8());
 
         auto image = Gfx::recolour(images[0], Colour::mutedSeaGreen);
-        Gfx::drawImage(&context, x - 32, y - 32, image);
+        Gfx::drawImage(&rt, x - 32, y - 32, image);
     }
 
     // 0x00434DA7
-    void CompetitorObject::drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
+    void CompetitorObject::drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
     {
         Ui::Point rowPosition = { x, y };
         {
@@ -29,7 +29,7 @@ namespace OpenLoco
             args.push<uint16_t>(intelligence);
             args.push(aiRatingToLevel(intelligence));
 
-            Gfx::drawStringLeft(context, rowPosition.x, rowPosition.y, Colour::black, StringIds::company_details_intelligence, &args);
+            Gfx::drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::company_details_intelligence, &args);
             rowPosition.y += descriptionRowHeight;
         }
         {
@@ -37,7 +37,7 @@ namespace OpenLoco
             args.push<uint16_t>(aggressiveness);
             args.push(aiRatingToLevel(aggressiveness));
 
-            Gfx::drawStringLeft(context, rowPosition.x, rowPosition.y, Colour::black, StringIds::company_details_aggressiveness, &args);
+            Gfx::drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::company_details_aggressiveness, &args);
             rowPosition.y += descriptionRowHeight;
         }
         {
@@ -45,7 +45,7 @@ namespace OpenLoco
             args.push<uint16_t>(competitiveness);
             args.push(aiRatingToLevel(competitiveness));
 
-            Gfx::drawStringLeft(context, rowPosition.x, rowPosition.y, Colour::black, StringIds::company_details_competitiveness, &args);
+            Gfx::drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::company_details_competitiveness, &args);
         }
     }
 

--- a/src/OpenLoco/Objects/CompetitorObject.h
+++ b/src/OpenLoco/Objects/CompetitorObject.h
@@ -9,7 +9,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -28,8 +28,8 @@ namespace OpenLoco
         uint8_t competitiveness; // 0x36
         uint8_t var_37;          // 0x37
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
-        void drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
+        void drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();

--- a/src/OpenLoco/Objects/CurrencyObject.cpp
+++ b/src/OpenLoco/Objects/CurrencyObject.cpp
@@ -45,7 +45,7 @@ namespace OpenLoco
     }
 
     // 0x0046DFC3
-    void CurrencyObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void CurrencyObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto currencyIndex = object_icon + 3;
 
@@ -58,7 +58,7 @@ namespace OpenLoco
         auto defaultWidth = _characterWidths[Font::large + 131];
         _characterWidths[Font::large + 131] = currencyElement->width + 1;
 
-        Gfx::drawStringCentred(context, x, y - 9, Colour::black, StringIds::object_currency_big_font);
+        Gfx::drawStringCentred(rt, x, y - 9, Colour::black, StringIds::object_currency_big_font);
 
         _characterWidths[Font::large + 131] = defaultWidth;
         *defaultElement = backupElement;

--- a/src/OpenLoco/Objects/CurrencyObject.h
+++ b/src/OpenLoco/Objects/CurrencyObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -26,7 +26,7 @@ namespace OpenLoco
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
     };
 #pragma pack(pop)
     static_assert(sizeof(CurrencyObject) == 0xC);

--- a/src/OpenLoco/Objects/DockObject.cpp
+++ b/src/OpenLoco/Objects/DockObject.cpp
@@ -7,18 +7,18 @@
 namespace OpenLoco
 {
     // 0x00490F14
-    void DockObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void DockObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
 
-        Gfx::drawImage(&context, x - 34, y - 34, colourImage);
+        Gfx::drawImage(&rt, x - 34, y - 34, colourImage);
     }
 
     // 0x00490F2C
-    void DockObject::drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
+    void DockObject::drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
     {
         Ui::Point rowPosition = { x, y };
-        ObjectManager::drawGenericDescription(context, rowPosition, designed_year, obsolete_year);
+        ObjectManager::drawGenericDescription(rt, rowPosition, designed_year, obsolete_year);
     }
 
     // 0x00490EED

--- a/src/OpenLoco/Objects/DockObject.h
+++ b/src/OpenLoco/Objects/DockObject.h
@@ -9,7 +9,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -33,8 +33,8 @@ namespace OpenLoco
         uint16_t obsolete_year; // 0x22
         Map::Pos2 boatPosition; // 0x24
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
-        void drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
+        void drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();

--- a/src/OpenLoco/Objects/HillShapesObject.cpp
+++ b/src/OpenLoco/Objects/HillShapesObject.cpp
@@ -5,11 +5,11 @@
 namespace OpenLoco
 {
     // 0x00463BBD
-    void HillShapesObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void HillShapesObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto imageId = image + hillHeightMapCount + mountainHeightMapCount;
 
-        Gfx::drawImage(&context, x, y, imageId);
+        Gfx::drawImage(&rt, x, y, imageId);
     }
 
     // 0x00463B70

--- a/src/OpenLoco/Objects/HillShapesObject.h
+++ b/src/OpenLoco/Objects/HillShapesObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -23,7 +23,7 @@ namespace OpenLoco
         uint32_t var_08;                // 0x08
         uint8_t pad_0C[0x0E - 0x0C];
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
         // 0x00463BB3
         bool validate() const { return true; }
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);

--- a/src/OpenLoco/Objects/IndustryObject.cpp
+++ b/src/OpenLoco/Objects/IndustryObject.cpp
@@ -87,13 +87,13 @@ namespace OpenLoco
     }
 
     // 0x0045932D
-    void IndustryObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void IndustryObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
-        drawIndustry(&context, x, y + 40);
+        drawIndustry(&rt, x, y + 40);
     }
 
     // 0x00458C7F
-    void IndustryObject::drawIndustry(Gfx::Context* clipped, int16_t x, int16_t y) const
+    void IndustryObject::drawIndustry(Gfx::RenderTarget* clipped, int16_t x, int16_t y) const
     {
         registers regs;
         regs.cx = x;

--- a/src/OpenLoco/Objects/IndustryObject.h
+++ b/src/OpenLoco/Objects/IndustryObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
     namespace IndustryObjectFlags
@@ -82,8 +82,8 @@ namespace OpenLoco
         bool producesCargo() const;
         char* getProducedCargoString(const char* buffer) const;
         char* getRequiredCargoString(const char* buffer) const;
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
-        void drawIndustry(Gfx::Context* clipped, int16_t x, int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
+        void drawIndustry(Gfx::RenderTarget* clipped, int16_t x, int16_t y) const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();

--- a/src/OpenLoco/Objects/InterfaceSkinObject.cpp
+++ b/src/OpenLoco/Objects/InterfaceSkinObject.cpp
@@ -23,10 +23,10 @@ namespace OpenLoco
     }
 
     // 0x0043C86A
-    void InterfaceSkinObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void InterfaceSkinObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto image = Gfx::recolour(img + InterfaceSkin::ImageIds::preview_image, Colour::mutedSeaGreen);
 
-        Gfx::drawImage(&context, x - 32, y - 32, image);
+        Gfx::drawImage(&rt, x - 32, y - 32, image);
     }
 }

--- a/src/OpenLoco/Objects/InterfaceSkinObject.h
+++ b/src/OpenLoco/Objects/InterfaceSkinObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -41,7 +41,7 @@ namespace OpenLoco
         bool validate() const { return true; }
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
     };
 #pragma pack(pop)
     static_assert(sizeof(InterfaceSkinObject) == 0x18);

--- a/src/OpenLoco/Objects/LandObject.cpp
+++ b/src/OpenLoco/Objects/LandObject.cpp
@@ -51,9 +51,9 @@ namespace OpenLoco
     }
 
     // 0x004699A8
-    void LandObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void LandObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         uint32_t imageId = image + (var_03 - 1) * var_0E;
-        Gfx::drawImage(&context, x, y, imageId);
+        Gfx::drawImage(&rt, x, y, imageId);
     }
 }

--- a/src/OpenLoco/Objects/LandObject.h
+++ b/src/OpenLoco/Objects/LandObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
     namespace LandObjectFlags
@@ -45,7 +45,7 @@ namespace OpenLoco
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
     };
     static_assert(sizeof(LandObject) == 0x1E);
 #pragma pack(pop)

--- a/src/OpenLoco/Objects/LevelCrossingObject.cpp
+++ b/src/OpenLoco/Objects/LevelCrossingObject.cpp
@@ -50,7 +50,7 @@ namespace OpenLoco
     }
 
     // 0x00478156
-    void LevelCrossingObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void LevelCrossingObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto imageId = (closedFrames + 1) * 8;
         auto frameCount = (closingFrames - 1);
@@ -59,16 +59,16 @@ namespace OpenLoco
         imageId += frameIndex;
         imageId += image;
 
-        Gfx::drawImage(&context, x, y, imageId);
-        Gfx::drawImage(&context, x, y, imageId + 1);
-        Gfx::drawImage(&context, x, y, imageId + 2);
-        Gfx::drawImage(&context, x, y, imageId + 3);
+        Gfx::drawImage(&rt, x, y, imageId);
+        Gfx::drawImage(&rt, x, y, imageId + 1);
+        Gfx::drawImage(&rt, x, y, imageId + 2);
+        Gfx::drawImage(&rt, x, y, imageId + 3);
     }
 
     // 0x004781A4
-    void LevelCrossingObject::drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
+    void LevelCrossingObject::drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
     {
         Ui::Point rowPosition = { x, y };
-        ObjectManager::drawGenericDescription(context, rowPosition, designedYear, 0xFFFF);
+        ObjectManager::drawGenericDescription(rt, rowPosition, designedYear, 0xFFFF);
     }
 }

--- a/src/OpenLoco/Objects/LevelCrossingObject.h
+++ b/src/OpenLoco/Objects/LevelCrossingObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -30,8 +30,8 @@ namespace OpenLoco
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
-        void drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
+        void drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
     };
 #pragma pack(pop)
     static_assert(sizeof(LevelCrossingObject) == 0x12);

--- a/src/OpenLoco/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/Objects/ObjectManager.cpp
@@ -965,13 +965,13 @@ namespace OpenLoco::ObjectManager
     // TODO: Should only be defined in ObjectSelectionWindow
     static const uint8_t descriptionRowHeight = 10;
 
-    void drawGenericDescription(Gfx::Context& context, Ui::Point& rowPosition, const uint16_t designed, const uint16_t obsolete)
+    void drawGenericDescription(Gfx::RenderTarget& rt, Ui::Point& rowPosition, const uint16_t designed, const uint16_t obsolete)
     {
         if (designed != 0)
         {
             FormatArguments args{};
             args.push(designed);
-            Gfx::drawStringLeft(context, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_designed, &args);
+            Gfx::drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_designed, &args);
             rowPosition.y += descriptionRowHeight;
         }
 
@@ -979,7 +979,7 @@ namespace OpenLoco::ObjectManager
         {
             FormatArguments args{};
             args.push(obsolete);
-            Gfx::drawStringLeft(context, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_obsolete, &args);
+            Gfx::drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_obsolete, &args);
             rowPosition.y += descriptionRowHeight;
         }
     }

--- a/src/OpenLoco/Objects/ObjectManager.h
+++ b/src/OpenLoco/Objects/ObjectManager.h
@@ -12,7 +12,7 @@ namespace OpenLoco
 
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
     struct Object;
@@ -166,7 +166,7 @@ namespace OpenLoco::ObjectManager
 
     size_t getByteLength(const LoadedObjectHandle& handle);
 
-    void drawGenericDescription(Gfx::Context& context, Ui::Point& rowPosition, const uint16_t designed, const uint16_t obsolete);
+    void drawGenericDescription(Gfx::RenderTarget& rt, Ui::Point& rowPosition, const uint16_t designed, const uint16_t obsolete);
 
     void updateYearly1();
     void updateYearly2();

--- a/src/OpenLoco/Objects/RegionObject.cpp
+++ b/src/OpenLoco/Objects/RegionObject.cpp
@@ -5,9 +5,9 @@
 namespace OpenLoco
 {
     // 0x0043CB93
-    void RegionObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void RegionObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
-        Gfx::drawImage(&context, x, y, image);
+        Gfx::drawImage(&rt, x, y, image);
     }
 
     // 0x0043CA8C

--- a/src/OpenLoco/Objects/RegionObject.h
+++ b/src/OpenLoco/Objects/RegionObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -22,7 +22,7 @@ namespace OpenLoco
         uint8_t var_09[4];
         uint8_t pad_0D[0x12 - 0xD];
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
         // 0x0043CB89
         bool validate() const { return true; }
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);

--- a/src/OpenLoco/Objects/RoadExtraObject.cpp
+++ b/src/OpenLoco/Objects/RoadExtraObject.cpp
@@ -6,15 +6,15 @@
 namespace OpenLoco
 {
     // 0x00477EB9
-    void RoadExtraObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void RoadExtraObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
 
-        Gfx::drawImage(&context, x, y, colourImage + 36);
-        Gfx::drawImage(&context, x, y, colourImage + 37);
-        Gfx::drawImage(&context, x, y, colourImage);
-        Gfx::drawImage(&context, x, y, colourImage + 33);
-        Gfx::drawImage(&context, x, y, colourImage + 32);
+        Gfx::drawImage(&rt, x, y, colourImage + 36);
+        Gfx::drawImage(&rt, x, y, colourImage + 37);
+        Gfx::drawImage(&rt, x, y, colourImage);
+        Gfx::drawImage(&rt, x, y, colourImage + 33);
+        Gfx::drawImage(&rt, x, y, colourImage + 32);
     }
 
     // 0x00477E92

--- a/src/OpenLoco/Objects/RoadExtraObject.h
+++ b/src/OpenLoco/Objects/RoadExtraObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -25,7 +25,7 @@ namespace OpenLoco
         uint32_t image;            // 0x0A
         uint32_t var_0E;
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();

--- a/src/OpenLoco/Objects/RoadObject.cpp
+++ b/src/OpenLoco/Objects/RoadObject.cpp
@@ -6,18 +6,18 @@
 namespace OpenLoco
 {
     // 0x00477DFE
-    void RoadObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void RoadObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
         if (paintStyle == 1)
         {
-            Gfx::drawImage(&context, x, y, colourImage + 34);
-            Gfx::drawImage(&context, x, y, colourImage + 36);
-            Gfx::drawImage(&context, x, y, colourImage + 38);
+            Gfx::drawImage(&rt, x, y, colourImage + 34);
+            Gfx::drawImage(&rt, x, y, colourImage + 36);
+            Gfx::drawImage(&rt, x, y, colourImage + 38);
         }
         else
         {
-            Gfx::drawImage(&context, x, y, colourImage + 34);
+            Gfx::drawImage(&rt, x, y, colourImage + 34);
         }
     }
 

--- a/src/OpenLoco/Objects/RoadObject.h
+++ b/src/OpenLoco/Objects/RoadObject.h
@@ -9,7 +9,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
     namespace Flags12
@@ -58,7 +58,7 @@ namespace OpenLoco
         uint8_t num_compatible; // 0x28
         uint8_t pad_29[0x30 - 0x29];
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();

--- a/src/OpenLoco/Objects/RoadStationObject.cpp
+++ b/src/OpenLoco/Objects/RoadStationObject.cpp
@@ -7,11 +7,11 @@
 namespace OpenLoco
 {
     // 0x00490C17
-    void RoadStationObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void RoadStationObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
 
-        Gfx::drawImage(&context, x - 34, y - 34, colourImage);
+        Gfx::drawImage(&rt, x - 34, y - 34, colourImage);
 
         auto colour = ExtColour::translucentMutedDarkRed1;
         if (!(flags & RoadStationFlags::recolourable))
@@ -21,14 +21,14 @@ namespace OpenLoco
 
         auto translucentImage = Gfx::recolourTranslucent(image + 1, colour);
 
-        Gfx::drawImage(&context, x - 34, y - 34, translucentImage);
+        Gfx::drawImage(&rt, x - 34, y - 34, translucentImage);
     }
 
     // 0x00490C59
-    void RoadStationObject::drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
+    void RoadStationObject::drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
     {
         Ui::Point rowPosition = { x, y };
-        ObjectManager::drawGenericDescription(context, rowPosition, designed_year, obsolete_year);
+        ObjectManager::drawGenericDescription(rt, rowPosition, designed_year, obsolete_year);
     }
 
     // 0x00490BD8

--- a/src/OpenLoco/Objects/RoadStationObject.h
+++ b/src/OpenLoco/Objects/RoadStationObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
     namespace RoadStationFlags
@@ -45,8 +45,8 @@ namespace OpenLoco
         uint8_t pad_2D;
         uint32_t var_2E[16];
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
-        void drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
+        void drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();

--- a/src/OpenLoco/Objects/RockObject.cpp
+++ b/src/OpenLoco/Objects/RockObject.cpp
@@ -23,9 +23,9 @@ namespace OpenLoco
     }
 
     // 0x00469A06
-    void RockObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void RockObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
-        Gfx::drawImage(&context, x - 30, y, image);
-        Gfx::drawImage(&context, x - 30, y, image + 16);
+        Gfx::drawImage(&rt, x - 30, y, image);
+        Gfx::drawImage(&rt, x - 30, y, image + 16);
     }
 }

--- a/src/OpenLoco/Objects/RockObject.h
+++ b/src/OpenLoco/Objects/RockObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -23,7 +23,7 @@ namespace OpenLoco
         bool validate() const { return true; }
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
     };
 #pragma pack(pop)
     static_assert(sizeof(RockObject) == 0x6);

--- a/src/OpenLoco/Objects/ScaffoldingObject.cpp
+++ b/src/OpenLoco/Objects/ScaffoldingObject.cpp
@@ -6,13 +6,13 @@
 namespace OpenLoco
 {
     // 0x0042DF15
-    void ScaffoldingObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void ScaffoldingObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolour(image, Colour::yellow);
 
-        Gfx::drawImage(&context, x, y + 23, colourImage + 24);
-        Gfx::drawImage(&context, x, y + 23, colourImage + 25);
-        Gfx::drawImage(&context, x, y + 23, colourImage + 27);
+        Gfx::drawImage(&rt, x, y + 23, colourImage + 24);
+        Gfx::drawImage(&rt, x, y + 23, colourImage + 25);
+        Gfx::drawImage(&rt, x, y + 23, colourImage + 27);
     }
 
     // 0x0042DED8

--- a/src/OpenLoco/Objects/ScaffoldingObject.h
+++ b/src/OpenLoco/Objects/ScaffoldingObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -20,7 +20,7 @@ namespace OpenLoco
         uint32_t image; // 0x02
         uint8_t pad_06[0x12 - 0x06];
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
         // 0x0042DF0B
         bool validate() const { return true; }
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);

--- a/src/OpenLoco/Objects/SnowObject.cpp
+++ b/src/OpenLoco/Objects/SnowObject.cpp
@@ -5,9 +5,9 @@
 namespace OpenLoco
 {
     // 0x00469A75
-    void SnowObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void SnowObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
-        Gfx::drawImage(&context, x, y, image);
+        Gfx::drawImage(&rt, x, y, image);
     }
 
     // 0x00469A35

--- a/src/OpenLoco/Objects/SnowObject.h
+++ b/src/OpenLoco/Objects/SnowObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -19,7 +19,7 @@ namespace OpenLoco
         string_id name;
         uint32_t image; // 0x02
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
         // 0x00469A6B
         bool validate() const { return true; }
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);

--- a/src/OpenLoco/Objects/StreetLightObject.cpp
+++ b/src/OpenLoco/Objects/StreetLightObject.cpp
@@ -8,14 +8,14 @@ namespace OpenLoco
     static const uint8_t descriptionRowHeight = 10;
 
     // 0x00477F69
-    void StreetLightObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void StreetLightObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         Ui::Point imgPosition = Ui::Point{ x, y } - Ui::Point{ 20, 1 };
         for (auto i = 0; i < 3; i++)
         {
             auto imageId = (i * 4) + image;
-            Gfx::drawImage(&context, imgPosition.x - 14, imgPosition.y, imageId + 2);
-            Gfx::drawImage(&context, imgPosition.x, imgPosition.y - 7, imageId);
+            Gfx::drawImage(&rt, imgPosition.x - 14, imgPosition.y, imageId + 2);
+            Gfx::drawImage(&rt, imgPosition.x, imgPosition.y - 7, imageId);
             imgPosition.x += 20;
             imgPosition.y += descriptionRowHeight;
         }

--- a/src/OpenLoco/Objects/StreetLightObject.h
+++ b/src/OpenLoco/Objects/StreetLightObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -20,7 +20,7 @@ namespace OpenLoco
         uint16_t designedYear[3]; // 0x02
         uint32_t image;           // 0x08
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
         // 0x00477F5F
         bool validate() const { return true; }
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);

--- a/src/OpenLoco/Objects/TrackExtraObject.cpp
+++ b/src/OpenLoco/Objects/TrackExtraObject.cpp
@@ -6,19 +6,19 @@
 namespace OpenLoco
 {
     // 0x004A6D5F
-    void TrackExtraObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void TrackExtraObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
 
         if (paintStyle == 0)
         {
-            Gfx::drawImage(&context, x, y, colourImage);
+            Gfx::drawImage(&rt, x, y, colourImage);
         }
         else
         {
-            Gfx::drawImage(&context, x, y, colourImage);
-            Gfx::drawImage(&context, x, y, colourImage + 97);
-            Gfx::drawImage(&context, x, y, colourImage + 96);
+            Gfx::drawImage(&rt, x, y, colourImage);
+            Gfx::drawImage(&rt, x, y, colourImage + 97);
+            Gfx::drawImage(&rt, x, y, colourImage + 96);
         }
     }
 

--- a/src/OpenLoco/Objects/TrackExtraObject.h
+++ b/src/OpenLoco/Objects/TrackExtraObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -25,7 +25,7 @@ namespace OpenLoco
         uint32_t image;            // 0x0A
         uint32_t var_0E;
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();

--- a/src/OpenLoco/Objects/TrackObject.cpp
+++ b/src/OpenLoco/Objects/TrackObject.cpp
@@ -6,13 +6,13 @@
 namespace OpenLoco
 {
     // 0x004A6CBA
-    void TrackObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void TrackObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
 
-        Gfx::drawImage(&context, x, y, colourImage + 18);
-        Gfx::drawImage(&context, x, y, colourImage + 20);
-        Gfx::drawImage(&context, x, y, colourImage + 22);
+        Gfx::drawImage(&rt, x, y, colourImage + 18);
+        Gfx::drawImage(&rt, x, y, colourImage + 20);
+        Gfx::drawImage(&rt, x, y, colourImage + 22);
     }
 
     // 0x004A6C6C

--- a/src/OpenLoco/Objects/TrackObject.h
+++ b/src/OpenLoco/Objects/TrackObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
     namespace Flags22
@@ -64,7 +64,7 @@ namespace OpenLoco
         uint8_t display_offset; // 0x34
         uint8_t pad_35;
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();

--- a/src/OpenLoco/Objects/TrainSignalObject.cpp
+++ b/src/OpenLoco/Objects/TrainSignalObject.cpp
@@ -69,7 +69,7 @@ namespace OpenLoco
     }
 
     // 0x004899A7
-    void TrainSignalObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void TrainSignalObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto frames = signalFrames[(((num_frames + 2) / 3) - 2)];
         auto frameCount = std::size(frames) - 1;
@@ -79,6 +79,6 @@ namespace OpenLoco
         frameIndex *= 8;
         auto colourImage = image + frameIndex;
 
-        Gfx::drawImage(&context, x, y + 15, colourImage);
+        Gfx::drawImage(&rt, x, y + 15, colourImage);
     }
 }

--- a/src/OpenLoco/Objects/TrainSignalObject.h
+++ b/src/OpenLoco/Objects/TrainSignalObject.h
@@ -9,7 +9,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
     namespace TrainSignalObjectFlags
@@ -48,7 +48,7 @@ namespace OpenLoco
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
     };
 #pragma pack(pop)
     static_assert(sizeof(TrainSignalObject) == 0x1E);

--- a/src/OpenLoco/Objects/TrainStationObject.cpp
+++ b/src/OpenLoco/Objects/TrainStationObject.cpp
@@ -8,11 +8,11 @@
 namespace OpenLoco
 {
     // 0x00490A26
-    void TrainStationObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void TrainStationObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
 
-        Gfx::drawImage(&context, x - 34, y - 34, colourImage);
+        Gfx::drawImage(&rt, x - 34, y - 34, colourImage);
 
         auto colour = ExtColour::translucentMutedDarkRed1;
         if (!(flags & TrainStationFlags::recolourable))
@@ -22,14 +22,14 @@ namespace OpenLoco
 
         auto translucentImage = Gfx::recolourTranslucent(image + 1, colour);
 
-        Gfx::drawImage(&context, x - 34, y - 34, translucentImage);
+        Gfx::drawImage(&rt, x - 34, y - 34, translucentImage);
     }
 
     // 0x00490A68
-    void TrainStationObject::drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
+    void TrainStationObject::drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const
     {
         Ui::Point rowPosition = { x, y };
-        ObjectManager::drawGenericDescription(context, rowPosition, designed_year, obsolete_year);
+        ObjectManager::drawGenericDescription(rt, rowPosition, designed_year, obsolete_year);
     }
 
     // 0x004909F3

--- a/src/OpenLoco/Objects/TrainStationObject.h
+++ b/src/OpenLoco/Objects/TrainStationObject.h
@@ -12,7 +12,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
     namespace TrainStationFlags
@@ -47,8 +47,8 @@ namespace OpenLoco
         std::byte* cargoOffsetBytes[4][4]; // 0x2E
         uint32_t var_6E[16];
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
-        void drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
+        void drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, [[maybe_unused]] const int16_t width) const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();

--- a/src/OpenLoco/Objects/TreeObject.cpp
+++ b/src/OpenLoco/Objects/TreeObject.cpp
@@ -7,7 +7,7 @@
 namespace OpenLoco
 {
     // 0x004BE2A2
-    void TreeObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void TreeObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         uint32_t image = getTreeGrowthDisplayOffset() * num_rotations;
         auto rotation = (num_rotations - 1) & 2;
@@ -42,10 +42,10 @@ namespace OpenLoco
                 snowImage = Gfx::recolour(snowImage, colour);
             }
             treePos.x = x + 28;
-            Gfx::drawImage(&context, treePos.x, treePos.y, snowImage);
+            Gfx::drawImage(&rt, treePos.x, treePos.y, snowImage);
             treePos.x = 28;
         }
-        Gfx::drawImage(&context, treePos.x, treePos.y, image);
+        Gfx::drawImage(&rt, treePos.x, treePos.y, image);
     }
 
     // 0x00500775

--- a/src/OpenLoco/Objects/TreeObject.h
+++ b/src/OpenLoco/Objects/TreeObject.h
@@ -9,7 +9,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
     namespace TreeObjectFlags
@@ -49,7 +49,7 @@ namespace OpenLoco
         int16_t rating;            // 0x48
         uint16_t var_4A;
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
         uint8_t getTreeGrowthDisplayOffset() const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);

--- a/src/OpenLoco/Objects/TunnelObject.cpp
+++ b/src/OpenLoco/Objects/TunnelObject.cpp
@@ -5,10 +5,10 @@
 namespace OpenLoco
 {
     // 0x00469806
-    void TunnelObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void TunnelObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
-        Gfx::drawImage(&context, x - 16, y + 15, image);
-        Gfx::drawImage(&context, x - 16, y + 15, image + 1);
+        Gfx::drawImage(&rt, x - 16, y + 15, image);
+        Gfx::drawImage(&rt, x - 16, y + 15, image + 1);
     }
 
     // 0x004697C9

--- a/src/OpenLoco/Objects/TunnelObject.h
+++ b/src/OpenLoco/Objects/TunnelObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -19,7 +19,7 @@ namespace OpenLoco
         string_id name;
         uint32_t image; // 0x02
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
         // 0x004697FC
         bool validate() const { return true; }
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);

--- a/src/OpenLoco/Objects/VehicleObject.cpp
+++ b/src/OpenLoco/Objects/VehicleObject.cpp
@@ -13,7 +13,7 @@ using namespace OpenLoco::Interop;
 namespace OpenLoco
 {
     // 0x004B7733
-    static void drawVehicle(Gfx::Context* context, const VehicleObject* vehicleObject, uint8_t eax, uint8_t esi, Ui::Point offset)
+    static void drawVehicle(Gfx::RenderTarget* rt, const VehicleObject* vehicleObject, uint8_t eax, uint8_t esi, Ui::Point offset)
     {
         // Eventually calls 0x4B777B part of 0x4B7741
         registers regs;
@@ -24,51 +24,51 @@ namespace OpenLoco
         regs.bl = enumValue(Colour::mutedSeaGreen);
         regs.bh = 2;
         regs.ebp = X86Pointer(vehicleObject);
-        regs.edi = X86Pointer(context);
+        regs.edi = X86Pointer(rt);
         call(0x4B7733, regs);
     }
 
     // 0x004B8C52
-    void VehicleObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void VehicleObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         // Rotation
         uint8_t unk1 = Ui::WindowManager::getVehiclePreviewRotationFrameUnk1();
         uint8_t unk2 = Ui::WindowManager::getVehiclePreviewRotationFrameUnk2();
 
-        drawVehicle(&context, this, unk1, unk2, Ui::Point{ x, y } + Ui::Point{ 0, 19 });
+        drawVehicle(&rt, this, unk1, unk2, Ui::Point{ x, y } + Ui::Point{ 0, 19 });
     }
 
     // TODO: Should only be defined in ObjectSelectionWindow
     static const uint8_t descriptionRowHeight = 10;
 
     // 0x004B8C9D
-    void VehicleObject::drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, const int16_t width) const
+    void VehicleObject::drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, const int16_t width) const
     {
         Ui::Point rowPosition = { x, y };
-        ObjectManager::drawGenericDescription(context, rowPosition, designed, obsolete);
+        ObjectManager::drawGenericDescription(rt, rowPosition, designed, obsolete);
         if (power != 0 && (mode == TransportMode::road || mode == TransportMode::rail))
         {
             FormatArguments args{};
             args.push(power);
-            Gfx::drawStringLeft(context, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_power, &args);
+            Gfx::drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_power, &args);
             rowPosition.y += descriptionRowHeight;
         }
         {
             FormatArguments args{};
             args.push<uint32_t>(StringManager::internalLengthToComma1DP(getLength()));
-            Gfx::drawStringLeft(context, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_length, &args);
+            Gfx::drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_length, &args);
             rowPosition.y += descriptionRowHeight;
         }
         {
             FormatArguments args{};
             args.push(weight);
-            Gfx::drawStringLeft(context, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_weight, &args);
+            Gfx::drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_weight, &args);
             rowPosition.y += descriptionRowHeight;
         }
         {
             FormatArguments args{};
             args.push(speed);
-            Gfx::drawStringLeft(context, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_max_speed, &args);
+            Gfx::drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_max_speed, &args);
         }
         auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
         // Clear buffer
@@ -78,7 +78,7 @@ namespace OpenLoco
 
         if (strlen(buffer) != 0)
         {
-            Gfx::drawStringLeftWrapped(context, rowPosition.x, rowPosition.y, width - 4, Colour::black, StringIds::buffer_1250);
+            Gfx::drawStringLeftWrapped(rt, rowPosition.x, rowPosition.y, width - 4, Colour::black, StringIds::buffer_1250);
         }
     }
 

--- a/src/OpenLoco/Objects/VehicleObject.h
+++ b/src/OpenLoco/Objects/VehicleObject.h
@@ -9,7 +9,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
     enum class TransportMode : uint8_t
@@ -241,8 +241,8 @@ namespace OpenLoco
         uint8_t numStartSounds;         // 0x15A use mask when accessing hasCrossingWhistle stuffed in (1 << 7)
         SoundObjectId_t startSounds[3]; // 0x15B sound array length numStartSounds highest sound is the crossing whistle
 
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
-        void drawDescription(Gfx::Context& context, const int16_t x, const int16_t y, const int16_t width) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
+        void drawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, const int16_t width) const;
         void getCargoString(char* buffer) const;
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);

--- a/src/OpenLoco/Objects/WallObject.cpp
+++ b/src/OpenLoco/Objects/WallObject.cpp
@@ -23,7 +23,7 @@ namespace OpenLoco
     }
 
     // 0x004C4B0B
-    void WallObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void WallObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto image = sprite;
         if (flags & (1 << 6))
@@ -35,16 +35,16 @@ namespace OpenLoco
             image = Gfx::recolour(sprite, Colour::mutedDarkRed);
         }
 
-        Gfx::drawImage(&context, x + 14, y + 16 + (var_08 * 2), image);
+        Gfx::drawImage(&rt, x + 14, y + 16 + (var_08 * 2), image);
         if (flags & (1 << 1))
         {
-            Gfx::drawImage(&context, x + 14, y + 16 + (var_08 * 2), Gfx::recolourTranslucent(sprite + 6, ExtColour::unk8C));
+            Gfx::drawImage(&rt, x + 14, y + 16 + (var_08 * 2), Gfx::recolourTranslucent(sprite + 6, ExtColour::unk8C));
         }
         else
         {
             if (flags & (1 << 4))
             {
-                Gfx::drawImage(&context, x + 14, y + 16 + (var_08 * 2), image + 1);
+                Gfx::drawImage(&rt, x + 14, y + 16 + (var_08 * 2), image + 1);
             }
         }
     }

--- a/src/OpenLoco/Objects/WallObject.h
+++ b/src/OpenLoco/Objects/WallObject.h
@@ -8,7 +8,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -27,7 +27,7 @@ namespace OpenLoco
         bool validate() const { return true; }
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
     };
 #pragma pack(pop)
     static_assert(sizeof(WallObject) == 0xA);

--- a/src/OpenLoco/Objects/WaterObject.cpp
+++ b/src/OpenLoco/Objects/WaterObject.cpp
@@ -38,10 +38,10 @@ namespace OpenLoco
     }
 
     // 0x004C56D3
-    void WaterObject::drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const
+    void WaterObject::drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolourTranslucent(Gfx::recolour(image + 35), ExtColour::null);
-        Gfx::drawImage(&context, x, y, colourImage);
-        Gfx::drawImage(&context, x, y, image + 30);
+        Gfx::drawImage(&rt, x, y, colourImage);
+        Gfx::drawImage(&rt, x, y, image + 30);
     }
 }

--- a/src/OpenLoco/Objects/WaterObject.h
+++ b/src/OpenLoco/Objects/WaterObject.h
@@ -7,7 +7,7 @@ namespace OpenLoco
 {
     namespace Gfx
     {
-        struct Context;
+        struct RenderTarget;
     }
 
 #pragma pack(push, 1)
@@ -26,7 +26,7 @@ namespace OpenLoco
         bool validate() const;
         void load(const LoadedObjectHandle& handle, stdx::span<std::byte> data);
         void unload();
-        void drawPreviewImage(Gfx::Context& context, const int16_t x, const int16_t y) const;
+        void drawPreviewImage(Gfx::RenderTarget& rt, const int16_t x, const int16_t y) const;
     };
 #pragma pack(pop)
     static_assert(sizeof(WaterObject) == 0xE);

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -312,7 +312,7 @@ namespace OpenLoco
         }
         Title::start();
         Gui::init();
-        Gfx::clear(Gfx::screenContext(), 0x0A0A0A0A);
+        Gfx::clear(Gfx::getScreenRT(), 0x0A0A0A0A);
     }
 
     static void loadFile(const fs::path& path)
@@ -556,7 +556,7 @@ namespace OpenLoco
                 Config::get().var_72 = 16;
                 const auto cursor = Ui::getCursorPos();
                 addr<0x00F2538C, Ui::Point32>() = cursor;
-                Gfx::clear(Gfx::screenContext(), 0);
+                Gfx::clear(Gfx::getScreenRT(), 0);
                 addr<0x00F2539C, int32_t>() = 0;
             }
             else

--- a/src/OpenLoco/Paint/Paint.h
+++ b/src/OpenLoco/Paint/Paint.h
@@ -22,7 +22,7 @@ namespace OpenLoco::Ui::ViewportInteraction
 
 namespace OpenLoco::Gfx
 {
-    struct Context;
+    struct RenderTarget;
 }
 
 namespace OpenLoco::Paint
@@ -146,11 +146,11 @@ namespace OpenLoco::Paint
         void generate();
         void arrangeStructs();
         void drawStructs();
-        void init(Gfx::Context& context, const uint16_t viewportFlags);
+        void init(Gfx::RenderTarget& rt, const uint16_t viewportFlags);
         [[nodiscard]] Ui::ViewportInteraction::InteractionArg getNormalInteractionInfo(const uint32_t flags);
         [[nodiscard]] Ui::ViewportInteraction::InteractionArg getStationNameInteractionInfo(const uint32_t flags);
         [[nodiscard]] Ui::ViewportInteraction::InteractionArg getTownNameInteractionInfo(const uint32_t flags);
-        Gfx::Context* getContext() { return _context; }
+        Gfx::RenderTarget* getRenderTarget() { return _renderTarget; }
         uint8_t getRotation() { return currentRotation; }
         int16_t getMaxHeight() { return _maxHeight; }
         uint32_t get112C300() { return _112C300; }
@@ -298,7 +298,7 @@ namespace OpenLoco::Paint
         inline static Interop::loco_global<uint16_t[2], 0x00525CE4> _525CE4;
         inline static Interop::loco_global<uint8_t, 0x00525CF0> _525CF0;
         inline static Interop::loco_global<uint16_t, 0x00525CF8> _525CF8;
-        inline static Interop::loco_global<Gfx::Context*, 0x00E0C3E0> _context;
+        inline static Interop::loco_global<Gfx::RenderTarget*, 0x00E0C3E0> _renderTarget;
         inline static Interop::loco_global<PaintEntry*, 0x00E0C404> _endOfPaintStructArray;
         inline static Interop::loco_global<PaintEntry*, 0x00E0C408> _paintHead;
         inline static Interop::loco_global<PaintEntry*, 0x00E0C40C> _nextFreePaintStruct;
@@ -363,7 +363,7 @@ namespace OpenLoco::Paint
         PaintStruct* createNormalPaintStruct(ImageId imageId, const Map::Pos3& offset, const Map::Pos3& boundBoxOffset, const Map::Pos3& boundBoxSize);
     };
 
-    PaintSession* allocateSession(Gfx::Context& context, const uint16_t viewportFlags);
+    PaintSession* allocateSession(Gfx::RenderTarget& rt, const uint16_t viewportFlags);
 
     void registerHooks();
 }

--- a/src/OpenLoco/Paint/PaintEntity.cpp
+++ b/src/OpenLoco/Paint/PaintEntity.cpp
@@ -17,8 +17,8 @@ namespace OpenLoco::Paint
     template<typename FilterType>
     static void paintEntitiesWithFilter(PaintSession& session, const Map::Pos2& loc, FilterType&& filter)
     {
-        auto* context = session.getContext();
-        if (Config::get().vehiclesMinScale < context->zoom_level)
+        auto* rt = session.getRenderTarget();
+        if (Config::get().vehiclesMinScale < rt->zoom_level)
         {
             return;
         }
@@ -32,10 +32,10 @@ namespace OpenLoco::Paint
         for (auto* entity : entities)
         {
             // TODO: Create a rect from context dims
-            auto left = context->x;
-            auto top = context->y;
-            auto right = left + context->width;
-            auto bottom = top + context->height;
+            auto left = rt->x;
+            auto top = rt->y;
+            auto right = left + rt->width;
+            auto bottom = top + rt->height;
 
             // TODO: Create a rect from sprite dims and use a contains function
             if (entity->sprite_top > bottom)

--- a/src/OpenLoco/Paint/PaintMiscEntity.cpp
+++ b/src/OpenLoco/Paint/PaintMiscEntity.cpp
@@ -3,6 +3,7 @@
 #include "../Config.h"
 #include "../Graphics/Gfx.h"
 #include "../Graphics/ImageIds.h"
+#include "../Graphics/RenderTarget.h"
 #include "../Interop/Interop.hpp"
 #include "../Localisation/StringIds.h"
 #include "../Map/Tile.h"
@@ -44,8 +45,8 @@ namespace OpenLoco::Paint
     // 0x00440331
     static void paintExhaustEntity(PaintSession& session, Exhaust* exhaustEntity)
     {
-        Gfx::Context* context = session.getContext();
-        if (context->zoom_level > 1)
+        Gfx::RenderTarget* rt = session.getRenderTarget();
+        if (rt->zoom_level > 1)
         {
             return;
         }
@@ -67,8 +68,8 @@ namespace OpenLoco::Paint
     // 0x004403C5
     static void paintRedGreenCurrencyEntity(PaintSession& session, MoneyEffect* moneyEffect)
     {
-        Gfx::Context* context = session.getContext();
-        if (context->zoom_level > 1)
+        Gfx::RenderTarget* rt = session.getRenderTarget();
+        if (rt->zoom_level > 1)
         {
             return;
         }
@@ -87,8 +88,8 @@ namespace OpenLoco::Paint
             return;
         }
 
-        Gfx::Context* context = session.getContext();
-        if (context->zoom_level > 1)
+        Gfx::RenderTarget* rt = session.getRenderTarget();
+        if (rt->zoom_level > 1)
         {
             return;
         }
@@ -103,8 +104,8 @@ namespace OpenLoco::Paint
     // 0x0044044E
     static void paintVehicleCrashParticleEntity(PaintSession& session, VehicleCrashParticle* particle)
     {
-        Gfx::Context* context = session.getContext();
-        if (context->zoom_level != 0)
+        Gfx::RenderTarget* rt = session.getRenderTarget();
+        if (rt->zoom_level != 0)
         {
             return;
         }
@@ -128,8 +129,8 @@ namespace OpenLoco::Paint
     // 0x0044051C
     static void paintExplosionCloudEntity(PaintSession& session, ExplosionCloud* particle)
     {
-        Gfx::Context* context = session.getContext();
-        if (context->zoom_level > 2)
+        Gfx::RenderTarget* rt = session.getRenderTarget();
+        if (rt->zoom_level > 2)
         {
             return;
         }
@@ -163,8 +164,8 @@ namespace OpenLoco::Paint
     // 0x00440557
     static void paintSplashEntity(PaintSession& session, Splash* particle)
     {
-        Gfx::Context* context = session.getContext();
-        if (context->zoom_level > 2)
+        Gfx::RenderTarget* rt = session.getRenderTarget();
+        if (rt->zoom_level > 2)
         {
             return;
         }
@@ -208,8 +209,8 @@ namespace OpenLoco::Paint
     // 0x00440592
     static void paintFireballEntity(PaintSession& session, Fireball* particle)
     {
-        Gfx::Context* context = session.getContext();
-        if (context->zoom_level > 2)
+        Gfx::RenderTarget* rt = session.getRenderTarget();
+        if (rt->zoom_level > 2)
         {
             return;
         }
@@ -256,8 +257,8 @@ namespace OpenLoco::Paint
     // 0x004404A6
     static void paintExplosionSmokeEntity(PaintSession& session, ExplosionSmoke* particle)
     {
-        Gfx::Context* context = session.getContext();
-        if (context->zoom_level > 1)
+        Gfx::RenderTarget* rt = session.getRenderTarget();
+        if (rt->zoom_level > 1)
         {
             return;
         }
@@ -283,8 +284,8 @@ namespace OpenLoco::Paint
     // 0x004404E1
     static void paintSmokeEntity(PaintSession& session, Smoke* particle)
     {
-        Gfx::Context* context = session.getContext();
-        if (context->zoom_level > 1)
+        Gfx::RenderTarget* rt = session.getRenderTarget();
+        if (rt->zoom_level > 1)
         {
             return;
         }

--- a/src/OpenLoco/Paint/PaintSignal.cpp
+++ b/src/OpenLoco/Paint/PaintSignal.cpp
@@ -194,7 +194,7 @@ namespace OpenLoco::Paint
         }
         else
         {
-            if (session.getViewFlags() & (1 << 4) && session.getContext()->zoom_level == 0)
+            if (session.getViewFlags() & (1 << 4) && session.getRenderTarget()->zoom_level == 0)
             {
                 session.setItemType(InteractionItem::noInteraction);
                 const auto imageId = ImageId{ getOneWayArrowImage(!isRight, trackId, rotation), Colour::mutedAvocadoGreen };
@@ -226,7 +226,7 @@ namespace OpenLoco::Paint
             return;
         }
 
-        if (session.getContext()->zoom_level > 1)
+        if (session.getRenderTarget()->zoom_level > 1)
         {
             return;
         }

--- a/src/OpenLoco/Paint/PaintStation.cpp
+++ b/src/OpenLoco/Paint/PaintStation.cpp
@@ -20,7 +20,7 @@ namespace OpenLoco::Paint
         {
             return;
         }
-        if (session.getContext()->zoom_level > 0)
+        if (session.getRenderTarget()->zoom_level > 0)
         {
             return;
         }

--- a/src/OpenLoco/Paint/PaintTile.cpp
+++ b/src/OpenLoco/Paint/PaintTile.cpp
@@ -29,11 +29,11 @@ namespace OpenLoco::Paint
 
         const auto loc2 = loc + kUnkOffsets[session.getRotation()];
         const auto vpPos = Map::gameToScreen(Map::Pos3(loc2.x, loc2.y, 16), session.getRotation());
-        if (vpPos.y + 32 <= session.getContext()->y)
+        if (vpPos.y + 32 <= session.getRenderTarget()->y)
         {
             return;
         }
-        if (vpPos.y - 20 >= session.getContext()->height + session.getContext()->y)
+        if (vpPos.y - 20 >= session.getRenderTarget()->height + session.getRenderTarget()->y)
         {
             return;
         }
@@ -184,11 +184,11 @@ namespace OpenLoco::Paint
         const auto vpPos = Map::gameToScreen(Map::Pos3(loc2.x, loc2.y, 0), session.getRotation());
         paintConstructionArrow(session, loc2);
 
-        if (vpPos.y + 52 <= session.getContext()->y)
+        if (vpPos.y + 52 <= session.getRenderTarget()->y)
         {
             return std::nullopt;
         }
-        if (vpPos.y - session.getMaxHeight() > session.getContext()->y + session.getContext()->height)
+        if (vpPos.y - session.getMaxHeight() > session.getRenderTarget()->y + session.getRenderTarget()->height)
         {
             return std::nullopt;
         }

--- a/src/OpenLoco/Paint/PaintTrack.cpp
+++ b/src/OpenLoco/Paint/PaintTrack.cpp
@@ -40,7 +40,7 @@ namespace OpenLoco::Paint
         }
         const auto height = elTrack.baseZ() * 4;
         const auto rotation = (session.getRotation() + elTrack.unkDirection()) & 0x3;
-        if ((session.getViewFlags() & (1 << 3)) && session.getContext()->zoom_level == 0)
+        if ((session.getViewFlags() & (1 << 3)) && session.getRenderTarget()->zoom_level == 0)
         {
             const bool isLast = elTrack.isFlag6();
             const bool isFirstTile = elTrack.sequenceIndex() == 0;
@@ -83,7 +83,7 @@ namespace OpenLoco::Paint
             call(trackPaintFunc, regs);
         }
 
-        if (session.getContext()->zoom_level > 0)
+        if (session.getRenderTarget()->zoom_level > 0)
         {
             return;
         }

--- a/src/OpenLoco/Paint/PaintTree.cpp
+++ b/src/OpenLoco/Paint/PaintTree.cpp
@@ -96,7 +96,7 @@ namespace OpenLoco::Paint
 
         if (shadowImageId)
         {
-            if (session.getContext()->zoom_level <= 1)
+            if (session.getRenderTarget()->zoom_level <= 1)
             {
                 session.addToPlotListAsParent(*shadowImageId, imageOffset, imageOffset, { 18, 18, 1 });
             }

--- a/src/OpenLoco/S5/S5.cpp
+++ b/src/OpenLoco/S5/S5.cpp
@@ -92,13 +92,13 @@ namespace OpenLoco::S5
     }
 
     // 0x0045A0B3
-    static void previewWindowDraw(Window& w, Gfx::Context* context)
+    static void previewWindowDraw(Window& w, Gfx::RenderTarget* rt)
     {
         for (auto viewport : w.viewports)
         {
             if (viewport != nullptr)
             {
-                viewport->render(context);
+                viewport->render(rt);
             }
         }
     }
@@ -134,17 +134,17 @@ namespace OpenLoco::S5
                     tempViewport->flags = ViewportFlags::town_names_displayed | ViewportFlags::station_names_displayed;
 
                     // Swap screen Context with our temporary one to draw the window then revert it back
-                    auto& context = Gfx::screenContext();
-                    auto backupContext = context;
-                    context.bits = reinterpret_cast<uint8_t*>(pixels);
-                    context.x = 0;
-                    context.y = 0;
-                    context.width = size.width;
-                    context.height = size.height;
-                    context.pitch = 0;
-                    context.zoom_level = 0;
+                    auto& rt = Gfx::getScreenRT();
+                    auto backupContext = rt;
+                    rt.bits = reinterpret_cast<uint8_t*>(pixels);
+                    rt.x = 0;
+                    rt.y = 0;
+                    rt.width = size.width;
+                    rt.height = size.height;
+                    rt.pitch = 0;
+                    rt.zoom_level = 0;
                     Gfx::redrawScreenRect(0, 0, size.width, size.height);
-                    context = backupContext;
+                    rt = backupContext;
                 }
 
                 WindowManager::close(WindowType::previewImage);

--- a/src/OpenLoco/Ui.cpp
+++ b/src/OpenLoco/Ui.cpp
@@ -367,13 +367,13 @@ namespace OpenLoco::Ui
 
         int32_t pitch = surface->pitch;
 
-        Gfx::Context context{};
-        context.bits = new uint8_t[surface->pitch * height];
-        context.width = width;
-        context.height = height;
-        context.pitch = pitch - width;
+        Gfx::RenderTarget rt{};
+        rt.bits = new uint8_t[surface->pitch * height];
+        rt.width = width;
+        rt.height = height;
+        rt.pitch = pitch - width;
 
-        screen_info->context = context;
+        screen_info->renderTarget = rt;
         screen_info->width = width;
         screen_info->height = height;
         screen_info->width_2 = width;
@@ -461,10 +461,10 @@ namespace OpenLoco::Ui
         }
 
         // Copy pixels from the virtual screen buffer to the surface
-        auto& context = Gfx::screenContext();
-        if (context.bits != nullptr)
+        auto& rt = Gfx::getScreenRT();
+        if (rt.bits != nullptr)
         {
-            std::memcpy(surface->pixels, context.bits, surface->pitch * surface->h);
+            std::memcpy(surface->pixels, rt.bits, surface->pitch * surface->h);
         }
 
         // Unlock the surface

--- a/src/OpenLoco/Ui.h
+++ b/src/OpenLoco/Ui.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Graphics/Gfx.h"
+#include "Graphics/RenderTarget.h"
 #include "Location.hpp"
 #include "Map/Map.hpp"
 #include <string>
@@ -25,7 +26,7 @@ namespace OpenLoco::Ui
 #pragma pack(push, 1)
     struct ScreenInfo
     {
-        Gfx::Context context;
+        Gfx::RenderTarget renderTarget;
         int16_t width;
         int16_t height;
         int16_t width_2;

--- a/src/OpenLoco/Ui/Dropdown.cpp
+++ b/src/OpenLoco/Ui/Dropdown.cpp
@@ -181,7 +181,7 @@ namespace OpenLoco::Ui::Dropdown
         }
 
         // 0x00494BF6
-        static void sub_494BF6(Window* self, Gfx::Context* context, string_id stringId, int16_t x, int16_t y, int16_t width, AdvancedColour colour, FormatArguments args)
+        static void sub_494BF6(Window* self, Gfx::RenderTarget* rt, string_id stringId, int16_t x, int16_t y, int16_t width, AdvancedColour colour, FormatArguments args)
         {
             StringManager::formatString(_byte_112CC04, stringId, &args);
 
@@ -191,13 +191,13 @@ namespace OpenLoco::Ui::Dropdown
 
             Gfx::setCurrentFontSpriteBase(Font::m1);
 
-            Gfx::drawString(*context, x, y, colour, _byte_112CC04);
+            Gfx::drawString(*rt, x, y, colour, _byte_112CC04);
         }
 
         // 0x004CD00E
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
+            self.draw(rt);
             _windowDropdownOnpaintCellX = 0;
             _windowDropdownOnpaintCellY = 0;
 
@@ -209,7 +209,7 @@ namespace OpenLoco::Ui::Dropdown
                     {
                         auto x = _windowDropdownOnpaintCellX * _dropdownItemWidth + self.x + 2;
                         auto y = _windowDropdownOnpaintCellY * _dropdownItemHeight + self.y + 2;
-                        Gfx::drawRect(*context, x, y, _dropdownItemWidth, _dropdownItemHeight, (1 << 25) | PaletteIndex::index_2E);
+                        Gfx::drawRect(*rt, x, y, _dropdownItemWidth, _dropdownItemHeight, (1 << 25) | PaletteIndex::index_2E);
                     }
 
                     auto args = FormatArguments();
@@ -248,7 +248,7 @@ namespace OpenLoco::Ui::Dropdown
                             auto x = _windowDropdownOnpaintCellX * _dropdownItemWidth + self.x + 2;
                             auto y = _windowDropdownOnpaintCellY * _dropdownItemHeight + self.y + 1;
                             auto width = self.width - 5;
-                            sub_494BF6(&self, context, dropdownItemFormat, x, y, width, colour, args);
+                            sub_494BF6(&self, rt, dropdownItemFormat, x, y, width, colour, args);
                         }
                     }
 
@@ -262,7 +262,7 @@ namespace OpenLoco::Ui::Dropdown
                         {
                             imageId++;
                         }
-                        Gfx::drawImage(context, x, y, imageId);
+                        Gfx::drawImage(rt, x, y, imageId);
                     }
                 }
                 else
@@ -272,16 +272,16 @@ namespace OpenLoco::Ui::Dropdown
 
                     if (!self.getColour(WindowColour::primary).isTranslucent())
                     {
-                        Gfx::drawRect(*context, x, y, _dropdownItemWidth - 1, 1, Colours::getShade(self.getColour(WindowColour::primary).c(), 3));
-                        Gfx::drawRect(*context, x, y + 1, _dropdownItemWidth - 1, 1, Colours::getShade(self.getColour(WindowColour::primary).c(), 7));
+                        Gfx::drawRect(*rt, x, y, _dropdownItemWidth - 1, 1, Colours::getShade(self.getColour(WindowColour::primary).c(), 3));
+                        Gfx::drawRect(*rt, x, y + 1, _dropdownItemWidth - 1, 1, Colours::getShade(self.getColour(WindowColour::primary).c(), 7));
                     }
                     else
                     {
                         uint32_t colour = enumValue(Colours::getTranslucent(self.getColour(WindowColour::primary).c())) | (1 << 25);
                         colour++; // Gets ExtColour::translucentXXX2 highlight
-                        Gfx::drawRect(*context, x, y, _dropdownItemWidth - 1, 1, colour);
+                        Gfx::drawRect(*rt, x, y, _dropdownItemWidth - 1, 1, colour);
                         colour++; // Gets ExtColour::translucentXXX0 shadow
-                        Gfx::drawRect(*context, x, y + 1, _dropdownItemWidth - 1, 1, colour);
+                        Gfx::drawRect(*rt, x, y + 1, _dropdownItemWidth - 1, 1, colour);
                     }
                 }
 

--- a/src/OpenLoco/Ui/Screenshot.cpp
+++ b/src/OpenLoco/Ui/Screenshot.cpp
@@ -92,18 +92,18 @@ namespace OpenLoco::Input
                 palette[i].red = _113ED20[i][2];
             }
             png_set_PLTE(png_ptr, info_ptr, palette, 246);
-            auto& context = Gfx::screenContext();
+            auto& rt = Gfx::getScreenRT();
 
             png_byte transparentIndex = 0;
             png_set_tRNS(png_ptr, info_ptr, &transparentIndex, 1, nullptr);
-            png_set_IHDR(png_ptr, info_ptr, context.width, context.height, 8, PNG_COLOR_TYPE_PALETTE, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
+            png_set_IHDR(png_ptr, info_ptr, rt.width, rt.height, 8, PNG_COLOR_TYPE_PALETTE, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
             png_write_info(png_ptr, info_ptr);
 
-            uint8_t* data = context.bits;
-            for (int y = 0; y < context.height; y++)
+            uint8_t* data = rt.bits;
+            for (int y = 0; y < rt.height; y++)
             {
                 png_write_row(png_ptr, data);
-                data += context.pitch + context.width;
+                data += rt.pitch + rt.width;
             }
 
             png_write_end(png_ptr, nullptr);

--- a/src/OpenLoco/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/Ui/ViewportInteraction.cpp
@@ -973,8 +973,8 @@ namespace OpenLoco::Ui::ViewportInteraction
     std::pair<ViewportInteraction::InteractionArg, Viewport*> getMapCoordinatesFromPos(int32_t screenX, int32_t screenY, int32_t flags)
     {
         static loco_global<uint8_t, 0x0050BF68> _50BF68; // If in get map coords
-        static loco_global<Gfx::Context, 0x00E0C3E4> _context1;
-        static loco_global<Gfx::Context, 0x00E0C3F4> _context2;
+        static loco_global<Gfx::RenderTarget, 0x00E0C3E4> _rt1;
+        static loco_global<Gfx::RenderTarget, 0x00E0C3F4> _rt2;
 
         _50BF68 = 1;
         ViewportInteraction::InteractionArg interaction{};
@@ -997,21 +997,21 @@ namespace OpenLoco::Ui::ViewportInteraction
 
             chosenV = vp;
             auto vpPos = vp->screenToViewport({ screenPos.x, screenPos.y });
-            _context1->zoom_level = vp->zoom;
-            _context1->x = (0xFFFF << vp->zoom) & vpPos.x;
-            _context1->y = (0xFFFF << vp->zoom) & vpPos.y;
-            _context2->x = _context1->x;
-            _context2->y = _context1->y;
-            _context2->width = 1;
-            _context2->height = 1;
-            _context2->zoom_level = _context1->zoom_level;
-            auto* session = Paint::allocateSession(_context2, vp->flags);
+            _rt1->zoom_level = vp->zoom;
+            _rt1->x = (0xFFFF << vp->zoom) & vpPos.x;
+            _rt1->y = (0xFFFF << vp->zoom) & vpPos.y;
+            _rt2->x = _rt1->x;
+            _rt2->y = _rt1->y;
+            _rt2->width = 1;
+            _rt2->height = 1;
+            _rt2->zoom_level = _rt1->zoom_level;
+            auto* session = Paint::allocateSession(_rt2, vp->flags);
             session->generate();
             session->arrangeStructs();
             interaction = session->getNormalInteractionInfo(flags);
             if (!(vp->flags & ViewportFlags::station_names_displayed))
             {
-                if (_context2->zoom_level <= Config::get().stationNamesMinScale)
+                if (_rt2->zoom_level <= Config::get().stationNamesMinScale)
                 {
                     auto stationInteraction = session->getStationNameInteractionInfo(flags);
                     if (stationInteraction.type != InteractionItem::noInteraction)

--- a/src/OpenLoco/Ui/WindowManager.h
+++ b/src/OpenLoco/Ui/WindowManager.h
@@ -9,7 +9,7 @@
 
 namespace OpenLoco::Gfx
 {
-    struct Context;
+    struct RenderTarget;
 }
 namespace OpenLoco::Ui
 {
@@ -64,7 +64,7 @@ namespace OpenLoco::Ui::WindowManager
     Window* createWindow(WindowType type, Ui::Point origin, Ui::Size size, uint32_t flags, WindowEventList* events);
     Window* createWindowCentred(WindowType type, Ui::Size size, uint32_t flags, WindowEventList* events);
     Window* createWindow(WindowType type, Ui::Size size, uint32_t flags, WindowEventList* events);
-    void drawSingle(Gfx::Context* context, Window* w, int32_t left, int32_t top, int32_t right, int32_t bottom);
+    void drawSingle(Gfx::RenderTarget* rt, Window* w, int32_t left, int32_t top, int32_t right, int32_t bottom);
     void dispatchUpdateAll();
     void callEvent8OnAllWindows();
     void callEvent9OnAllWindows();
@@ -443,7 +443,7 @@ namespace OpenLoco::Ui::Windows
         }
         namespace Common
         {
-            int16_t sub_4B743B(uint8_t al, uint8_t ah, int16_t cx, int16_t dx, Vehicles::VehicleBase* vehicle, Gfx::Context* const pDrawpixelinfo);
+            int16_t sub_4B743B(uint8_t al, uint8_t ah, int16_t cx, int16_t dx, Vehicles::VehicleBase* vehicle, Gfx::RenderTarget* const pDrawpixelinfo);
         }
         bool rotate();
     }

--- a/src/OpenLoco/Viewport.cpp
+++ b/src/OpenLoco/Viewport.cpp
@@ -22,21 +22,21 @@ namespace OpenLoco::Ui
     }
 
     // 0x0045A0E7
-    void Viewport::render(Gfx::Context* context)
+    void Viewport::render(Gfx::RenderTarget* rt)
     {
-        auto contextRect = context->getUiRect();
+        auto uiRect = rt->getUiRect();
         auto viewRect = getUiRect();
 
-        if (!contextRect.intersects(viewRect))
+        if (!uiRect.intersects(viewRect))
         {
             return;
         }
-        auto intersection = contextRect.intersection(viewRect);
-        paint(context, screenToViewport(intersection));
+        auto intersection = uiRect.intersection(viewRect);
+        paint(rt, screenToViewport(intersection));
     }
 
     // 0x0045A1A4
-    void Viewport::paint(Gfx::Context* context, const Rect& rect)
+    void Viewport::paint(Gfx::RenderTarget* rt, const Rect& rect)
     {
         registers regs{};
         regs.ax = rect.left();
@@ -44,7 +44,7 @@ namespace OpenLoco::Ui
         regs.dx = rect.right();
         regs.bp = rect.bottom();
         regs.esi = X86Pointer(this);
-        regs.edi = X86Pointer(context);
+        regs.edi = X86Pointer(rt);
         call(0x0045A1A4, regs);
     }
 

--- a/src/OpenLoco/Viewport.hpp
+++ b/src/OpenLoco/Viewport.hpp
@@ -153,7 +153,7 @@ namespace OpenLoco::Ui
             return Rect::fromLTRB(leftTop.x, leftTop.y, rightBottom.x, rightBottom.y);
         }
 
-        void render(Gfx::Context* context);
+        void render(Gfx::RenderTarget* rt);
         viewport_pos centre2dCoordinates(const Map::Pos3& loc);
         SavedViewSimple toSavedView() const;
 
@@ -163,7 +163,7 @@ namespace OpenLoco::Ui
         std::optional<Map::Pos2> getCentreScreenMapPosition() const;
 
     private:
-        void paint(Gfx::Context* context, const Ui::Rect& rect);
+        void paint(Gfx::RenderTarget* rt, const Ui::Rect& rect);
     };
 
     struct ViewportConfig

--- a/src/OpenLoco/Widget.cpp
+++ b/src/OpenLoco/Widget.cpp
@@ -35,25 +35,25 @@ namespace OpenLoco::Ui
 
     static loco_global<char[2], 0x005045F8> _strCheckmark;
 
-    void draw_11_c(Gfx::Context* context, const Window* window, Widget* widget, AdvancedColour colour, bool disabled, int16_t x, int16_t y, string_id string);
-    void draw_14(Gfx::Context* context, Widget* widget, AdvancedColour colour, bool disabled, int16_t x, int16_t y, string_id string);
+    void draw_11_c(Gfx::RenderTarget* rt, const Window* window, Widget* widget, AdvancedColour colour, bool disabled, int16_t x, int16_t y, string_id string);
+    void draw_14(Gfx::RenderTarget* rt, Widget* widget, AdvancedColour colour, bool disabled, int16_t x, int16_t y, string_id string);
 
     // 0x004CF3EB
-    static void drawStationNameBackground(Gfx::Context* context, const Window* window, const Widget* widget, int16_t x, int16_t y, AdvancedColour colour, int16_t width)
+    static void drawStationNameBackground(Gfx::RenderTarget* rt, const Window* window, const Widget* widget, int16_t x, int16_t y, AdvancedColour colour, int16_t width)
     {
-        Gfx::drawImage(context, x - 4, y, Gfx::recolour(ImageIds::curved_border_left, colour.c()));
-        Gfx::drawImage(context, x + width, y, Gfx::recolour(ImageIds::curved_border_right, colour.c()));
-        Gfx::fillRect(*context, x, y, x + width - 1, y + 11, Colours::getShade(colour.c(), 5));
+        Gfx::drawImage(rt, x - 4, y, Gfx::recolour(ImageIds::curved_border_left, colour.c()));
+        Gfx::drawImage(rt, x + width, y, Gfx::recolour(ImageIds::curved_border_right, colour.c()));
+        Gfx::fillRect(*rt, x, y, x + width - 1, y + 11, Colours::getShade(colour.c(), 5));
     }
 
-    void Widget::draw(Gfx::Context* context, Window* window, const uint64_t pressedWidgets, const uint64_t toolWidgets, const uint64_t hoveredWidgets, uint8_t& scrollviewIndex)
+    void Widget::draw(Gfx::RenderTarget* rt, Window* window, const uint64_t pressedWidgets, const uint64_t toolWidgets, const uint64_t hoveredWidgets, uint8_t& scrollviewIndex)
     {
         if ((window->flags & WindowFlags::noBackground) == 0)
         {
             // Check if widget is outside the draw region
-            if (window->x + left >= context->x + context->width && window->x + right < context->x)
+            if (window->x + left >= rt->x + rt->width && window->x + right < rt->x)
             {
-                if (window->y + top >= context->y + context->height && window->y + bottom < context->y)
+                if (window->y + top >= rt->y + rt->height && window->y + bottom < rt->y)
                 {
                     return;
                 }
@@ -82,15 +82,15 @@ namespace OpenLoco::Ui
                 break;
 
             case WidgetType::panel:
-                drawPanel(context, window, widgetFlags, wndColour);
+                drawPanel(rt, window, widgetFlags, wndColour);
                 break;
 
             case WidgetType::frame:
-                drawFrame(context, window, widgetFlags, wndColour);
+                drawFrame(rt, window, widgetFlags, wndColour);
                 break;
 
             case WidgetType::wt_3:
-                draw_3(context, window, widgetFlags, wndColour, enabled, disabled, activated);
+                draw_3(rt, window, widgetFlags, wndColour, enabled, disabled, activated);
                 break;
 
             case WidgetType::wt_4:
@@ -101,15 +101,15 @@ namespace OpenLoco::Ui
             case WidgetType::wt_6:
             case WidgetType::toolbarTab:
             case WidgetType::tab:
-                drawTab(context, window, widgetFlags, wndColour, enabled, disabled, activated);
+                drawTab(rt, window, widgetFlags, wndColour, enabled, disabled, activated);
                 break;
 
             case WidgetType::buttonWithImage:
-                drawButtonWithImage(context, window, widgetFlags, wndColour, enabled, disabled, activated, hovered);
+                drawButtonWithImage(rt, window, widgetFlags, wndColour, enabled, disabled, activated, hovered);
                 break;
 
             case WidgetType::buttonWithColour:
-                drawButtonWithColour(context, window, widgetFlags, wndColour, enabled, disabled, activated, hovered);
+                drawButtonWithColour(rt, window, widgetFlags, wndColour, enabled, disabled, activated, hovered);
                 break;
 
             case WidgetType::button:
@@ -119,28 +119,28 @@ namespace OpenLoco::Ui
                 {
                     assert(false); // Unused
                 }
-                drawButton(context, window, widgetFlags, wndColour, enabled, disabled, activated);
-                draw_13(context, window, widgetFlags, wndColour, enabled, disabled, activated);
+                drawButton(rt, window, widgetFlags, wndColour, enabled, disabled, activated);
+                draw_13(rt, window, widgetFlags, wndColour, enabled, disabled, activated);
                 break;
 
             case WidgetType::wt_13:
-                draw_13(context, window, widgetFlags, wndColour, enabled, disabled, activated);
+                draw_13(rt, window, widgetFlags, wndColour, enabled, disabled, activated);
                 break;
 
             case WidgetType::wt_15:
-                draw_15(context, window, widgetFlags, wndColour, disabled);
+                draw_15(rt, window, widgetFlags, wndColour, disabled);
                 break;
 
             case WidgetType::groupbox:
                 // NB: widget type 16 has been repurposed to add groupboxes; the original type 16 was unused.
-                drawGroupbox(context, window);
+                drawGroupbox(rt, window);
                 break;
 
             case WidgetType::textbox:
             case WidgetType::combobox:
             case WidgetType::viewport:
-                drawTextBox(context, window, widgetFlags, wndColour);
-                draw_15(context, window, widgetFlags, wndColour, disabled);
+                drawTextBox(rt, window, widgetFlags, wndColour);
+                draw_15(rt, window, widgetFlags, wndColour, disabled);
                 break;
 
             case WidgetType::wt_20:
@@ -149,63 +149,63 @@ namespace OpenLoco::Ui
                 break;
 
             case WidgetType::caption_22:
-                draw_22_caption(context, window, widgetFlags, wndColour);
+                draw_22_caption(rt, window, widgetFlags, wndColour);
                 break;
 
             case WidgetType::caption_23:
-                draw_23_caption(context, window, widgetFlags, wndColour);
+                draw_23_caption(rt, window, widgetFlags, wndColour);
                 break;
 
             case WidgetType::caption_24:
-                draw_24_caption(context, window, widgetFlags, wndColour);
+                draw_24_caption(rt, window, widgetFlags, wndColour);
                 break;
 
             case WidgetType::caption_25:
-                draw_25_caption(context, window, widgetFlags, wndColour);
+                draw_25_caption(rt, window, widgetFlags, wndColour);
                 break;
 
             case WidgetType::scrollview:
-                drawScrollview(context, window, widgetFlags, wndColour, enabled, disabled, activated, hovered, scrollviewIndex);
+                drawScrollview(rt, window, widgetFlags, wndColour, enabled, disabled, activated, hovered, scrollviewIndex);
                 scrollviewIndex++;
                 break;
 
             case WidgetType::checkbox:
-                draw_27_checkbox(context, window, widgetFlags, wndColour, enabled, disabled, activated);
-                draw_27_label(context, window, widgetFlags, wndColour, disabled);
+                draw_27_checkbox(rt, window, widgetFlags, wndColour, enabled, disabled, activated);
+                draw_27_label(rt, window, widgetFlags, wndColour, disabled);
                 break;
 
             case WidgetType::wt_28:
                 assert(false); // Unused
-                draw_27_label(context, window, widgetFlags, wndColour, disabled);
+                draw_27_label(rt, window, widgetFlags, wndColour, disabled);
                 break;
 
             case WidgetType::wt_29:
                 assert(false); // Unused
-                draw_29(context, window);
+                draw_29(rt, window);
                 break;
         }
     }
     // 0x004CF487
-    void Widget::drawViewportCentreButton(Gfx::Context* context, const Window* window, const WidgetIndex_t widgetIndex)
+    void Widget::drawViewportCentreButton(Gfx::RenderTarget* rt, const Window* window, const WidgetIndex_t widgetIndex)
     {
         auto& widget = window->widgets[widgetIndex];
         if (Input::isHovering(window->type, window->number, widgetIndex))
         {
-            Gfx::drawRect(*context, widget.left + window->x, widget.top + window->y, widget.width(), widget.height(), 0x2000000 | 54);
-            Gfx::drawRect(*context, widget.left + window->x, widget.top + window->y, widget.width(), widget.height(), 0x2000000 | 52);
+            Gfx::drawRect(*rt, widget.left + window->x, widget.top + window->y, widget.width(), widget.height(), 0x2000000 | 54);
+            Gfx::drawRect(*rt, widget.left + window->x, widget.top + window->y, widget.width(), widget.height(), 0x2000000 | 52);
 
             uint8_t flags = 0;
             if (Input::isPressed(window->type, window->number, widgetIndex))
                 flags = 0x20;
 
-            Gfx::drawRectInset(*context, widget.left + window->x, widget.top + window->y, widget.width(), widget.height(), window->getColour(WindowColour::secondary).translucent().u8(), flags);
+            Gfx::drawRectInset(*rt, widget.left + window->x, widget.top + window->y, widget.width(), widget.height(), window->getColour(WindowColour::secondary).translucent().u8(), flags);
         }
 
-        Gfx::drawImage(context, widget.left + window->x, widget.top + window->y, Gfx::recolour(ImageIds::centre_viewport, window->getColour(WindowColour::secondary).c()));
+        Gfx::drawImage(rt, widget.left + window->x, widget.top + window->y, Gfx::recolour(ImageIds::centre_viewport, window->getColour(WindowColour::secondary).c()));
     }
 
     // 0x004CAB8E
-    static void draw_resize_handle(Gfx::Context* context, const Window* window, Widget* widget, AdvancedColour colour)
+    static void draw_resize_handle(Gfx::RenderTarget* rt, const Window* window, Widget* widget, AdvancedColour colour)
     {
         if (!(window->flags & WindowFlags::resizable))
         {
@@ -220,10 +220,10 @@ namespace OpenLoco::Ui
         int16_t x = widget->right + window->x - 18;
         int16_t y = widget->bottom + window->y - 18;
         uint32_t image = Gfx::recolour(ImageIds::window_resize_handle, colour.c());
-        Gfx::drawImage(context, x, y, image);
+        Gfx::drawImage(rt, x, y, image);
     }
 
-    void Widget::sub_4CADE8(Gfx::Context* context, const Window* window, AdvancedColour colour, bool enabled, bool disabled, bool activated)
+    void Widget::sub_4CADE8(Gfx::RenderTarget* rt, const Window* window, AdvancedColour colour, bool enabled, bool disabled, bool activated)
     {
         Ui::Point placeForImage(left + window->x, top + window->y);
         const bool isColourSet = image & Widget::imageIdColourSet;
@@ -251,16 +251,16 @@ namespace OpenLoco::Ui
             if (colour.isTranslucent())
             {
                 c = Colours::getShade(colour.c(), 4);
-                Gfx::drawImageSolid(*context, placeForImage + Ui::Point{ 1, 1 }, pureImage, c);
+                Gfx::drawImageSolid(*rt, placeForImage + Ui::Point{ 1, 1 }, pureImage, c);
                 c = Colours::getShade(colour.c(), 2);
-                Gfx::drawImageSolid(*context, placeForImage, pureImage, c);
+                Gfx::drawImageSolid(*rt, placeForImage, pureImage, c);
             }
             else
             {
                 c = Colours::getShade(colour.c(), 6);
-                Gfx::drawImageSolid(*context, placeForImage + Ui::Point{ 1, 1 }, pureImage, c);
+                Gfx::drawImageSolid(*rt, placeForImage + Ui::Point{ 1, 1 }, pureImage, c);
                 c = Colours::getShade(colour.c(), 4);
-                Gfx::drawImageSolid(*context, placeForImage, pureImage, c);
+                Gfx::drawImageSolid(*rt, placeForImage, pureImage, c);
             }
 
             return;
@@ -278,21 +278,21 @@ namespace OpenLoco::Ui
             imageId = imageId.withPrimary(colour.c());
         }
 
-        Gfx::drawImage(*context, placeForImage, imageId);
+        Gfx::drawImage(*rt, placeForImage, imageId);
     }
 
     // 0x004CAB58
-    void Widget::drawPanel(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour)
+    void Widget::drawPanel(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour)
     {
-        Gfx::fillRectInset(*context, window->x + left, window->y + top, window->x + right, window->y + bottom, colour.u8(), flags);
+        Gfx::fillRectInset(*rt, window->x + left, window->y + top, window->x + right, window->y + bottom, colour.u8(), flags);
 
-        draw_resize_handle(context, window, this, colour);
+        draw_resize_handle(rt, window, this, colour);
     }
 
     // 0x004CAAB9
-    void Widget::drawFrame(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour)
+    void Widget::drawFrame(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour)
     {
-        auto clipped = Gfx::clipContext(*context, Ui::Rect(left + window->x, top + window->y, right - left, 41));
+        auto clipped = Gfx::clipRenderTarget(*rt, Ui::Rect(left + window->x, top + window->y, right - left, 41));
         if (clipped)
         {
             uint32_t imageId = image;
@@ -318,17 +318,17 @@ namespace OpenLoco::Ui
         }
 
         Gfx::fillRect(
-            *context,
+            *rt,
             window->x + right,
             window->y + top,
             window->x + right,
             window->y + top + 40,
             shade);
 
-        draw_resize_handle(context, window, this, colour);
+        draw_resize_handle(rt, window, this, colour);
     }
 
-    void Widget::draw_3(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
+    void Widget::draw_3(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
     {
         int16_t t, l, b, r;
         t = window->y + top;
@@ -344,27 +344,27 @@ namespace OpenLoco::Ui
         if (content == kContentUnk)
         {
             flags |= 0x10;
-            Gfx::fillRectInset(*context, l, t, r, b, colour.u8(), flags);
+            Gfx::fillRectInset(*rt, l, t, r, b, colour.u8(), flags);
             return;
         }
 
         if (window->flags & WindowFlags::flag_6)
         {
-            Gfx::fillRect(*context, l, t, r, b, 0x2000000 | 52);
+            Gfx::fillRect(*rt, l, t, r, b, 0x2000000 | 52);
         }
 
-        Gfx::fillRectInset(*context, l, t, r, b, colour.u8(), flags);
+        Gfx::fillRectInset(*rt, l, t, r, b, colour.u8(), flags);
 
         if (content == kContentNull)
         {
             return;
         }
 
-        sub_4CADE8(context, window, colour, enabled, disabled, activated);
+        sub_4CADE8(rt, window, colour, enabled, disabled, activated);
     }
 
     // 0x004CABFE
-    void Widget::drawTab(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
+    void Widget::drawTab(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
     {
         if (content == kContentNull)
         {
@@ -373,7 +373,7 @@ namespace OpenLoco::Ui
 
         if (!disabled)
         {
-            sub_4CADE8(context, window, colour, enabled, disabled, activated);
+            sub_4CADE8(rt, window, colour, enabled, disabled, activated);
             return;
         }
 
@@ -384,7 +384,7 @@ namespace OpenLoco::Ui
 
         if (type != WidgetType::toolbarTab)
         {
-            sub_4CADE8(context, window, colour, enabled, disabled, activated);
+            sub_4CADE8(rt, window, colour, enabled, disabled, activated);
             return;
         }
 
@@ -397,16 +397,16 @@ namespace OpenLoco::Ui
             imageId = imageId.withPrimary(colour.c());
         }
 
-        Gfx::drawImage(*context, Ui::Point(window->x + left, window->y + top), imageId);
+        Gfx::drawImage(*rt, Ui::Point(window->x + left, window->y + top), imageId);
     }
 
     // 0x004CACD4
-    void Widget::drawButtonWithImage(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered)
+    void Widget::drawButtonWithImage(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered)
     {
         if (!disabled && hovered)
         {
             // TODO: Fix mixed windows
-            draw_3(context, window, flags, colour, enabled, disabled, activated);
+            draw_3(rt, window, flags, colour, enabled, disabled, activated);
             return;
         }
 
@@ -423,12 +423,12 @@ namespace OpenLoco::Ui
                 // 0x004CABE8
 
                 flags |= 0x10;
-                Gfx::fillRectInset(*context, l, t, r, b, colour.u8(), flags);
+                Gfx::fillRectInset(*rt, l, t, r, b, colour.u8(), flags);
 
                 return;
             }
 
-            Gfx::fillRectInset(*context, l, t, r, b, colour.u8(), flags);
+            Gfx::fillRectInset(*rt, l, t, r, b, colour.u8(), flags);
         }
 
         if (content == kContentNull)
@@ -436,11 +436,11 @@ namespace OpenLoco::Ui
             return;
         }
 
-        sub_4CADE8(context, window, colour, enabled, disabled, activated);
+        sub_4CADE8(rt, window, colour, enabled, disabled, activated);
     }
 
     // 0x004CAC5F
-    void Widget::drawButtonWithColour(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered)
+    void Widget::drawButtonWithColour(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered)
     {
         if (content == kContentNull)
         {
@@ -467,11 +467,11 @@ namespace OpenLoco::Ui
             imageId = imageId.withPrimary(colour.c());
         }
 
-        Gfx::drawImage(*context, Ui::Point(window->x + left, window->y + top), imageId);
+        Gfx::drawImage(*rt, Ui::Point(window->x + left, window->y + top), imageId);
     }
 
     // 0x004CB164
-    void Widget::drawButton(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
+    void Widget::drawButton(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
     {
         int l = window->x + left;
         int r = window->x + right;
@@ -483,11 +483,11 @@ namespace OpenLoco::Ui
             flags |= 0x20;
         }
 
-        Gfx::fillRectInset(*context, l, t, r, b, colour.u8(), flags);
+        Gfx::fillRectInset(*rt, l, t, r, b, colour.u8(), flags);
     }
 
     // 0x004CB1BE
-    void Widget::draw_13(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
+    void Widget::draw_13(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
     {
         if (content == kContentNull)
         {
@@ -510,16 +510,16 @@ namespace OpenLoco::Ui
 
         if (type == WidgetType::buttonTableHeader)
         {
-            draw_14(context, this, colour, disabled, x, y, string);
+            draw_14(rt, this, colour, disabled, x, y, string);
         }
         else
         {
-            draw_11_c(context, window, this, colour, disabled, x, y, string);
+            draw_11_c(rt, window, this, colour, disabled, x, y, string);
         }
     }
 
     // 0x004CB21D
-    void draw_11_c(Gfx::Context* context, const Window* window, Widget* widget, AdvancedColour colour, bool disabled, int16_t x, int16_t y, string_id string)
+    void draw_11_c(Gfx::RenderTarget* rt, const Window* window, Widget* widget, AdvancedColour colour, bool disabled, int16_t x, int16_t y, string_id string)
     {
         colour = colour.opaque();
         if (disabled)
@@ -529,11 +529,11 @@ namespace OpenLoco::Ui
 
         int16_t centreX = window->x + (widget->left + widget->right + 1) / 2 - 1;
         int16_t width = widget->right - widget->left - 2;
-        Gfx::drawStringCentredClipped(*context, centreX, y, width, colour, string, _commonFormatArgs);
+        Gfx::drawStringCentredClipped(*rt, centreX, y, width, colour, string, _commonFormatArgs);
     }
 
     // 0x004CB263
-    void draw_14(Gfx::Context* context, Widget* widget, AdvancedColour colour, bool disabled, int16_t x, int16_t y, string_id string)
+    void draw_14(Gfx::RenderTarget* rt, Widget* widget, AdvancedColour colour, bool disabled, int16_t x, int16_t y, string_id string)
     {
         x = x + 1;
 
@@ -544,11 +544,11 @@ namespace OpenLoco::Ui
         }
 
         int width = widget->right - widget->left - 2;
-        Gfx::drawStringLeftClipped(*context, x, y, width, colour, string, _commonFormatArgs);
+        Gfx::drawStringLeftClipped(*rt, x, y, width, colour, string, _commonFormatArgs);
     }
 
     // 0x4CB2D6
-    void Widget::draw_15(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool disabled)
+    void Widget::draw_15(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool disabled)
     {
         if (content == kContentNull || content == kContentUnk)
         {
@@ -564,34 +564,34 @@ namespace OpenLoco::Ui
             colour = colour.FD();
         }
 
-        drawStringLeft(*context, window->x + left + 1, window->y + top, colour, text, _commonFormatArgs);
+        drawStringLeft(*rt, window->x + left + 1, window->y + top, colour, text, _commonFormatArgs);
     }
 
     // 0x4CB29C
-    void Widget::drawTextBox(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour)
+    void Widget::drawTextBox(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour)
     {
-        Gfx::fillRectInset(*context, window->x + left, window->y + top, window->x + right, window->y + bottom, colour.u8(), flags | 0x60);
+        Gfx::fillRectInset(*rt, window->x + left, window->y + top, window->x + right, window->y + bottom, colour.u8(), flags | 0x60);
     }
 
     // 0x004CA6AE
-    void Widget::draw_22_caption(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour)
+    void Widget::draw_22_caption(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour)
     {
         int l = window->x + left;
         int r = window->x + right;
         int t = window->y + top;
         int b = window->y + bottom;
-        Gfx::fillRectInset(*context, l, t, r, b, colour.u8(), flags | 0x60);
-        Gfx::fillRect(*context, l + 1, t + 1, r - 1, b - 1, 0x2000000 | 46);
+        Gfx::fillRectInset(*rt, l, t, r, b, colour.u8(), flags | 0x60);
+        Gfx::fillRect(*rt, l + 1, t + 1, r - 1, b - 1, 0x2000000 | 46);
 
         int16_t width = r - l - 4 - 10;
         int16_t y = t + 1;
         int16_t x = l + 2 + (width / 2);
 
-        Gfx::drawStringCentredClipped(*context, x, y, width, AdvancedColour(Colour::white).outline(), text, _commonFormatArgs);
+        Gfx::drawStringCentredClipped(*rt, x, y, width, AdvancedColour(Colour::white).outline(), text, _commonFormatArgs);
     }
 
     // 0x004CA750
-    void Widget::draw_23_caption(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour)
+    void Widget::draw_23_caption(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour)
     {
         char stringBuffer[512];
         stringBuffer[0] = ControlCodes::colour_black;
@@ -606,13 +606,13 @@ namespace OpenLoco::Ui
         x -= width / 2;
         int16_t y = window->y + top + 1;
 
-        drawStationNameBackground(context, window, this, x, y, colour, width);
+        drawStationNameBackground(rt, window, this, x, y, colour, width);
 
-        Gfx::drawString(*context, x, y, Colour::black, stringBuffer);
+        Gfx::drawString(*rt, x, y, Colour::black, stringBuffer);
     }
 
     // 0x004CA7F6
-    void Widget::draw_24_caption(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour)
+    void Widget::draw_24_caption(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour)
     {
         char stringBuffer[512];
         stringBuffer[0] = ControlCodes::window_colour_1;
@@ -626,11 +626,11 @@ namespace OpenLoco::Ui
         int16_t stringWidth = Gfx::clipString(width - 8, stringBuffer);
         x -= (stringWidth - 1) / 2;
 
-        Gfx::drawString(*context, x, window->y + top + 1, AdvancedColour(Colour::black).outline(), stringBuffer);
+        Gfx::drawString(*rt, x, window->y + top + 1, AdvancedColour(Colour::black).outline(), stringBuffer);
     }
 
     // 0x004CA88B
-    void Widget::draw_25_caption(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour)
+    void Widget::draw_25_caption(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour)
     {
         char stringBuffer[512];
         stringBuffer[0] = ControlCodes::colour_white;
@@ -644,10 +644,10 @@ namespace OpenLoco::Ui
         int16_t stringWidth = Gfx::clipString(width - 8, stringBuffer);
         x -= (stringWidth - 1) / 2;
 
-        Gfx::drawString(*context, x, window->y + top + 1, AdvancedColour(Colour::black).outline(), stringBuffer);
+        Gfx::drawString(*rt, x, window->y + top + 1, AdvancedColour(Colour::black).outline(), stringBuffer);
     }
 
-    static void draw_hscroll(Gfx::Context* context, const Window* window, Widget* widget, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered, int16_t scrollview_index)
+    static void draw_hscroll(Gfx::RenderTarget* rt, const Window* window, Widget* widget, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered, int16_t scrollview_index)
     {
         const auto* scroll_area = &window->scrollAreas[scrollview_index];
 
@@ -670,11 +670,11 @@ namespace OpenLoco::Ui
         {
             f = flags | 0x20;
         }
-        Gfx::fillRectInset(*context, ax, cx, ax + 9, dx, colour.u8(), f);
+        Gfx::fillRectInset(*rt, ax, cx, ax + 9, dx, colour.u8(), f);
         // popa
 
         // pusha
-        Gfx::drawString(*context, ax + 2, cx, Colour::black, (char*)0x005045F2);
+        Gfx::drawString(*rt, ax + 2, cx, Colour::black, (char*)0x005045F2);
         // popa
 
         // pusha
@@ -683,23 +683,23 @@ namespace OpenLoco::Ui
         {
             f = flags | 0x20;
         }
-        Gfx::fillRectInset(*context, bx - 9, cx, bx, dx, colour.u8(), f);
+        Gfx::fillRectInset(*rt, bx - 9, cx, bx, dx, colour.u8(), f);
         // popa
 
         // pusha
-        Gfx::drawString(*context, bx - 6 - 1, cx, Colour::black, (char*)0x005045F5);
+        Gfx::drawString(*rt, bx - 6 - 1, cx, Colour::black, (char*)0x005045F5);
         // popa
 
         // pusha
-        Gfx::fillRect(*context, ax + 10, cx, bx - 10, dx, Colours::getShade(colour.c(), 7));
-        Gfx::fillRect(*context, ax + 10, cx, bx - 10, dx, 0x1000000 | Colours::getShade(colour.c(), 3));
+        Gfx::fillRect(*rt, ax + 10, cx, bx - 10, dx, Colours::getShade(colour.c(), 7));
+        Gfx::fillRect(*rt, ax + 10, cx, bx - 10, dx, 0x1000000 | Colours::getShade(colour.c(), 3));
         // popa
 
         // pusha
-        Gfx::fillRect(*context, ax + 10, cx + 2, bx - 10, cx + 2, Colours::getShade(colour.c(), 3));
-        Gfx::fillRect(*context, ax + 10, cx + 3, bx - 10, cx + 3, Colours::getShade(colour.c(), 7));
-        Gfx::fillRect(*context, ax + 10, cx + 7, bx - 10, cx + 7, Colours::getShade(colour.c(), 3));
-        Gfx::fillRect(*context, ax + 10, cx + 8, bx - 10, cx + 8, Colours::getShade(colour.c(), 7));
+        Gfx::fillRect(*rt, ax + 10, cx + 2, bx - 10, cx + 2, Colours::getShade(colour.c(), 3));
+        Gfx::fillRect(*rt, ax + 10, cx + 3, bx - 10, cx + 3, Colours::getShade(colour.c(), 7));
+        Gfx::fillRect(*rt, ax + 10, cx + 7, bx - 10, cx + 7, Colours::getShade(colour.c(), 3));
+        Gfx::fillRect(*rt, ax + 10, cx + 8, bx - 10, cx + 8, Colours::getShade(colour.c(), 7));
         // popa
 
         // pusha
@@ -708,11 +708,11 @@ namespace OpenLoco::Ui
         {
             f = 0x20;
         }
-        Gfx::fillRectInset(*context, ax - 1 + scroll_area->hThumbLeft, cx, ax - 1 + scroll_area->hThumbRight, dx, colour.u8(), f);
+        Gfx::fillRectInset(*rt, ax - 1 + scroll_area->hThumbLeft, cx, ax - 1 + scroll_area->hThumbRight, dx, colour.u8(), f);
         // popa
     }
 
-    static void draw_vscroll(Gfx::Context* context, const Window* window, Widget* widget, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered, int16_t scrollview_index)
+    static void draw_vscroll(Gfx::RenderTarget* rt, const Window* window, Widget* widget, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered, int16_t scrollview_index)
     {
         const auto* scroll_area = &window->scrollAreas[scrollview_index];
 
@@ -735,11 +735,11 @@ namespace OpenLoco::Ui
         {
             f = flags | 0x20;
         }
-        Gfx::fillRectInset(*context, ax, cx, bx, cx + 9, colour.u8(), f);
+        Gfx::fillRectInset(*rt, ax, cx, bx, cx + 9, colour.u8(), f);
         // popa
 
         // pusha
-        Gfx::drawString(*context, ax + 1, cx - 1, Colour::black, (char*)0x005045EC);
+        Gfx::drawString(*rt, ax + 1, cx - 1, Colour::black, (char*)0x005045EC);
         // popa
 
         // pusha
@@ -748,23 +748,23 @@ namespace OpenLoco::Ui
         {
             f = flags | 0x20;
         }
-        Gfx::fillRectInset(*context, ax, dx - 9, bx, dx, colour.u8(), f);
+        Gfx::fillRectInset(*rt, ax, dx - 9, bx, dx, colour.u8(), f);
         // popa
 
         // pusha
-        Gfx::drawString(*context, ax + 1, dx - 8 - 1, Colour::black, (char*)0x005045EF);
+        Gfx::drawString(*rt, ax + 1, dx - 8 - 1, Colour::black, (char*)0x005045EF);
         // popa
 
         // pusha
-        Gfx::fillRect(*context, ax, cx + 10, bx, dx - 10, Colours::getShade(colour.c(), 7));
-        Gfx::fillRect(*context, ax, cx + 10, bx, dx - 10, 0x1000000 | Colours::getShade(colour.c(), 3));
+        Gfx::fillRect(*rt, ax, cx + 10, bx, dx - 10, Colours::getShade(colour.c(), 7));
+        Gfx::fillRect(*rt, ax, cx + 10, bx, dx - 10, 0x1000000 | Colours::getShade(colour.c(), 3));
         // popa
 
         // pusha
-        Gfx::fillRect(*context, ax + 2, cx + 10, ax + 2, dx - 10, Colours::getShade(colour.c(), 3));
-        Gfx::fillRect(*context, ax + 3, cx + 10, ax + 3, dx - 10, Colours::getShade(colour.c(), 7));
-        Gfx::fillRect(*context, ax + 7, cx + 10, ax + 7, dx - 10, Colours::getShade(colour.c(), 3));
-        Gfx::fillRect(*context, ax + 8, cx + 10, ax + 8, dx - 10, Colours::getShade(colour.c(), 7));
+        Gfx::fillRect(*rt, ax + 2, cx + 10, ax + 2, dx - 10, Colours::getShade(colour.c(), 3));
+        Gfx::fillRect(*rt, ax + 3, cx + 10, ax + 3, dx - 10, Colours::getShade(colour.c(), 7));
+        Gfx::fillRect(*rt, ax + 7, cx + 10, ax + 7, dx - 10, Colours::getShade(colour.c(), 3));
+        Gfx::fillRect(*rt, ax + 8, cx + 10, ax + 8, dx - 10, Colours::getShade(colour.c(), 7));
         // popa
 
         // pusha
@@ -773,19 +773,19 @@ namespace OpenLoco::Ui
         {
             f = flags | 0x20;
         }
-        Gfx::fillRectInset(*context, ax, cx - 1 + scroll_area->vThumbTop, bx, cx - 1 + scroll_area->vThumbBottom, colour.u8(), f);
+        Gfx::fillRectInset(*rt, ax, cx - 1 + scroll_area->vThumbTop, bx, cx - 1 + scroll_area->vThumbBottom, colour.u8(), f);
         // popa
     }
 
     // 0x004CB31C
-    void Widget::drawScrollview(Gfx::Context* context, Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered, int scrollview_index)
+    void Widget::drawScrollview(Gfx::RenderTarget* rt, Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered, int scrollview_index)
     {
         int16_t l = window->x + left;
         int16_t t = window->y + top;
         int16_t r = window->x + right;
         int16_t b = window->y + bottom;
 
-        Gfx::fillRectInset(*context, l, t, r, b, colour.u8(), flags | 0x60);
+        Gfx::fillRectInset(*rt, l, t, r, b, colour.u8(), flags | 0x60);
 
         l++;
         t++;
@@ -797,17 +797,17 @@ namespace OpenLoco::Ui
         Gfx::setCurrentFontSpriteBase(Font::medium_bold);
         if (scroll_area->flags & Ui::ScrollView::ScrollFlags::hscrollbarVisible)
         {
-            draw_hscroll(context, window, this, flags, colour, enabled, disabled, activated, hovered, scrollview_index);
+            draw_hscroll(rt, window, this, flags, colour, enabled, disabled, activated, hovered, scrollview_index);
             b -= 11;
         }
 
         if (scroll_area->flags & Ui::ScrollView::ScrollFlags::vscrollbarVisible)
         {
-            draw_vscroll(context, window, this, flags, colour, enabled, disabled, activated, hovered, scrollview_index);
+            draw_vscroll(rt, window, this, flags, colour, enabled, disabled, activated, hovered, scrollview_index);
             r -= 11;
         }
 
-        Gfx::Context cropped = *context;
+        Gfx::RenderTarget cropped = *rt;
         b++;
         r++;
 
@@ -854,12 +854,12 @@ namespace OpenLoco::Ui
     }
 
     // 0x004CB00B
-    void Widget::draw_27_checkbox(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
+    void Widget::draw_27_checkbox(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
     {
         if (enabled)
         {
             Gfx::fillRectInset(
-                *context,
+                *rt,
                 window->x + left,
                 window->y + top,
                 window->x + left + 9,
@@ -871,12 +871,12 @@ namespace OpenLoco::Ui
         if (activated)
         {
             Gfx::setCurrentFontSpriteBase(Font::medium_bold);
-            Gfx::drawString(*context, window->x + left, window->y + top, colour.opaque(), _strCheckmark);
+            Gfx::drawString(*rt, window->x + left, window->y + top, colour.opaque(), _strCheckmark);
         }
     }
 
     // 0x004CB080
-    void Widget::draw_27_label(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool disabled)
+    void Widget::draw_27_label(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool disabled)
     {
         if (content == kContentNull)
         {
@@ -890,20 +890,20 @@ namespace OpenLoco::Ui
             colour = colour.inset();
         }
 
-        Gfx::drawStringLeft(*context, window->x + left + 14, window->y + top, colour, text, _commonFormatArgs);
+        Gfx::drawStringLeft(*rt, window->x + left + 14, window->y + top, colour, text, _commonFormatArgs);
     }
 
     // 0x004CA679
-    void Widget::draw_29(Gfx::Context* context, const Window* window)
+    void Widget::draw_29(Gfx::RenderTarget* rt, const Window* window)
     {
         int l = window->x + left;
         int r = window->x + right;
         int t = window->y + top;
         int b = window->y + bottom;
-        Gfx::fillRect(*context, l, t, r, b, Colours::getShade(Colour::black, 5));
+        Gfx::fillRect(*rt, l, t, r, b, Colours::getShade(Colour::black, 5));
     }
 
-    void Widget::drawGroupbox(Gfx::Context* const context, const Window* window)
+    void Widget::drawGroupbox(Gfx::RenderTarget* const rt, const Window* window)
     {
         const auto colour = window->getColour(windowColour).opaque();
         int32_t l = window->x + left + 5;
@@ -918,7 +918,7 @@ namespace OpenLoco::Ui
             char buffer[512] = { 0 };
             StringManager::formatString(buffer, sizeof(buffer), text);
 
-            Gfx::drawString(*context, l, t, colour, buffer);
+            Gfx::drawString(*rt, l, t, colour, buffer);
             textEndPos = l + Gfx::getStringWidth(buffer) + 1;
         }
 
@@ -929,28 +929,28 @@ namespace OpenLoco::Ui
         b = window->y + bottom;
 
         // Border left of text
-        Gfx::fillRect(*context, l, t, l + 4, t, Colours::getShade(colour.c(), 4));
-        Gfx::fillRect(*context, l + 1, t + 1, l + 4, t + 1, Colours::getShade(colour.c(), 7));
+        Gfx::fillRect(*rt, l, t, l + 4, t, Colours::getShade(colour.c(), 4));
+        Gfx::fillRect(*rt, l + 1, t + 1, l + 4, t + 1, Colours::getShade(colour.c(), 7));
 
         // Border right of text
-        Gfx::fillRect(*context, textEndPos, t, r - 1, t, Colours::getShade(colour.c(), 4));
-        Gfx::fillRect(*context, textEndPos, t + 1, r - 2, t + 1, Colours::getShade(colour.c(), 7));
+        Gfx::fillRect(*rt, textEndPos, t, r - 1, t, Colours::getShade(colour.c(), 4));
+        Gfx::fillRect(*rt, textEndPos, t + 1, r - 2, t + 1, Colours::getShade(colour.c(), 7));
 
         // Border right
-        Gfx::fillRect(*context, r - 1, t + 1, r - 1, b - 1, Colours::getShade(colour.c(), 4));
-        Gfx::fillRect(*context, r, t, r, b, Colours::getShade(colour.c(), 7));
+        Gfx::fillRect(*rt, r - 1, t + 1, r - 1, b - 1, Colours::getShade(colour.c(), 4));
+        Gfx::fillRect(*rt, r, t, r, b, Colours::getShade(colour.c(), 7));
 
         // Border bottom
-        Gfx::fillRect(*context, l, b - 1, r - 2, b - 1, Colours::getShade(colour.c(), 4));
-        Gfx::fillRect(*context, l, b, r - 1, b, Colours::getShade(colour.c(), 7));
+        Gfx::fillRect(*rt, l, b - 1, r - 2, b - 1, Colours::getShade(colour.c(), 4));
+        Gfx::fillRect(*rt, l, b, r - 1, b, Colours::getShade(colour.c(), 7));
 
         // Border left
-        Gfx::fillRect(*context, l, t + 1, l, b - 2, Colours::getShade(colour.c(), 4));
-        Gfx::fillRect(*context, l + 1, t + 2, l + 1, b - 2, Colours::getShade(colour.c(), 7));
+        Gfx::fillRect(*rt, l, t + 1, l, b - 2, Colours::getShade(colour.c(), 4));
+        Gfx::fillRect(*rt, l + 1, t + 2, l + 1, b - 2, Colours::getShade(colour.c(), 7));
     }
 
     // 0x004CF194
-    void Widget::drawTab(Window* w, Gfx::Context* ctx, int32_t imageId, WidgetIndex_t index)
+    void Widget::drawTab(Window* w, Gfx::RenderTarget* rt, int32_t imageId, WidgetIndex_t index)
     {
         auto widget = &w->widgets[index];
 
@@ -982,18 +982,18 @@ namespace OpenLoco::Ui
         {
             if (imageId != kContentUnk)
             {
-                Gfx::drawImage(ctx, pos.x, pos.y, imageId);
+                Gfx::drawImage(rt, pos.x, pos.y, imageId);
             }
         }
         else
         {
             if (imageId != kContentUnk)
             {
-                Gfx::drawImage(ctx, pos.x, pos.y + 1, imageId);
+                Gfx::drawImage(rt, pos.x, pos.y + 1, imageId);
             }
 
-            Gfx::drawImage(ctx, pos.x, pos.y, Gfx::recolourTranslucent(ImageIds::tab, ExtColour::unk33));
-            Gfx::drawRect(*ctx, pos.x, pos.y + 26, 31, 1, Colours::getShade(w->getColour(WindowColour::secondary).c(), 7));
+            Gfx::drawImage(rt, pos.x, pos.y, Gfx::recolourTranslucent(ImageIds::tab, ExtColour::unk33));
+            Gfx::drawRect(*rt, pos.x, pos.y + 26, 31, 1, Colours::getShade(w->getColour(WindowColour::secondary).c(), 7));
         }
     }
 

--- a/src/OpenLoco/Widget.h
+++ b/src/OpenLoco/Widget.h
@@ -37,39 +37,39 @@ namespace OpenLoco::Ui
         uint16_t width() const;
         uint16_t height() const;
 
-        static void drawViewportCentreButton(Gfx::Context* context, const Window* window, const WidgetIndex_t widgetIndex);
-        static void drawTab(Window* w, Gfx::Context* ctx, int32_t imageId, WidgetIndex_t index);
+        static void drawViewportCentreButton(Gfx::RenderTarget* rt, const Window* window, const WidgetIndex_t widgetIndex);
+        static void drawTab(Window* w, Gfx::RenderTarget* ctx, int32_t imageId, WidgetIndex_t index);
 
         // typical tab width, to be used in most (all?) cases
         static constexpr uint16_t kDefaultTabWidth = 30;
         static void leftAlignTabs(Window& window, uint8_t firstTabIndex, uint8_t lastTabIndex, uint16_t tabWidth = kDefaultTabWidth);
 
-        void draw(Gfx::Context* context, Window* window, const uint64_t pressedWidgets, const uint64_t toolWidgets, const uint64_t hoveredWidgets, uint8_t& scrollviewIndex);
+        void draw(Gfx::RenderTarget* rt, Window* window, const uint64_t pressedWidgets, const uint64_t toolWidgets, const uint64_t hoveredWidgets, uint8_t& scrollviewIndex);
 
     private:
-        void sub_4CADE8(Gfx::Context* context, const Window* window, AdvancedColour colour, bool enabled, bool disabled, bool activated);
+        void sub_4CADE8(Gfx::RenderTarget* rt, const Window* window, AdvancedColour colour, bool enabled, bool disabled, bool activated);
 
-        void drawPanel(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour);
-        void drawFrame(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour);
+        void drawPanel(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour);
+        void drawFrame(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour);
 
-        void draw_3(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated);
-        void drawTab(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated);
-        void drawButtonWithImage(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered);
-        void drawButtonWithColour(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered);
-        void drawButton(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated);
-        void draw_13(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated);
-        void draw_15(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool disabled);
-        void drawTextBox(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour);
-        void draw_22_caption(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour);
-        void draw_23_caption(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour);
-        void draw_24_caption(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour);
-        void draw_25_caption(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour);
-        void drawScrollview(Gfx::Context* context, Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered, int scrollview_index);
-        void draw_27_checkbox(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated);
-        void draw_27_label(Gfx::Context* context, const Window* window, uint16_t flags, AdvancedColour colour, bool disabled);
-        void draw_29(Gfx::Context* context, const Window* window);
+        void draw_3(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated);
+        void drawTab(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated);
+        void drawButtonWithImage(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered);
+        void drawButtonWithColour(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered);
+        void drawButton(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated);
+        void draw_13(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated);
+        void draw_15(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool disabled);
+        void drawTextBox(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour);
+        void draw_22_caption(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour);
+        void draw_23_caption(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour);
+        void draw_24_caption(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour);
+        void draw_25_caption(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour);
+        void drawScrollview(Gfx::RenderTarget* rt, Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered, int scrollview_index);
+        void draw_27_checkbox(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool enabled, bool disabled, bool activated);
+        void draw_27_label(Gfx::RenderTarget* rt, const Window* window, uint16_t flags, AdvancedColour colour, bool disabled);
+        void draw_29(Gfx::RenderTarget* rt, const Window* window);
 
-        void drawGroupbox(Gfx::Context* const context, const Window* window);
+        void drawGroupbox(Gfx::RenderTarget* const rt, const Window* window);
     };
 #pragma pack(pop)
     static_assert(sizeof(Widget) == 0x10);

--- a/src/OpenLoco/Window.cpp
+++ b/src/OpenLoco/Window.cpp
@@ -109,13 +109,13 @@ namespace OpenLoco::Ui
     }
 
     // 0x0045A0B3
-    void Window::drawViewports(Gfx::Context* context)
+    void Window::drawViewports(Gfx::RenderTarget* rt)
     {
         if (viewports[0] != nullptr)
-            viewports[0]->render(context);
+            viewports[0]->render(rt);
 
         if (viewports[1] != nullptr)
-            viewports[1]->render(context);
+            viewports[1]->render(rt);
     }
 
     // 0x0045FCE6
@@ -1381,7 +1381,7 @@ namespace OpenLoco::Ui
         eventHandlers->prepareDraw(*this);
     }
 
-    void Window::callDraw(Gfx::Context* context)
+    void Window::callDraw(Gfx::RenderTarget* rt)
     {
         if (eventHandlers->draw == nullptr)
             return;
@@ -1390,15 +1390,15 @@ namespace OpenLoco::Ui
         {
             registers regs;
             regs.esi = X86Pointer(this);
-            regs.edi = X86Pointer(context);
+            regs.edi = X86Pointer(rt);
             call((int32_t)this->eventHandlers->draw, regs);
             return;
         }
 
-        eventHandlers->draw(*this, context);
+        eventHandlers->draw(*this, rt);
     }
 
-    void Window::callDrawScroll(Gfx::Context* context, uint32_t scrollIndex)
+    void Window::callDrawScroll(Gfx::RenderTarget* rt, uint32_t scrollIndex)
     {
         if (eventHandlers->drawScroll == nullptr)
             return;
@@ -1408,20 +1408,20 @@ namespace OpenLoco::Ui
             registers regs;
             regs.ax = scrollIndex;
             regs.esi = X86Pointer(this);
-            regs.edi = X86Pointer(context);
+            regs.edi = X86Pointer(rt);
             call((int32_t)eventHandlers->drawScroll, regs);
             return;
         }
 
-        eventHandlers->drawScroll(*this, *context, scrollIndex);
+        eventHandlers->drawScroll(*this, *rt, scrollIndex);
     }
 
     // 0x004CA4DF
-    void Window::draw(Gfx::Context* context)
+    void Window::draw(Gfx::RenderTarget* rt)
     {
         if ((this->flags & WindowFlags::transparent) && !(this->flags & WindowFlags::noBackground))
         {
-            Gfx::fillRect(*context, this->x, this->y, this->x + this->width - 1, this->y + this->height - 1, 0x2000000 | 52);
+            Gfx::fillRect(*rt, this->x, this->y, this->x + this->width - 1, this->y + this->height - 1, 0x2000000 | 52);
         }
 
         uint64_t pressed_widget = 0;
@@ -1456,13 +1456,13 @@ namespace OpenLoco::Ui
                 break;
             }
 
-            widget->draw(context, this, pressed_widget, tool_widget, hovered_widget, scrollviewIndex);
+            widget->draw(rt, this, pressed_widget, tool_widget, hovered_widget, scrollviewIndex);
         }
 
         if (this->flags & WindowFlags::whiteBorderMask)
         {
             Gfx::fillRectInset(
-                *context,
+                *rt,
                 this->x,
                 this->y,
                 this->x + this->width - 1,

--- a/src/OpenLoco/Window.h
+++ b/src/OpenLoco/Window.h
@@ -150,8 +150,8 @@ namespace OpenLoco::Ui
                 Ui::CursorId (*cursor)(Window&, int16_t, int16_t, int16_t, Ui::CursorId);
                 void (*onMove)(Window&, const int16_t x, const int16_t y);
                 void (*prepareDraw)(Window&);
-                void (*draw)(Window&, Gfx::Context*);
-                void (*drawScroll)(Window&, Gfx::Context&, const uint32_t scrollIndex);
+                void (*draw)(Window&, Gfx::RenderTarget*);
+                void (*drawScroll)(Window&, Gfx::RenderTarget&, const uint32_t scrollIndex);
             };
         };
 
@@ -385,7 +385,7 @@ namespace OpenLoco::Ui
         void initScrollWidgets();
         int8_t getScrollDataIndex(WidgetIndex_t index);
         void setDisabledWidgetsAndInvalidate(uint32_t _disabled_widgets);
-        void drawViewports(Gfx::Context* context);
+        void drawViewports(Gfx::RenderTarget* rt);
         void viewportCentreMain();
         void viewportSetUndergroundFlag(bool underground, Ui::Viewport* vp);
         void viewportGetMapCoordsByCursor(int16_t* map_x, int16_t* map_y, int16_t* offset_x, int16_t* offset_y);
@@ -407,7 +407,7 @@ namespace OpenLoco::Ui
         void moveInsideScreenEdges();
         bool moveToCentre();
         WidgetIndex_t findWidgetAt(int16_t xPos, int16_t yPos);
-        void draw(OpenLoco::Gfx::Context* context);
+        void draw(OpenLoco::Gfx::RenderTarget* rt);
 
         void callClose();                                                                              // 0
         void callOnMouseUp(WidgetIndex_t widgetIndex);                                                 // 1
@@ -435,8 +435,8 @@ namespace OpenLoco::Ui
         Ui::CursorId callCursor(int16_t widgetIdx, int16_t xPos, int16_t yPos, Ui::CursorId fallback); // 24
         void callOnMove(int16_t xPos, int16_t yPos);                                                   // 25
         void callPrepareDraw();                                                                        // 26
-        void callDraw(Gfx::Context* context);                                                          // 27
-        void callDrawScroll(Gfx::Context* context, uint32_t scrollIndex);                              // 28
+        void callDraw(Gfx::RenderTarget* rt);                                                          // 27
+        void callDrawScroll(Gfx::RenderTarget* rt, uint32_t scrollIndex);                              // 28
 
         WidgetIndex_t firstActivatedWidgetInRange(WidgetIndex_t minIndex, WidgetIndex_t maxIndex);
         WidgetIndex_t prevAvailableWidgetInRange(WidgetIndex_t minIndex, WidgetIndex_t maxIndex);

--- a/src/OpenLoco/Windows/About.cpp
+++ b/src/OpenLoco/Windows/About.cpp
@@ -75,46 +75,46 @@ namespace OpenLoco::Ui::Windows::About
     }
 
     // 0x0043B2E4
-    static void draw(Ui::Window& window, Gfx::Context* const context)
+    static void draw(Ui::Window& window, Gfx::RenderTarget* const rt)
     {
         // Draw widgets.
-        window.draw(context);
+        window.draw(rt);
 
         const int16_t x = window.x + windowSize.width / 2;
         int16_t y = window.y + 25;
 
-        drawStringCentred(*context, x, y, Colour::black, StringIds::about_locomotion_69, nullptr);
+        drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_69, nullptr);
 
         y += 10;
-        drawStringCentred(*context, x, y, Colour::black, StringIds::about_locomotion_70, nullptr);
+        drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_70, nullptr);
 
         // Chris Sawyer logo
-        drawImage(context, window.x + 92, window.y + 52, ImageIds::chris_sawyer_logo_small);
+        drawImage(rt, window.x + 92, window.y + 52, ImageIds::chris_sawyer_logo_small);
 
         y += 79;
-        drawStringCentred(*context, x, y, Colour::black, StringIds::about_locomotion_71, nullptr);
+        drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_71, nullptr);
 
         y += 10;
-        drawStringCentred(*context, x, y, Colour::black, StringIds::about_locomotion_72, nullptr);
+        drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_72, nullptr);
 
         y += 10;
-        drawStringCentred(*context, x, y, Colour::black, StringIds::about_locomotion_73, nullptr);
+        drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_73, nullptr);
 
         y += 10;
-        drawStringCentred(*context, x, y, Colour::black, StringIds::about_locomotion_74, nullptr);
+        drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_74, nullptr);
 
         y += 13;
-        drawStringCentred(*context, x, y, Colour::black, StringIds::about_locomotion_75, nullptr);
+        drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_75, nullptr);
 
         y += 25;
-        drawStringCentred(*context, x, y, Colour::black, StringIds::about_locomotion_76, nullptr);
+        drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_76, nullptr);
 
         y += 10;
-        drawStringCentred(*context, x, y, Colour::black, StringIds::about_locomotion_77, nullptr);
+        drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_77, nullptr);
 
         // Licenced to Atari
         y += 25;
-        drawStringCentred(*context, x, y, Colour::black, StringIds::licenced_to_atari_inc, nullptr);
+        drawStringCentred(*rt, x, y, Colour::black, StringIds::licenced_to_atari_inc, nullptr);
     }
 
     static void initEvents()

--- a/src/OpenLoco/Windows/AboutMusic.cpp
+++ b/src/OpenLoco/Windows/AboutMusic.cpp
@@ -91,14 +91,14 @@ namespace OpenLoco::Ui::Windows::AboutMusic
     }
 
     // 0x0043B8B8
-    static void draw(Ui::Window& window, Gfx::Context* const context)
+    static void draw(Ui::Window& window, Gfx::RenderTarget* const rt)
     {
         // Draw widgets.
-        window.draw(context);
+        window.draw(rt);
     }
 
     // 0x0043B8BE
-    static void drawScroll(Ui::Window&, Gfx::Context& context, const uint32_t)
+    static void drawScroll(Ui::Window&, Gfx::RenderTarget& rt, const uint32_t)
     {
         static const std::pair<string_id, string_id> stringsToDraw[numSongs] = {
             { StringIds::locomotion_title, StringIds::locomotion_title_credit },
@@ -142,15 +142,15 @@ namespace OpenLoco::Ui::Windows::AboutMusic
             // TODO: optimisation: don't draw past fold.
 
             // Song name
-            drawStringCentred(context, x, y, Colour::black, songStrings.first, nullptr);
+            drawStringCentred(rt, x, y, Colour::black, songStrings.first, nullptr);
             y += 10;
 
             // Credit line
-            drawStringCentred(context, x, y, Colour::black, songStrings.second, nullptr);
+            drawStringCentred(rt, x, y, Colour::black, songStrings.second, nullptr);
             y += 10;
 
             // Show CS' copyright after every two lines.
-            drawStringCentred(context, x, y, Colour::black, StringIds::music_copyright, nullptr);
+            drawStringCentred(rt, x, y, Colour::black, StringIds::music_copyright, nullptr);
             y += 14;
         }
     }

--- a/src/OpenLoco/Windows/Cheats.cpp
+++ b/src/OpenLoco/Windows/Cheats.cpp
@@ -52,7 +52,7 @@ namespace OpenLoco::Ui::Windows::Cheats
 
         constexpr uint64_t enabledWidgets = (1 << Widx::close_button) | (1 << Widx::tab_finances) | (1 << Widx::tab_companies) | (1 << Widx::tab_vehicles) | (1 << Widx::tab_towns);
 
-        static void drawTabs(Ui::Window* const self, Gfx::Context* const context)
+        static void drawTabs(Ui::Window* const self, Gfx::RenderTarget* const rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
@@ -83,13 +83,13 @@ namespace OpenLoco::Ui::Windows::Cheats
                 else
                     imageId += financesTabImageIds[0];
 
-                Widget::drawTab(self, context, imageId, Widx::tab_finances);
+                Widget::drawTab(self, rt, imageId, Widx::tab_finances);
             }
 
             // Companies tab
             {
                 const uint32_t imageId = skin->img + InterfaceSkin::ImageIds::tab_company;
-                Widget::drawTab(self, context, imageId, Widx::tab_companies);
+                Widget::drawTab(self, rt, imageId, Widx::tab_companies);
             }
 
             // Vehicles tab
@@ -116,13 +116,13 @@ namespace OpenLoco::Ui::Windows::Cheats
 
                 imageId = Gfx::recolour(imageId, companyColour);
 
-                Widget::drawTab(self, context, imageId, Widx::tab_vehicles);
+                Widget::drawTab(self, rt, imageId, Widx::tab_vehicles);
             }
 
             // Towns tab
             {
                 const uint32_t imageId = skin->img + InterfaceSkin::ImageIds::toolbar_menu_towns;
-                Widget::drawTab(self, context, imageId, Widx::tab_towns);
+                Widget::drawTab(self, rt, imageId, Widx::tab_towns);
             }
         }
 
@@ -212,17 +212,17 @@ namespace OpenLoco::Ui::Windows::Cheats
             self.activatedWidgets = (1 << Common::Widx::tab_finances);
         }
 
-        static void draw(Ui::Window& self, Gfx::Context* const context)
+        static void draw(Ui::Window& self, Gfx::RenderTarget* const rt)
         {
             // Draw widgets and tabs.
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             // Add cash step label and value
             {
                 auto& widget = self.widgets[Widx::cash_step_value];
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + 10,
                     self.y + widget.top,
                     Colour::black,
@@ -231,7 +231,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                 auto args = FormatArguments::common();
                 args.push(_cashIncreaseStep);
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + widget.left + 1,
                     self.y + widget.top,
                     Colour::black,
@@ -243,7 +243,7 @@ namespace OpenLoco::Ui::Windows::Cheats
             {
                 auto& widget = self.widgets[Widx::loan_value];
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + 10,
                     self.y + widget.top,
                     Colour::black,
@@ -254,7 +254,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                 args.push(company->currentLoan);
 
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + widget.left + 1,
                     self.y + widget.top,
                     Colour::black,
@@ -266,7 +266,7 @@ namespace OpenLoco::Ui::Windows::Cheats
             {
                 auto& widget = self.widgets[Widx::year_step_value];
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + 10,
                     self.y + widget.top,
                     Colour::black,
@@ -275,7 +275,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                 auto args = FormatArguments::common();
                 args.push(_date.year);
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + widget.left + 1,
                     self.y + widget.top,
                     Colour::black,
@@ -287,7 +287,7 @@ namespace OpenLoco::Ui::Windows::Cheats
             {
                 auto& widget = self.widgets[Widx::month_step_value];
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + 10,
                     self.y + widget.top,
                     Colour::black,
@@ -296,7 +296,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                 auto args = FormatArguments::common();
                 args.push((string_id)OpenLoco::StringManager::monthToString(_date.month).second);
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + widget.left + 1,
                     self.y + widget.top,
                     Colour::black,
@@ -308,7 +308,7 @@ namespace OpenLoco::Ui::Windows::Cheats
             {
                 auto& widget = self.widgets[Widx::day_step_value];
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + 10,
                     self.y + widget.top,
                     Colour::black,
@@ -317,7 +317,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                 auto args = FormatArguments::common();
                 args.push(_date.day + 1); // +1 since days in game are 0-based, but IRL they are 1-based
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + widget.left + 1,
                     self.y + widget.top,
                     Colour::black,
@@ -503,17 +503,17 @@ namespace OpenLoco::Ui::Windows::Cheats
             }
         }
 
-        static void draw(Ui::Window& self, Gfx::Context* const context)
+        static void draw(Ui::Window& self, Gfx::RenderTarget* const rt)
         {
             // Draw widgets and tabs.
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             // Draw current company name
             auto company = CompanyManager::get(_targetCompanyId);
             auto& widget = self.widgets[Widx::target_company_dropdown];
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 self.x + widget.left,
                 self.y + widget.top,
                 Colour::black,
@@ -659,11 +659,11 @@ namespace OpenLoco::Ui::Windows::Cheats
             }
         }
 
-        static void draw(Ui::Window& self, Gfx::Context* const context)
+        static void draw(Ui::Window& self, Gfx::RenderTarget* const rt)
         {
             // Draw widgets and tabs.
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
         }
 
         static void onMouseUp(Ui::Window& self, const WidgetIndex_t widgetIndex)
@@ -778,11 +778,11 @@ namespace OpenLoco::Ui::Windows::Cheats
             self.activatedWidgets = (1 << Common::Widx::tab_towns);
         }
 
-        static void draw(Ui::Window& self, Gfx::Context* const context)
+        static void draw(Ui::Window& self, Gfx::RenderTarget* const rt)
         {
             // Draw widgets and tabs.
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
         }
 
         static void onMouseUp(Ui::Window& self, const WidgetIndex_t widgetIndex)

--- a/src/OpenLoco/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/Windows/CompanyFaceSelection.cpp
@@ -210,9 +210,9 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x435003
-    static void draw(Window& self, Gfx::Context* const context)
+    static void draw(Window& self, Gfx::RenderTarget* const rt)
     {
-        self.draw(context);
+        self.draw(rt);
         if (self.rowHover == -1)
         {
             return;
@@ -224,11 +224,11 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
             const auto t = self.y + 1 + self.widgets[widx::face_frame].top;
             const auto r = self.x - 1 + self.widgets[widx::face_frame].right;
             const auto b = self.y - 1 + self.widgets[widx::face_frame].bottom;
-            Gfx::fillRect(*context, l, t, r, b, colour);
+            Gfx::fillRect(*rt, l, t, r, b, colour);
 
             const CompetitorObject* competitor = _loadedObject;
             uint32_t img = competitor->images[0] + 1 + (1 << 29);
-            Gfx::drawImage(context, l, t, img);
+            Gfx::drawImage(rt, l, t, img);
         }
 
         {
@@ -239,7 +239,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
             *str++ = ControlCodes::window_colour_2;
             auto objectPtr = self.object;
             strcpy(str, ObjectManager::ObjectIndexEntry::read(&objectPtr)._name);
-            Gfx::drawStringCentredClipped(*context, x, y, width, Colour::black, StringIds::buffer_2039);
+            Gfx::drawStringCentredClipped(*rt, x, y, width, Colour::black, StringIds::buffer_2039);
         }
 
         // There was code for displaying competitor stats if window opened with none
@@ -247,9 +247,9 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x00435152
-    static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
+    static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
     {
-        Gfx::clearSingle(context, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
+        Gfx::clearSingle(rt, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
 
         auto index = 0;
         for (const auto& object : ObjectManager::getAvailableObjects(ObjectType::competitor))
@@ -260,7 +260,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
             if (index == self.rowHover)
             {
                 inlineColour = ControlCodes::window_colour_2;
-                Gfx::fillRect(context, 0, y, self.width, y + 9, 0x2000000 | 48);
+                Gfx::fillRect(rt, 0, y, self.width, y + 9, 0x2000000 | 48);
             }
 
             std::string name(object.second._name);
@@ -273,7 +273,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
                 Gfx::setCurrentFontSpriteBase(Font::m1);
                 stringColour = self.getColour(WindowColour::secondary).opaque().inset();
             }
-            Gfx::drawString(context, 0, y - 1, stringColour, const_cast<char*>(name.c_str()));
+            Gfx::drawString(rt, 0, y - 1, stringColour, const_cast<char*>(name.c_str()));
 
             index++;
         }

--- a/src/OpenLoco/Windows/CompanyList.cpp
+++ b/src/OpenLoco/Windows/CompanyList.cpp
@@ -92,9 +92,9 @@ namespace OpenLoco::Ui::Windows::CompanyList
         static void prepareDraw(Window& self);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
         static void refreshCompanyList(Window* self);
-        static void drawTabs(Window* self, Gfx::Context* context);
-        static void drawGraph(Window* self, Gfx::Context* context);
-        static void drawGraphAndLegend(Window* self, Gfx::Context* context);
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt);
+        static void drawGraph(Window* self, Gfx::RenderTarget* rt);
+        static void drawGraphAndLegend(Window* self, Gfx::RenderTarget* rt);
         static void initEvents();
     }
 
@@ -431,10 +431,10 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00435E56
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             auto args = FormatArguments();
             if (self.var_83C == 1)
@@ -446,24 +446,24 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             auto xPos = self.x + 3;
             auto yPos = self.y + self.height - 13;
-            Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::black_stringid, &args);
+            Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x00435EA7
-        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
         {
             auto colour = Colours::getShade(self.getColour(WindowColour::secondary).c(), 3);
-            Gfx::clearSingle(context, colour);
+            Gfx::clearSingle(rt, colour);
 
             auto yBottom = 0;
             for (auto i = 0; i < self.var_83C; i++, yBottom += 25)
             {
                 auto yTop = yBottom + 25;
 
-                if (yTop <= context.y)
+                if (yTop <= rt.y)
                     continue;
 
-                yTop = context.y + context.height;
+                yTop = rt.y + rt.height;
 
                 if (yBottom >= yTop)
                     continue;
@@ -477,7 +477,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 if (rowItem == self.rowHover)
                 {
-                    Gfx::drawRect(context, 0, yBottom, self.width, 24, (1 << 25) | PaletteIndex::index_30);
+                    Gfx::drawRect(rt, 0, yBottom, self.width, 24, (1 << 25) | PaletteIndex::index_30);
 
                     stringId = StringIds::wcolour2_stringid;
                 }
@@ -492,7 +492,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     args.push(imageId);
                     args.push(company->name);
 
-                    Gfx::drawStringLeftClipped(context, 0, yBottom - 1, 173, Colour::black, stringId, &args);
+                    Gfx::drawStringLeftClipped(rt, 0, yBottom - 1, 173, Colour::black, stringId, &args);
                 }
 
                 {
@@ -502,7 +502,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     args.rewind();
                     args.push(ownerStatus);
 
-                    Gfx::drawStringLeftClipped(context, 175, yBottom + 7, 208, Colour::black, stringId, &args);
+                    Gfx::drawStringLeftClipped(rt, 175, yBottom + 7, 208, Colour::black, stringId, &args);
                 }
 
                 auto performanceStringId = StringIds::performance_index;
@@ -523,7 +523,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     args.push(performanceStringId);
                     formatPerformanceIndex(company->performanceIndex, args);
 
-                    Gfx::drawStringLeftClipped(context, 385, yBottom - 1, 143, Colour::black, stringId, &args);
+                    Gfx::drawStringLeftClipped(rt, 385, yBottom - 1, 143, Colour::black, stringId, &args);
                 }
 
                 {
@@ -532,7 +532,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     args.push(StringIds::company_value_currency);
                     args.push(company->companyValueHistory[0]);
 
-                    Gfx::drawStringLeftClipped(context, 530, yBottom - 1, 98, Colour::black, stringId, &args);
+                    Gfx::drawStringLeftClipped(rt, 530, yBottom - 1, 98, Colour::black, stringId, &args);
                 }
             }
         }
@@ -652,10 +652,10 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00436490
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             _graphLeft = self.x + 4;
             _graphTop = self.y + self.widgets[Common::widx::panel].top + 4;
@@ -699,7 +699,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _dword_113DD8A = 100;
             _dword_113DD8E = 2;
 
-            Common::drawGraphAndLegend(&self, context);
+            Common::drawGraphAndLegend(&self, rt);
         }
 
         // 0x004361D8
@@ -743,10 +743,10 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x004367B4
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             _graphLeft = self.x + 4;
             _graphTop = self.y + self.widgets[Common::widx::panel].top + 4;
@@ -790,7 +790,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _dword_113DD8A = 1000;
             _dword_113DD8E = 2;
 
-            Common::drawGraphAndLegend(&self, context);
+            Common::drawGraphAndLegend(&self, rt);
         }
 
         // 0x00436201
@@ -834,10 +834,10 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00436AD8
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             _graphLeft = self.x + 4;
             _graphTop = self.y + self.widgets[Common::widx::panel].top + 4;
@@ -881,7 +881,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _dword_113DD8A = 1000;
             _dword_113DD8E = 2;
 
-            Common::drawGraphAndLegend(&self, context);
+            Common::drawGraphAndLegend(&self, rt);
         }
 
         // 0x00436227
@@ -925,10 +925,10 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00436DFC
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             _graphLeft = self.x + 4;
             _graphTop = self.y + self.widgets[Common::widx::panel].top + 4;
@@ -972,7 +972,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _dword_113DD8A = 10000;
             _dword_113DD8E = 2;
 
-            Common::drawGraphAndLegend(&self, context);
+            Common::drawGraphAndLegend(&self, rt);
         }
 
         // 0x0043624D
@@ -1016,7 +1016,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00437949
-        static void drawGraphLegend(Window* self, Gfx::Context* context, int16_t x, int16_t y)
+        static void drawGraphLegend(Window* self, Gfx::RenderTarget* rt, int16_t x, int16_t y)
         {
             auto cargoCount = 0;
             for (uint8_t i = 0; i < ObjectManager::getMaxObjects(ObjectType::cargo); i++)
@@ -1036,13 +1036,13 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 if (!(self->var_854 & (1 << cargoCount)) || !(_word_9C68C7 & (1 << 2)))
                 {
-                    Gfx::fillRect(*context, x, y + 3, x + 4, y + 7, palette);
+                    Gfx::fillRect(*rt, x, y + 3, x + 4, y + 7, palette);
                 }
 
                 auto args = FormatArguments();
                 args.push(cargo->name);
 
-                Gfx::drawStringLeftClipped(*context, x + 6, y, 94, Colour::black, stringId, &args);
+                Gfx::drawStringLeftClipped(*rt, x + 6, y, 94, Colour::black, stringId, &args);
 
                 y += 10;
                 cargoCount++;
@@ -1050,10 +1050,10 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00437120
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             _graphLeft = self.x + 4;
             _graphTop = self.y + self.widgets[Common::widx::panel].top + 14;
@@ -1095,7 +1095,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _dword_113DD7C = 2;
             _byte_113DD99 = 1;
 
-            Common::drawGraph(&self, context);
+            Common::drawGraph(&self, rt);
 
             if (self.var_854 != 0)
             {
@@ -1112,13 +1112,13 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 _dword_113DD8E = _dword_113DD8E | (1 << 2);
 
-                Common::drawGraph(&self, context);
+                Common::drawGraph(&self, rt);
             }
 
             auto x = self.width + self.x - 104;
             auto y = self.y + 52;
 
-            drawGraphLegend(&self, context, x, y);
+            drawGraphLegend(&self, rt, x, y);
 
             x = self.x + 8;
             y = self.widgets[Common::widx::panel].top + self.y + 1;
@@ -1127,12 +1127,12 @@ namespace OpenLoco::Ui::Windows::CompanyList
             args.push<uint16_t>(100);
             args.push<uint16_t>(10);
 
-            Gfx::drawStringLeft(*context, x, y, Colour::black, StringIds::cargo_deliver_graph_title, &args);
+            Gfx::drawStringLeft(*rt, x, y, Colour::black, StringIds::cargo_deliver_graph_title, &args);
 
             x = self.x + 160;
             y = self.height + self.y - 13;
 
-            Gfx::drawStringLeft(*context, x, y, Colour::black, StringIds::cargo_transit_time);
+            Gfx::drawStringLeft(*rt, x, y, Colour::black, StringIds::cargo_transit_time);
         }
 
         // 0x004379F2
@@ -1219,10 +1219,10 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x0043745A
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             auto y = self.y + 47;
 
@@ -1242,7 +1242,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     };
 
                     auto x = self.x + 4;
-                    Gfx::drawStringLeft(*context, x, y, Colour::black, string[i], &args);
+                    Gfx::drawStringLeft(*rt, x, y, Colour::black, string[i], &args);
                 }
                 y += 11;
 
@@ -1257,7 +1257,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     imageId = Gfx::recolour(imageId, company->mainColours.primary);
 
                     auto x = self.x + 4;
-                    Gfx::drawImage(context, x, y, imageId);
+                    Gfx::drawImage(rt, x, y, imageId);
 
                     x = self.x + 33;
                     y += 7;
@@ -1267,7 +1267,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     args.push<uint16_t>(0);
                     args.push(_dword_526258[i]);
 
-                    Gfx::drawStringLeft(*context, x, y, Colour::black, StringIds::record_date_achieved, &args);
+                    Gfx::drawStringLeft(*rt, x, y, Colour::black, StringIds::record_date_achieved, &args);
                     y += 17;
                 }
 
@@ -1472,7 +1472,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00437637
-        static void drawTabs(Window* self, Gfx::Context* context)
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
@@ -1481,7 +1481,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 uint32_t imageId = skin->img;
                 imageId += InterfaceSkin::ImageIds::tab_companies;
 
-                Widget::drawTab(self, context, imageId, widx::tab_company_list);
+                Widget::drawTab(self, rt, imageId, widx::tab_company_list);
             }
 
             // Performance Index Tab
@@ -1505,7 +1505,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 imageId = Gfx::recolour(imageId, self->getColour(WindowColour::secondary).c());
 
-                Widget::drawTab(self, context, imageId, widx::tab_performance);
+                Widget::drawTab(self, rt, imageId, widx::tab_performance);
             }
 
             // Cargo Unit Tab
@@ -1529,7 +1529,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 imageId = Gfx::recolour(imageId, self->getColour(WindowColour::secondary).c());
 
-                Widget::drawTab(self, context, imageId, widx::tab_cargo_units);
+                Widget::drawTab(self, rt, imageId, widx::tab_cargo_units);
             }
 
             // Cargo Distance Tab
@@ -1553,7 +1553,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 imageId = Gfx::recolour(imageId, self->getColour(WindowColour::secondary).c());
 
-                Widget::drawTab(self, context, imageId, widx::tab_cargo_distance);
+                Widget::drawTab(self, rt, imageId, widx::tab_cargo_distance);
             }
 
             // Company Values Tab
@@ -1577,13 +1577,13 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 imageId = Gfx::recolour(imageId, self->getColour(WindowColour::secondary).c());
 
-                Widget::drawTab(self, context, imageId, widx::tab_values);
+                Widget::drawTab(self, rt, imageId, widx::tab_values);
 
                 if (!(self->isDisabled(widx::tab_values)))
                 {
                     auto x = self->widgets[widx::tab_values].left + self->x + 28;
                     auto y = self->widgets[widx::tab_values].top + self->y + 14 + 1;
-                    Gfx::drawStringRight(*context, x, y, Colour::black, StringIds::currency_symbol);
+                    Gfx::drawStringRight(*rt, x, y, Colour::black, StringIds::currency_symbol);
                 }
             }
 
@@ -1593,13 +1593,13 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 uint32_t imageId = skin->img;
                 imageId += InterfaceSkin::ImageIds::tab_cargo_payment_rates;
 
-                Widget::drawTab(self, context, imageId, widx::tab_payment_rates);
+                Widget::drawTab(self, rt, imageId, widx::tab_payment_rates);
 
                 if (!(self->isDisabled(widx::tab_payment_rates)))
                 {
                     auto x = self->widgets[widx::tab_payment_rates].left + self->x + 28;
                     auto y = self->widgets[widx::tab_payment_rates].top + self->y + 14 + 1;
-                    Gfx::drawStringRight(*context, x, y, Colour::black, StringIds::currency_symbol);
+                    Gfx::drawStringRight(*rt, x, y, Colour::black, StringIds::currency_symbol);
                 }
             }
 
@@ -1610,7 +1610,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 imageId = Gfx::recolour(imageId, self->getColour(WindowColour::secondary).c());
 
-                Widget::drawTab(self, context, imageId, widx::tab_speed_records);
+                Widget::drawTab(self, rt, imageId, widx::tab_speed_records);
             }
         }
 
@@ -1626,16 +1626,16 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x004CF824
-        static void drawGraph(Window* self, Gfx::Context* context)
+        static void drawGraph(Window* self, Gfx::RenderTarget* rt)
         {
             registers regs;
             regs.esi = X86Pointer(self);
-            regs.edi = X86Pointer(context);
+            regs.edi = X86Pointer(rt);
             call(0x004CF824, regs);
         }
 
         // 0x00437810
-        static void drawGraphLegend(Window* self, Gfx::Context* context, int16_t x, int16_t y)
+        static void drawGraphLegend(Window* self, Gfx::RenderTarget* rt, int16_t x, int16_t y)
         {
             auto companyCount = 0;
             for (auto& company : CompanyManager::companies())
@@ -1651,13 +1651,13 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 if (!(self->var_854 & (1 << companyCount)) || !(_word_9C68C7 & (1 << 2)))
                 {
-                    Gfx::fillRect(*context, x, y + 3, x + 4, y + 7, colour);
+                    Gfx::fillRect(*rt, x, y + 3, x + 4, y + 7, colour);
                 }
 
                 auto args = FormatArguments();
                 args.push(company.name);
 
-                Gfx::drawStringLeftClipped(*context, x + 6, y, 94, Colour::black, stringId, &args);
+                Gfx::drawStringLeftClipped(*rt, x + 6, y, 94, Colour::black, stringId, &args);
 
                 y += 10;
                 companyCount++;
@@ -1665,7 +1665,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x004365E4
-        static void drawGraphAndLegend(Window* self, Gfx::Context* context)
+        static void drawGraphAndLegend(Window* self, Gfx::RenderTarget* rt)
         {
             auto totalMonths = (getCurrentYear() * 12) + static_cast<uint16_t>(getCurrentMonth());
 
@@ -1673,7 +1673,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _dword_113DD7C = 1;
             _byte_113DD99 = 1;
 
-            Common::drawGraph(self, context);
+            Common::drawGraph(self, rt);
 
             if (self->var_854 != 0)
             {
@@ -1691,13 +1691,13 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 _dword_113DD8E = _dword_113DD8E | (1 << 2);
 
-                Common::drawGraph(self, context);
+                Common::drawGraph(self, rt);
             }
 
             auto x = self->width + self->x - 104;
             auto y = self->y + 52;
 
-            Common::drawGraphLegend(self, context, x, y);
+            Common::drawGraphLegend(self, rt, x, y);
         }
         static void initEvents()
         {

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -92,8 +92,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void switchCompany(Window* self, int16_t itemIndex);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
         static void switchTabWidgets(Window* self);
-        static void drawCompanySelect(const Window* const self, Gfx::Context* const context);
-        static void drawTabs(Window* self, Gfx::Context* context);
+        static void drawCompanySelect(const Window* const self, Gfx::RenderTarget* const rt);
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt);
     }
 
     namespace Status
@@ -184,11 +184,11 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432055
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
-            Common::drawCompanySelect(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
+            Common::drawCompanySelect(&self, rt);
             const auto company = CompanyManager::get(CompanyId(self.number));
             const auto competitor = ObjectManager::get<CompetitorObject>(company->competitorId);
 
@@ -196,7 +196,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             {
                 auto& widget = self.widgets[widx::face];
                 Gfx::drawStringCentred(
-                    *context,
+                    *rt,
                     self.x + (widget.left + widget.right) / 2,
                     self.y + widget.top - 12,
                     Colour::black,
@@ -209,7 +209,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 const uint32_t image = Gfx::recolour(competitor->images[company->ownerEmotion] + 1, company->mainColours.primary);
                 const uint16_t x = self.x + self.widgets[widx::face].left + 1;
                 const uint16_t y = self.y + self.widgets[widx::face].top + 1;
-                Gfx::drawImage(context, x, y, image);
+                Gfx::drawImage(rt, x, y, image);
             }
 
             // If the owner's been naughty, draw some jail bars over them.
@@ -218,7 +218,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 const uint32_t image = ImageIds::owner_jailed;
                 const uint16_t x = self.x + self.widgets[widx::face].left + 1;
                 const uint16_t y = self.y + self.widgets[widx::face].top + 1;
-                Gfx::drawImage(context, x, y, image);
+                Gfx::drawImage(rt, x, y, image);
             }
 
             // Draw owner name
@@ -227,7 +227,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 auto& widget = self.widgets[widx::change_owner_name];
                 auto origin = Ui::Point(self.x + (widget.left + widget.right) / 2, self.y + widget.top + 5);
                 Gfx::drawStringCentredWrapped(
-                    *context,
+                    *rt,
                     origin,
                     widget.right - widget.left,
                     Colour::black,
@@ -248,7 +248,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
                 auto& widget = self.widgets[widx::unk_11];
                 Gfx::drawStringLeftClipped(
-                    *context,
+                    *rt,
                     self.x + widget.left - 1,
                     self.y + widget.top - 1,
                     widget.right - widget.left,
@@ -259,8 +259,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             if (self.viewports[0] != nullptr)
             {
-                self.drawViewports(context);
-                Widget::drawViewportCentreButton(context, &self, (WidgetIndex_t)widx::centre_on_viewport);
+                self.drawViewports(rt);
+                Widget::drawViewportCentreButton(rt, &self, (WidgetIndex_t)widx::centre_on_viewport);
             }
         }
 
@@ -714,28 +714,28 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             Widget::leftAlignTabs(self, Common::widx::tab_status, Common::widx::tab_challenge);
         }
 
-        static void drawAIdetails(Gfx::Context& context, const int32_t x, int32_t& y, const OpenLoco::Company& company)
+        static void drawAIdetails(Gfx::RenderTarget& rt, const int32_t x, int32_t& y, const OpenLoco::Company& company)
         {
             const auto competitor = ObjectManager::get<CompetitorObject>(company.competitorId);
             {
                 FormatArguments args{};
                 args.push<uint16_t>(competitor->intelligence);
                 args.push(aiRatingToLevel(competitor->intelligence));
-                Gfx::drawStringLeft(context, x, y, Colour::black, StringIds::company_details_intelligence, &args);
+                Gfx::drawStringLeft(rt, x, y, Colour::black, StringIds::company_details_intelligence, &args);
                 y += 10;
             }
             {
                 FormatArguments args{};
                 args.push<uint16_t>(competitor->aggressiveness);
                 args.push(aiRatingToLevel(competitor->aggressiveness));
-                Gfx::drawStringLeft(context, x, y, Colour::black, StringIds::company_details_aggressiveness, &args);
+                Gfx::drawStringLeft(rt, x, y, Colour::black, StringIds::company_details_aggressiveness, &args);
                 y += 10;
             }
             {
                 FormatArguments args{};
                 args.push<uint16_t>(competitor->competitiveness);
                 args.push(aiRatingToLevel(competitor->competitiveness));
-                Gfx::drawStringLeft(context, x, y, Colour::black, StringIds::company_details_competitiveness, &args);
+                Gfx::drawStringLeft(rt, x, y, Colour::black, StringIds::company_details_competitiveness, &args);
                 y += 10;
             }
         }
@@ -752,18 +752,18 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         };
 
         // 0x00432919
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
-            Common::drawCompanySelect(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
+            Common::drawCompanySelect(&self, rt);
 
             auto company = CompanyManager::get(CompanyId(self.number));
             auto x = self.x + 3;
             auto y = self.y + 48;
             {
                 auto args = FormatArguments::common(company->startedDate);
-                Gfx::drawStringLeft(*context, x, y, Colour::black, StringIds::company_details_started, &args);
+                Gfx::drawStringLeft(*rt, x, y, Colour::black, StringIds::company_details_started, &args);
                 y += 10;
             }
 
@@ -780,19 +780,19 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 {
                     formatId = StringIds::company_details_performance_increasing;
                 }
-                Gfx::drawStringLeft(*context, x, y, Colour::black, formatId, &args);
+                Gfx::drawStringLeft(*rt, x, y, Colour::black, formatId, &args);
                 y += 25;
             }
 
             {
                 auto args = FormatArguments::common(company->ownerName);
-                Gfx::drawStringLeftClipped(*context, x, y, 213, Colour::black, StringIds::owner_label, &args);
+                Gfx::drawStringLeftClipped(*rt, x, y, 213, Colour::black, StringIds::owner_label, &args);
                 y += 10;
             }
 
             if (!CompanyManager::isPlayerCompany(CompanyId(self.number)))
             {
-                drawAIdetails(*context, x + 5, y, *company);
+                drawAIdetails(*rt, x + 5, y, *company);
             }
             y += 5;
 
@@ -803,7 +803,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     if (count != 0)
                     {
                         auto args = FormatArguments::common(count);
-                        Gfx::drawStringLeft(*context, x, y, Colour::black, transportTypeCountString[i], &args);
+                        Gfx::drawStringLeft(*rt, x, y, Colour::black, transportTypeCountString[i], &args);
                         y += 10;
                     }
                 }
@@ -812,7 +812,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             {
                 x = self.x + (self.widgets[widx::viewport].left + self.widgets[widx::viewport].right) / 2;
                 y = self.y + self.widgets[widx::viewport].top - 12;
-                Gfx::drawStringCentred(*context, x, y, Colour::black, StringIds::wcolour2_headquarters);
+                Gfx::drawStringCentred(*rt, x, y, Colour::black, StringIds::wcolour2_headquarters);
             }
 
             if (company->headquartersX == -1)
@@ -823,13 +823,13 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     static_cast<int16_t>(self.y + self.widgets[widx::viewport].top + self.widgets[widx::viewport].height() / 2 - 5)
                 };
                 width -= 2;
-                Gfx::drawStringCentredWrapped(*context, loc, width, Colour::black, StringIds::not_yet_constructed);
+                Gfx::drawStringCentredWrapped(*rt, loc, width, Colour::black, StringIds::not_yet_constructed);
             }
 
             if (self.viewports[0] != nullptr)
             {
-                self.drawViewports(context);
-                Widget::drawViewportCentreButton(context, &self, widx::centre_on_viewport);
+                self.drawViewports(rt);
+                Widget::drawViewportCentreButton(rt, &self, widx::centre_on_viewport);
             }
         }
 
@@ -1340,11 +1340,11 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432F9A
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
-            Common::drawCompanySelect(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
+            Common::drawCompanySelect(&self, rt);
 
             const auto& widget = self.widgets[widx::main_colour_scheme];
             const uint16_t x = self.x + 6;
@@ -1352,7 +1352,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // 'Main colour scheme'
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 x,
                 y,
                 Colour::black,
@@ -1361,7 +1361,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             // 'Special colour schemes used for'
             y += 17;
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 x,
                 y,
                 Colour::black,
@@ -1659,18 +1659,18 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x004333D0
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
-            Common::drawCompanySelect(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
+            Common::drawCompanySelect(&self, rt);
 
             const auto company = CompanyManager::get(CompanyId(self.number));
 
             // Draw 'expenditure/income' label
             {
                 Gfx::drawStringLeftUnderline(
-                    *context,
+                    *rt,
                     self.x + 5,
                     self.y + 47,
                     Colour::black,
@@ -1705,12 +1705,12 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 if (i % 2 == 0)
                 {
                     auto colour = Colours::getShade(self.getColour(WindowColour::secondary).c(), 6) | 0x1000000;
-                    Gfx::fillRect(*context, self.x + 4, y, self.x + 129, y + 9, colour);
+                    Gfx::fillRect(*rt, self.x + 4, y, self.x + 129, y + 9, colour);
                 }
 
                 auto args = FormatArguments::common(ExpenditureLabels[i]);
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + 5,
                     y - 1,
                     Colour::black,
@@ -1723,7 +1723,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             // 'Current loan' label
             {
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + 7,
                     self.y + self.widgets[widx::currentLoan].top,
                     Colour::black,
@@ -1736,7 +1736,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 FormatArguments args{};
                 args.push<uint16_t>(loanInterestRate);
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + self.widgets[widx::currentLoan].right + 3,
                     self.y + self.widgets[widx::currentLoan].top + 1,
                     Colour::black,
@@ -1756,7 +1756,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     cash_format = StringIds::cash_negative;
 
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + 7,
                     self.y + self.widgets[widx::currentLoan].top + 13,
                     Colour::black,
@@ -1770,7 +1770,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 auto args = FormatArguments::common(company->companyValueHistory[0]);
 
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + 7,
                     self.y + self.widgets[widx::currentLoan].top + 26,
                     Colour::black,
@@ -1784,7 +1784,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 auto args = FormatArguments::common(company->vehicleProfit);
 
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + 7,
                     self.y + self.widgets[widx::currentLoan].top + 39,
                     Colour::black,
@@ -1793,7 +1793,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             }
         }
 
-        static void drawFinanceYear(Gfx::Context* context, int16_t x, int16_t& y, uint16_t columnYear, uint16_t currentYear)
+        static void drawFinanceYear(Gfx::RenderTarget* rt, int16_t x, int16_t& y, uint16_t columnYear, uint16_t currentYear)
         {
             auto args = FormatArguments::common(StringIds::uint16_raw, columnYear);
 
@@ -1804,7 +1804,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             }
 
             Gfx::drawStringRightUnderline(
-                *context,
+                *rt,
                 x,
                 y,
                 Colour::black,
@@ -1813,7 +1813,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             y += 14;
         }
 
-        static currency48_t drawFinanceExpenditureColumn(Gfx::Context* context, const int16_t x, int16_t& y, uint8_t columnIndex, Company& company)
+        static currency48_t drawFinanceExpenditureColumn(Gfx::RenderTarget* rt, const int16_t x, int16_t& y, uint8_t columnIndex, Company& company)
         {
             currency48_t sum = 0;
             for (auto j = 0; j < ExpenditureType::Count; j++)
@@ -1826,7 +1826,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     auto args = FormatArguments::common(StringIds::currency48, expenditures);
 
                     Gfx::drawStringRight(
-                        *context,
+                        *rt,
                         x,
                         y,
                         Colour::black,
@@ -1838,7 +1838,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             return sum;
         }
 
-        static void drawFinanceSum(Gfx::Context* context, int16_t x, int16_t& y, currency48_t sum)
+        static void drawFinanceSum(Gfx::RenderTarget* rt, int16_t x, int16_t& y, currency48_t sum)
         {
             auto mainFormat = StringIds::black_stringid;
             auto sumFormat = StringIds::plus_currency48;
@@ -1851,13 +1851,13 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             y += 4;
 
-            Gfx::drawStringRight(*context, x, y, Colour::black, mainFormat, &args);
+            Gfx::drawStringRight(*rt, x, y, Colour::black, mainFormat, &args);
 
-            Gfx::fillRect(*context, x - expenditureColumnWidth + 10, y - 2, x, y - 2, enumValue(Colour::darkGreen));
+            Gfx::fillRect(*rt, x - expenditureColumnWidth + 10, y - 2, x, y - 2, enumValue(Colour::darkGreen));
         }
 
         // 0x0043361E
-        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
         {
             int16_t y = 47 - self.widgets[widx::scrollview].top + 14;
 
@@ -1867,7 +1867,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 if (i % 2 == 0)
                 {
                     auto colour = Colours::getShade(self.getColour(WindowColour::secondary).c(), 6) | 0x1000000;
-                    Gfx::fillRect(context, 0, y, expenditureColumnWidth * 17, y + 9, colour);
+                    Gfx::fillRect(rt, 0, y, expenditureColumnWidth * 17, y + 9, colour);
                 }
 
                 y += 10;
@@ -1886,9 +1886,9 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
                 uint16_t columnYear = curYear - (expenditureYears - i) + 1;
                 uint8_t columnIndex = expenditureYears - i - 1;
-                drawFinanceYear(&context, x, y, columnYear, curYear);
-                auto sum = drawFinanceExpenditureColumn(&context, x, y, columnIndex, *company);
-                drawFinanceSum(&context, x, y, sum);
+                drawFinanceYear(&rt, x, y, columnYear, curYear);
+                auto sum = drawFinanceExpenditureColumn(&rt, x, y, columnIndex, *company);
+                drawFinanceSum(&rt, x, y, sum);
 
                 x += expenditureColumnWidth;
             }
@@ -2136,16 +2136,16 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433ACD
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             uint16_t y = self.y + 47;
 
             // 'Cargo delivered'
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 self.x + 5,
                 y,
                 Colour::black,
@@ -2170,7 +2170,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 args.push(company->cargoDelivered[i]);
 
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + 10,
                     y,
                     Colour::black,
@@ -2185,7 +2185,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             if (numPrinted == 0)
             {
                 Gfx::drawStringLeft(
-                    *context,
+                    *rt,
                     self.x + 10,
                     y,
                     Colour::black,
@@ -2324,10 +2324,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433DEB
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
             *buffer_2039++ = static_cast<char>(ControlCodes::colour_black);
@@ -2336,15 +2336,15 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             int16_t y = self.y + 47;
             // for example: "Provide the transport services on this little island" for "Boulder Breakers" scenario
-            y = Gfx::drawStringLeftWrapped(*context, self.x + 5, y, self.width - 10, Colour::black, StringIds::buffer_2039);
+            y = Gfx::drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::buffer_2039);
             y += 5;
-            Gfx::drawStringLeft(*context, self.x + 5, y, Colour::black, StringIds::challenge_label);
+            Gfx::drawStringLeft(*rt, self.x + 5, y, Colour::black, StringIds::challenge_label);
             y += 10;
 
             {
                 FormatArguments args = {};
                 Scenario::formatChallengeArguments(args);
-                y = Gfx::drawStringLeftWrapped(*context, self.x + 5, y, self.width - 10, Colour::black, StringIds::challenge_value, &args);
+                y = Gfx::drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::challenge_value, &args);
                 y += 5;
             }
 
@@ -2356,13 +2356,13 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 uint16_t months = Scenario::getObjectiveProgress().completedChallengeInMonths % 12;
 
                 auto args = FormatArguments::common(years, months);
-                Gfx::drawStringLeftWrapped(*context, self.x + 5, y, self.width - 10, Colour::black, StringIds::success_you_completed_the_challenge_in_years_months, &args);
+                Gfx::drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::success_you_completed_the_challenge_in_years_months, &args);
                 return;
             }
 
             if ((playerCompany->challengeFlags & CompanyFlags::challengeFailed) != 0)
             {
-                Gfx::drawStringLeftWrapped(*context, self.x + 5, y, self.width - 10, Colour::black, StringIds::failed_you_failed_to_complete_the_challenge);
+                Gfx::drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::failed_you_failed_to_complete_the_challenge);
                 return;
             }
 
@@ -2376,14 +2376,14 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 args.skip(2);
                 args.push(years);
                 args.push(months);
-                Gfx::drawStringLeftWrapped(*context, self.x + 5, y, self.width - 10, Colour::black, StringIds::beaten_by_other_player_completed_in_years_months, &args);
+                Gfx::drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::beaten_by_other_player_completed_in_years_months, &args);
                 return;
             }
 
             {
                 FormatArguments args{};
                 args.push<uint16_t>(playerCompany->challengeProgress);
-                y = Gfx::drawStringLeftWrapped(*context, self.x + 5, y, self.width - 10, Colour::black, StringIds::progress_towards_completing_challenge_percent, &args);
+                y = Gfx::drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::progress_towards_completing_challenge_percent, &args);
             }
 
             if ((Scenario::getObjective().flags & Scenario::ObjectiveFlags::withinTimeLimit) != 0)
@@ -2394,7 +2394,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 uint16_t months = monthsLeft % 12;
 
                 auto args = FormatArguments::common(years, months);
-                Gfx::drawStringLeftWrapped(*context, self.x + 5, y, self.width + 10, Colour::black, StringIds::time_remaining_years_months, &args);
+                Gfx::drawStringLeftWrapped(*rt, self.x + 5, y, self.width + 10, Colour::black, StringIds::time_remaining_years_months, &args);
                 return;
             }
         }
@@ -2643,7 +2643,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             GameCommands::do_30(CompanyId(0), 0, buffer[6], buffer[7], buffer[8]);
         }
 
-        static void drawCompanySelect(const Window* const self, Gfx::Context* const context)
+        static void drawCompanySelect(const Window* const self, Gfx::RenderTarget* const rt)
         {
             const auto company = CompanyManager::get(CompanyId(self->number));
             const auto competitor = ObjectManager::get<CompetitorObject>(company->competitorId);
@@ -2652,24 +2652,24 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             const uint32_t image = Gfx::recolour(competitor->images[company->ownerEmotion], company->mainColours.primary);
             const uint16_t x = self->x + self->widgets[Common::widx::company_select].left + 1;
             const uint16_t y = self->y + self->widgets[Common::widx::company_select].top + 1;
-            Gfx::drawImage(context, x, y, image);
+            Gfx::drawImage(rt, x, y, image);
         }
 
         // 0x00434413
-        static void drawTabs(Window* self, Gfx::Context* context)
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
             // Status tab
             {
                 const uint32_t imageId = skin->img + InterfaceSkin::ImageIds::tab_company;
-                Widget::drawTab(self, context, imageId, widx::tab_status);
+                Widget::drawTab(self, rt, imageId, widx::tab_status);
             }
 
             // Details tab
             {
                 const uint32_t imageId = Gfx::recolour(skin->img + InterfaceSkin::ImageIds::tab_company_details, self->getColour(WindowColour::primary).c());
-                Widget::drawTab(self, context, imageId, widx::tab_details);
+                Widget::drawTab(self, rt, imageId, widx::tab_details);
             }
 
             // Colour scheme tab
@@ -2691,7 +2691,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 else
                     imageId += colourSchemeTabImageIds[0];
 
-                Widget::drawTab(self, context, imageId, widx::tab_colour_scheme);
+                Widget::drawTab(self, rt, imageId, widx::tab_colour_scheme);
             }
 
             // Finances tab
@@ -2721,7 +2721,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 else
                     imageId += financesTabImageIds[0];
 
-                Widget::drawTab(self, context, imageId, widx::tab_finances);
+                Widget::drawTab(self, rt, imageId, widx::tab_finances);
             }
 
             // Cargo delivered tab
@@ -2739,7 +2739,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 else
                     imageId += cargoDeliveredTabImageIds[0];
 
-                Widget::drawTab(self, context, imageId, widx::tab_cargo_delivered);
+                Widget::drawTab(self, rt, imageId, widx::tab_cargo_delivered);
             }
 
             // Challenge tab
@@ -2769,7 +2769,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 else
                     imageId += challengeTabImageIds[0];
 
-                Widget::drawTab(self, context, imageId, widx::tab_challenge);
+                Widget::drawTab(self, rt, imageId, widx::tab_challenge);
             }
         }
     }

--- a/src/OpenLoco/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/Windows/Construction/Common.cpp
@@ -742,7 +742,7 @@ namespace OpenLoco::Ui::Windows::Construction
         }
 
         // 0x0049EFEF
-        static void drawRoadTabs(Window* self, Gfx::Context* context)
+        static void drawRoadTabs(Window* self, Gfx::RenderTarget* rt)
         {
             auto company = CompanyManager::getPlayerCompany();
             auto companyColour = company->mainColours.primary;
@@ -753,11 +753,11 @@ namespace OpenLoco::Ui::Windows::Construction
                 if (self->currentTab == widx::tab_construction - widx::tab_construction)
                     imageId += (self->frame_no / 4) % 32;
 
-                Widget::drawTab(self, context, Gfx::recolour(imageId, companyColour), widx::tab_construction);
+                Widget::drawTab(self, rt, Gfx::recolour(imageId, companyColour), widx::tab_construction);
             }
             // Station Tab
             {
-                Widget::drawTab(self, context, ImageIds::null, widx::tab_station);
+                Widget::drawTab(self, rt, ImageIds::null, widx::tab_station);
                 if (!self->isDisabled(widx::tab_station))
                 {
                     auto x = self->widgets[widx::tab_station].left + self->x + 1;
@@ -767,7 +767,7 @@ namespace OpenLoco::Ui::Windows::Construction
                     if (self->currentTab == widx::tab_station - widx::tab_construction)
                         height++;
 
-                    auto clipped = Gfx::clipContext(*context, Ui::Rect(x, y, width, height));
+                    auto clipped = Gfx::clipRenderTarget(*rt, Ui::Rect(x, y, width, height));
                     if (clipped)
                     {
                         clipped->zoom_level = 1;
@@ -787,12 +787,12 @@ namespace OpenLoco::Ui::Windows::Construction
                         Gfx::drawImage(&*clipped, -4, -10, imageId);
                     }
 
-                    Widget::drawTab(self, context, -2, widx::tab_station);
+                    Widget::drawTab(self, rt, -2, widx::tab_station);
                 }
             }
             // Overhead tab
             {
-                Widget::drawTab(self, context, ImageIds::null, widx::tab_overhead);
+                Widget::drawTab(self, rt, ImageIds::null, widx::tab_overhead);
                 if (!self->isDisabled(widx::tab_station))
                 {
                     auto x = self->widgets[widx::tab_overhead].left + self->x + 2;
@@ -806,17 +806,17 @@ namespace OpenLoco::Ui::Windows::Construction
                             auto imageId = roadExtraObj->var_0E;
                             if (self->currentTab == widx::tab_overhead - widx::tab_construction)
                                 imageId += (self->frame_no / 2) % 8;
-                            Gfx::drawImage(context, x, y, imageId);
+                            Gfx::drawImage(rt, x, y, imageId);
                         }
                     }
 
-                    Widget::drawTab(self, context, -2, widx::tab_overhead);
+                    Widget::drawTab(self, rt, -2, widx::tab_overhead);
                 }
             }
         }
 
         // 0x0049ED40
-        static void drawTrackTabs(Window* self, Gfx::Context* context)
+        static void drawTrackTabs(Window* self, Gfx::RenderTarget* rt)
         {
             auto company = CompanyManager::getPlayerCompany();
             auto companyColour = company->mainColours.primary;
@@ -827,7 +827,7 @@ namespace OpenLoco::Ui::Windows::Construction
                 if (self->currentTab == widx::tab_construction - widx::tab_construction)
                     imageId += (self->frame_no / 4) % 15;
 
-                Widget::drawTab(self, context, Gfx::recolour(imageId, companyColour), widx::tab_construction);
+                Widget::drawTab(self, rt, Gfx::recolour(imageId, companyColour), widx::tab_construction);
             }
             // Station Tab
             {
@@ -835,7 +835,7 @@ namespace OpenLoco::Ui::Windows::Construction
                 {
                     auto imageId = ObjectManager::get<InterfaceSkinObject>()->img + InterfaceSkin::ImageIds::toolbar_menu_airport;
 
-                    Widget::drawTab(self, context, imageId, widx::tab_station);
+                    Widget::drawTab(self, rt, imageId, widx::tab_station);
                 }
                 else
                 {
@@ -843,11 +843,11 @@ namespace OpenLoco::Ui::Windows::Construction
                     {
                         auto imageId = ObjectManager::get<InterfaceSkinObject>()->img + InterfaceSkin::ImageIds::toolbar_menu_ship_port;
 
-                        Widget::drawTab(self, context, imageId, widx::tab_station);
+                        Widget::drawTab(self, rt, imageId, widx::tab_station);
                     }
                     else
                     {
-                        Widget::drawTab(self, context, ImageIds::null, widx::tab_station);
+                        Widget::drawTab(self, rt, ImageIds::null, widx::tab_station);
                         if (!self->isDisabled(widx::tab_station))
                         {
                             auto x = self->widgets[widx::tab_station].left + self->x + 1;
@@ -857,7 +857,7 @@ namespace OpenLoco::Ui::Windows::Construction
                             if (self->currentTab == widx::tab_station - widx::tab_construction)
                                 height++;
 
-                            auto clipped = Gfx::clipContext(*context, Ui::Rect(x, y, width, height));
+                            auto clipped = Gfx::clipRenderTarget(*rt, Ui::Rect(x, y, width, height));
                             if (clipped)
                             {
                                 clipped->zoom_level = 1;
@@ -879,14 +879,14 @@ namespace OpenLoco::Ui::Windows::Construction
                                 Gfx::drawImage(&*clipped, -4, -9, imageId);
                             }
 
-                            Widget::drawTab(self, context, -2, widx::tab_station);
+                            Widget::drawTab(self, rt, -2, widx::tab_station);
                         }
                     }
                 }
             }
             // Signal Tab
             {
-                Widget::drawTab(self, context, ImageIds::null, widx::tab_signal);
+                Widget::drawTab(self, rt, ImageIds::null, widx::tab_signal);
                 if (!self->isDisabled(widx::tab_signal))
                 {
                     auto x = self->widgets[widx::tab_signal].left + self->x + 1;
@@ -896,7 +896,7 @@ namespace OpenLoco::Ui::Windows::Construction
                     if (self->currentTab == widx::tab_station - widx::tab_construction)
                         height++;
 
-                    auto clipped = Gfx::clipContext(*context, Ui::Rect(x, y, width, height));
+                    auto clipped = Gfx::clipRenderTarget(*rt, Ui::Rect(x, y, width, height));
                     if (clipped)
                     {
                         auto trainSignalObject = ObjectManager::get<TrainSignalObject>(_lastSelectedSignal);
@@ -913,12 +913,12 @@ namespace OpenLoco::Ui::Windows::Construction
                         Gfx::drawImage(&*clipped, 15, 31, imageId);
                     }
 
-                    Widget::drawTab(self, context, -2, widx::tab_signal);
+                    Widget::drawTab(self, rt, -2, widx::tab_signal);
                 }
             }
             // Overhead Tab
             {
-                Widget::drawTab(self, context, ImageIds::null, widx::tab_overhead);
+                Widget::drawTab(self, rt, ImageIds::null, widx::tab_overhead);
                 if (!self->isDisabled(widx::tab_station))
                 {
                     auto x = self->widgets[widx::tab_overhead].left + self->x + 2;
@@ -932,25 +932,25 @@ namespace OpenLoco::Ui::Windows::Construction
                             auto imageId = trackExtraObj->var_0E;
                             if (self->currentTab == widx::tab_overhead - widx::tab_construction)
                                 imageId += (self->frame_no / 2) % 8;
-                            Gfx::drawImage(context, x, y, imageId);
+                            Gfx::drawImage(rt, x, y, imageId);
                         }
                     }
 
-                    Widget::drawTab(self, context, -2, widx::tab_overhead);
+                    Widget::drawTab(self, rt, -2, widx::tab_overhead);
                 }
             }
         }
 
         // 0x0049ED33
-        void drawTabs(Window* self, Gfx::Context* context)
+        void drawTabs(Window* self, Gfx::RenderTarget* rt)
         {
             if (_trackType & (1 << 7))
             {
-                drawRoadTabs(self, context);
+                drawRoadTabs(self, rt);
             }
             else
             {
-                drawTrackTabs(self, context);
+                drawTrackTabs(self, rt);
             }
         }
 

--- a/src/OpenLoco/Windows/Construction/Construction.h
+++ b/src/OpenLoco/Windows/Construction/Construction.h
@@ -127,7 +127,7 @@ namespace OpenLoco::Ui::Windows::Construction
         void resetWindow(Window& self, WidgetIndex_t tabWidgetIndex);
         void switchTab(Window* self, WidgetIndex_t widgetIndex);
         void repositionTabs(Window* self);
-        void drawTabs(Window* self, Gfx::Context* context);
+        void drawTabs(Window* self, Gfx::RenderTarget* rt);
         void initEvents();
         void onClose(Window& self);
         void onUpdate(Window* self, uint8_t flag);
@@ -221,8 +221,8 @@ namespace OpenLoco::Ui::Windows::Construction
         void activateSelectedConstructionWidgets();
         void tabReset(Window* self);
         void initEvents();
-        void drawTrack(const Map::Pos3& pos, uint16_t selectedMods, uint8_t trackType, uint8_t trackPieceId, uint8_t rotation, Gfx::Context& context);
-        void drawRoad(const Map::Pos3& pos, uint16_t selectedMods, uint8_t trackType, uint8_t trackPieceId, uint8_t rotation, Gfx::Context& context);
+        void drawTrack(const Map::Pos3& pos, uint16_t selectedMods, uint8_t trackType, uint8_t trackPieceId, uint8_t rotation, Gfx::RenderTarget& rt);
+        void drawRoad(const Map::Pos3& pos, uint16_t selectedMods, uint8_t trackType, uint8_t trackPieceId, uint8_t rotation, Gfx::RenderTarget& rt);
         void removeTrackGhosts();
         void previousTrackPiece(Window* self);
         void nextTrackPiece(Window* self);

--- a/src/OpenLoco/Windows/Construction/OverheadTab.cpp
+++ b/src/OpenLoco/Windows/Construction/OverheadTab.cpp
@@ -467,17 +467,17 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
     }
 
     // 0x0049EA3E
-    static void draw(Window& self, Gfx::Context* context)
+    static void draw(Window& self, Gfx::RenderTarget* rt)
     {
-        self.draw(context);
-        Common::drawTabs(&self, context);
+        self.draw(rt);
+        Common::drawTabs(&self, rt);
         if (_lastSelectedMods & 0xF)
         {
             auto xPos = self.x + self.widgets[widx::image].left + 1;
             auto yPos = self.y + self.widgets[widx::image].top + 1;
             auto width = self.widgets[widx::image].width();
             auto height = self.widgets[widx::image].height();
-            auto clipped = Gfx::clipContext(*context, Ui::Rect(xPos, yPos, width, height));
+            auto clipped = Gfx::clipRenderTarget(*rt, Ui::Rect(xPos, yPos, width, height));
             if (clipped)
             {
                 coord_t x = 0x2010;
@@ -516,7 +516,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
             auto args = FormatArguments();
             args.push<uint32_t>(_modCost);
 
-            Gfx::drawStringCentred(*context, xPos, yPos, Colour::black, StringIds::build_cost, &args);
+            Gfx::drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::build_cost, &args);
         }
     }
 

--- a/src/OpenLoco/Windows/Construction/SignalTab.cpp
+++ b/src/OpenLoco/Windows/Construction/SignalTab.cpp
@@ -296,10 +296,10 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
     }
 
     // 0x0049E501
-    static void draw(Window& self, Gfx::Context* context)
+    static void draw(Window& self, Gfx::RenderTarget* rt)
     {
-        self.draw(context);
-        Common::drawTabs(&self, context);
+        self.draw(rt);
+        Common::drawTabs(&self, rt);
 
         auto trainSignalObject = ObjectManager::get<TrainSignalObject>(_lastSelectedSignal);
 
@@ -311,7 +311,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
             auto args = FormatArguments();
             args.push(trainSignalObject->var_0C);
 
-            Gfx::drawStringLeftWrapped(*context, xPos, yPos, width, Colour::black, StringIds::signal_black, &args);
+            Gfx::drawStringLeftWrapped(*rt, xPos, yPos, width, Colour::black, StringIds::signal_black, &args);
         }
 
         auto imageId = trainSignalObject->image;
@@ -319,14 +319,14 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
         xPos = self.widgets[widx::both_directions].mid_x() + self.x;
         yPos = self.widgets[widx::both_directions].bottom + self.y - 4;
 
-        Gfx::drawImage(context, xPos - 8, yPos, imageId);
+        Gfx::drawImage(rt, xPos - 8, yPos, imageId);
 
-        Gfx::drawImage(context, xPos + 8, yPos, imageId + 4);
+        Gfx::drawImage(rt, xPos + 8, yPos, imageId + 4);
 
         xPos = self.widgets[widx::single_direction].mid_x() + self.x;
         yPos = self.widgets[widx::single_direction].bottom + self.y - 4;
 
-        Gfx::drawImage(context, xPos, yPos, imageId);
+        Gfx::drawImage(rt, xPos, yPos, imageId);
 
         if (_signalCost != 0x80000000 && _signalCost != 0)
         {
@@ -336,7 +336,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
             xPos = self.x + 69;
             yPos = self.widgets[widx::single_direction].bottom + self.y + 5;
 
-            Gfx::drawStringCentred(*context, xPos, yPos, Colour::black, StringIds::build_cost, &args);
+            Gfx::drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::build_cost, &args);
         }
     }
 

--- a/src/OpenLoco/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/Windows/Construction/StationTab.cpp
@@ -614,10 +614,10 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     }
 
     // 0x0049DE40
-    static void draw(Window& self, Gfx::Context* context)
+    static void draw(Window& self, Gfx::RenderTarget* rt)
     {
-        self.draw(context);
-        Common::drawTabs(&self, context);
+        self.draw(rt);
+        Common::drawTabs(&self, rt);
 
         auto company = CompanyManager::getPlayerCompany();
         auto companyColour = company->mainColours.primary;
@@ -628,20 +628,20 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         {
             auto airportObj = ObjectManager::get<AirportObject>(_lastSelectedStationType);
             auto imageId = Gfx::recolour(airportObj->image, companyColour);
-            Gfx::drawImage(context, xPos, yPos, imageId);
+            Gfx::drawImage(rt, xPos, yPos, imageId);
         }
         else if (_byte_1136063 & (1 << 6))
         {
             auto dockObj = ObjectManager::get<DockObject>(_lastSelectedStationType);
             auto imageId = Gfx::recolour(dockObj->image, companyColour);
-            Gfx::drawImage(context, xPos, yPos, imageId);
+            Gfx::drawImage(rt, xPos, yPos, imageId);
         }
         else if (_trackType & (1 << 7))
         {
             auto roadStationObj = ObjectManager::get<RoadStationObject>(_lastSelectedStationType);
 
             auto imageId = Gfx::recolour(roadStationObj->image + RoadStation::ImageIds::preview_image, companyColour);
-            Gfx::drawImage(context, xPos, yPos, imageId);
+            Gfx::drawImage(rt, xPos, yPos, imageId);
 
             auto colour = Colours::getTranslucent(companyColour);
             if (!(roadStationObj->flags & RoadStationFlags::recolourable))
@@ -650,14 +650,14 @@ namespace OpenLoco::Ui::Windows::Construction::Station
             }
 
             imageId = Gfx::recolourTranslucent(roadStationObj->image + RoadStation::ImageIds::preview_image_windows, colour);
-            Gfx::drawImage(context, xPos, yPos, imageId);
+            Gfx::drawImage(rt, xPos, yPos, imageId);
         }
         else
         {
             auto trainStationObj = ObjectManager::get<TrainStationObject>(_lastSelectedStationType);
 
             auto imageId = Gfx::recolour(trainStationObj->image + TrainStation::ImageIds::preview_image, companyColour);
-            Gfx::drawImage(context, xPos, yPos, imageId);
+            Gfx::drawImage(rt, xPos, yPos, imageId);
 
             auto colour = Colours::getTranslucent(companyColour);
             if (!(trainStationObj->flags & TrainStationFlags::recolourable))
@@ -666,7 +666,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
             }
 
             imageId = Gfx::recolourTranslucent(trainStationObj->image + TrainStation::ImageIds::preview_image_windows, colour);
-            Gfx::drawImage(context, xPos, yPos, imageId);
+            Gfx::drawImage(rt, xPos, yPos, imageId);
         }
 
         if (_stationCost != 0x80000000 && _stationCost != 0)
@@ -677,13 +677,13 @@ namespace OpenLoco::Ui::Windows::Construction::Station
             auto args = FormatArguments();
             args.push<uint32_t>(_stationCost);
 
-            Gfx::drawStringCentred(*context, xPos, yPos, Colour::black, StringIds::build_cost, &args);
+            Gfx::drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::build_cost, &args);
         }
 
         xPos = self.x + 3;
         yPos = self.widgets[widx::image].bottom + self.y + 16;
         auto width = self.width - 4;
-        Gfx::drawRectInset(*context, xPos, yPos, width, 1, self.getColour(WindowColour::secondary).u8(), (1 << 5));
+        Gfx::drawRectInset(*rt, xPos, yPos, width, 1, self.getColour(WindowColour::secondary).u8(), (1 << 5));
 
         if (!(_byte_522096 & (1 << 3)))
             return;
@@ -705,17 +705,17 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         xPos = self.x + 69;
         yPos = self.widgets[widx::image].bottom + self.y + 18;
         width = self.width - 4;
-        Gfx::drawStringCentredClipped(*context, xPos, yPos, width, Colour::black, StringIds::new_station_buffer, &args);
+        Gfx::drawStringCentredClipped(*rt, xPos, yPos, width, Colour::black, StringIds::new_station_buffer, &args);
 
         xPos = self.x + 2;
         yPos = self.widgets[widx::image].bottom + self.y + 29;
         Ui::Point origin = { xPos, yPos };
 
-        Gfx::drawStringLeft(*context, &origin, Colour::black, StringIds::catchment_area_accepts);
+        Gfx::drawStringLeft(*rt, &origin, Colour::black, StringIds::catchment_area_accepts);
 
         if (_constructingStationAcceptedCargoTypes == 0)
         {
-            Gfx::drawStringLeft(*context, origin.x, origin.y, Colour::black, StringIds::catchment_area_nothing);
+            Gfx::drawStringLeft(*rt, origin.x, origin.y, Colour::black, StringIds::catchment_area_nothing);
         }
         else
         {
@@ -729,7 +729,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                     {
                         auto cargoObj = ObjectManager::get<CargoObject>(i);
 
-                        Gfx::drawImage(context, origin.x, origin.y, cargoObj->unit_inline_sprite);
+                        Gfx::drawImage(rt, origin.x, origin.y, cargoObj->unit_inline_sprite);
                         origin.x += 10;
                     }
                 }
@@ -740,11 +740,11 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         yPos = self.widgets[widx::image].bottom + self.y + 49;
         origin = { xPos, yPos };
 
-        Gfx::drawStringLeft(*context, &origin, Colour::black, StringIds::catchment_area_produces);
+        Gfx::drawStringLeft(*rt, &origin, Colour::black, StringIds::catchment_area_produces);
 
         if (_constructingStationProducedCargoTypes == 0)
         {
-            Gfx::drawStringLeft(*context, origin.x, origin.y, Colour::black, StringIds::catchment_area_nothing);
+            Gfx::drawStringLeft(*rt, origin.x, origin.y, Colour::black, StringIds::catchment_area_nothing);
         }
         else
         {
@@ -758,7 +758,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                     {
                         auto cargoObj = ObjectManager::get<CargoObject>(i);
 
-                        Gfx::drawImage(context, origin.x, origin.y, cargoObj->unit_inline_sprite);
+                        Gfx::drawImage(rt, origin.x, origin.y, cargoObj->unit_inline_sprite);
                         origin.x += 10;
                     }
                 }

--- a/src/OpenLoco/Windows/DragVehiclePart.cpp
+++ b/src/OpenLoco/Windows/DragVehiclePart.cpp
@@ -66,9 +66,9 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
         WindowManager::invalidate(WindowType::vehicle, enumValue(*_dragVehicleHead));
     }
 
-    static void draw(Ui::Window& self, Gfx::Context* const context)
+    static void draw(Ui::Window& self, Gfx::RenderTarget* const rt)
     {
-        auto clipped = Gfx::clipContext(*context, Ui::Rect(self.x, self.y, self.width, self.height));
+        auto clipped = Gfx::clipRenderTarget(*rt, Ui::Rect(self.x, self.y, self.width, self.height));
         if (clipped)
         {
             Vehicle::Common::sub_4B743B(0, 0, 0, 19, _dragCarComponent, &*clipped);

--- a/src/OpenLoco/Windows/EditKeyboardShortcut.cpp
+++ b/src/OpenLoco/Windows/EditKeyboardShortcut.cpp
@@ -65,14 +65,14 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
     }
 
     // 0x004BE8DF
-    static void draw(Ui::Window& self, Gfx::Context* const ctx)
+    static void draw(Ui::Window& self, Gfx::RenderTarget* const rt)
     {
-        self.draw(ctx);
+        self.draw(rt);
 
         FormatArguments args{};
         args.push(ShortcutManager::getName(static_cast<Shortcut>(*_editingShortcutIndex)));
         auto point = Ui::Point(self.x + 140, self.y + 32);
-        Gfx::drawStringCentredWrapped(*ctx, point, 272, Colour::black, StringIds::change_keyboard_shortcut_desc, &args);
+        Gfx::drawStringCentredWrapped(*rt, point, 272, Colour::black, StringIds::change_keyboard_shortcut_desc, &args);
     }
 
     // 0x004BE821

--- a/src/OpenLoco/Windows/Error.cpp
+++ b/src/OpenLoco/Windows/Error.cpp
@@ -27,7 +27,7 @@ namespace OpenLoco::Ui::Windows::Error
     {
         static WindowEventList events;
 
-        static void draw(Ui::Window& self, Gfx::Context* context);
+        static void draw(Ui::Window& self, Gfx::RenderTarget* rt);
         static void onPeriodicUpdate(Ui::Window& self);
         static void initEvents();
     }
@@ -204,7 +204,7 @@ namespace OpenLoco::Ui::Windows::Error
     namespace Common
     {
         // 0x00431C05
-        static void draw(Ui::Window& self, Gfx::Context* context)
+        static void draw(Ui::Window& self, Gfx::RenderTarget* rt)
         {
             uint16_t x = self.x;
             uint16_t y = self.y;
@@ -212,22 +212,22 @@ namespace OpenLoco::Ui::Windows::Error
             uint16_t height = self.height;
             auto skin = ObjectManager::get<InterfaceSkinObject>()->colour_09;
 
-            Gfx::drawRect(*context, x + 1, y + 1, width - 2, height - 2, 0x2000000 | 45);
-            Gfx::drawRect(*context, x + 1, y + 1, width - 2, height - 2, 0x2000000 | (116 + enumValue(skin)));
+            Gfx::drawRect(*rt, x + 1, y + 1, width - 2, height - 2, 0x2000000 | 45);
+            Gfx::drawRect(*rt, x + 1, y + 1, width - 2, height - 2, 0x2000000 | (116 + enumValue(skin)));
 
-            Gfx::drawRect(*context, x, y + 2, 1, height - 4, 0x2000000 | 46);
-            Gfx::drawRect(*context, x + width - 1, y + 2, 1, height - 4, 0x2000000 | 46);
-            Gfx::drawRect(*context, x + 2, y + height - 1, width - 4, 1, 0x2000000 | 46);
-            Gfx::drawRect(*context, x + 2, y, width - 4, 1, 0x2000000 | 46);
+            Gfx::drawRect(*rt, x, y + 2, 1, height - 4, 0x2000000 | 46);
+            Gfx::drawRect(*rt, x + width - 1, y + 2, 1, height - 4, 0x2000000 | 46);
+            Gfx::drawRect(*rt, x + 2, y + height - 1, width - 4, 1, 0x2000000 | 46);
+            Gfx::drawRect(*rt, x + 2, y, width - 4, 1, 0x2000000 | 46);
 
-            Gfx::drawRect(*context, x + 1, y + 1, 1, 1, 0x2000000 | 46);
-            Gfx::drawRect(*context, x + width - 1 - 1, y + 1, 1, 1, 0x2000000 | 46);
-            Gfx::drawRect(*context, x + 1, y + height - 1 - 1, 1, 1, 0x2000000 | 46);
-            Gfx::drawRect(*context, x + width - 1 - 1, y + height - 1 - 1, 1, 1, 0x2000000 | 46);
+            Gfx::drawRect(*rt, x + 1, y + 1, 1, 1, 0x2000000 | 46);
+            Gfx::drawRect(*rt, x + width - 1 - 1, y + 1, 1, 1, 0x2000000 | 46);
+            Gfx::drawRect(*rt, x + 1, y + height - 1 - 1, 1, 1, 0x2000000 | 46);
+            Gfx::drawRect(*rt, x + width - 1 - 1, y + height - 1 - 1, 1, 1, 0x2000000 | 46);
 
             if (_errorCompetitorId == CompanyId::null)
             {
-                Gfx::drawStringCentredRaw(*context, ((width + 1) / 2) + x - 1, y + 1, _word_9C66B3, Colour::black, &_byte_9C64B3[0]);
+                Gfx::drawStringCentredRaw(*rt, ((width + 1) / 2) + x - 1, y + 1, _word_9C66B3, Colour::black, &_byte_9C64B3[0]);
             }
             else
             {
@@ -241,14 +241,14 @@ namespace OpenLoco::Ui::Windows::Error
                 imageId = Gfx::recolour(imageId, company->mainColours.primary);
                 imageId++;
 
-                Gfx::drawImage(context, xPos, yPos, imageId);
+                Gfx::drawImage(rt, xPos, yPos, imageId);
 
                 if (company->jailStatus != 0)
                 {
-                    Gfx::drawImage(context, xPos, yPos, ImageIds::owner_jailed);
+                    Gfx::drawImage(rt, xPos, yPos, ImageIds::owner_jailed);
                 }
 
-                Gfx::drawStringCentredRaw(*context, self.x + 156, self.y + 20, _word_9C66B3, Colour::black, &_byte_9C64B3[0]);
+                Gfx::drawStringCentredRaw(*rt, self.x + 156, self.y + 20, _word_9C66B3, Colour::black, &_byte_9C64B3[0]);
             }
         }
 

--- a/src/OpenLoco/Windows/IndustryList.cpp
+++ b/src/OpenLoco/Windows/IndustryList.cpp
@@ -62,7 +62,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
         static void initEvents();
         static void refreshIndustryList(Window* self);
-        static void drawTabs(Window* self, Gfx::Context* context);
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt);
         static void prepareDraw(Window& self);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
     }
@@ -132,10 +132,10 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00457CD9
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
             auto args = FormatArguments();
             auto xPos = self.x + 4;
             auto yPos = self.y + self.height - 12;
@@ -146,7 +146,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 args.push(StringIds::status_num_industries_plural);
             args.push(self.var_83C);
 
-            Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::black_stringid, &args);
+            Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x00457EC4
@@ -378,10 +378,10 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00457D2A
-        static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
         {
             auto shade = Colours::getShade(self.getColour(WindowColour::secondary).c(), 4);
-            Gfx::clearSingle(context, shade);
+            Gfx::clearSingle(rt, shade);
 
             uint16_t yPos = 0;
             for (uint16_t i = 0; i < self.var_83C; i++)
@@ -389,7 +389,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 IndustryId industryId = IndustryId(self.rowInfo[i]);
 
                 // Skip items outside of view, or irrelevant to the current filter.
-                if (yPos + rowHeight < context.y || yPos >= yPos + rowHeight + context.height || industryId == IndustryId::null)
+                if (yPos + rowHeight < rt.y || yPos >= yPos + rowHeight + rt.height || industryId == IndustryId::null)
                 {
                     yPos += rowHeight;
                     continue;
@@ -400,7 +400,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 // Highlight selection.
                 if (industryId == IndustryId(self.rowHover))
                 {
-                    Gfx::drawRect(context, 0, yPos, self.width, rowHeight, 0x2000030);
+                    Gfx::drawRect(rt, 0, yPos, self.width, rowHeight, 0x2000030);
                     text_colour_id = StringIds::wcolour2_stringid;
                 }
 
@@ -414,7 +414,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     args.push(industry->name);
                     args.push(industry->town);
 
-                    Gfx::drawStringLeftClipped(context, 0, yPos, 198, Colour::black, text_colour_id, &args);
+                    Gfx::drawStringLeftClipped(rt, 0, yPos, 198, Colour::black, text_colour_id, &args);
                 }
                 // Industry Status
                 {
@@ -424,7 +424,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     auto args = FormatArguments();
                     args.push(StringIds::buffer_1250);
 
-                    Gfx::drawStringLeftClipped(context, 200, yPos, 238, Colour::black, text_colour_id, &args);
+                    Gfx::drawStringLeftClipped(rt, 200, yPos, 238, Colour::black, text_colour_id, &args);
                 }
                 // Industry Production Delivered
                 {
@@ -439,7 +439,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     auto args = FormatArguments();
                     args.push<uint16_t>(productionTransported);
 
-                    Gfx::drawStringLeftClipped(context, 440, yPos, 138, Colour::black, StringIds::production_transported_percent, &args);
+                    Gfx::drawStringLeftClipped(rt, 440, yPos, 138, Colour::black, StringIds::production_transported_percent, &args);
                 }
                 yPos += rowHeight;
             }
@@ -618,17 +618,17 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x0045826C
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             if (self.var_83C == 0)
             {
                 auto xPos = self.x + 3;
                 auto yPos = self.y + self.height - 13;
                 auto width = self.width - 19;
-                Gfx::drawStringLeftClipped(*context, xPos, yPos, width, Colour::black, StringIds::no_industry_available);
+                Gfx::drawStringLeftClipped(*rt, xPos, yPos, width, Colour::black, StringIds::no_industry_available);
                 return;
             }
 
@@ -663,14 +663,14 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 auto yPos = self.y + self.height - 13;
                 widthOffset = 138;
 
-                Gfx::drawStringRight(*context, xPos, yPos, Colour::black, StringIds::build_cost, &args);
+                Gfx::drawStringRight(*rt, xPos, yPos, Colour::black, StringIds::build_cost, &args);
             }
 
             auto xPos = self.x + 3;
             auto yPos = self.y + self.height - 13;
             auto width = self.width - 19 - widthOffset;
 
-            Gfx::drawStringLeftClipped(*context, xPos, yPos, width, Colour::black, StringIds::black_stringid, &industryObj->name);
+            Gfx::drawStringLeftClipped(*rt, xPos, yPos, width, Colour::black, StringIds::black_stringid, &industryObj->name);
         }
 
         // 0x0045843A
@@ -873,10 +873,10 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458352
-        static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
         {
             auto shade = Colours::getShade(self.getColour(WindowColour::secondary).c(), 4);
-            Gfx::clearSingle(context, shade);
+            Gfx::clearSingle(rt, shade);
 
             loco_global<uint16_t, 0x00E0C3C6> word_E0C3C6;
             uint16_t xPos = 0;
@@ -889,18 +889,18 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     if (self.rowInfo[i] == self.var_846)
                     {
                         word_E0C3C6 = AdvancedColour::translucent_flag;
-                        Gfx::drawRectInset(context, xPos, yPos, rowHeight, rowHeight, self.getColour(WindowColour::secondary).u8(), AdvancedColour::translucent_flag);
+                        Gfx::drawRectInset(rt, xPos, yPos, rowHeight, rowHeight, self.getColour(WindowColour::secondary).u8(), AdvancedColour::translucent_flag);
                     }
                 }
                 else
                 {
                     word_E0C3C6 = AdvancedColour::translucent_flag | AdvancedColour::outline_flag;
-                    Gfx::drawRectInset(context, xPos, yPos, rowHeight, rowHeight, self.getColour(WindowColour::secondary).u8(), (AdvancedColour::translucent_flag | AdvancedColour::outline_flag));
+                    Gfx::drawRectInset(rt, xPos, yPos, rowHeight, rowHeight, self.getColour(WindowColour::secondary).u8(), (AdvancedColour::translucent_flag | AdvancedColour::outline_flag));
                 }
 
                 auto industryObj = ObjectManager::get<IndustryObject>(self.rowInfo[i]);
 
-                auto clipped = Gfx::clipContext(context, Ui::Rect(xPos + 1, yPos + 1, 110, 110));
+                auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(xPos + 1, yPos + 1, 110, 110));
                 if (clipped)
                 {
                     industryObj->drawIndustry(&*clipped, 56, 96);
@@ -1255,7 +1255,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458A57
-        static void drawTabs(Window* self, Gfx::Context* context)
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
@@ -1264,7 +1264,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 uint32_t imageId = skin->img;
                 imageId += InterfaceSkin::ImageIds::toolbar_menu_industries;
 
-                Widget::drawTab(self, context, imageId, widx::tab_industry_list);
+                Widget::drawTab(self, rt, imageId, widx::tab_industry_list);
             }
 
             // Fund New Industries Tab
@@ -1293,7 +1293,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 else
                     imageId += fundNewIndustriesImageIds[0];
 
-                Widget::drawTab(self, context, imageId, widx::tab_new_industry);
+                Widget::drawTab(self, rt, imageId, widx::tab_new_industry);
             }
         }
 

--- a/src/OpenLoco/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/Windows/IndustryWindow.cpp
@@ -59,9 +59,9 @@ namespace OpenLoco::Ui::Windows::Industry
         static void update(Window& self);
         static void renameIndustryPrompt(Window* self, WidgetIndex_t widgetIndex);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
-        static void drawTabs(Window* self, Gfx::Context* context);
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt);
         static void setDisabledWidgets(Window* self);
-        static void draw(Window& self, Gfx::Context* context);
+        static void draw(Window& self, Gfx::RenderTarget* rt);
         static void onMouseUp(Window& self, WidgetIndex_t widgetIndex);
         static void initEvents();
     }
@@ -129,12 +129,12 @@ namespace OpenLoco::Ui::Windows::Industry
         }
 
         // 0x00455C22
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
-            self.drawViewports(context);
-            Widget::drawViewportCentreButton(context, &self, widx::centre_on_viewport);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
+            self.drawViewports(rt);
+            Widget::drawViewportCentreButton(rt, &self, widx::centre_on_viewport);
 
             const char* buffer = StringManager::getString(StringIds::buffer_1250);
             auto industry = IndustryManager::get(IndustryId(self.number));
@@ -147,7 +147,7 @@ namespace OpenLoco::Ui::Windows::Industry
             auto x = self.x + widget->left - 1;
             auto y = self.y + widget->top - 1;
             auto width = widget->width();
-            Gfx::drawStringLeftClipped(*context, x, y, width, Colour::black, StringIds::black_stringid, &args);
+            Gfx::drawStringLeftClipped(*rt, x, y, width, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x00455C86
@@ -438,10 +438,10 @@ namespace OpenLoco::Ui::Windows::Industry
         }
 
         // 0x00456705
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             auto industry = IndustryManager::get(IndustryId(self.number));
             const auto* industryObj = industry->getObject();
@@ -454,7 +454,7 @@ namespace OpenLoco::Ui::Windows::Industry
             {
                 origin.x += 4;
                 origin.y += 10;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::received_cargo);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::received_cargo);
 
                 auto cargoNumber = 0;
                 for (const auto& receivedCargoType : industryObj->required_cargo_type)
@@ -474,7 +474,7 @@ namespace OpenLoco::Ui::Windows::Industry
                         }
                         args.push<uint32_t>(industry->receivedCargoQuantityPreviousMonth[cargoNumber]);
 
-                        origin.y = Gfx::drawStringLeftWrapped(*context, origin.x, origin.y, 290, Colour::black, StringIds::black_stringid, &args);
+                        origin.y = Gfx::drawStringLeftWrapped(*rt, origin.x, origin.y, 290, Colour::black, StringIds::black_stringid, &args);
                     }
                     cargoNumber++;
                 }
@@ -485,7 +485,7 @@ namespace OpenLoco::Ui::Windows::Industry
             // Draw Last Months produced cargo stats
             if (industry->canProduceCargo())
             {
-                Gfx::drawStringLeft(*context, origin.x, origin.y, Colour::black, StringIds::produced_cargo);
+                Gfx::drawStringLeft(*rt, origin.x, origin.y, Colour::black, StringIds::produced_cargo);
                 origin.y += 10;
                 origin.x += 4;
 
@@ -508,7 +508,7 @@ namespace OpenLoco::Ui::Windows::Industry
                         args.push<uint32_t>(industry->producedCargoQuantityPreviousMonth[cargoNumber]);
                         args.push<uint16_t>(industry->producedCargoPercentTransportedPreviousMonth[cargoNumber]);
 
-                        origin.y = Gfx::drawStringLeftWrapped(*context, origin.x, origin.y, 290, Colour::black, StringIds::transported_cargo, &args);
+                        origin.y = Gfx::drawStringLeftWrapped(*rt, origin.x, origin.y, 290, Colour::black, StringIds::transported_cargo, &args);
                     }
                     cargoNumber++;
                 }
@@ -566,10 +566,10 @@ namespace OpenLoco::Ui::Windows::Industry
         }
 
         // 0x00456079
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             // Draw Units of Cargo sub title
             const auto industry = IndustryManager::get(IndustryId(self.number));
@@ -583,7 +583,7 @@ namespace OpenLoco::Ui::Windows::Industry
                 int16_t x = self.x + 2;
                 int16_t y = self.y - 24 + 68;
 
-                Gfx::drawStringLeft(*context, x, y, Colour::black, StringIds::production_graph_label, &args);
+                Gfx::drawStringLeft(*rt, x, y, Colour::black, StringIds::production_graph_label, &args);
             }
 
             // Draw Y label and grid lines.
@@ -594,9 +594,9 @@ namespace OpenLoco::Ui::Windows::Industry
                 auto args = FormatArguments();
                 args.push(yTick);
 
-                Gfx::drawRect(*context, self.x + 41, yPos, 239, 1, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
+                Gfx::drawRect(*rt, self.x + 41, yPos, 239, 1, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
 
-                Gfx::drawStringRight(*context, self.x + 39, yPos - 6, Colour::black, StringIds::population_graph_people, &args);
+                Gfx::drawStringRight(*rt, self.x + 39, yPos - 6, Colour::black, StringIds::population_graph_people, &args);
 
                 yTick += 1000;
             }
@@ -621,10 +621,10 @@ namespace OpenLoco::Ui::Windows::Industry
                         auto args = FormatArguments();
                         args.push(year);
 
-                        Gfx::drawStringCentred(*context, xPos, yPos, Colour::black, StringIds::population_graph_year, &args);
+                        Gfx::drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::population_graph_year, &args);
                     }
 
-                    Gfx::drawRect(*context, xPos, yPos + 11, 1, self.height - 74, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
+                    Gfx::drawRect(*rt, xPos, yPos + 11, 1, self.height - 74, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
                 }
 
                 const auto history = productionTabWidx == widx::tab_production ? industry->producedCargoMonthlyHistory1 : industry->producedCargoMonthlyHistory2;
@@ -639,7 +639,7 @@ namespace OpenLoco::Ui::Windows::Industry
                     {
                         if (yPos2 <= graphBottom)
                         {
-                            Gfx::drawLine(*context, xPos, yPos1, xPos + 1, yPos2, Colours::getShade(self.getColour(WindowColour::secondary).c(), 7));
+                            Gfx::drawLine(*rt, xPos, yPos1, xPos + 1, yPos2, Colours::getShade(self.getColour(WindowColour::secondary).c(), 7));
                         }
                     }
                 }
@@ -795,7 +795,7 @@ namespace OpenLoco::Ui::Windows::Industry
             self->moveInsideScreenEdges();
         }
 
-        static void drawProductionTab(Window* self, Gfx::Context* context, uint8_t productionTabNumber)
+        static void drawProductionTab(Window* self, Gfx::RenderTarget* rt, uint8_t productionTabNumber)
         {
             static const uint32_t productionTabImageIds[] = {
                 InterfaceSkin::ImageIds::tab_production_frame0,
@@ -833,17 +833,17 @@ namespace OpenLoco::Ui::Windows::Industry
 
                 auto xPos = widget.left + self->x;
                 auto yPos = widget.top + self->y;
-                Gfx::drawImage(context, xPos, yPos, imageId);
+                Gfx::drawImage(rt, xPos, yPos, imageId);
 
                 auto caroObj = ObjectManager::get<CargoObject>(industryObj->produced_cargo_type[productionTabNumber]);
-                Gfx::drawImage(context, xPos + 18, yPos + 14, caroObj->unit_inline_sprite);
+                Gfx::drawImage(rt, xPos + 18, yPos + 14, caroObj->unit_inline_sprite);
 
-                Widget::drawTab(self, context, -2, tab);
+                Widget::drawTab(self, rt, -2, tab);
             }
         }
 
         // 0x00456A98
-        static void drawTabs(Window* self, Gfx::Context* context)
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
@@ -851,17 +851,17 @@ namespace OpenLoco::Ui::Windows::Industry
             {
                 uint32_t imageId = skin->img;
                 imageId += InterfaceSkin::ImageIds::toolbar_menu_industries;
-                Widget::drawTab(self, context, imageId, widx::tab_industry);
+                Widget::drawTab(self, rt, imageId, widx::tab_industry);
             }
 
             // Production Tab
             {
-                drawProductionTab(self, context, 0);
+                drawProductionTab(self, rt, 0);
             }
 
             // 2nd Production Tab
             {
-                drawProductionTab(self, context, 1);
+                drawProductionTab(self, rt, 1);
             }
 
             // Transported Tab
@@ -881,7 +881,7 @@ namespace OpenLoco::Ui::Windows::Industry
                     imageId += transportedTabImageIds[(self->frame_no / 4) % std::size(transportedTabImageIds)];
                 else
                     imageId += transportedTabImageIds[0];
-                Widget::drawTab(self, context, imageId, widx::tab_transported);
+                Widget::drawTab(self, rt, imageId, widx::tab_transported);
             }
         }
 

--- a/src/OpenLoco/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/Windows/KeyboardShortcuts.cpp
@@ -44,8 +44,8 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
         };
     }
 
-    static void draw(Ui::Window& self, Gfx::Context* context);
-    static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex);
+    static void draw(Ui::Window& self, Gfx::RenderTarget* rt);
+    static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex);
     static void onMouseUp(Window& self, WidgetIndex_t widgetIndex);
     static void resetShortcuts(Window* self);
     static std::optional<FormatArguments> tooltip(Window&, WidgetIndex_t);
@@ -93,10 +93,10 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     }
 
     // 0x004BE726
-    static void draw(Ui::Window& self, Gfx::Context* context)
+    static void draw(Ui::Window& self, Gfx::RenderTarget* rt)
     {
         // Draw widgets.
-        self.draw(context);
+        self.draw(rt);
     }
 
     static void getBindingString(uint32_t keyCode, char* buffer, const size_t bufferLength)
@@ -152,11 +152,11 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     }
 
     // 0x004BE72C
-    static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex)
+    static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
     {
         auto colour = self.getColour(WindowColour::secondary).c();
         auto shade = Colours::getShade(colour, 4);
-        Gfx::clearSingle(context, shade);
+        Gfx::clearSingle(rt, shade);
 
         const auto& shortcuts = Config::getNew().shortcuts;
         auto yPos = 0;
@@ -165,7 +165,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
             string_id format = StringIds::black_stringid;
             if (i == self.rowHover)
             {
-                Gfx::drawRect(context, 0, yPos, 800, rowHeight, 0x2000030);
+                Gfx::drawRect(rt, 0, yPos, 800, rowHeight, 0x2000030);
                 format = StringIds::wcolour2_stringid;
             }
 
@@ -191,7 +191,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
             formatter.push(baseStringId);
             formatter.push(buffer);
 
-            Gfx::drawStringLeft(context, 0, yPos - 1, Colour::black, format, &formatter);
+            Gfx::drawStringLeft(rt, 0, yPos - 1, Colour::black, format, &formatter);
             yPos += rowHeight;
         }
     }

--- a/src/OpenLoco/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/Windows/LandscapeGeneration.cpp
@@ -66,7 +66,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         static void switchTab(Window* window, WidgetIndex_t widgetIndex);
 
         // 0x0043ECA4
-        static void drawTabs(Window* window, Gfx::Context* context)
+        static void drawTabs(Window* window, Gfx::RenderTarget* rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
@@ -85,39 +85,39 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                 else
                     imageId += optionTabImageIds[0];
 
-                Widget::drawTab(window, context, imageId, widx::tab_options);
+                Widget::drawTab(window, rt, imageId, widx::tab_options);
             }
 
             // Land tab
             {
                 auto land = ObjectManager::get<LandObject>(LastGameOptionManager::getLastLand());
                 const uint32_t imageId = land->var_16 + Land::ImageIds::toolbar_terraform_land;
-                Widget::drawTab(window, context, imageId, widx::tab_land);
+                Widget::drawTab(window, rt, imageId, widx::tab_land);
             }
 
             // Forest tab
             {
                 const uint32_t imageId = skin->img + InterfaceSkin::ImageIds::toolbar_menu_plant_trees;
-                Widget::drawTab(window, context, imageId, widx::tab_forests);
+                Widget::drawTab(window, rt, imageId, widx::tab_forests);
             }
 
             // Towns tab
             {
                 const uint32_t imageId = skin->img + InterfaceSkin::ImageIds::toolbar_menu_towns;
-                Widget::drawTab(window, context, imageId, widx::tab_towns);
+                Widget::drawTab(window, rt, imageId, widx::tab_towns);
             }
 
             // Industries tab
             {
                 const uint32_t imageId = skin->img + InterfaceSkin::ImageIds::toolbar_menu_industries;
-                Widget::drawTab(window, context, imageId, widx::tab_industries);
+                Widget::drawTab(window, rt, imageId, widx::tab_industries);
             }
         }
 
-        static void draw(Window& window, Gfx::Context* context)
+        static void draw(Window& window, Gfx::RenderTarget* rt)
         {
-            window.draw(context);
-            drawTabs(&window, context);
+            window.draw(rt);
+            drawTabs(&window, rt);
         }
 
         static void prepareDraw(Window& window)
@@ -169,12 +169,12 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         static WindowEventList events;
 
         // 0x0043DC30
-        static void draw(Window& window, Gfx::Context* context)
+        static void draw(Window& window, Gfx::RenderTarget* rt)
         {
-            Common::draw(window, context);
+            Common::draw(window, rt);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::start_year].top,
                 Colour::black,
@@ -370,40 +370,40 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         static WindowEventList events;
 
         // 0x0043DF89
-        static void draw(Window& window, Gfx::Context* context)
+        static void draw(Window& window, Gfx::RenderTarget* rt)
         {
-            Common::draw(window, context);
+            Common::draw(window, rt);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::generator].top,
                 Colour::black,
                 StringIds::generator);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::sea_level].top,
                 Colour::black,
                 StringIds::sea_level);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::min_land_height].top,
                 Colour::black,
                 StringIds::min_land_height);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::topography_style].top,
                 Colour::black,
                 StringIds::topography_style);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::hill_density].top,
                 Colour::black,
@@ -423,7 +423,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         };
 
         // 0x0043E01C
-        static void drawScroll(Ui::Window& window, Gfx::Context& context, const uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& window, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
         {
             uint16_t yPos = 0;
             for (uint16_t i = 0; i < maxLandObjects; i++)
@@ -434,26 +434,26 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
                 // Draw tile icon.
                 const uint32_t imageId = landObject->var_16 + OpenLoco::Land::ImageIds::landscape_generator_tile_icon;
-                Gfx::drawImage(&context, 2, yPos + 1, imageId);
+                Gfx::drawImage(&rt, 2, yPos + 1, imageId);
 
                 // Draw land description.
                 commonFormatArgs[0] = landObject->name;
-                Gfx::drawStringLeftClipped(context, 24, yPos + 5, 121, Colour::black, StringIds::wcolour2_stringid, &*commonFormatArgs);
+                Gfx::drawStringLeftClipped(rt, 24, yPos + 5, 121, Colour::black, StringIds::wcolour2_stringid, &*commonFormatArgs);
 
                 // Draw rectangle.
-                Gfx::fillRectInset(context, 150, yPos + 5, 340, yPos + 16, window.getColour(WindowColour::secondary).u8(), 0b110000);
+                Gfx::fillRectInset(rt, 150, yPos + 5, 340, yPos + 16, window.getColour(WindowColour::secondary).u8(), 0b110000);
 
                 // Draw current distribution setting.
                 const string_id distributionId = landDistributionLabelIds[enumValue(S5::getOptions().landDistributionPatterns[i])];
                 commonFormatArgs[0] = distributionId;
-                Gfx::drawStringLeftClipped(context, 151, yPos + 5, 177, Colour::black, StringIds::black_stringid, &*commonFormatArgs);
+                Gfx::drawStringLeftClipped(rt, 151, yPos + 5, 177, Colour::black, StringIds::black_stringid, &*commonFormatArgs);
 
                 // Draw rectangle (knob).
                 const uint8_t flags = window.rowHover == i ? 0b110000 : 0;
-                Gfx::fillRectInset(context, 329, yPos + 6, 339, yPos + 15, window.getColour(WindowColour::secondary).u8(), flags);
+                Gfx::fillRectInset(rt, 329, yPos + 6, 339, yPos + 15, window.getColour(WindowColour::secondary).u8(), flags);
 
                 // Draw triangle (knob).
-                Gfx::drawStringLeft(context, 330, yPos + 6, Colour::black, StringIds::dropdown, nullptr);
+                Gfx::drawStringLeft(rt, 330, yPos + 6, Colour::black, StringIds::dropdown, nullptr);
 
                 yPos += rowHeight;
             }
@@ -752,61 +752,61 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         static WindowEventList events;
 
         // 0x0043E53A
-        static void draw(Window& window, Gfx::Context* context)
+        static void draw(Window& window, Gfx::RenderTarget* rt)
         {
-            Common::draw(window, context);
+            Common::draw(window, rt);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::number_of_forests].top,
                 Colour::black,
                 StringIds::number_of_forests);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::min_forest_radius].top,
                 Colour::black,
                 StringIds::min_forest_radius);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::max_forest_radius].top,
                 Colour::black,
                 StringIds::max_forest_radius);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::min_forest_density].top,
                 Colour::black,
                 StringIds::min_forest_density);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::max_forest_density].top,
                 Colour::black,
                 StringIds::max_forest_density);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::number_random_trees].top,
                 Colour::black,
                 StringIds::number_random_trees);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::min_altitude_for_trees].top,
                 Colour::black,
                 StringIds::min_altitude_for_trees);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::max_altitude_for_trees].top,
                 Colour::black,
@@ -990,19 +990,19 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         static WindowEventList events;
 
         // 0x0043E9A3
-        static void draw(Window& window, Gfx::Context* context)
+        static void draw(Window& window, Gfx::RenderTarget* rt)
         {
-            Common::draw(window, context);
+            Common::draw(window, rt);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::number_of_towns].top,
                 Colour::black,
                 StringIds::number_of_towns);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::max_town_size].top,
                 Colour::black,
@@ -1131,12 +1131,12 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         static WindowEventList events;
 
         // 0x0043EB9D
-        static void draw(Window& window, Gfx::Context* context)
+        static void draw(Window& window, Gfx::RenderTarget* rt)
         {
-            Common::draw(window, context);
+            Common::draw(window, rt);
 
             Gfx::drawStringLeft(
-                *context,
+                *rt,
                 window.x + 10,
                 window.y + window.widgets[widx::num_industries].top,
                 Colour::black,

--- a/src/OpenLoco/Windows/LandscapeGenerationConfirm.cpp
+++ b/src/OpenLoco/Windows/LandscapeGenerationConfirm.cpp
@@ -36,16 +36,16 @@ namespace OpenLoco::Ui::Windows::LandscapeGenerationConfirm
     static WindowEventList events;
 
     // 0x004C18A5
-    static void draw(Window& window, Gfx::Context* context)
+    static void draw(Window& window, Gfx::RenderTarget* rt)
     {
-        window.draw(context);
+        window.draw(rt);
 
         static loco_global<string_id, 0x0112C826> commonFormatArgs;
         string_id prompt = window.var_846 == 0 ? StringIds::prompt_confirm_generate_landscape : StringIds::prompt_confirm_random_landscape;
         *commonFormatArgs = prompt;
 
         auto origin = Ui::Point(window.x + (window.width / 2), window.y + 41);
-        Gfx::drawStringCentredWrapped(*context, origin, window.width, Colour::black, StringIds::wcolour2_stringid, (const char*)&*commonFormatArgs);
+        Gfx::drawStringCentredWrapped(*rt, origin, window.width, Colour::black, StringIds::wcolour2_stringid, (const char*)&*commonFormatArgs);
     }
 
     // 0x004C18E4

--- a/src/OpenLoco/Windows/Main.cpp
+++ b/src/OpenLoco/Windows/Main.cpp
@@ -54,9 +54,9 @@ namespace OpenLoco::Ui::Windows::Main
     }
 
     // 0x0043B2E4
-    static void draw(Ui::Window& window, Gfx::Context* const context)
+    static void draw(Ui::Window& window, Gfx::RenderTarget* const rt)
     {
-        window.drawViewports(context);
+        window.drawViewports(rt);
     }
 
     static void initEvents()

--- a/src/OpenLoco/Windows/MapToolTip.cpp
+++ b/src/OpenLoco/Windows/MapToolTip.cpp
@@ -113,7 +113,7 @@ namespace OpenLoco::Ui::Windows::MapToolTip
     }
 
     // 0x004CF010
-    static void draw(Window& self, Gfx::Context* context)
+    static void draw(Window& self, Gfx::RenderTarget* rt)
     {
         auto args = FormatArguments::mapToolTip();
         StringManager::ArgsWrapper argsWrap(&args);
@@ -126,25 +126,25 @@ namespace OpenLoco::Ui::Windows::MapToolTip
         if (_mapTooltipOwner == CompanyId::null || _mapTooltipOwner == CompanyManager::getControllingId())
         {
             Ui::Point origin(self.x + self.width / 2, self.y + self.height / 2 - 5);
-            Gfx::drawStringCentredWrapped(*context, origin, self.width, Colour::black, StringIds::outlined_wcolour2_stringid, &args);
+            Gfx::drawStringCentredWrapped(*rt, origin, self.width, Colour::black, StringIds::outlined_wcolour2_stringid, &args);
         }
         else
         {
             Ui::Point origin(self.x + self.width / 2 + 13, self.y + self.height / 2 - 5);
-            auto width = Gfx::drawStringCentredWrapped(*context, origin, self.width - 28, Colour::black, StringIds::outlined_wcolour2_stringid, &args);
+            auto width = Gfx::drawStringCentredWrapped(*rt, origin, self.width - 28, Colour::black, StringIds::outlined_wcolour2_stringid, &args);
 
             auto left = self.width / 2 + self.x + 13 - width / 2 - 28;
             auto top = self.height / 2 - 13 + self.y;
             auto right = left + 25;
             auto bottom = top + 25;
 
-            Gfx::fillRect(*context, left, top, right, bottom, enumValue(Colour::darkGreen));
+            Gfx::fillRect(*rt, left, top, right, bottom, enumValue(Colour::darkGreen));
 
             auto* company = CompanyManager::get(_mapTooltipOwner);
             auto* competitor = ObjectManager::get<CompetitorObject>(company->competitorId);
             auto imageId = Gfx::recolour(competitor->images[company->ownerEmotion], company->mainColours.primary);
 
-            Gfx::drawImage(context, left + 1, top + 1, imageId);
+            Gfx::drawImage(rt, left + 1, top + 1, imageId);
         }
     }
 

--- a/src/OpenLoco/Windows/MapWindow.cpp
+++ b/src/OpenLoco/Windows/MapWindow.cpp
@@ -454,7 +454,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046D0E0
-    static void drawTabs(Window* self, Gfx::Context* context)
+    static void drawTabs(Window* self, Gfx::RenderTarget* rt)
     {
         auto skin = ObjectManager::get<InterfaceSkinObject>();
 
@@ -463,7 +463,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             uint32_t imageId = skin->img;
             imageId += InterfaceSkin::ImageIds::toolbar_menu_map_north;
 
-            Widget::drawTab(self, context, imageId, widx::tabOverall);
+            Widget::drawTab(self, rt, imageId, widx::tabOverall);
         }
 
         // tabVehicles,
@@ -497,7 +497,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
                 imageId = Gfx::recolour(imageId, colour);
 
-                Widget::drawTab(self, context, imageId, widx::tabVehicles);
+                Widget::drawTab(self, rt, imageId, widx::tabVehicles);
             }
         }
 
@@ -506,7 +506,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             uint32_t imageId = skin->img;
             imageId += InterfaceSkin::ImageIds::toolbar_menu_industries;
 
-            Widget::drawTab(self, context, imageId, widx::tabIndustries);
+            Widget::drawTab(self, rt, imageId, widx::tabIndustries);
         }
 
         // tabRoutes,
@@ -526,7 +526,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 else
                     imageId += routeImageIds[0];
 
-                Widget::drawTab(self, context, imageId, widx::tabRoutes);
+                Widget::drawTab(self, rt, imageId, widx::tabRoutes);
             }
         }
 
@@ -537,13 +537,13 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 uint32_t imageId = skin->img;
                 imageId += InterfaceSkin::ImageIds::tab_companies;
 
-                Widget::drawTab(self, context, imageId, widx::tabOwnership);
+                Widget::drawTab(self, rt, imageId, widx::tabOwnership);
             }
         }
     }
 
     // 0x0046D273
-    static void drawGraphKeyOverall(Window* self, Gfx::Context* context, uint16_t x, uint16_t* y)
+    static void drawGraphKeyOverall(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t* y)
     {
         static const PaletteIndex_t overallColours[] = {
             PaletteIndex::index_41,
@@ -568,7 +568,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             auto colour = overallColours[i];
             if (!(self->var_854 & (1 << i)) || !(mapFrameNumber & (1 << 2)))
             {
-                Gfx::drawRect(*context, x, *y + 3, 5, 5, colour);
+                Gfx::drawRect(*rt, x, *y + 3, 5, 5, colour);
             }
             auto args = FormatArguments();
             args.push(lineNames[i]);
@@ -580,7 +580,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 stringId = StringIds::small_white_string;
             }
 
-            Gfx::drawStringLeftClipped(*context, x + 6, *y, 94, Colour::black, stringId, &args);
+            Gfx::drawStringLeftClipped(*rt, x + 6, *y, 94, Colour::black, stringId, &args);
 
             *y += 10;
         }
@@ -597,7 +597,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     };
 
     // 0x0046D379
-    static void drawGraphKeyVehicles(Window* self, Gfx::Context* context, uint16_t x, uint16_t* y)
+    static void drawGraphKeyVehicles(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t* y)
     {
         static const string_id lineNames[] = {
             StringIds::forbid_trains,
@@ -614,7 +614,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             {
                 auto colour = vehicleTypeColours[i];
 
-                Gfx::drawRect(*context, x, *y + 3, 5, 5, colour);
+                Gfx::drawRect(*rt, x, *y + 3, 5, 5, colour);
             }
             auto args = FormatArguments();
             args.push(lineNames[i]);
@@ -626,14 +626,14 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 stringId = StringIds::small_white_string;
             }
 
-            Gfx::drawStringLeftClipped(*context, x + 6, *y, 94, Colour::black, stringId, &args);
+            Gfx::drawStringLeftClipped(*rt, x + 6, *y, 94, Colour::black, stringId, &args);
 
             *y += 10;
         }
     }
 
     // 0x0046D47F
-    static void drawGraphKeyIndustries(Window* self, Gfx::Context* context, uint16_t x, uint16_t* y)
+    static void drawGraphKeyIndustries(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t* y)
     {
         static const PaletteIndex_t industryColours[] = {
             PaletteIndex::index_0A,
@@ -680,7 +680,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             {
                 auto colour = industryColours[_byte_F253CE[i]];
 
-                Gfx::drawRect(*context, x, *y + 3, 5, 5, colour);
+                Gfx::drawRect(*rt, x, *y + 3, 5, 5, colour);
             }
 
             auto args = FormatArguments();
@@ -693,14 +693,14 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 stringId = StringIds::small_white_string;
             }
 
-            Gfx::drawStringLeftClipped(*context, x + 6, *y, 94, Colour::black, stringId, &args);
+            Gfx::drawStringLeftClipped(*rt, x + 6, *y, 94, Colour::black, stringId, &args);
 
             *y += 10;
         }
     }
 
     // 0x0046D5A4
-    static void drawGraphKeyRoutes(Window* self, Gfx::Context* context, uint16_t x, uint16_t* y)
+    static void drawGraphKeyRoutes(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t* y)
     {
         for (auto i = 0; _byte_F253DF[i] != 0xFF; i++)
         {
@@ -709,7 +709,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
             if (!(self->var_854 & (1 << i)) || !(mapFrameNumber & (1 << 2)))
             {
-                Gfx::drawRect(*context, x, *y + 3, 5, 5, colour);
+                Gfx::drawRect(*rt, x, *y + 3, 5, 5, colour);
             }
 
             auto routeType = StringIds::map_routes_aircraft;
@@ -743,14 +743,14 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 stringId = StringIds::small_white_string;
             }
 
-            Gfx::drawStringLeftClipped(*context, x + 6, *y, 94, Colour::black, stringId, &args);
+            Gfx::drawStringLeftClipped(*rt, x + 6, *y, 94, Colour::black, stringId, &args);
 
             *y += 10;
         }
     }
 
     // 0x0046D6E1
-    static void drawGraphKeyCompanies(Window* self, Gfx::Context* context, uint16_t x, uint16_t* y)
+    static void drawGraphKeyCompanies(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t* y)
     {
         for (const auto& company : CompanyManager::companies())
         {
@@ -759,7 +759,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
             if (!(self->var_854 & (1 << enumValue(index))) || !(mapFrameNumber & (1 << 2)))
             {
-                Gfx::drawRect(*context, x, *y + 3, 5, 5, colour);
+                Gfx::drawRect(*rt, x, *y + 3, 5, 5, colour);
             }
 
             auto args = FormatArguments();
@@ -772,7 +772,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 stringId = StringIds::small_white_string;
             }
 
-            Gfx::drawStringLeftClipped(*context, x + 6, *y, 94, Colour::black, stringId, &args);
+            Gfx::drawStringLeftClipped(*rt, x + 6, *y, 94, Colour::black, stringId, &args);
 
             *y += 10;
         }
@@ -906,10 +906,10 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046B779
-    static void draw(Window& self, Gfx::Context* context)
+    static void draw(Window& self, Gfx::RenderTarget* rt)
     {
-        self.draw(context);
-        drawTabs(&self, context);
+        self.draw(rt);
+        drawTabs(&self, rt);
 
         {
             auto x = self.x + self.width - 104;
@@ -918,23 +918,23 @@ namespace OpenLoco::Ui::Windows::MapWindow
             switch (self.currentTab + widx::tabOverall)
             {
                 case widx::tabOverall:
-                    drawGraphKeyOverall(&self, context, x, &y);
+                    drawGraphKeyOverall(&self, rt, x, &y);
                     break;
 
                 case widx::tabVehicles:
-                    drawGraphKeyVehicles(&self, context, x, &y);
+                    drawGraphKeyVehicles(&self, rt, x, &y);
                     break;
 
                 case widx::tabIndustries:
-                    drawGraphKeyIndustries(&self, context, x, &y);
+                    drawGraphKeyIndustries(&self, rt, x, &y);
                     break;
 
                 case widx::tabRoutes:
-                    drawGraphKeyRoutes(&self, context, x, &y);
+                    drawGraphKeyRoutes(&self, rt, x, &y);
                     break;
 
                 case widx::tabOwnership:
-                    drawGraphKeyCompanies(&self, context, x, &y);
+                    drawGraphKeyCompanies(&self, rt, x, &y);
                     break;
             }
 
@@ -968,28 +968,28 @@ namespace OpenLoco::Ui::Windows::MapWindow
         auto y = self.y + self.widgets[widx::statusBar].top - 1;
         auto width = self.widgets[widx::statusBar].width();
 
-        Gfx::drawStringLeftClipped(*context, x, y, width, Colour::black, StringIds::black_stringid, &args);
+        Gfx::drawStringLeftClipped(*rt, x, y, width, Colour::black, StringIds::black_stringid, &args);
     }
 
     // 0x0046BF0F based on
-    static void drawVehicleOnMap(Gfx::Context* context, Vehicles::VehicleBase* vehicle, uint8_t colour)
+    static void drawVehicleOnMap(Gfx::RenderTarget* rt, Vehicles::VehicleBase* vehicle, uint8_t colour)
     {
         if (vehicle->position.x == Location::null)
             return;
 
         auto trainPos = locationToMapWindowPos(vehicle->position);
 
-        Gfx::fillRect(*context, trainPos.x, trainPos.y, trainPos.x, trainPos.y, colour);
+        Gfx::fillRect(*rt, trainPos.x, trainPos.y, trainPos.x, trainPos.y, colour);
     }
 
     // 0x0046C294
-    static std::pair<Point, Point> drawRouteLine(Gfx::Context* context, Point startPos, Point endPos, Pos2 stationPos, uint8_t colour)
+    static std::pair<Point, Point> drawRouteLine(Gfx::RenderTarget* rt, Point startPos, Point endPos, Pos2 stationPos, uint8_t colour)
     {
         auto newStartPos = locationToMapWindowPos({ stationPos.x, stationPos.y });
 
         if (endPos.x != Location::null)
         {
-            Gfx::drawLine(*context, endPos.x, endPos.y, newStartPos.x, newStartPos.y, colour);
+            Gfx::drawLine(*rt, endPos.x, endPos.y, newStartPos.x, newStartPos.y, colour);
         }
 
         endPos = newStartPos;
@@ -1044,7 +1044,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046C18D
-    static void drawRoutesOnMap(Gfx::Context* context, Vehicles::Vehicle train)
+    static void drawRoutesOnMap(Gfx::RenderTarget* rt, Vehicles::Vehicle train)
     {
         auto colour = getRouteColour(train);
 
@@ -1061,7 +1061,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 auto station = StationManager::get(stationOrder->getStation());
                 Pos2 stationPos = { station->x, station->y };
 
-                auto routePos = drawRouteLine(context, startPos, endPos, stationPos, *colour);
+                auto routePos = drawRouteLine(rt, startPos, endPos, stationPos, *colour);
                 startPos = routePos.first;
                 endPos = routePos.second;
             }
@@ -1070,7 +1070,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
         if (startPos.x == Location::null || endPos.x == Location::null)
             return;
 
-        Gfx::drawLine(*context, startPos.x, startPos.y, endPos.x, endPos.y, *colour);
+        Gfx::drawLine(*rt, startPos.x, startPos.y, endPos.x, endPos.y, *colour);
     }
 
     // 0x0046C426
@@ -1125,7 +1125,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046BE6E, 0x0046C35A
-    static void drawVehiclesOnMap(Gfx::Context* context, WidgetIndex_t widgetIndex)
+    static void drawVehiclesOnMap(Gfx::RenderTarget* rt, WidgetIndex_t widgetIndex)
     {
         for (auto vehicle : EntityManager::VehicleList())
         {
@@ -1140,18 +1140,18 @@ namespace OpenLoco::Ui::Windows::MapWindow
             for (auto& car : train.cars)
             {
                 auto colour = getVehicleColour(widgetIndex, train, car);
-                car.applyToComponents([context, colour](auto& component) { drawVehicleOnMap(context, &component, colour); });
+                car.applyToComponents([rt, colour](auto& component) { drawVehicleOnMap(rt, &component, colour); });
             }
 
             if (widgetIndex == widx::tabRoutes)
             {
-                drawRoutesOnMap(context, train);
+                drawRoutesOnMap(rt, train);
             }
         }
     }
 
     // 0x0046BE51, 0x0046BE34
-    static void drawRectOnMap(Gfx::Context* context, int16_t left, int16_t top, int16_t right, int16_t bottom, uint32_t colour)
+    static void drawRectOnMap(Gfx::RenderTarget* rt, int16_t left, int16_t top, int16_t right, int16_t bottom, uint32_t colour)
     {
         if (left > right)
         {
@@ -1163,11 +1163,11 @@ namespace OpenLoco::Ui::Windows::MapWindow
             std::swap(top, bottom);
         }
 
-        Gfx::fillRect(*context, left, top, right, bottom, colour);
+        Gfx::fillRect(*rt, left, top, right, bottom, colour);
     }
 
     // 0x0046BE51
-    static void drawViewOnMap(Gfx::Context* context, int16_t left, int16_t top, int16_t right, int16_t bottom)
+    static void drawViewOnMap(Gfx::RenderTarget* rt, int16_t left, int16_t top, int16_t right, int16_t bottom)
     {
         left /= 32;
         top /= 16;
@@ -1180,11 +1180,11 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
         uint32_t colour = (1 << 24) | PaletteIndex::index_0A;
 
-        drawRectOnMap(context, left, top, right, bottom, colour);
+        drawRectOnMap(rt, left, top, right, bottom, colour);
     }
 
     // 0x0046BE34
-    static void drawViewCornersOnMap(Gfx::Context* context, int16_t left, int16_t top, int16_t leftOffset, int16_t topOffset, int16_t rightOffset, int16_t bottomOffset)
+    static void drawViewCornersOnMap(Gfx::RenderTarget* rt, int16_t left, int16_t top, int16_t leftOffset, int16_t topOffset, int16_t rightOffset, int16_t bottomOffset)
     {
         left /= 32;
         top /= 16;
@@ -1199,11 +1199,11 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
         uint32_t colour = PaletteIndex::index_0A;
 
-        drawRectOnMap(context, left, top, right, bottom, colour);
+        drawRectOnMap(rt, left, top, right, bottom, colour);
     }
 
     // 0x0046BAD5
-    static void drawViewportPosition(Gfx::Context* context)
+    static void drawViewportPosition(Gfx::RenderTarget* rt)
     {
         auto window = WindowManager::getMainWindow();
 
@@ -1222,7 +1222,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             auto bottom = viewport->view_y;
             right += viewport->view_width;
 
-            drawViewOnMap(context, left, top, right, bottom);
+            drawViewOnMap(rt, left, top, right, bottom);
         }
 
         {
@@ -1234,7 +1234,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             right += viewport->view_width;
             bottom += viewport->view_height;
 
-            drawViewOnMap(context, left, top, right, bottom);
+            drawViewOnMap(rt, left, top, right, bottom);
         }
 
         {
@@ -1244,7 +1244,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             auto bottom = viewport->view_y;
             bottom += viewport->view_height;
 
-            drawViewOnMap(context, left, top, right, bottom);
+            drawViewOnMap(rt, left, top, right, bottom);
         }
 
         {
@@ -1256,7 +1256,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             right += viewport->view_width;
             bottom += viewport->view_height;
 
-            drawViewOnMap(context, left, top, right, bottom);
+            drawViewOnMap(rt, left, top, right, bottom);
         }
 
         if (!(mapFrameNumber & (1 << 2)))
@@ -1271,7 +1271,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             auto left = viewport->view_x;
             auto top = viewport->view_y;
 
-            drawViewCornersOnMap(context, left, top, 0, 0, cornerSize, 0);
+            drawViewCornersOnMap(rt, left, top, 0, 0, cornerSize, 0);
         }
 
         {
@@ -1279,22 +1279,14 @@ namespace OpenLoco::Ui::Windows::MapWindow
             left += viewport->view_width;
             auto top = viewport->view_y;
 
-            drawViewCornersOnMap(context, left, top, -cornerSize, 0, 0, 0);
+            drawViewCornersOnMap(rt, left, top, -cornerSize, 0, 0, 0);
         }
 
         {
             auto left = viewport->view_x;
             auto top = viewport->view_y;
 
-            drawViewCornersOnMap(context, left, top, 0, 0, 0, cornerSize);
-        }
-
-        {
-            auto left = viewport->view_x;
-            auto top = viewport->view_y;
-            top += viewport->view_height;
-
-            drawViewCornersOnMap(context, left, top, 0, -cornerSize, 0, 0);
+            drawViewCornersOnMap(rt, left, top, 0, 0, 0, cornerSize);
         }
 
         {
@@ -1302,24 +1294,15 @@ namespace OpenLoco::Ui::Windows::MapWindow
             auto top = viewport->view_y;
             top += viewport->view_height;
 
-            drawViewCornersOnMap(context, left, top, 0, 0, cornerSize, 0);
+            drawViewCornersOnMap(rt, left, top, 0, -cornerSize, 0, 0);
         }
 
         {
             auto left = viewport->view_x;
-            left += viewport->view_width;
             auto top = viewport->view_y;
             top += viewport->view_height;
 
-            drawViewCornersOnMap(context, left, top, -cornerSize, 0, 0, 0);
-        }
-
-        {
-            auto left = viewport->view_x;
-            left += viewport->view_width;
-            auto top = viewport->view_y;
-
-            drawViewCornersOnMap(context, left, top, 0, 0, 0, cornerSize);
+            drawViewCornersOnMap(rt, left, top, 0, 0, cornerSize, 0);
         }
 
         {
@@ -1328,12 +1311,29 @@ namespace OpenLoco::Ui::Windows::MapWindow
             auto top = viewport->view_y;
             top += viewport->view_height;
 
-            drawViewCornersOnMap(context, left, top, 0, -cornerSize, 0, 0);
+            drawViewCornersOnMap(rt, left, top, -cornerSize, 0, 0, 0);
+        }
+
+        {
+            auto left = viewport->view_x;
+            left += viewport->view_width;
+            auto top = viewport->view_y;
+
+            drawViewCornersOnMap(rt, left, top, 0, 0, 0, cornerSize);
+        }
+
+        {
+            auto left = viewport->view_x;
+            left += viewport->view_width;
+            auto top = viewport->view_y;
+            top += viewport->view_height;
+
+            drawViewCornersOnMap(rt, left, top, 0, -cornerSize, 0, 0);
         }
     }
 
     // 0x0046C481
-    static void drawTownNames(Gfx::Context* context)
+    static void drawTownNames(Gfx::RenderTarget* rt)
     {
         for (const auto& town : TownManager::towns())
         {
@@ -1350,17 +1350,17 @@ namespace OpenLoco::Ui::Windows::MapWindow
             townPos.y -= 3;
 
             Gfx::setCurrentFontSpriteBase(Font::small);
-            Gfx::drawString(*context, townPos.x, townPos.y, AdvancedColour(Colour::purple).outline(), _stringFormatBuffer);
+            Gfx::drawString(*rt, townPos.x, townPos.y, AdvancedColour(Colour::purple).outline(), _stringFormatBuffer);
         }
     }
 
     // 0x0046B806
-    static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
+    static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
     {
         if (!Game::hasFlags(1u << 0))
             return;
 
-        Gfx::clearSingle(context, PaletteIndex::index_0A);
+        Gfx::clearSingle(rt, PaletteIndex::index_0A);
 
         auto element = Gfx::getG1Element(0);
         auto backupElement = *element;
@@ -1376,7 +1376,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
         Gfx::getG1Element(0)->y_offset = -8;
         Gfx::getG1Element(0)->flags = 0;
 
-        Gfx::drawImage(&context, 0, 0, 0);
+        Gfx::drawImage(&rt, 0, 0, 0);
 
         *element = backupElement;
 
@@ -1385,13 +1385,13 @@ namespace OpenLoco::Ui::Windows::MapWindow
             countVehiclesOnMap();
         }
 
-        drawVehiclesOnMap(&context, self.currentTab + widx::tabOverall);
+        drawVehiclesOnMap(&rt, self.currentTab + widx::tabOverall);
 
-        drawViewportPosition(&context);
+        drawViewportPosition(&rt);
 
         if (self.savedView.mapX & (1 << 0))
         {
-            drawTownNames(&context);
+            drawTownNames(&rt);
         }
     }
 

--- a/src/OpenLoco/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/Windows/MessageWindow.cpp
@@ -57,7 +57,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         static void prepareDraw(Window& self);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
         static void onUpdate(Window& self);
-        static void drawTabs(Window* self, Gfx::Context* context);
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt);
         static void initEvents();
     }
 
@@ -208,29 +208,29 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042A5CC
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
         }
 
         // 0x0042A5D7
-        static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
         {
             auto colour = Colours::getShade(self.getColour(WindowColour::secondary).c(), 4);
 
-            Gfx::clearSingle(context, colour);
+            Gfx::clearSingle(rt, colour);
 
             auto height = 0;
             for (auto i = 0; i < _messageCount; i++)
             {
-                if (height + messageHeight <= context.y)
+                if (height + messageHeight <= rt.y)
                 {
                     height += messageHeight;
                     continue;
                 }
 
-                if (height >= context.y + context.height)
+                if (height >= rt.y + rt.height)
                 {
                     height += messageHeight;
                     continue;
@@ -246,7 +246,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
 
                 if (self.rowHover == i)
                 {
-                    Gfx::drawRect(context, 0, height, self.width, 38, (1 << 25) | PaletteIndex::index_30);
+                    Gfx::drawRect(rt, 0, height, self.width, 38, (1 << 25) | PaletteIndex::index_30);
                     stringId = StringIds::wcolour2_stringid;
                 }
 
@@ -255,14 +255,14 @@ namespace OpenLoco::Ui::Windows::MessageWindow
                     args.push(StringIds::tiny_font_date);
                     args.push(message->date);
 
-                    Gfx::drawStringLeft(context, 0, height, Colour::black, stringId, &args);
+                    Gfx::drawStringLeft(rt, 0, height, Colour::black, stringId, &args);
                 }
                 {
                     auto args = FormatArguments();
                     args.push(StringIds::buffer_2039);
 
                     auto width = self.widgets[widx::scrollview].width() - 14;
-                    Gfx::drawStringLeftWrapped(context, 0, height + 6, width, Colour::black, stringId, &args);
+                    Gfx::drawStringLeftWrapped(rt, 0, height + 6, width, Colour::black, stringId, &args);
                     height += messageHeight;
                 }
             }
@@ -500,10 +500,10 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042AA02
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
             auto yPos = self.widgets[widx::company_major_news].top + self.y;
 
             const string_id newsStringIds[] = {
@@ -527,7 +527,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
                     auto args = FormatArguments();
                     args.push(newsStringIds[i]);
 
-                    Gfx::drawStringLeft(*context, self.x + 4, yPos, Colour::black, StringIds::wcolour2_stringid, &args);
+                    Gfx::drawStringLeft(*rt, self.x + 4, yPos, Colour::black, StringIds::wcolour2_stringid, &args);
                 }
 
                 {
@@ -535,7 +535,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
                     auto args = FormatArguments();
                     args.push(newsDropdownStringIds[static_cast<uint8_t>(Config::get().newsSettings[i])]);
 
-                    Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::black_stringid, &args);
+                    Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::black_stringid, &args);
                 }
                 yPos += 15;
             }
@@ -640,7 +640,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042AB92
-        static void drawTabs(Window* self, Gfx::Context* context)
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
@@ -649,7 +649,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
                 uint32_t imageId = skin->img;
                 imageId += InterfaceSkin::ImageIds::tab_messages;
 
-                Widget::drawTab(self, context, imageId, widx::tab_messages);
+                Widget::drawTab(self, rt, imageId, widx::tab_messages);
             }
 
             // Setting Tab
@@ -657,7 +657,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
                 uint32_t imageId = skin->img;
                 imageId += InterfaceSkin::ImageIds::tab_message_settings;
 
-                Widget::drawTab(self, context, imageId, widx::tab_settings);
+                Widget::drawTab(self, rt, imageId, widx::tab_settings);
             }
         }
 

--- a/src/OpenLoco/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/Windows/MusicSelection.cpp
@@ -39,8 +39,8 @@ namespace OpenLoco::Ui::Windows::MusicSelection
 
     static WindowEventList _events;
 
-    static void draw(Ui::Window& window, Gfx::Context* context);
-    static void drawScroll(Ui::Window& window, Gfx::Context& context, const uint32_t scrollIndex);
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt);
+    static void drawScroll(Ui::Window& window, Gfx::RenderTarget& rt, const uint32_t scrollIndex);
     static void getScrollSize(Ui::Window& window, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);
     static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex);
     static void onScrollMouseDown(Ui::Window& window, int16_t x, int16_t y, uint8_t scroll_index);
@@ -91,17 +91,17 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     }
 
     // 0x004C165D
-    static void draw(Ui::Window& window, Gfx::Context* context)
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
     {
         // Draw widgets.
-        window.draw(context);
+        window.draw(rt);
     }
 
     // 0x004C1663
-    static void drawScroll(Ui::Window& window, Gfx::Context& context, const uint32_t scrollIndex)
+    static void drawScroll(Ui::Window& window, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
     {
         auto shade = Colours::getShade(window.getColour(WindowColour::secondary).c(), 4);
-        Gfx::clearSingle(context, shade);
+        Gfx::clearSingle(rt, shade);
 
         const auto& config = Config::get();
 
@@ -113,20 +113,20 @@ namespace OpenLoco::Ui::Windows::MusicSelection
             // Draw hovered track
             if (i == window.rowHover)
             {
-                Gfx::drawRect(context, 0, y, 800, rowHeight, 0x2000030);
+                Gfx::drawRect(rt, 0, y, 800, rowHeight, 0x2000030);
                 text_colour_id = StringIds::wcolour2_stringid;
             }
 
             // Draw checkbox.
-            Gfx::fillRectInset(context, 2, y, 11, y + 10, window.getColour(WindowColour::secondary).u8(), 0xE0);
+            Gfx::fillRectInset(rt, 2, y, 11, y + 10, window.getColour(WindowColour::secondary).u8(), 0xE0);
 
             // Draw checkmark if track is enabled.
             if (config.enabledMusic[i])
-                Gfx::drawStringLeft(context, 2, y, window.getColour(WindowColour::secondary), StringIds::wcolour2_stringid, (void*)&StringIds::checkmark);
+                Gfx::drawStringLeft(rt, 2, y, window.getColour(WindowColour::secondary), StringIds::wcolour2_stringid, (void*)&StringIds::checkmark);
 
             // Draw track name.
             string_id music_title_id = Audio::getMusicInfo(i)->titleId;
-            Gfx::drawStringLeft(context, 15, y, window.getColour(WindowColour::secondary), text_colour_id, (void*)&music_title_id);
+            Gfx::drawStringLeft(rt, 15, y, window.getColour(WindowColour::secondary), text_colour_id, (void*)&music_title_id);
 
             y += rowHeight;
         }

--- a/src/OpenLoco/Windows/NetworkStatus.cpp
+++ b/src/OpenLoco/Windows/NetworkStatus.cpp
@@ -102,14 +102,14 @@ namespace OpenLoco::Ui::Windows::NetworkStatus
         StringManager::setString(StringIds::buffer_1250, _text.c_str());
     }
 
-    static void draw(Window& self, Gfx::Context* context)
+    static void draw(Window& self, Gfx::RenderTarget* rt)
     {
-        self.draw(context);
+        self.draw(rt);
 
         uint16_t x = self.x + (self.width / 2);
         uint16_t y = self.y + (self.height / 2);
         uint16_t width = self.width;
-        Gfx::drawStringCentredClipped(*context, x, y, width, Colour::black, StringIds::buffer_1250, nullptr);
+        Gfx::drawStringCentredClipped(*rt, x, y, width, Colour::black, StringIds::buffer_1250, nullptr);
     }
 
     static void initEvents()

--- a/src/OpenLoco/Windows/News/News.cpp
+++ b/src/OpenLoco/Windows/News/News.cpp
@@ -455,17 +455,17 @@ namespace OpenLoco::Ui::Windows::NewsWindow
         }
 
         // 0x0042A136
-        static void sub_42A136(Window* self, Gfx::Context* context, Message* news)
+        static void sub_42A136(Window* self, Gfx::RenderTarget* rt, Message* news)
         {
             registers regs;
-            regs.edi = X86Pointer(context);
+            regs.edi = X86Pointer(rt);
             regs.esi = X86Pointer(self);
             regs.ebp = X86Pointer(news);
             call(0x0042A136, regs);
         }
 
         // 0x0042A036
-        static void drawViewportString(Gfx::Context* context, uint16_t x, uint16_t y, uint16_t width, MessageItemArgumentType itemType, uint16_t itemIndex)
+        static void drawViewportString(Gfx::RenderTarget* rt, uint16_t x, uint16_t y, uint16_t width, MessageItemArgumentType itemType, uint16_t itemIndex)
         {
             auto args = FormatArguments();
 
@@ -547,7 +547,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 case MessageItemArgumentType::company:
                 case MessageItemArgumentType::vehicleTab:
                 {
-                    Gfx::drawStringCentredClipped(*context, x, y, width, Colour::black, StringIds::black_tiny_font, &args);
+                    Gfx::drawStringCentredClipped(*rt, x, y, width, Colour::black, StringIds::black_tiny_font, &args);
                     break;
                 }
 
@@ -559,13 +559,13 @@ namespace OpenLoco::Ui::Windows::NewsWindow
         }
 
         // 0x00429872
-        static void drawLateNews(Window* self, Gfx::Context* context, Message* news)
+        static void drawLateNews(Window* self, Gfx::RenderTarget* rt, Message* news)
         {
-            Gfx::drawImage(context, self->x, self->y, ImageIds::news_background_new_left);
+            Gfx::drawImage(rt, self->x, self->y, ImageIds::news_background_new_left);
 
-            Gfx::drawImage(context, self->x + (windowSize.width / 2), self->y, ImageIds::news_background_new_right);
+            Gfx::drawImage(rt, self->x + (windowSize.width / 2), self->y, ImageIds::news_background_new_right);
 
-            self->draw(context);
+            self->draw(rt);
 
             char* newsString = news->messageString;
             auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
@@ -586,21 +586,21 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             int16_t y = self->y + 38;
             Ui::Point origin = { x, y };
 
-            Gfx::drawStringCentredWrapped(*context, origin, 352, Colour::black, StringIds::buffer_2039);
+            Gfx::drawStringCentredWrapped(*rt, origin, 352, Colour::black, StringIds::buffer_2039);
 
             x = self->x + 1;
             y = self->y + 1;
             origin = { x, y };
 
-            Gfx::drawStringLeft(*context, &origin, Colour::black, StringIds::news_date, &news->date);
+            Gfx::drawStringLeft(*rt, &origin, Colour::black, StringIds::news_date, &news->date);
 
-            self->drawViewports(context);
+            self->drawViewports(rt);
 
-            sub_42A136(self, context, news);
+            sub_42A136(self, rt, news);
         }
 
         // 0x00429934
-        static void drawMiddleNews(Window* self, Gfx::Context* context, Message* news)
+        static void drawMiddleNews(Window* self, Gfx::RenderTarget* rt, Message* news)
         {
             const auto& mtd = getMessageTypeDescriptor(news->type);
             if (mtd.hasFlag(MessageTypeFlags::hasFirstItem))
@@ -614,7 +614,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                         auto width = self->widgets[Common::widx::viewport1].width() + 1;
                         auto height = self->widgets[Common::widx::viewport1].height() + 1;
                         auto colour = (1 << 25) | PaletteIndex::index_35;
-                        Gfx::drawRect(*context, x, y, width, height, colour);
+                        Gfx::drawRect(*rt, x, y, width, height, colour);
                     }
                 }
             }
@@ -630,24 +630,24 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                         auto width = self->widgets[Common::widx::viewport2].width() + 1;
                         auto height = self->widgets[Common::widx::viewport2].height() + 1;
                         auto colour = (1 << 25) | PaletteIndex::index_35;
-                        Gfx::drawRect(*context, x, y, width, height, colour);
+                        Gfx::drawRect(*rt, x, y, width, height, colour);
                     }
                 }
             }
         }
 
         // 0x004299E7
-        static void drawEarlyNews(Window* self, Gfx::Context* context, Message* news)
+        static void drawEarlyNews(Window* self, Gfx::RenderTarget* rt, Message* news)
         {
             auto imageId = Gfx::recolour(ImageIds::news_background_old_left, ExtColour::translucentBrown1);
 
-            Gfx::drawImage(context, self->x, self->y, imageId);
+            Gfx::drawImage(rt, self->x, self->y, imageId);
 
             imageId = Gfx::recolour(ImageIds::news_background_old_right, ExtColour::translucentBrown1);
 
-            Gfx::drawImage(context, self->x + (windowSize.width / 2), self->y, imageId);
+            Gfx::drawImage(rt, self->x + (windowSize.width / 2), self->y, imageId);
 
-            self->draw(context);
+            self->draw(rt);
 
             char* newsString = news->messageString;
             auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
@@ -668,36 +668,36 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             int16_t y = self->y + 38;
             Ui::Point origin = { x, y };
 
-            Gfx::drawStringCentredWrapped(*context, origin, 352, Colour::black, StringIds::buffer_2039);
+            Gfx::drawStringCentredWrapped(*rt, origin, 352, Colour::black, StringIds::buffer_2039);
 
             origin.x = self->x + 4;
             origin.y = self->y + 5;
 
-            Gfx::drawStringLeft(*context, &origin, Colour::black, StringIds::news_date, &news->date);
+            Gfx::drawStringLeft(*rt, &origin, Colour::black, StringIds::news_date, &news->date);
 
-            self->drawViewports(context);
+            self->drawViewports(rt);
 
-            sub_42A136(self, context, news);
+            sub_42A136(self, rt, news);
 
             x = self->x + 3;
             y = self->y + 5;
             auto width = self->width - 6;
             auto height = self->height;
             auto colour = (1 << 25) | PaletteIndex::index_68;
-            Gfx::drawRect(*context, x, y, width, height, colour);
+            Gfx::drawRect(*rt, x, y, width, height, colour);
 
             x = self->widgets[Common::widx::viewport1].left + self->x;
             y = self->widgets[Common::widx::viewport1].top + self->y;
             width = self->widgets[Common::widx::viewport1].width();
             height = self->widgets[Common::widx::viewport1].height();
             colour = (1 << 25) | PaletteIndex::index_68;
-            Gfx::drawRect(*context, x, y, width, height, colour);
+            Gfx::drawRect(*rt, x, y, width, height, colour);
         }
 
         // 0x00429761
-        static void drawStationNews(Window* self, Gfx::Context* context, Message* news)
+        static void drawStationNews(Window* self, Gfx::RenderTarget* rt, Message* news)
         {
-            self->draw(context);
+            self->draw(rt);
 
             char* newsString = news->messageString;
             auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
@@ -711,9 +711,9 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             int16_t y = self->y + 17;
             Ui::Point origin = { x, y };
 
-            Gfx::drawStringCentredWrapped(*context, origin, 338, Colour::black, StringIds::buffer_2039);
+            Gfx::drawStringCentredWrapped(*rt, origin, 338, Colour::black, StringIds::buffer_2039);
 
-            self->drawViewports(context);
+            self->drawViewports(rt);
             const auto& mtd = getMessageTypeDescriptor(news->type);
             if (mtd.hasFlag(MessageTypeFlags::hasFirstItem))
             {
@@ -726,7 +726,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                         auto width = self->widgets[Common::widx::viewport1].width();
                         auto height = self->widgets[Common::widx::viewport1].height();
                         auto colour = (1 << 25) | PaletteIndex::index_35;
-                        Gfx::drawRect(*context, x, y, width, height, colour);
+                        Gfx::drawRect(*rt, x, y, width, height, colour);
                     }
                 }
             }
@@ -742,14 +742,14 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                         auto width = self->widgets[Common::widx::viewport2].width();
                         auto height = self->widgets[Common::widx::viewport2].height();
                         auto colour = (1 << 25) | PaletteIndex::index_35;
-                        Gfx::drawRect(*context, x, y, width, height, colour);
+                        Gfx::drawRect(*rt, x, y, width, height, colour);
                     }
                 }
             }
         }
 
         // 0x00429739
-        static void draw(Ui::Window& self, Gfx::Context* context)
+        static void draw(Ui::Window& self, Gfx::RenderTarget* rt)
         {
             auto news = MessageManager::get(MessageManager::getActiveIndex());
             const auto& mtd = getMessageTypeDescriptor(news->type);
@@ -758,21 +758,21 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             {
                 if (calcDate(news->date).year >= 1945)
                 {
-                    drawLateNews(&self, context, news);
+                    drawLateNews(&self, rt, news);
 
                     if (calcDate(news->date).year < 1985)
                     {
-                        drawMiddleNews(&self, context, news);
+                        drawMiddleNews(&self, rt, news);
                     }
                 }
                 else
                 {
-                    drawEarlyNews(&self, context, news);
+                    drawEarlyNews(&self, rt, news);
                 }
             }
             else
             {
-                drawStationNews(&self, context, news);
+                drawStationNews(&self, rt, news);
             }
 
             if (mtd.hasFlag(MessageTypeFlags::hasFirstItem))
@@ -784,7 +784,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     auto y = self.widgets[Common::widx::viewport1Button].bottom - 7 + self.y;
                     auto width = self.widgets[Common::widx::viewport1Button].width() - 1;
 
-                    drawViewportString(context, x, y, width, mtd.argumentTypes[0], news->itemSubjects[0]);
+                    drawViewportString(rt, x, y, width, mtd.argumentTypes[0], news->itemSubjects[0]);
                 }
             }
             if (mtd.hasFlag(MessageTypeFlags::hasSecondItem))
@@ -796,7 +796,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     auto y = self.widgets[Common::widx::viewport2Button].bottom - 7 + self.y;
                     auto width = self.widgets[Common::widx::viewport2Button].width() - 1;
 
-                    drawViewportString(context, x, y, width, mtd.argumentTypes[1], news->itemSubjects[1]);
+                    drawViewportString(rt, x, y, width, mtd.argumentTypes[1], news->itemSubjects[1]);
                 }
             }
         }

--- a/src/OpenLoco/Windows/News/Ticker.cpp
+++ b/src/OpenLoco/Windows/News/Ticker.cpp
@@ -139,7 +139,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
     }
 
     // 0x004950EF
-    static void sub_4950EF(Gfx::Context* clipped, string_id buffer, uint32_t eax, uint32_t ebp, int16_t x, int16_t y)
+    static void sub_4950EF(Gfx::RenderTarget* clipped, string_id buffer, uint32_t eax, uint32_t ebp, int16_t x, int16_t y)
     {
         registers regs;
         regs.bx = buffer;
@@ -152,7 +152,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
     }
 
     // 0x00429DAA
-    static void draw(Ui::Window& self, Gfx::Context* context)
+    static void draw(Ui::Window& self, Gfx::RenderTarget* rt)
     {
         if (self.var_852 != 0)
             return;
@@ -167,7 +167,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
         auto width = self.width;
         auto height = self.height;
 
-        auto clipped = Gfx::clipContext(*context, { x, y, width, height });
+        auto clipped = Gfx::clipRenderTarget(*rt, { x, y, width, height });
 
         if (!clipped)
             return;

--- a/src/OpenLoco/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/Windows/ObjectSelectionWindow.cpp
@@ -256,7 +256,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static const uint8_t rowOffsetY = 24;
 
     // 0x0047328D
-    static void drawTabs(Window* self, Gfx::Context* context)
+    static void drawTabs(Window* self, Gfx::RenderTarget* rt)
     {
         auto y = self->widgets[widx::panel].top + self->y - 26;
         auto x = self->x + 3;
@@ -274,25 +274,25 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 if (_tabInformation[index].index == self->currentTab)
                 {
                     image = Gfx::recolour(ImageIds::selected_tab, self->getColour(WindowColour::secondary).c());
-                    Gfx::drawImage(context, xPos, yPos, image);
+                    Gfx::drawImage(rt, xPos, yPos, image);
 
                     image = Gfx::recolour(_tabDisplayInfo[_tabInformation[index].index].image, Colour::mutedSeaGreen);
-                    Gfx::drawImage(context, xPos, yPos, image);
+                    Gfx::drawImage(rt, xPos, yPos, image);
                 }
                 else
                 {
-                    Gfx::drawImage(context, xPos, yPos, image);
+                    Gfx::drawImage(rt, xPos, yPos, image);
 
                     image = Gfx::recolour(_tabDisplayInfo[_tabInformation[index].index].image, Colour::mutedSeaGreen);
-                    Gfx::drawImage(context, xPos, yPos, image);
+                    Gfx::drawImage(rt, xPos, yPos, image);
 
                     image = Gfx::recolourTranslucent(ImageIds::tab, ExtColour::unk33);
-                    Gfx::drawImage(context, xPos, yPos, image);
+                    Gfx::drawImage(rt, xPos, yPos, image);
 
                     if (row < 1)
                     {
                         auto colour = Colours::getShade(self->getColour(WindowColour::secondary).c(), 7);
-                        Gfx::drawRect(*context, xPos, yPos + 26, 31, 1, colour);
+                        Gfx::drawRect(*rt, xPos, yPos + 26, 31, 1, colour);
                     }
                 }
                 xPos += 31;
@@ -305,20 +305,20 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static const uint8_t descriptionRowHeight = 10;
 
     template<typename T>
-    static void callDrawPreviewImage(Gfx::Context& context, const Ui::Point& drawingOffset, void* objectPtr)
+    static void callDrawPreviewImage(Gfx::RenderTarget& rt, const Ui::Point& drawingOffset, void* objectPtr)
     {
         auto object = reinterpret_cast<T*>(objectPtr);
-        object->drawPreviewImage(context, drawingOffset.x, drawingOffset.y);
+        object->drawPreviewImage(rt, drawingOffset.x, drawingOffset.y);
     }
 
     // 0x00473579
-    static void drawPreviewImage(ObjectHeader* header, Gfx::Context* context, int16_t x, int16_t y, void* objectPtr)
+    static void drawPreviewImage(ObjectHeader* header, Gfx::RenderTarget* rt, int16_t x, int16_t y, void* objectPtr)
     {
         auto type = header->getType();
 
         // Clip the draw area to simplify image draw
         Ui::Point drawAreaPos = Ui::Point{ x, y } - objectPreviewOffset;
-        auto clipped = Gfx::clipContext(*context, Ui::Rect(drawAreaPos.x, drawAreaPos.y, objectPreviewSize.width, objectPreviewSize.height));
+        auto clipped = Gfx::clipRenderTarget(*rt, Ui::Rect(drawAreaPos.x, drawAreaPos.y, objectPreviewSize.width, objectPreviewSize.height));
         if (!clipped)
             return;
 
@@ -443,18 +443,18 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     template<typename T>
-    static void callDrawDescription(Gfx::Context& context, const int16_t x, const int16_t y, const int16_t width, void* objectPtr)
+    static void callDrawDescription(Gfx::RenderTarget& rt, const int16_t x, const int16_t y, const int16_t width, void* objectPtr)
     {
         auto object = reinterpret_cast<T*>(objectPtr);
-        object->drawDescription(context, x, y, width);
+        object->drawDescription(rt, x, y, width);
     }
 
-    static void drawDescription(ObjectHeader* header, Window* self, Gfx::Context* context, int16_t x, int16_t y, void* objectPtr)
+    static void drawDescription(ObjectHeader* header, Window* self, Gfx::RenderTarget* rt, int16_t x, int16_t y, void* objectPtr)
     {
         int16_t width = self->x + self->width - x;
         int16_t height = self->y + self->height - y;
         // Clip the draw area to simplify image draw
-        auto clipped = Gfx::clipContext(*context, Ui::Rect(x, y, width, height));
+        auto clipped = Gfx::clipRenderTarget(*rt, Ui::Rect(x, y, width, height));
         if (!clipped)
             return;
 
@@ -499,12 +499,12 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x004733F5
-    static void draw(Window& self, Gfx::Context* context)
+    static void draw(Window& self, Gfx::RenderTarget* rt)
     {
-        Gfx::fillRectInset(*context, self.x, self.y + 20, self.x + self.width - 1, self.y + 20 + 60, self.getColour(WindowColour::primary).u8(), 0);
-        self.draw(context);
+        Gfx::fillRectInset(*rt, self.x, self.y + 20, self.x + self.width - 1, self.y + 20 + 60, self.getColour(WindowColour::primary).u8(), 0);
+        self.draw(rt);
 
-        drawTabs(&self, context);
+        drawTabs(&self, rt);
 
         bool doDefault = true;
         if (self.object != nullptr)
@@ -521,13 +521,13 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         {
             auto widget = widgets[widx::objectImage];
             auto colour = Colours::getShade(self.getColour(WindowColour::secondary).c(), 5);
-            Gfx::drawRect(*context, self.x + widget.left, self.y + widget.top, widget.width(), widget.height(), colour);
+            Gfx::drawRect(*rt, self.x + widget.left, self.y + widget.top, widget.width(), widget.height(), colour);
         }
         else
         {
             auto widget = widgets[widx::objectImage];
             auto colour = Colours::getShade(self.getColour(WindowColour::secondary).c(), 0);
-            Gfx::drawRect(*context, self.x + widget.left + 1, self.y + widget.top + 1, widget.width() - 2, widget.height() - 2, colour);
+            Gfx::drawRect(*rt, self.x + widget.left + 1, self.y + widget.top + 1, widget.width() - 2, widget.height() - 2, colour);
         }
 
         auto type = self.currentTab;
@@ -536,7 +536,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         args.push(_112C1C5[type]);
         args.push(ObjectManager::getMaxObjects(static_cast<ObjectType>(type)));
 
-        Gfx::drawStringLeft(*context, self.x + 3, self.y + self.height - 12, Colour::black, 2038, &args);
+        Gfx::drawStringLeft(*rt, self.x + 3, self.y + self.height - 12, Colour::black, 2038, &args);
 
         if (self.rowHover == -1)
             return;
@@ -551,7 +551,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
             drawPreviewImage(
                 ObjectManager::ObjectIndexEntry::read(&objectPtr)._header,
-                context,
+                rt,
                 widgets[widx::objectImage].mid_x() + 1 + self.x,
                 widgets[widx::objectImage].mid_y() + 1 + self.y,
                 _50D15C);
@@ -569,7 +569,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
             strncpy(buffer, ObjectManager::ObjectIndexEntry::read(&objectPtr)._name, 510);
 
-            Gfx::drawStringCentredClipped(*context, x, y, width, Colour::black, StringIds::buffer_2039);
+            Gfx::drawStringCentredClipped(*rt, x, y, width, Colour::black, StringIds::buffer_2039);
         }
 
         {
@@ -578,7 +578,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             drawDescription(
                 ObjectManager::ObjectIndexEntry::read(&objectPtr)._header,
                 &self,
-                context,
+                rt,
                 self.widgets[widx::scrollview].right + self.x + 4,
                 y + descriptionRowHeight,
                 _50D15C);
@@ -586,9 +586,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x0047361D
-    static void drawScroll(Window& self, Gfx::Context& context, const uint32_t)
+    static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t)
     {
-        Gfx::clearSingle(context, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
+        Gfx::clearSingle(rt, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
 
         if (ObjectManager::getNumInstalledObjects() == 0)
             return;
@@ -598,7 +598,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         for (auto [i, object] : objects)
         {
             uint8_t flags = (1 << 7) | (1 << 6) | (1 << 5);
-            Gfx::fillRectInset(context, 2, y, 11, y + 10, self.getColour(WindowColour::secondary).u8(), flags);
+            Gfx::fillRectInset(rt, 2, y, 11, y + 10, self.getColour(WindowColour::secondary).u8(), flags);
 
             uint8_t textColour = ControlCodes::colour_black;
 
@@ -608,7 +608,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 auto windowObjectName = ObjectManager::ObjectIndexEntry::read(&objectPtr)._name;
                 if (object._name == windowObjectName)
                 {
-                    Gfx::fillRect(context, 0, y, self.width, y + rowHeight - 1, (1 << 25) | PaletteIndex::index_30);
+                    Gfx::fillRect(rt, 0, y, self.width, y + rowHeight - 1, (1 << 25) | PaletteIndex::index_30);
                     textColour = ControlCodes::window_colour_2;
                 }
             }
@@ -630,7 +630,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                     checkColour = checkColour.inset();
                 }
 
-                Gfx::drawString(context, x, y, checkColour, _strCheckmark);
+                Gfx::drawString(rt, x, y, checkColour, _strCheckmark);
             }
 
             char buffer[512]{};
@@ -638,7 +638,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             strncpy(&buffer[1], object._name, 510);
             Gfx::setCurrentFontSpriteBase(Font::medium_bold);
 
-            Gfx::drawString(context, 15, y, Colour::black, buffer);
+            Gfx::drawString(rt, 15, y, Colour::black, buffer);
             y += rowHeight;
         }
     }

--- a/src/OpenLoco/Windows/Options.cpp
+++ b/src/OpenLoco/Windows/Options.cpp
@@ -74,10 +74,10 @@ namespace OpenLoco::Ui::Windows::Options
             miscellaneous,
         };
 
-        static void drawTabs(Window* w, Gfx::Context* ctx)
+        static void drawTabs(Window* w, Gfx::RenderTarget* rt)
         {
-            Widget::drawTab(w, ctx, ImageIds::tab_display, Widx::tab_display);
-            Widget::drawTab(w, ctx, ImageIds::tab_sound, Widx::tab_sound);
+            Widget::drawTab(w, rt, ImageIds::tab_display, Widx::tab_display);
+            Widget::drawTab(w, rt, ImageIds::tab_sound, Widx::tab_sound);
 
             static const uint32_t music_tab_ids[] = {
                 ImageIds::tab_music_0,
@@ -102,7 +102,7 @@ namespace OpenLoco::Ui::Windows::Options
             {
                 imageId = music_tab_ids[(w->frame_no / 4) % 16];
             }
-            Widget::drawTab(w, ctx, imageId, Widx::tab_music);
+            Widget::drawTab(w, rt, imageId, Widx::tab_music);
 
             static const uint32_t globe_tab_ids[] = {
                 ImageIds::tab_globe_0,
@@ -143,10 +143,10 @@ namespace OpenLoco::Ui::Windows::Options
             {
                 imageId = globe_tab_ids[(w->frame_no / 2) % 32];
             }
-            Widget::drawTab(w, ctx, imageId, Widx::tab_regional);
+            Widget::drawTab(w, rt, imageId, Widx::tab_regional);
 
-            Widget::drawTab(w, ctx, ImageIds::tab_control, Widx::tab_controls);
-            Widget::drawTab(w, ctx, ImageIds::tab_miscellaneous, Widx::tab_miscellaneous);
+            Widget::drawTab(w, rt, ImageIds::tab_control, Widx::tab_controls);
+            Widget::drawTab(w, rt, ImageIds::tab_miscellaneous, Widx::tab_miscellaneous);
         }
 
 #define common_options_widgets(window_size, window_caption_id)                                                                                                                         \
@@ -637,35 +637,35 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004BFAF9
-        static void draw(Window& w, Gfx::Context* context)
+        static void draw(Window& w, Gfx::RenderTarget* rt)
         {
             // Draw widgets.
-            w.draw(context);
+            w.draw(rt);
 
-            Common::drawTabs(&w, context);
+            Common::drawTabs(&w, rt);
 
             int16_t x = w.x + 10;
             int16_t y = w.y + Display::_widgets[Display::Widx::screen_mode].top + 1;
-            drawStringLeft(*context, x, y, Colour::black, StringIds::options_screen_mode, nullptr);
+            drawStringLeft(*rt, x, y, Colour::black, StringIds::options_screen_mode, nullptr);
 
             y = w.y + Display::_widgets[Display::Widx::display_resolution].top + 1;
-            drawStringLeft(*context, x, y, Colour::black, StringIds::display_resolution, nullptr);
+            drawStringLeft(*rt, x, y, Colour::black, StringIds::display_resolution, nullptr);
 
             y = w.y + Display::_widgets[Display::Widx::construction_marker].top + 1;
-            drawStringLeft(*context, x, y, Colour::black, StringIds::construction_marker, nullptr);
+            drawStringLeft(*rt, x, y, Colour::black, StringIds::construction_marker, nullptr);
 
             y = w.y + Display::_widgets[Display::Widx::vehicles_min_scale].top + 1;
-            drawStringLeft(*context, x, y, Colour::black, StringIds::vehicles_min_scale, nullptr);
+            drawStringLeft(*rt, x, y, Colour::black, StringIds::vehicles_min_scale, nullptr);
 
             y = w.y + Display::_widgets[Display::Widx::station_names_min_scale].top + 1;
-            drawStringLeft(*context, x, y, Colour::black, StringIds::station_names_min_scale, nullptr);
+            drawStringLeft(*rt, x, y, Colour::black, StringIds::station_names_min_scale, nullptr);
 
             y = w.y + Display::_widgets[Display::Widx::display_scale].top + 1;
-            drawStringLeft(*context, x, y, Colour::black, StringIds::window_scale_factor, nullptr);
+            drawStringLeft(*rt, x, y, Colour::black, StringIds::window_scale_factor, nullptr);
 
             int scale = (int)(Config::getNew().scaleFactor * 100);
             auto& scale_widget = w.widgets[Widx::display_scale];
-            drawStringLeft(*context, w.x + scale_widget.left + 1, w.y + scale_widget.top + 1, Colour::black, StringIds::scale_formatted, &scale);
+            drawStringLeft(*rt, w.x + scale_widget.left + 1, w.y + scale_widget.top + 1, Colour::black, StringIds::scale_formatted, &scale);
         }
 
         static void applyScreenModeRestrictions(Window* w)
@@ -760,12 +760,12 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C02F5
-        static void draw(Window& w, Gfx::Context* context)
+        static void draw(Window& w, Gfx::RenderTarget* rt)
         {
             // Draw widgets.
-            w.draw(context);
+            w.draw(rt);
 
-            Common::drawTabs(&w, context);
+            Common::drawTabs(&w, rt);
         }
 
         static void onMouseUp(Window& w, WidgetIndex_t wi)
@@ -978,21 +978,21 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C05F9
-        static void draw(Window& w, Gfx::Context* context)
+        static void draw(Window& w, Gfx::RenderTarget* rt)
         {
             // Draw widgets.
-            w.draw(context);
+            w.draw(rt);
 
-            Common::drawTabs(&w, context);
+            Common::drawTabs(&w, rt);
 
-            Gfx::drawStringLeft(*context, w.x + 10, w.y + w.widgets[Widx::currently_playing_btn].top, Colour::black, StringIds::currently_playing, nullptr);
+            Gfx::drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::currently_playing_btn].top, Colour::black, StringIds::currently_playing, nullptr);
 
-            Gfx::drawStringLeft(*context, w.x + 183, w.y + w.widgets[Widx::volume].top + 7, Colour::black, StringIds::volume, nullptr);
+            Gfx::drawStringLeft(*rt, w.x + 183, w.y + w.widgets[Widx::volume].top + 7, Colour::black, StringIds::volume, nullptr);
 
-            Gfx::drawImage(context, w.x + w.widgets[Widx::volume].left, w.y + w.widgets[Widx::volume].top, Gfx::recolour(ImageIds::volume_slider_track, w.getColour(WindowColour::secondary).c()));
+            Gfx::drawImage(rt, w.x + w.widgets[Widx::volume].left, w.y + w.widgets[Widx::volume].top, Gfx::recolour(ImageIds::volume_slider_track, w.getColour(WindowColour::secondary).c()));
 
             int16_t x = 90 + (Config::get().volume / 32);
-            Gfx::drawImage(context, w.x + w.widgets[Widx::volume].left + x, w.y + w.widgets[Widx::volume].top, Gfx::recolour(ImageIds::volume_slider_thumb, w.getColour(WindowColour::secondary).c()));
+            Gfx::drawImage(rt, w.x + w.widgets[Widx::volume].left + x, w.y + w.widgets[Widx::volume].top, Gfx::recolour(ImageIds::volume_slider_thumb, w.getColour(WindowColour::secondary).c()));
         }
 
         static void onMouseUp(Window& w, WidgetIndex_t wi)
@@ -1376,17 +1376,17 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C0B5B
-        static void draw(Window& w, Gfx::Context* context)
+        static void draw(Window& w, Gfx::RenderTarget* rt)
         {
             // Draw widgets.
-            w.draw(context);
-            Common::drawTabs(&w, context);
+            w.draw(rt);
+            Common::drawTabs(&w, rt);
 
-            Gfx::drawStringLeft(*context, w.x + 10, w.y + w.widgets[Widx::language].top + 1, Colour::black, StringIds::options_language, nullptr);
-            Gfx::drawStringLeft(*context, w.x + 10, w.y + w.widgets[Widx::distance_speed].top + 1, Colour::black, StringIds::distance_and_speed, nullptr);
-            Gfx::drawStringLeft(*context, w.x + 10, w.y + w.widgets[Widx::heights].top + 1, Colour::black, StringIds::heights, nullptr);
-            Gfx::drawStringLeft(*context, w.x + 10, w.y + w.widgets[Widx::currency].top + 1, Colour::black, StringIds::current_game_currency, nullptr);
-            Gfx::drawStringLeft(*context, w.x + 10, w.y + w.widgets[Widx::preferred_currency].top + 1, Colour::black, StringIds::new_game_currency, nullptr);
+            Gfx::drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::language].top + 1, Colour::black, StringIds::options_language, nullptr);
+            Gfx::drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::distance_speed].top + 1, Colour::black, StringIds::distance_and_speed, nullptr);
+            Gfx::drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::heights].top + 1, Colour::black, StringIds::heights, nullptr);
+            Gfx::drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::currency].top + 1, Colour::black, StringIds::current_game_currency, nullptr);
+            Gfx::drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::preferred_currency].top + 1, Colour::black, StringIds::new_game_currency, nullptr);
         }
 
         static void onMouseUp(Window& w, WidgetIndex_t wi)
@@ -1804,10 +1804,10 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C113F
-        static void draw(Window& w, Gfx::Context* context)
+        static void draw(Window& w, Gfx::RenderTarget* rt)
         {
-            w.draw(context);
-            Common::drawTabs(&w, context);
+            w.draw(rt);
+            Common::drawTabs(&w, rt);
         }
 
         // 0x004C114A
@@ -2010,20 +2010,20 @@ namespace OpenLoco::Ui::Windows::Options
             sub_4C13BE(&w);
         }
 
-        static void drawDropdownContent(Window* w, Gfx::Context* context, WidgetIndex_t widgetIndex, string_id stringId, int32_t value)
+        static void drawDropdownContent(Window* w, Gfx::RenderTarget* rt, WidgetIndex_t widgetIndex, string_id stringId, int32_t value)
         {
             auto& widget = w->widgets[widgetIndex];
             FormatArguments args = {};
             args.push(stringId);
             args.push(value);
-            drawStringLeft(*context, w->x + widget.left + 1, w->y + widget.top + 1, Colour::black, StringIds::black_stringid, &args);
+            drawStringLeft(*rt, w->x + widget.left + 1, w->y + widget.top + 1, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x004C1282
-        static void draw(Window& w, Gfx::Context* context)
+        static void draw(Window& w, Gfx::RenderTarget* rt)
         {
-            w.draw(context);
-            Common::drawTabs(&w, context);
+            w.draw(rt);
+            Common::drawTabs(&w, rt);
 
             auto buffer = (char*)StringManager::getString(StringIds::buffer_2039);
             char* playerName = Config::get().preferredName;
@@ -2032,10 +2032,10 @@ namespace OpenLoco::Ui::Windows::Options
 
             FormatArguments args = {};
             args.push(StringIds::buffer_2039);
-            Gfx::drawStringLeft(*context, w.x + 10, w.y + w.widgets[Widx::change_btn].top + 1, Colour::black, StringIds::wcolour2_preferred_owner_name, &args);
+            Gfx::drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::change_btn].top + 1, Colour::black, StringIds::wcolour2_preferred_owner_name, &args);
 
             auto y = w.y + w.widgets[Widx::autosave_frequency].top + 1;
-            drawStringLeft(*context, w.x + 10, y, Colour::black, StringIds::autosave_frequency, nullptr);
+            drawStringLeft(*rt, w.x + 10, y, Colour::black, StringIds::autosave_frequency, nullptr);
 
             auto freq = Config::getNew().autosaveFrequency;
             string_id stringId;
@@ -2051,13 +2051,13 @@ namespace OpenLoco::Ui::Windows::Options
                     stringId = StringIds::autosave_every_x_months;
                     break;
             }
-            drawDropdownContent(&w, context, Widx::autosave_frequency, stringId, freq);
+            drawDropdownContent(&w, rt, Widx::autosave_frequency, stringId, freq);
 
             y = w.y + w.widgets[Widx::autosave_amount].top + 1;
-            drawStringLeft(*context, w.x + 10, y, Colour::black, StringIds::autosave_amount, nullptr);
+            drawStringLeft(*rt, w.x + 10, y, Colour::black, StringIds::autosave_amount, nullptr);
 
             auto scale = Config::getNew().autosaveAmount;
-            drawDropdownContent(&w, context, Widx::autosave_amount, StringIds::int_32, scale);
+            drawDropdownContent(&w, rt, Widx::autosave_amount, StringIds::int_32, scale);
         }
 
         static void changeAutosaveAmount(Window* w, int32_t delta)

--- a/src/OpenLoco/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/Windows/PlayerInfoPanel.cpp
@@ -60,7 +60,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     static loco_global<uint16_t, 0x0113DC78> _113DC78; // Dropdown flags?
 
     static void prepareDraw(Window& window);
-    static void draw(Ui::Window& window, Gfx::Context* context);
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt);
     static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex);
     static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex);
     static void onDropdown(Window& w, WidgetIndex_t widgetIndex, int16_t item_index);
@@ -204,20 +204,20 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     }
 
     // 0x43944B
-    static void draw(Ui::Window& window, Gfx::Context* context)
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
     {
         Widget& frame = _widgets[Widx::outer_frame];
-        Gfx::drawRect(*context, window.x + frame.left, window.y + frame.top, frame.width(), frame.height(), 0x2000000 | 52);
+        Gfx::drawRect(*rt, window.x + frame.left, window.y + frame.top, frame.width(), frame.height(), 0x2000000 | 52);
 
         // Draw widgets.
-        window.draw(context);
+        window.draw(rt);
 
-        drawRectInset(*context, window.x + frame.left + 1, window.y + frame.top + 1, frame.width() - 2, frame.height() - 2, window.getColour(WindowColour::secondary).u8(), 0x30);
+        drawRectInset(*rt, window.x + frame.left + 1, window.y + frame.top + 1, frame.width() - 2, frame.height() - 2, window.getColour(WindowColour::secondary).u8(), 0x30);
 
         auto playerCompany = CompanyManager::get(CompanyManager::getControllingId());
         auto competitor = ObjectManager::get<CompetitorObject>(playerCompany->competitorId);
         auto image = Gfx::recolour(competitor->images[playerCompany->ownerEmotion], playerCompany->mainColours.primary);
-        Gfx::drawImage(context, window.x + frame.left + 2, window.y + frame.top + 2, image);
+        Gfx::drawImage(rt, window.x + frame.left + 2, window.y + frame.top + 2, image);
 
         auto x = window.x + frame.width() / 2 + 12;
         {
@@ -242,7 +242,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
             auto args = FormatArguments();
             args.push(playerCompany->cash.var_00);
             args.push(playerCompany->cash.var_04);
-            Gfx::drawStringCentred(*context, x, window.y + frame.top + 2, colour, companyValueString, &args);
+            Gfx::drawStringCentred(*rt, x, window.y + frame.top + 2, colour, companyValueString, &args);
         }
 
         {
@@ -265,7 +265,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
 
             auto args = FormatArguments();
             args.push(playerCompany->performanceIndex);
-            Gfx::drawStringCentred(*context, x, window.y + frame.top + 14, colour, performanceString, &args);
+            Gfx::drawStringCentred(*rt, x, window.y + frame.top + 14, colour, performanceString, &args);
         }
     }
 

--- a/src/OpenLoco/Windows/ProgressBar.cpp
+++ b/src/OpenLoco/Windows/ProgressBar.cpp
@@ -94,11 +94,11 @@ namespace OpenLoco::Ui::Windows::ProgressBar
     }
 
     // 004CF7A0
-    static void draw(Window& self, Gfx::Context* context)
+    static void draw(Window& self, Gfx::RenderTarget* rt)
     {
-        self.draw(context);
+        self.draw(rt);
 
-        auto clipped = Gfx::clipContext(*context, Ui::Rect(self.x + 2, self.y + 17, self.width - 5, self.height - 19));
+        auto clipped = Gfx::clipRenderTarget(*rt, Ui::Rect(self.x + 2, self.y + 17, self.width - 5, self.height - 19));
         if (!clipped)
             return;
 

--- a/src/OpenLoco/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/Windows/PromptBrowseWindow.cpp
@@ -75,9 +75,9 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     static fs::path getDirectory(const fs::path& path);
     static std::string getBasename(const fs::path& path);
 
-    static void drawSavePreview(Ui::Window& window, Gfx::Context& context, int32_t x, int32_t y, int32_t width, int32_t height, const S5::SaveDetails& saveInfo);
-    static void drawLandscapePreview(Ui::Window& window, Gfx::Context& context, int32_t x, int32_t y, int32_t width, int32_t height);
-    static void drawTextInput(Ui::Window* window, Gfx::Context& context, const char* text, int32_t caret, bool showCaret);
+    static void drawSavePreview(Ui::Window& window, Gfx::RenderTarget& rt, int32_t x, int32_t y, int32_t width, int32_t height, const S5::SaveDetails& saveInfo);
+    static void drawLandscapePreview(Ui::Window& window, Gfx::RenderTarget& rt, int32_t x, int32_t y, int32_t width, int32_t height);
+    static void drawTextInput(Ui::Window* window, Gfx::RenderTarget& rt, const char* text, int32_t caret, bool showCaret);
     static void upOneLevel();
     static void changeDirectory(const fs::path& path);
     static void processFileForLoadSave(Window* window);
@@ -371,14 +371,14 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x00445E38
-    static void draw(Ui::Window& window, Gfx::Context* context)
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
     {
-        window.draw(context);
+        window.draw(rt);
 
         {
             auto folder = &_displayFolderBuffer[0];
             auto args = getStringPtrFormatArgs(folder);
-            Gfx::drawStringLeft(*context, window.x + 3, window.y + window.widgets[widx::parent_button].top + 6, Colour::black, StringIds::window_browse_folder, &args);
+            Gfx::drawStringLeft(*rt, window.x + 3, window.y + window.widgets[widx::parent_button].top + 6, Colour::black, StringIds::window_browse_folder, &args);
         }
 
         auto selectedIndex = window.var_85A;
@@ -396,7 +396,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                 const std::string nameBuffer = selectedFile.stem().u8string();
                 auto args = getStringPtrFormatArgs(nameBuffer.c_str());
                 Gfx::drawStringCentredClipped(
-                    *context,
+                    *rt,
                     x + (width / 2),
                     y,
                     width,
@@ -411,12 +411,12 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                     auto saveInfo = *((const S5::SaveDetails**)0x50AEA8);
                     if (saveInfo != (void*)-1)
                     {
-                        drawSavePreview(window, *context, x, y, width, 201, *saveInfo);
+                        drawSavePreview(window, *rt, x, y, width, 201, *saveInfo);
                     }
                 }
                 else if (*_fileType == BrowseFileType::landscape)
                 {
-                    drawLandscapePreview(window, *context, x, y, width, 129);
+                    drawLandscapePreview(window, *rt, x, y, width, 129);
                 }
             }
         }
@@ -425,10 +425,10 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         if (filenameBox.type != WidgetType::none)
         {
             // Draw filename label
-            Gfx::drawStringLeft(*context, window.x + 3, window.y + filenameBox.top + 2, Colour::black, StringIds::window_browse_filename, nullptr);
+            Gfx::drawStringLeft(*rt, window.x + 3, window.y + filenameBox.top + 2, Colour::black, StringIds::window_browse_filename, nullptr);
 
             // Clip to text box
-            auto context2 = Gfx::clipContext(*context, Ui::Rect(window.x + filenameBox.left + 1, window.y + filenameBox.top + 1, filenameBox.right - filenameBox.left - 1, filenameBox.bottom - filenameBox.top - 1));
+            auto context2 = Gfx::clipRenderTarget(*rt, Ui::Rect(window.x + filenameBox.left + 1, window.y + filenameBox.top + 1, filenameBox.right - filenameBox.left - 1, filenameBox.bottom - filenameBox.top - 1));
             if (context2)
             {
                 drawTextInput(&window, *context2, inputSession.buffer.c_str(), inputSession.cursorPosition, (inputSession.cursorFrame & 0x10) == 0);
@@ -436,9 +436,9 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         }
     }
 
-    static void drawSavePreview(Ui::Window& window, Gfx::Context& context, int32_t x, int32_t y, int32_t width, int32_t height, const S5::SaveDetails& saveInfo)
+    static void drawSavePreview(Ui::Window& window, Gfx::RenderTarget& rt, int32_t x, int32_t y, int32_t width, int32_t height, const S5::SaveDetails& saveInfo)
     {
-        Gfx::fillRectInset(context, x, y, x + width, y + height, window.getColour(WindowColour::secondary).u8(), 0x30);
+        Gfx::fillRectInset(rt, x, y, x + width, y + height, window.getColour(WindowColour::secondary).u8(), 0x30);
 
         auto imageId = 0;
         auto g1 = Gfx::getG1Element(imageId);
@@ -450,7 +450,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             g1->offset = (uint8_t*)saveInfo.image;
             g1->width = 250;
             g1->height = 200;
-            Gfx::drawImage(&context, x + 1, y + 1, imageId);
+            Gfx::drawImage(&rt, x + 1, y + 1, imageId);
             *g1 = backupg1;
         }
         y += 207;
@@ -460,17 +460,17 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         // Company
         {
             auto args = getStringPtrFormatArgs(saveInfo.company);
-            y = Gfx::drawStringLeftWrapped(context, x, y, maxWidth, Colour::black, StringIds::window_browse_company, &args);
+            y = Gfx::drawStringLeftWrapped(rt, x, y, maxWidth, Colour::black, StringIds::window_browse_company, &args);
         }
 
         // Owner
         {
             auto args = getStringPtrFormatArgs(saveInfo.owner);
-            y = Gfx::drawStringLeftWrapped(context, x, y, maxWidth, Colour::black, StringIds::owner_label, &args);
+            y = Gfx::drawStringLeftWrapped(rt, x, y, maxWidth, Colour::black, StringIds::owner_label, &args);
         }
 
         // Date
-        y = Gfx::drawStringLeftWrapped(context, x, y, maxWidth, Colour::black, StringIds::window_browse_date, &saveInfo.date);
+        y = Gfx::drawStringLeftWrapped(rt, x, y, maxWidth, Colour::black, StringIds::window_browse_date, &saveInfo.date);
 
         // Challenge progress
         auto flags = saveInfo.challengeFlags;
@@ -487,13 +487,13 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                     progress = saveInfo.challenge_progress;
                 }
             }
-            Gfx::drawStringLeftWrapped(context, x, y, maxWidth, Colour::black, stringId, &progress);
+            Gfx::drawStringLeftWrapped(rt, x, y, maxWidth, Colour::black, stringId, &progress);
         }
     }
 
-    static void drawLandscapePreview(Ui::Window& window, Gfx::Context& context, int32_t x, int32_t y, int32_t width, int32_t height)
+    static void drawLandscapePreview(Ui::Window& window, Gfx::RenderTarget& rt, int32_t x, int32_t y, int32_t width, int32_t height)
     {
-        Gfx::fillRectInset(context, x, y, x + width, y + height, window.getColour(WindowColour::secondary).u8(), 0x30);
+        Gfx::fillRectInset(rt, x, y, x + width, y + height, window.getColour(WindowColour::secondary).u8(), 0x30);
 
         if (S5::getPreviewOptions().scenarioFlags & Scenario::Flags::landscapeGenerationDone)
         {
@@ -508,29 +508,29 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                 g1->offset = (uint8_t*)0x9CCBDE;
                 g1->width = 128;
                 g1->height = 128;
-                Gfx::drawImage(&context, x + 1, y + 1, imageId);
+                Gfx::drawImage(&rt, x + 1, y + 1, imageId);
                 *g1 = backupg1;
 
-                Gfx::drawImage(&context, x, y + 1, ImageIds::height_map_compass);
+                Gfx::drawImage(&rt, x, y + 1, ImageIds::height_map_compass);
             }
         }
         else
         {
             // Randomly generated landscape
             auto imageId = Gfx::recolour(ImageIds::random_map_watermark, window.getColour(WindowColour::secondary).c());
-            Gfx::drawImage(&context, x, y, imageId);
+            Gfx::drawImage(&rt, x, y, imageId);
             auto origin = Ui::Point(x + 64, y + 60);
-            Gfx::drawStringCentredWrapped(context, origin, 128, Colour::black, StringIds::randomly_generated_landscape);
+            Gfx::drawStringCentredWrapped(rt, origin, 128, Colour::black, StringIds::randomly_generated_landscape);
         }
     }
 
-    static void drawTextInput(Ui::Window* window, Gfx::Context& context, const char* text, int32_t caret, bool showCaret)
+    static void drawTextInput(Ui::Window* window, Gfx::RenderTarget& rt, const char* text, int32_t caret, bool showCaret)
     {
         // Draw text box text
         Ui::Point origin = { 0, 1 };
         {
             auto args = getStringPtrFormatArgs(text);
-            Gfx::drawStringLeft(context, &origin, Colour::black, StringIds::black_stringid, &args);
+            Gfx::drawStringLeft(rt, &origin, Colour::black, StringIds::black_stringid, &args);
         }
 
         if (showCaret)
@@ -538,7 +538,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             if (caret == -1)
             {
                 // Draw horizontal caret
-                Gfx::drawStringLeft(context, &origin, Colour::black, StringIds::window_browse_input_caret, nullptr);
+                Gfx::drawStringLeft(rt, &origin, Colour::black, StringIds::window_browse_input_caret, nullptr);
             }
             else
             {
@@ -547,10 +547,10 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                 const std::string gbuffer = std::string(text, caret);
                 auto args = getStringPtrFormatArgs(gbuffer.c_str());
                 origin = { 0, 1 };
-                Gfx::drawStringLeft(context, &origin, Colour::black, StringIds::black_stringid, &args);
+                Gfx::drawStringLeft(rt, &origin, Colour::black, StringIds::black_stringid, &args);
 
                 // Draw vertical caret
-                Gfx::drawRect(context, origin.x, origin.y, 1, 9, Colours::getShade(window->getColour(WindowColour::secondary).c(), 9));
+                Gfx::drawRect(rt, origin.x, origin.y, 1, 9, Colours::getShade(window->getColour(WindowColour::secondary).c(), 9));
             }
         }
     }
@@ -561,10 +561,10 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x00446314
-    static void drawScroll(Ui::Window& window, Gfx::Context& context, const uint32_t scrollIndex)
+    static void drawScroll(Ui::Window& window, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
     {
         // Background
-        Gfx::clearSingle(context, Colours::getShade(window.getColour(WindowColour::secondary).c(), 4));
+        Gfx::clearSingle(rt, Colours::getShade(window.getColour(WindowColour::secondary).c(), 4));
 
         // Directories / files
         auto i = 0;
@@ -572,13 +572,13 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         auto lineHeight = window.rowHeight;
         for (const auto& entry : _files)
         {
-            if (y + lineHeight >= context.y && y <= context.y + context.height)
+            if (y + lineHeight >= rt.y && y <= rt.y + rt.height)
             {
                 // Draw the row highlight
                 auto stringId = StringIds::black_stringid;
                 if (i == window.var_85A)
                 {
-                    Gfx::drawRect(context, 0, y, window.width, lineHeight, 0x2000000 | 48);
+                    Gfx::drawRect(rt, 0, y, window.width, lineHeight, 0x2000000 | 48);
                     stringId = StringIds::wcolour2_stringid;
                 }
 
@@ -586,7 +586,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                 auto x = 1;
                 if (isRootPath(entry) || fs::is_directory(entry))
                 {
-                    Gfx::drawImage(&context, x, y, ImageIds::icon_folder);
+                    Gfx::drawImage(&rt, x, y, ImageIds::icon_folder);
                     x += 14;
                 }
 
@@ -595,7 +595,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
 
                 // Draw the name
                 auto args = getStringPtrFormatArgs(nameBuffer.c_str());
-                Gfx::drawStringLeft(context, x, y, Colour::black, stringId, &args);
+                Gfx::drawStringLeft(rt, x, y, Colour::black, stringId, &args);
             }
             y += lineHeight;
             i++;

--- a/src/OpenLoco/Windows/PromptOkCancelWindow.cpp
+++ b/src/OpenLoco/Windows/PromptOkCancelWindow.cpp
@@ -126,15 +126,15 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
     }
 
     // 0x004470AA
-    static void draw(Window& self, Gfx::Context* const context)
+    static void draw(Window& self, Gfx::RenderTarget* const rt)
     {
-        self.draw(context);
+        self.draw(rt);
 
         FormatArguments args{};
         args.push(StringIds::buffer_2039);
 
         auto origin = Ui::Point(self.x + self.width / 2, self.y + 41);
-        Gfx::drawStringCentredWrapped(*context, origin, self.width, Colour::black, StringIds::wcolour2_stringid, &args);
+        Gfx::drawStringCentredWrapped(*rt, origin, self.width, Colour::black, StringIds::wcolour2_stringid, &args);
     }
 
     static void initEvents()

--- a/src/OpenLoco/Windows/PromptSaveWindow.cpp
+++ b/src/OpenLoco/Windows/PromptSaveWindow.cpp
@@ -104,9 +104,9 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
         return window;
     }
 
-    static void draw(Window& self, Gfx::Context* const context)
+    static void draw(Window& self, Gfx::RenderTarget* const rt)
     {
-        self.draw(context);
+        self.draw(rt);
     }
 
     // 0x0043C3F4

--- a/src/OpenLoco/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/Windows/ScenarioOptions.cpp
@@ -73,7 +73,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x004400A4
-        static void drawTabs(Window* window, Gfx::Context* context)
+        static void drawTabs(Window* window, Gfx::RenderTarget* rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
@@ -104,13 +104,13 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                 else
                     imageId += challengeTabImageIds[0];
 
-                Widget::drawTab(window, context, imageId, widx::tab_challenge);
+                Widget::drawTab(window, rt, imageId, widx::tab_challenge);
             }
 
             // Companies tab
             {
                 const uint32_t imageId = skin->img + InterfaceSkin::ImageIds::tab_companies;
-                Widget::drawTab(window, context, imageId, widx::tab_companies);
+                Widget::drawTab(window, rt, imageId, widx::tab_companies);
             }
 
             // Finances tab
@@ -140,20 +140,20 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                 else
                     imageId += financesTabImageIds[0];
 
-                Widget::drawTab(window, context, imageId, widx::tab_finances);
+                Widget::drawTab(window, rt, imageId, widx::tab_finances);
             }
 
             // Scenario details tab
             {
                 const uint32_t imageId = skin->img + InterfaceSkin::ImageIds::tab_scenario_details;
-                Widget::drawTab(window, context, imageId, widx::tab_scenario);
+                Widget::drawTab(window, rt, imageId, widx::tab_scenario);
             }
         }
 
-        static void draw(Window& window, Gfx::Context* context)
+        static void draw(Window& window, Gfx::RenderTarget* rt)
         {
-            window.draw(context);
-            drawTabs(&window, context);
+            window.draw(rt);
+            drawTabs(&window, rt);
         }
 
         static void prepareDraw(Window& self);
@@ -198,18 +198,18 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         static WindowEventList events;
 
         // 0x0043FC91
-        static void draw(Ui::Window& window, Gfx::Context* context)
+        static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
         {
-            Common::draw(window, context);
+            Common::draw(window, rt);
 
             const int16_t xPos = window.x + 5;
             int16_t yPos = window.y + widgets[widx::check_time_limit].bottom + 10;
-            Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::challenge_label);
+            Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::challenge_label);
 
             FormatArguments args = {};
             OpenLoco::Scenario::formatChallengeArguments(args);
             yPos += 10;
-            Gfx::drawStringLeftWrapped(*context, xPos, yPos, window.width - 10, Colour::black, StringIds::challenge_value, &args);
+            Gfx::drawStringLeftWrapped(*rt, xPos, yPos, window.width - 10, Colour::black, StringIds::challenge_value, &args);
         }
 
         static const string_id objectiveTypeLabelIds[] = {
@@ -595,56 +595,56 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         static WindowEventList events;
 
         // 0x0043F4EB
-        static void draw(Ui::Window& window, Gfx::Context* context)
+        static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
         {
-            Common::draw(window, context);
+            Common::draw(window, rt);
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::max_competing_companies].top + 1;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::max_competing_companies);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::max_competing_companies);
             }
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::delay_before_competing_companies_start].top + 1;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::delay_before_competing_companies_start);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::delay_before_competing_companies_start);
             }
 
             {
                 const int16_t xPos = window.x + 15;
                 int16_t yPos = window.y + widgets[widx::preferred_intelligence].top - 14;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::selection_of_competing_companies);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::selection_of_competing_companies);
             }
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::preferred_intelligence].top + 1;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::preferred_intelligence);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::preferred_intelligence);
             }
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::preferred_aggressiveness].top + 1;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::preferred_aggressiveness);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::preferred_aggressiveness);
             }
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::preferred_competitiveness].top + 1;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::preferred_competitiveness);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::preferred_competitiveness);
             }
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::competitor_forbid_trains].top - 12;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::forbid_competing_companies_from_using);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::forbid_competing_companies_from_using);
             }
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::player_forbid_trains].top - 12;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::forbid_player_companies_from_using);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::forbid_player_companies_from_using);
             }
         }
 
@@ -851,26 +851,26 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         static WindowEventList events;
 
         // 0x0043F97D
-        static void draw(Ui::Window& window, Gfx::Context* context)
+        static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
         {
-            Common::draw(window, context);
+            Common::draw(window, rt);
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::starting_loan].top + 1;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::starting_loan);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::starting_loan);
             }
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::max_loan_size].top + 1;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::max_loan_size);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::max_loan_size);
             }
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::loan_interest_rate].top + 1;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::loan_interest_rate);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::loan_interest_rate);
             }
         }
 
@@ -978,9 +978,9 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         static WindowEventList events;
 
         // 0x0043F004
-        static void draw(Ui::Window& window, Gfx::Context* context)
+        static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
         {
-            Common::draw(window, context);
+            Common::draw(window, rt);
 
             {
                 // Prepare scenario name text.
@@ -995,19 +995,19 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::change_name_btn].top + 1;
                 int16_t width = widgets[widx::change_name_btn].left - 20;
-                Gfx::drawStringLeftClipped(*context, xPos, yPos, width, Colour::black, StringIds::scenario_name_stringid, &*commonFormatArgs);
+                Gfx::drawStringLeftClipped(*rt, xPos, yPos, width, Colour::black, StringIds::scenario_name_stringid, &*commonFormatArgs);
             }
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::scenario_group].top + 1;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::scenario_group);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::scenario_group);
             }
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::change_details_btn].top + 1;
-                Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::scenario_details);
+                Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::scenario_details);
             }
 
             {
@@ -1021,7 +1021,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     commonFormatArgs[0] = stex->details;
 
                 auto& target = window.widgets[widx::change_details_btn];
-                Gfx::drawStringLeftWrapped(*context, window.x + 16, window.y + 12 + target.top, target.left - 26, Colour::black, StringIds::black_stringid, &*commonFormatArgs);
+                Gfx::drawStringLeftWrapped(*rt, window.x + 16, window.y + 12 + target.top, target.left - 26, Colour::black, StringIds::black_stringid, &*commonFormatArgs);
             }
         }
 

--- a/src/OpenLoco/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/Windows/ScenarioSelect.cpp
@@ -152,12 +152,12 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     }
 
     // 0x004439AF
-    static void draw(Window& self, Gfx::Context* context)
+    static void draw(Window& self, Gfx::RenderTarget* rt)
     {
-        Gfx::drawRectInset(*context, self.x, self.y + 20, self.width, 41, self.getColour(WindowColour::primary).u8(), 0);
+        Gfx::drawRectInset(*rt, self.x, self.y + 20, self.width, 41, self.getColour(WindowColour::primary).u8(), 0);
 
         // Draw widgets.
-        self.draw(context);
+        self.draw(rt);
 
         static const string_id scenarioGroupIds[] = {
             StringIds::scenario_group_beginner,
@@ -178,7 +178,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             auto origin = Ui::Point(widget.mid_x() + self.x, widget.mid_y() + self.y - 3 - offset);
             const string_id caption = scenarioGroupIds[i];
 
-            Gfx::drawStringCentredWrapped(*context, origin, widget.width() - 4, Colour::black, StringIds::wcolour2_stringid, &caption);
+            Gfx::drawStringCentredWrapped(*rt, origin, widget.width() - 4, Colour::black, StringIds::wcolour2_stringid, &caption);
         }
 
         // Scenario selected?
@@ -214,7 +214,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             args.push(StringIds::buffer_2039);
 
             x += colWidth / 2;
-            Gfx::drawStringCentredClipped(*context, x, y, 170, Colour::black, StringIds::wcolour2_stringid, &args);
+            Gfx::drawStringCentredClipped(*rt, x, y, 170, Colour::black, StringIds::wcolour2_stringid, &args);
 
             y += 14;
         }
@@ -222,7 +222,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
         // Outline for preview image
         {
             x = baseX + 20;
-            Gfx::drawRectInset(*context, x, y, 130, 130, self.getColour(WindowColour::secondary).u8(), 0x30);
+            Gfx::drawRectInset(*rt, x, y, 130, 130, self.getColour(WindowColour::secondary).u8(), 0x30);
 
             x += 1;
             y += 1;
@@ -243,11 +243,11 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
                 g1->height = 128;
 
                 // Draw preview image and restore original G1 image.
-                Gfx::drawImage(context, x, y, imageId);
+                Gfx::drawImage(rt, x, y, imageId);
                 *g1 = backupG1;
 
                 // Draw compass
-                Gfx::drawImage(context, x, y, ImageIds::height_map_compass);
+                Gfx::drawImage(rt, x, y, ImageIds::height_map_compass);
             }
         }
         else
@@ -257,7 +257,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 
             // No preview image -- a placeholder will have to do.
             auto image = Gfx::recolour(ImageIds::random_map_watermark, self.getColour(WindowColour::secondary).c());
-            Gfx::drawImage(context, x, y, image);
+            Gfx::drawImage(rt, x, y, image);
 
             x += 64;
             y += 59;
@@ -267,7 +267,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 
             // Overlay random map note.
             auto origin = Ui::Point(x, y);
-            Gfx::drawStringCentredWrapped(*context, origin, 128, Colour::black, StringIds::wcolour2_stringid, &args);
+            Gfx::drawStringCentredWrapped(*rt, origin, 128, Colour::black, StringIds::wcolour2_stringid, &args);
         }
 
         {
@@ -280,12 +280,12 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 
             auto args = FormatArguments();
             args.push(StringIds::buffer_2039);
-            y = Gfx::drawStringLeftWrapped(*context, x, y, 170, Colour::black, StringIds::black_stringid, &args);
+            y = Gfx::drawStringLeftWrapped(*rt, x, y, 170, Colour::black, StringIds::black_stringid, &args);
 
             // Challenge header
             y += 5;
             auto origin = Ui::Point(x, y);
-            Gfx::drawStringLeft(*context, &origin, Colour::black, StringIds::challenge_label, nullptr);
+            Gfx::drawStringLeft(*rt, &origin, Colour::black, StringIds::challenge_label, nullptr);
 
             // Challenge text
             str = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
@@ -294,20 +294,20 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             y += 10;
             args = FormatArguments();
             args.push(StringIds::buffer_1250);
-            y = Gfx::drawStringLeftWrapped(*context, x, y, 170, Colour::black, StringIds::challenge_value, &args);
+            y = Gfx::drawStringLeftWrapped(*rt, x, y, 170, Colour::black, StringIds::challenge_value, &args);
 
             // Start year
             y += 5;
             args = FormatArguments();
             args.push(scenarioInfo->startYear);
-            Gfx::drawStringLeft(*context, x, y, Colour::black, StringIds::challenge_start_date, &args);
+            Gfx::drawStringLeft(*rt, x, y, Colour::black, StringIds::challenge_start_date, &args);
 
             // Competing companies
             y += 10;
             args = FormatArguments();
             args.push<uint16_t>(scenarioInfo->numCompetingCompanies);
             string_id competitionStringId = scenarioInfo->numCompetingCompanies == 0 ? StringIds::challenge_competing_companies_none : StringIds::challenge_competing_companies_up_to;
-            y = Gfx::drawStringLeftWrapped(*context, x, y, 170, Colour::black, competitionStringId, &args);
+            y = Gfx::drawStringLeftWrapped(*rt, x, y, 170, Colour::black, competitionStringId, &args);
 
             if (scenarioInfo->numCompetingCompanies == 0 || scenarioInfo->competingCompanyDelay == 0)
                 return;
@@ -316,15 +316,15 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             args = FormatArguments();
             args.push<uint16_t>(scenarioInfo->competingCompanyDelay);
             competitionStringId = scenarioInfo->numCompetingCompanies == 1 ? StringIds::competition_not_starting_for_month : StringIds::competition_not_starting_for_months;
-            Gfx::drawStringLeft(*context, x, y, Colour::black, competitionStringId, &args);
+            Gfx::drawStringLeft(*rt, x, y, Colour::black, competitionStringId, &args);
         }
     }
 
     // 0x00443D02
-    static void drawScroll(Window& self, Gfx::Context& context, const uint32_t)
+    static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t)
     {
         auto colour = Colours::getShade(self.getColour(WindowColour::secondary).c(), 4);
-        Gfx::clearSingle(context, colour);
+        Gfx::clearSingle(rt, colour);
 
         using namespace ScenarioManager;
         auto scenarioCount = getScenarioCountByCategory(self.currentTab);
@@ -336,7 +336,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             if (scenarioInfo == nullptr)
                 continue;
 
-            if (y + rowHeight < context.y || y > context.y + context.height)
+            if (y + rowHeight < rt.y || y > rt.y + rt.height)
             {
                 y += rowHeight;
                 continue;
@@ -346,7 +346,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             auto formatStringId = StringIds::black_stringid;
             if (scenarioInfo == reinterpret_cast<ScenarioIndexEntry*>(self.info))
             {
-                Gfx::drawRect(context, 0, y, self.width, rowHeight - 1, 0x2000000 | 48);
+                Gfx::drawRect(rt, 0, y, self.width, rowHeight - 1, 0x2000000 | 48);
                 formatStringId = StringIds::wcolour2_stringid;
             }
 
@@ -359,7 +359,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
                 args.push(StringIds::buffer_2039);
 
                 const int16_t x = 210;
-                Gfx::drawStringCentred(context, x, y + 1, Colour::black, formatStringId, &args);
+                Gfx::drawStringCentred(rt, x, y + 1, Colour::black, formatStringId, &args);
             }
 
             // Completed?
@@ -370,7 +370,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             }
 
             // Draw checkmark to indicate completion
-            Gfx::drawImage(&context, self.widgets[widx::list].width() - ScrollView::barWidth - 25, y + 1, ImageIds::scenario_completed_tick);
+            Gfx::drawImage(&rt, self.widgets[widx::list].width() - ScrollView::barWidth - 25, y + 1, ImageIds::scenario_completed_tick);
 
             // 'Completed by' info
             {
@@ -384,7 +384,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
                 args.push<uint16_t>(scenarioInfo->completedMonths % 12);
 
                 const int16_t x = (self.widgets[widx::list].width() - ScrollView::barWidth) / 2;
-                Gfx::drawStringCentred(context, x, y + 10, Colour::black, formatStringId, &args);
+                Gfx::drawStringCentred(rt, x, y + 10, Colour::black, formatStringId, &args);
             }
 
             y += rowHeight;

--- a/src/OpenLoco/Windows/StationWindow.cpp
+++ b/src/OpenLoco/Windows/StationWindow.cpp
@@ -61,7 +61,7 @@ namespace OpenLoco::Ui::Windows::Station
         static void update(Window& self);
         static void renameStationPrompt(Window* self, WidgetIndex_t widgetIndex);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
-        static void drawTabs(Window* self, Gfx::Context* context);
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt);
         static void enableRenameByCaption(Window* self);
         static void initEvents();
     }
@@ -111,12 +111,12 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048E470
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
-            self.drawViewports(context);
-            Widget::drawViewportCentreButton(context, &self, widx::centre_on_viewport);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
+            self.drawViewports(rt);
+            Widget::drawViewportCentreButton(rt, &self, widx::centre_on_viewport);
 
             auto station = StationManager::get(StationId(self.number));
             const char* buffer = StringManager::getString(StringIds::buffer_1250);
@@ -129,7 +129,7 @@ namespace OpenLoco::Ui::Windows::Station
             const auto x = self.x + widget.left - 1;
             const auto y = self.y + widget.top - 1;
             const auto width = widget.width() - 1;
-            Gfx::drawStringLeftClipped(*context, x, y, width, Colour::black, StringIds::black_stringid, &args);
+            Gfx::drawStringLeftClipped(*rt, x, y, width, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x0048E4D4
@@ -358,10 +358,10 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048E8DE
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
             buffer = StringManager::formatString(buffer, StringIds::accepted_cargo_separator);
@@ -396,7 +396,7 @@ namespace OpenLoco::Ui::Windows::Station
             const auto y = self.y + widget.top - 1;
             const auto width = widget.width();
 
-            Gfx::drawStringLeftClipped(*context, x, y, width, Colour::black, StringIds::buffer_1250);
+            Gfx::drawStringLeftClipped(*rt, x, y, width, Colour::black, StringIds::buffer_1250);
         }
 
         // 0x0048EB0B
@@ -463,9 +463,9 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048E986
-        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
         {
-            Gfx::clearSingle(context, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
+            Gfx::clearSingle(rt, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
 
             const auto station = StationManager::get(StationId(self.number));
             int16_t y = 1;
@@ -492,7 +492,7 @@ namespace OpenLoco::Ui::Windows::Station
                     for (; units > 0; units--)
                     {
                         {
-                            Gfx::drawImage(&context, xPos, y, cargoObj->unit_inline_sprite);
+                            Gfx::drawImage(&rt, xPos, y, cargoObj->unit_inline_sprite);
                             xPos += 10;
                         }
                     }
@@ -512,7 +512,7 @@ namespace OpenLoco::Ui::Windows::Station
                 const auto& widget = self.widgets[widx::scrollview];
                 auto xPos = widget.width() - 14;
 
-                Gfx::drawStringRight(context, xPos, y, AdvancedColour(Colour::black).outline(), cargoStr, &args);
+                Gfx::drawStringRight(rt, xPos, y, AdvancedColour(Colour::black).outline(), cargoStr, &args);
                 y += 10;
                 if (cargo.origin != StationId(self.number))
                 {
@@ -521,7 +521,7 @@ namespace OpenLoco::Ui::Windows::Station
                     args2.push(originStation->name);
                     args2.push(originStation->town);
 
-                    Gfx::drawStringRight(context, xPos, y, AdvancedColour(Colour::black).outline(), StringIds::station_cargo_en_route_end, &args2);
+                    Gfx::drawStringRight(rt, xPos, y, AdvancedColour(Colour::black).outline(), StringIds::station_cargo_en_route_end, &args2);
                     y += 10;
                 }
                 y += 2;
@@ -536,7 +536,7 @@ namespace OpenLoco::Ui::Windows::Station
             {
                 auto args = FormatArguments();
                 args.push(StringIds::nothing_waiting);
-                Gfx::drawStringLeft(context, 1, 0, Colour::black, StringIds::black_stringid, &args);
+                Gfx::drawStringLeft(rt, 1, 0, Colour::black, StringIds::black_stringid, &args);
             }
         }
 
@@ -601,10 +601,10 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048ED24
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
         }
 
         // 0x0048EE1A
@@ -657,21 +657,21 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EF02
-        static void drawRatingBar(Window* self, Gfx::Context* context, int16_t x, int16_t y, uint8_t amount, Colour colour)
+        static void drawRatingBar(Window* self, Gfx::RenderTarget* rt, int16_t x, int16_t y, uint8_t amount, Colour colour)
         {
-            Gfx::fillRectInset(*context, x, y, x + 99, y + 9, self->getColour(WindowColour::secondary).u8(), 48);
+            Gfx::fillRectInset(*rt, x, y, x + 99, y + 9, self->getColour(WindowColour::secondary).u8(), 48);
 
             uint16_t rating = (amount * 96) / 256;
             if (rating > 2)
             {
-                Gfx::fillRectInset(*context, x + 2, y + 2, x + 1 + rating, y + 8, enumValue(colour), 0);
+                Gfx::fillRectInset(*rt, x + 2, y + 2, x + 1 + rating, y + 8, enumValue(colour), 0);
             }
         }
 
         // 0x0048ED2F
-        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
         {
-            Gfx::clearSingle(context, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
+            Gfx::clearSingle(rt, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
 
             const auto station = StationManager::get(StationId(self.number));
             int16_t y = 0;
@@ -686,7 +686,7 @@ namespace OpenLoco::Ui::Windows::Station
                 }
 
                 auto cargoObj = ObjectManager::get<CargoObject>(cargoId);
-                Gfx::drawStringLeftClipped(context, 1, y, 98, Colour::black, StringIds::wcolour2_stringid, &cargoObj->name);
+                Gfx::drawStringLeftClipped(rt, 1, y, 98, Colour::black, StringIds::wcolour2_stringid, &cargoObj->name);
 
                 auto rating = cargo.rating;
                 auto colour = Colour::green;
@@ -700,10 +700,10 @@ namespace OpenLoco::Ui::Windows::Station
                 }
 
                 uint8_t amount = (rating * 327) / 256;
-                drawRatingBar(&self, &context, 100, y, amount, colour);
+                drawRatingBar(&self, &rt, 100, y, amount, colour);
 
                 uint16_t percent = rating / 2;
-                Gfx::drawStringLeft(context, 201, y, Colour::black, StringIds::station_cargo_rating_percent, &percent);
+                Gfx::drawStringLeft(rt, 201, y, Colour::black, StringIds::station_cargo_rating_percent, &percent);
                 y += 10;
                 cargoId++;
             }
@@ -921,7 +921,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EFBC
-        static void drawTabs(Window* self, Gfx::Context* context)
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
             auto station = StationManager::get(StationId(self->number));
@@ -931,7 +931,7 @@ namespace OpenLoco::Ui::Windows::Station
             {
                 uint32_t imageId = Gfx::recolour(skin->img, companyColour);
                 imageId += InterfaceSkin::ImageIds::toolbar_menu_stations;
-                Widget::drawTab(self, context, imageId, widx::tab_station);
+                Widget::drawTab(self, rt, imageId, widx::tab_station);
             }
 
             // Cargo tab
@@ -949,13 +949,13 @@ namespace OpenLoco::Ui::Windows::Station
                 else
                     imageId += cargoTabImageIds[0];
 
-                Widget::drawTab(self, context, imageId, widx::tab_cargo);
+                Widget::drawTab(self, rt, imageId, widx::tab_cargo);
             }
 
             // Cargo ratings tab
             {
                 const uint32_t imageId = skin->img + InterfaceSkin::ImageIds::tab_cargo_ratings;
-                Widget::drawTab(self, context, imageId, widx::tab_cargo_ratings);
+                Widget::drawTab(self, rt, imageId, widx::tab_cargo_ratings);
 
                 auto widget = self->widgets[widx::tab_cargo_ratings];
                 auto yOffset = widget.top + self->y + 14;
@@ -967,7 +967,7 @@ namespace OpenLoco::Ui::Windows::Station
                     auto& cargo = cargoStats;
                     if (!cargo.empty())
                     {
-                        Gfx::fillRect(*context, xOffset, yOffset, xOffset + 22, yOffset + 1, (1 << 25) | PaletteIndex::index_30);
+                        Gfx::fillRect(*rt, xOffset, yOffset, xOffset + 22, yOffset + 1, (1 << 25) | PaletteIndex::index_30);
 
                         auto ratingColour = Colour::green;
                         if (cargo.rating < 100)
@@ -978,7 +978,7 @@ namespace OpenLoco::Ui::Windows::Station
                         }
 
                         auto ratingBarLength = (cargo.rating * 30) / 256;
-                        Gfx::fillRect(*context, xOffset, yOffset, xOffset - 1 + ratingBarLength, yOffset + 1, Colours::getShade(ratingColour, 6));
+                        Gfx::fillRect(*rt, xOffset, yOffset, xOffset - 1 + ratingBarLength, yOffset + 1, Colours::getShade(ratingColour, 6));
 
                         yOffset += 3;
                         totalRatingBars++;

--- a/src/OpenLoco/Windows/TerraForm.cpp
+++ b/src/OpenLoco/Windows/TerraForm.cpp
@@ -93,7 +93,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
         static void initEvents();
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
-        static void drawTabs(Window* self, Gfx::Context* context);
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt);
         static void prepareDraw(Window& self);
         static void onUpdate(Window& self);
         static void onResize(Window& self, uint8_t height);
@@ -692,10 +692,10 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BB8C9
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             auto treeId = self.var_846;
             if (treeId == 0xFFFF)
@@ -727,15 +727,15 @@ namespace OpenLoco::Ui::Windows::Terraform
             {
                 auto xPos = self.x + 3 + self.width - 17;
                 auto yPos = self.y + self.height - 13;
-                Gfx::drawStringRight(*context, xPos, yPos, Colour::black, StringIds::build_cost, &args);
+                Gfx::drawStringRight(*rt, xPos, yPos, Colour::black, StringIds::build_cost, &args);
             }
             auto xPos = self.x + 3;
             auto yPos = self.y + self.height - 13;
             auto width = self.width - 19 - xPos;
-            Gfx::drawStringLeftClipped(*context, xPos, yPos, width, Colour::black, StringIds::black_stringid, &treeObj->name);
+            Gfx::drawStringLeftClipped(*rt, xPos, yPos, width, Colour::black, StringIds::black_stringid, &treeObj->name);
         }
 
-        static void drawTreeThumb(TreeObject* treeObj, Gfx::Context* clipped)
+        static void drawTreeThumb(TreeObject* treeObj, Gfx::RenderTarget* clipped)
         {
             uint32_t image = treeObj->getTreeGrowthDisplayOffset() * treeObj->num_rotations;
             auto rotation = (treeObj->num_rotations - 1) & _treeRotation;
@@ -757,10 +757,10 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BB982
-        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
         {
             auto shade = Colours::getShade(self.getColour(WindowColour::secondary).c(), 3);
-            Gfx::clearSingle(context, shade);
+            Gfx::clearSingle(rt, shade);
 
             uint16_t xPos = 0;
             uint16_t yPos = 0;
@@ -772,17 +772,17 @@ namespace OpenLoco::Ui::Windows::Terraform
                     if (self.rowInfo[i] == self.var_846)
                     {
                         _lastTreeColourFlag = AdvancedColour::translucent_flag;
-                        Gfx::drawRectInset(context, xPos, yPos, 65, rowHeight - 1, self.getColour(WindowColour::secondary).u8(), AdvancedColour::translucent_flag);
+                        Gfx::drawRectInset(rt, xPos, yPos, 65, rowHeight - 1, self.getColour(WindowColour::secondary).u8(), AdvancedColour::translucent_flag);
                     }
                 }
                 else
                 {
                     _lastTreeColourFlag = AdvancedColour::translucent_flag | AdvancedColour::outline_flag;
-                    Gfx::drawRectInset(context, xPos, yPos, 65, rowHeight - 1, self.getColour(WindowColour::secondary).u8(), (AdvancedColour::translucent_flag | AdvancedColour::outline_flag));
+                    Gfx::drawRectInset(rt, xPos, yPos, 65, rowHeight - 1, self.getColour(WindowColour::secondary).u8(), (AdvancedColour::translucent_flag | AdvancedColour::outline_flag));
                 }
 
                 auto treeObj = ObjectManager::get<TreeObject>(self.rowInfo[i]);
-                auto clipped = Gfx::clipContext(context, Ui::Rect(xPos + 1, yPos + 1, 64, rowHeight - 2));
+                auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(xPos + 1, yPos + 1, 64, rowHeight - 2));
                 if (clipped)
                 {
                     drawTreeThumb(treeObj, &*clipped);
@@ -1043,10 +1043,10 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC5E7
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             if (_raiseLandCost == 0x80000000)
                 return;
@@ -1062,7 +1062,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             auto args = FormatArguments();
             args.push<uint32_t>(_raiseLandCost);
 
-            Gfx::drawStringCentred(*context, xPos, yPos, Colour::black, StringIds::clear_land_cost, &args);
+            Gfx::drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::clear_land_cost, &args);
         }
 
         static void initEvents()
@@ -1545,15 +1545,15 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC909
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
             auto imgId = skin->img;
             self.widgets[widx::paint_mode].image = imgId + InterfaceSkin::ImageIds::tab_colour_scheme_frame0;
 
-            self.draw(context);
+            self.draw(rt);
 
-            Common::drawTabs(&self, context);
+            Common::drawTabs(&self, rt);
 
             auto xPos = self.widgets[widx::tool_area].left + self.widgets[widx::tool_area].right;
             xPos /= 2;
@@ -1566,7 +1566,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 {
                     auto args = FormatArguments();
                     args.push<uint32_t>(_raiseLandCost);
-                    Gfx::drawStringCentred(*context, xPos, yPos, Colour::black, StringIds::increase_height_cost, &args);
+                    Gfx::drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::increase_height_cost, &args);
                 }
             }
 
@@ -1578,7 +1578,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 {
                     auto args = FormatArguments();
                     args.push<uint32_t>(_lowerLandCost);
-                    Gfx::drawStringCentred(*context, xPos, yPos, Colour::black, StringIds::decrease_height_cost, &args);
+                    Gfx::drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::decrease_height_cost, &args);
                 }
             }
         }
@@ -1830,10 +1830,10 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCCFF
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             auto xPos = self.widgets[widx::tool_area].left + self.widgets[widx::tool_area].right;
             xPos /= 2;
@@ -1847,7 +1847,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     auto args = FormatArguments();
                     args.push<uint32_t>(_raiseWaterCost);
 
-                    Gfx::drawStringCentred(*context, xPos, yPos, Colour::black, StringIds::increase_height_cost, &args);
+                    Gfx::drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::increase_height_cost, &args);
                 }
             }
 
@@ -1860,7 +1860,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     auto args = FormatArguments();
                     args.push<uint32_t>(_lowerWaterCost);
 
-                    Gfx::drawStringCentred(*context, xPos, yPos, Colour::black, StringIds::decrease_height_cost, &args);
+                    Gfx::drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::decrease_height_cost, &args);
                 }
             }
         }
@@ -2271,10 +2271,10 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC0C2
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             auto wallId = self.var_846;
             if (wallId == 0xFFFF)
@@ -2289,14 +2289,14 @@ namespace OpenLoco::Ui::Windows::Terraform
             auto yPos = self.y + self.height - 13;
             auto width = self.width - 19;
 
-            Gfx::drawStringLeftClipped(*context, xPos, yPos, width, Colour::black, StringIds::black_stringid, &wallObj->name);
+            Gfx::drawStringLeftClipped(*rt, xPos, yPos, width, Colour::black, StringIds::black_stringid, &wallObj->name);
         }
 
         // 0x004BC11C
-        static void drawScroll(Window& self, Gfx::Context& context, uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, uint32_t scrollIndex)
         {
             auto shade = Colours::getShade(self.getColour(WindowColour::secondary).c(), 3);
-            Gfx::clearSingle(context, shade);
+            Gfx::clearSingle(rt, shade);
 
             uint16_t xPos = 0;
             uint16_t yPos = 0;
@@ -2306,17 +2306,17 @@ namespace OpenLoco::Ui::Windows::Terraform
                 {
                     if (self.rowInfo[i] == self.var_846)
                     {
-                        Gfx::drawRectInset(context, xPos, yPos, 40, rowHeight, self.getColour(WindowColour::secondary).u8(), AdvancedColour::translucent_flag);
+                        Gfx::drawRectInset(rt, xPos, yPos, 40, rowHeight, self.getColour(WindowColour::secondary).u8(), AdvancedColour::translucent_flag);
                     }
                 }
                 else
                 {
-                    Gfx::drawRectInset(context, xPos, yPos, 40, rowHeight, self.getColour(WindowColour::secondary).u8(), (AdvancedColour::translucent_flag | AdvancedColour::outline_flag));
+                    Gfx::drawRectInset(rt, xPos, yPos, 40, rowHeight, self.getColour(WindowColour::secondary).u8(), (AdvancedColour::translucent_flag | AdvancedColour::outline_flag));
                 }
 
                 auto wallObj = ObjectManager::get<WallObject>(self.rowInfo[i]);
 
-                auto clipped = Gfx::clipContext(context, Ui::Rect(xPos + 1, yPos + 1, 39, 47));
+                auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(xPos + 1, yPos + 1, 39, 47));
                 if (clipped)
                     Gfx::drawImage(&*clipped, 34, 28, wallObj->sprite);
 
@@ -2442,7 +2442,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCF7F
-        static void drawTabs(Window* self, Gfx::Context* context)
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
@@ -2451,14 +2451,14 @@ namespace OpenLoco::Ui::Windows::Terraform
                 uint32_t imageId = skin->img;
                 imageId += InterfaceSkin::ImageIds::toolbar_menu_bulldozer;
 
-                Widget::drawTab(self, context, imageId, widx::tab_clear_area);
+                Widget::drawTab(self, rt, imageId, widx::tab_clear_area);
             }
             // Adjust Land Tab
             {
                 auto landObj = ObjectManager::get<LandObject>(LastGameOptionManager::getLastLand());
                 uint32_t imageId = landObj->var_16 + Land::ImageIds::toolbar_terraform_land;
 
-                Widget::drawTab(self, context, imageId, widx::tab_adjust_land);
+                Widget::drawTab(self, rt, imageId, widx::tab_adjust_land);
             }
             // Adjust Water Tab
             {
@@ -2467,21 +2467,21 @@ namespace OpenLoco::Ui::Windows::Terraform
                 if (self->currentTab == widx::tab_adjust_water - widx::tab_clear_area)
                     imageId += (self->frame_no / 2) % 16;
 
-                Widget::drawTab(self, context, imageId, widx::tab_adjust_water);
+                Widget::drawTab(self, rt, imageId, widx::tab_adjust_water);
             }
             // Plant Trees Tab
             {
                 uint32_t imageId = skin->img;
                 imageId += InterfaceSkin::ImageIds::toolbar_menu_plant_trees;
 
-                Widget::drawTab(self, context, imageId, widx::tab_plant_trees);
+                Widget::drawTab(self, rt, imageId, widx::tab_plant_trees);
             }
             // Build Walls Tab
             {
                 uint32_t imageId = skin->img;
                 imageId += InterfaceSkin::ImageIds::toolbar_menu_build_walls;
 
-                Widget::drawTab(self, context, imageId, widx::tab_build_walls);
+                Widget::drawTab(self, rt, imageId, widx::tab_build_walls);
             }
         }
 

--- a/src/OpenLoco/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/Windows/TextInputWindow.cpp
@@ -82,7 +82,7 @@ namespace OpenLoco::Ui::Windows::TextInput
     }
 
     static void prepareDraw(Ui::Window& window);
-    static void draw(Ui::Window& window, Gfx::Context* context);
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt);
     static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex);
     static void onUpdate(Ui::Window& window);
 
@@ -218,18 +218,18 @@ namespace OpenLoco::Ui::Windows::TextInput
      * @param window @<esi>
      * @param context @<edi>
      */
-    static void draw(Ui::Window& window, Gfx::Context* context)
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
     {
-        window.draw(context);
+        window.draw(rt);
 
         *((string_id*)(&_commonFormatArgs[0])) = _message;
         memcpy(&_commonFormatArgs[2], _formatArgs + 8, 8);
 
         Ui::Point position = { (int16_t)(window.x + window.width / 2), (int16_t)(window.y + 30) };
-        Gfx::drawStringCentredWrapped(*context, position, window.width - 8, Colour::black, StringIds::wcolour2_stringid, &_commonFormatArgs[0]);
+        Gfx::drawStringCentredWrapped(*rt, position, window.width - 8, Colour::black, StringIds::wcolour2_stringid, &_commonFormatArgs[0]);
 
         auto widget = &_widgets[Widx::input];
-        auto clipped = Gfx::clipContext(*context, Ui::Rect(widget->left + 1 + window.x, widget->top + 1 + window.y, widget->width() - 2, widget->height() - 2));
+        auto clipped = Gfx::clipRenderTarget(*rt, Ui::Rect(widget->left + 1 + window.x, widget->top + 1 + window.y, widget->width() - 2, widget->height() - 2));
         if (!clipped)
         {
             return;

--- a/src/OpenLoco/Windows/TileInspector.cpp
+++ b/src/OpenLoco/Windows/TileInspector.cpp
@@ -117,21 +117,21 @@ namespace OpenLoco::Ui::Windows::TileInspector
             self.activatedWidgets &= ~(1 << widx::select);
     }
 
-    static void draw(Ui::Window& self, Gfx::Context* const context)
+    static void draw(Ui::Window& self, Gfx::RenderTarget* const rt)
     {
         // Draw widgets.
-        self.draw(context);
+        self.draw(rt);
 
         // Coord X/Y labels
         {
             auto args = FormatArguments::common(StringIds::tile_inspector_x_coord);
             auto& widget = self.widgets[widx::xPos];
-            Gfx::drawStringLeft(*context, self.x + widget.left - 15, self.y + widget.top + 1, Colour::black, StringIds::wcolour2_stringid, &args);
+            Gfx::drawStringLeft(*rt, self.x + widget.left - 15, self.y + widget.top + 1, Colour::black, StringIds::wcolour2_stringid, &args);
         }
         {
             auto args = FormatArguments::common(StringIds::tile_inspector_y_coord);
             auto& widget = self.widgets[widx::yPos];
-            Gfx::drawStringLeft(*context, self.x + widget.left - 15, self.y + widget.top + 1, Colour::black, StringIds::wcolour2_stringid, &args);
+            Gfx::drawStringLeft(*rt, self.x + widget.left - 15, self.y + widget.top + 1, Colour::black, StringIds::wcolour2_stringid, &args);
         }
 
         // Coord X/Y values
@@ -139,13 +139,13 @@ namespace OpenLoco::Ui::Windows::TileInspector
             FormatArguments args = {};
             args.push<int16_t>(_currentPosition.x);
             auto& widget = self.widgets[widx::xPos];
-            Gfx::drawStringLeft(*context, self.x + widget.left + 2, self.y + widget.top + 1, Colour::black, StringIds::tile_inspector_coord, &args);
+            Gfx::drawStringLeft(*rt, self.x + widget.left + 2, self.y + widget.top + 1, Colour::black, StringIds::tile_inspector_coord, &args);
         }
         {
             FormatArguments args = {};
             args.push<int16_t>(_currentPosition.y);
             auto& widget = self.widgets[widx::yPos];
-            Gfx::drawStringLeft(*context, self.x + widget.left + 2, self.y + widget.top + 1, Colour::black, StringIds::tile_inspector_coord, &args);
+            Gfx::drawStringLeft(*rt, self.x + widget.left + 2, self.y + widget.top + 1, Colour::black, StringIds::tile_inspector_coord, &args);
         }
 
         // Selected element details
@@ -159,7 +159,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
             snprintf(&buffer[1], std::size(buffer) - 1, "Data: %02x %02x %02x %02x %02x %02x %02x %02x", data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
 
             auto widget = self.widgets[widx::detailsGroup];
-            Gfx::drawString(*context, self.x + widget.left + 7, self.y + widget.top + 14, Colour::black, buffer);
+            Gfx::drawString(*rt, self.x + widget.left + 7, self.y + widget.top + 14, Colour::black, buffer);
         }
     }
 
@@ -294,7 +294,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         return StringIds::empty;
     }
 
-    static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t)
+    static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t)
     {
         if (_currentPosition == TilePos2(0, 0))
             return;
@@ -307,12 +307,12 @@ namespace OpenLoco::Ui::Windows::TileInspector
             string_id formatString;
             if (self.var_842 == rowNum)
             {
-                Gfx::fillRect(context, 0, yPos, self.width, yPos + self.rowHeight, enumValue(Colour::darkGreen));
+                Gfx::fillRect(rt, 0, yPos, self.width, yPos + self.rowHeight, enumValue(Colour::darkGreen));
                 formatString = StringIds::white_stringid;
             }
             else if (self.rowHover == rowNum)
             {
-                Gfx::fillRect(context, 0, yPos, self.width, yPos + self.rowHeight, 0x2000030);
+                Gfx::fillRect(rt, 0, yPos, self.width, yPos + self.rowHeight, 0x2000030);
                 formatString = StringIds::wcolour2_stringid;
             }
             else
@@ -341,7 +341,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
                 args.push(elementName);
             }
 
-            Gfx::drawStringLeft(context, 0, yPos, Colour::black, formatString, &args);
+            Gfx::drawStringLeft(rt, 0, yPos, Colour::black, formatString, &args);
             rowNum++;
             yPos += self.rowHeight;
         }

--- a/src/OpenLoco/Windows/TimePanel.cpp
+++ b/src/OpenLoco/Windows/TimePanel.cpp
@@ -58,7 +58,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     static WindowEventList _events;
 
     static void prepareDraw(Window& window);
-    static void draw(Ui::Window& self, Gfx::Context* context);
+    static void draw(Ui::Window& self, Gfx::RenderTarget* rt);
     static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex);
     static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex);
     static void textInput(Window& w, WidgetIndex_t widgetIndex, const char* str);
@@ -167,15 +167,15 @@ namespace OpenLoco::Ui::Windows::TimePanel
     };
 
     // 0x004397BE
-    static void draw(Ui::Window& self, Gfx::Context* context)
+    static void draw(Ui::Window& self, Gfx::RenderTarget* rt)
     {
         Widget& frame = _widgets[Widx::outer_frame];
-        Gfx::drawRect(*context, self.x + frame.left, self.y + frame.top, frame.width(), frame.height(), 0x2000000 | 52);
+        Gfx::drawRect(*rt, self.x + frame.left, self.y + frame.top, frame.width(), frame.height(), 0x2000000 | 52);
 
         // Draw widgets.
-        self.draw(context);
+        self.draw(rt);
 
-        Gfx::drawRectInset(*context, self.x + frame.left + 1, self.y + frame.top + 1, frame.width() - 2, frame.height() - 2, self.getColour(WindowColour::secondary).u8(), 0x30);
+        Gfx::drawRectInset(*rt, self.x + frame.left + 1, self.y + frame.top + 1, frame.width() - 2, frame.height() - 2, self.getColour(WindowColour::secondary).u8(), 0x30);
 
         *(uint32_t*)&_common_format_args[0] = getCurrentDay();
         string_id format = StringIds::date_daymonthyear;
@@ -193,10 +193,10 @@ namespace OpenLoco::Ui::Windows::TimePanel
         {
             c = Colour::white;
         }
-        Gfx::drawStringCentred(*context, self.x + _widgets[Widx::date_btn].mid_x(), self.y + _widgets[Widx::date_btn].top + 1, c, format, &*_common_format_args);
+        Gfx::drawStringCentred(*rt, self.x + _widgets[Widx::date_btn].mid_x(), self.y + _widgets[Widx::date_btn].top + 1, c, format, &*_common_format_args);
 
         auto skin = ObjectManager::get<InterfaceSkinObject>();
-        Gfx::drawImage(context, self.x + _widgets[Widx::map_chat_menu].left - 2, self.y + _widgets[Widx::map_chat_menu].top - 1, skin->img + map_sprites_by_rotation[WindowManager::getCurrentRotation()]);
+        Gfx::drawImage(rt, self.x + _widgets[Widx::map_chat_menu].left - 2, self.y + _widgets[Widx::map_chat_menu].top - 1, skin->img + map_sprites_by_rotation[WindowManager::getCurrentRotation()]);
     }
 
     // 0x004398FB

--- a/src/OpenLoco/Windows/TitleExit.cpp
+++ b/src/OpenLoco/Windows/TitleExit.cpp
@@ -32,7 +32,7 @@ namespace OpenLoco::Ui::Windows::TitleExit
 
     static void onMouseUp(Window& window, WidgetIndex_t widgetIndex);
     static void prepareDraw(Ui::Window& self);
-    static void draw(Ui::Window& window, Gfx::Context* context);
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt);
 
     Window* open()
     {
@@ -67,15 +67,15 @@ namespace OpenLoco::Ui::Windows::TitleExit
     }
 
     // 0x00439236
-    static void draw(Ui::Window& window, Gfx::Context* context)
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
     {
         // Draw widgets.
-        window.draw(context);
+        window.draw(rt);
 
         int16_t x = window.x + window.width / 2;
         int16_t y = window.y + window.widgets[Widx::exit_button].top + 8;
         Ui::Point origin = { x, y };
-        Gfx::drawStringCentredWrapped(*context, origin, window.width, Colour::black, StringIds::title_exit_game);
+        Gfx::drawStringCentredWrapped(*rt, origin, window.width, Colour::black, StringIds::title_exit_game);
     }
 
     // 0x00439268

--- a/src/OpenLoco/Windows/TitleLogo.cpp
+++ b/src/OpenLoco/Windows/TitleLogo.cpp
@@ -27,7 +27,7 @@ namespace OpenLoco::Ui::Windows::TitleLogo
     static WindowEventList _events;
 
     static void onMouseUp(Window& window, WidgetIndex_t widgetIndex);
-    static void draw(Ui::Window& window, Gfx::Context* context);
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt);
 
     Window* open()
     {
@@ -53,9 +53,9 @@ namespace OpenLoco::Ui::Windows::TitleLogo
     }
 
     // 0x00439298
-    static void draw(Ui::Window& window, Gfx::Context* context)
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
     {
-        Gfx::drawImage(context, window.x, window.y, ImageIds::locomotion_logo);
+        Gfx::drawImage(rt, window.x, window.y, ImageIds::locomotion_logo);
     }
 
     // 0x004392AD

--- a/src/OpenLoco/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/Windows/TitleMenu.cpp
@@ -145,7 +145,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     static void onUpdate(Window& window);
     static void onTextInput(Window& window, WidgetIndex_t widgetIndex, const char* input);
     static Ui::CursorId onCursor(Window& window, int16_t widgetIdx, int16_t xPos, int16_t yPos, Ui::CursorId fallback);
-    static void draw(Ui::Window& window, Gfx::Context* context);
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt);
     static void prepareDraw(Ui::Window& window);
 
     // static loco_global<WindowEventList[1], 0x004f9ec8> _events;
@@ -218,10 +218,10 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     }
 
     // 0x00438EC7
-    static void draw(Ui::Window& window, Gfx::Context* context)
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
     {
         // Draw widgets.
-        window.draw(context);
+        window.draw(rt);
 
         if (window.widgets[Widx::scenario_list_btn].type != Ui::WidgetType::none)
         {
@@ -234,8 +234,8 @@ namespace OpenLoco::Ui::Windows::TitleMenu
                 image_id = globe_spin[((window.var_846 / 2) % globe_spin.size())];
             }
 
-            OpenLoco::Gfx::drawImage(context, x, y, image_id);
-            OpenLoco::Gfx::drawImage(context, x, y, ImageIds::title_menu_sparkle);
+            OpenLoco::Gfx::drawImage(rt, x, y, image_id);
+            OpenLoco::Gfx::drawImage(rt, x, y, ImageIds::title_menu_sparkle);
         }
 
         if (window.widgets[Widx::load_game_btn].type != Ui::WidgetType::none)
@@ -249,8 +249,8 @@ namespace OpenLoco::Ui::Windows::TitleMenu
                 image_id = globe_spin[((window.var_846 / 2) % globe_spin.size())];
             }
 
-            OpenLoco::Gfx::drawImage(context, x, y, image_id);
-            OpenLoco::Gfx::drawImage(context, x, y, ImageIds::title_menu_save);
+            OpenLoco::Gfx::drawImage(rt, x, y, image_id);
+            OpenLoco::Gfx::drawImage(rt, x, y, ImageIds::title_menu_save);
         }
 
         if (window.widgets[Widx::tutorial_btn].type != Ui::WidgetType::none)
@@ -264,10 +264,10 @@ namespace OpenLoco::Ui::Windows::TitleMenu
                 image_id = globe_spin[((window.var_846 / 2) % globe_spin.size())];
             }
 
-            OpenLoco::Gfx::drawImage(context, x, y, image_id);
+            OpenLoco::Gfx::drawImage(rt, x, y, image_id);
 
             // TODO: base lesson overlay on language
-            OpenLoco::Gfx::drawImage(context, x, y, ImageIds::title_menu_lesson_l);
+            OpenLoco::Gfx::drawImage(rt, x, y, ImageIds::title_menu_lesson_l);
         }
 
         if (window.widgets[Widx::scenario_editor_btn].type != Ui::WidgetType::none)
@@ -281,7 +281,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
                 image_id = globe_construct[((window.var_846 / 2) % globe_construct.size())];
             }
 
-            OpenLoco::Gfx::drawImage(context, x, y, image_id);
+            OpenLoco::Gfx::drawImage(rt, x, y, image_id);
         }
 
         if (window.widgets[Widx::multiplayer_toggle_btn].type != Ui::WidgetType::none)
@@ -304,7 +304,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
                 string = StringIds::two_player_mode_connected;
             }
 
-            drawStringCentredClipped(*context, x, y, ww - 4, Colour::black, string, (char*)0x112c826);
+            drawStringCentredClipped(*rt, x, y, ww - 4, Colour::black, string, (char*)0x112c826);
         }
     }
 

--- a/src/OpenLoco/Windows/TitleOptions.cpp
+++ b/src/OpenLoco/Windows/TitleOptions.cpp
@@ -31,7 +31,7 @@ namespace OpenLoco::Ui::Windows::TitleOptions
     static WindowEventList _events;
 
     static void onMouseUp(Window& window, WidgetIndex_t widgetIndex);
-    static void draw(Ui::Window& window, Gfx::Context* context);
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt);
 
     Window* open()
     {
@@ -56,16 +56,16 @@ namespace OpenLoco::Ui::Windows::TitleOptions
         return window;
     }
 
-    static void draw(Ui::Window& window, Gfx::Context* context)
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
     {
         // Draw widgets.
-        window.draw(context);
+        window.draw(rt);
 
         int16_t x = window.x + window.width / 2;
         int16_t y = window.y + window.widgets[Widx::options_button].top + 2;
         Ui::Point origin = { x, y };
 
-        Gfx::drawStringCentredWrapped(*context, origin, window.width, Colour::white, StringIds::outlined_wcolour2_stringid, (const char*)&StringIds::options);
+        Gfx::drawStringCentredWrapped(*rt, origin, window.width, Colour::white, StringIds::outlined_wcolour2_stringid, (const char*)&StringIds::options);
     }
 
     static void onMouseUp(Window& window, WidgetIndex_t widgetIndex)

--- a/src/OpenLoco/Windows/TitleVersion.cpp
+++ b/src/OpenLoco/Windows/TitleVersion.cpp
@@ -16,7 +16,7 @@ namespace OpenLoco::Ui::Windows::TitleVersion
 
     static Ui::WindowEventList _events;
 
-    static void draw(Ui::Window& window, Gfx::Context* context);
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt);
 
     Window* open()
     {
@@ -36,9 +36,9 @@ namespace OpenLoco::Ui::Windows::TitleVersion
     }
 
     // 0x00439236
-    static void draw(Ui::Window& window, Gfx::Context* context)
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
     {
         auto versionInfo = getVersionInfo();
-        Gfx::drawString(*context, window.x, window.y, AdvancedColour(Colour::white).outline(), (void*)versionInfo.c_str());
+        Gfx::drawString(*rt, window.x, window.y, AdvancedColour(Colour::white).outline(), (void*)versionInfo.c_str());
     }
 }

--- a/src/OpenLoco/Windows/ToolTip.cpp
+++ b/src/OpenLoco/Windows/ToolTip.cpp
@@ -165,27 +165,27 @@ namespace OpenLoco::Ui::Windows::ToolTip
     }
 
     // 0x004C9397
-    static void draw(Ui::Window& window, Gfx::Context* context)
+    static void draw(Ui::Window& window, Gfx::RenderTarget* rt)
     {
         uint16_t x = window.x;
         uint16_t y = window.y;
         uint16_t width = window.width;
         uint16_t height = window.height;
 
-        Gfx::drawRect(*context, x + 1, y + 1, width - 2, height - 2, 0x2000000 | 45);
-        Gfx::drawRect(*context, x + 1, y + 1, width - 2, height - 2, 0x2000000 | (116 + enumValue(ObjectManager::get<InterfaceSkinObject>()->colour_08)));
+        Gfx::drawRect(*rt, x + 1, y + 1, width - 2, height - 2, 0x2000000 | 45);
+        Gfx::drawRect(*rt, x + 1, y + 1, width - 2, height - 2, 0x2000000 | (116 + enumValue(ObjectManager::get<InterfaceSkinObject>()->colour_08)));
 
-        Gfx::drawRect(*context, x, y + 2, 1, height - 4, 0x2000000 | 46);
-        Gfx::drawRect(*context, x + width - 1, y + 2, 1, height - 4, 0x2000000 | 46);
-        Gfx::drawRect(*context, x + 2, y + height - 1, width - 4, 1, 0x2000000 | 46);
-        Gfx::drawRect(*context, x + 2, y, width - 4, 1, 0x2000000 | 46);
+        Gfx::drawRect(*rt, x, y + 2, 1, height - 4, 0x2000000 | 46);
+        Gfx::drawRect(*rt, x + width - 1, y + 2, 1, height - 4, 0x2000000 | 46);
+        Gfx::drawRect(*rt, x + 2, y + height - 1, width - 4, 1, 0x2000000 | 46);
+        Gfx::drawRect(*rt, x + 2, y, width - 4, 1, 0x2000000 | 46);
 
-        Gfx::drawRect(*context, x + 1, y + 1, 1, 1, 0x2000000 | 46);
-        Gfx::drawRect(*context, x + width - 1 - 1, y + 1, 1, 1, 0x2000000 | 46);
-        Gfx::drawRect(*context, x + 1, y + height - 1 - 1, 1, 1, 0x2000000 | 46);
-        Gfx::drawRect(*context, x + width - 1 - 1, y + height - 1 - 1, 1, 1, 0x2000000 | 46);
+        Gfx::drawRect(*rt, x + 1, y + 1, 1, 1, 0x2000000 | 46);
+        Gfx::drawRect(*rt, x + width - 1 - 1, y + 1, 1, 1, 0x2000000 | 46);
+        Gfx::drawRect(*rt, x + 1, y + height - 1 - 1, 1, 1, 0x2000000 | 46);
+        Gfx::drawRect(*rt, x + width - 1 - 1, y + height - 1 - 1, 1, 1, 0x2000000 | 46);
 
-        Gfx::drawStringCentredRaw(*context, ((width + 1) / 2) + x - 1, y + 1, _lineBreakCount, Colour::black, _text);
+        Gfx::drawStringCentredRaw(*rt, ((width + 1) / 2) + x - 1, y + 1, _lineBreakCount, Colour::black, _text);
     }
 
     // 0x004C94F7

--- a/src/OpenLoco/Windows/ToolbarBottomEditor.cpp
+++ b/src/OpenLoco/Windows/ToolbarBottomEditor.cpp
@@ -62,30 +62,30 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
     }
 
     // 0x0043CE65
-    static void draw(Window& self, Gfx::Context* ctx)
+    static void draw(Window& self, Gfx::RenderTarget* rt)
     {
         Widget& previous = self.widgets[widx::previous_frame];
         Widget& next = self.widgets[widx::next_frame];
 
         if (EditorController::canGoBack())
         {
-            Gfx::drawRect(*ctx, previous.left + self.x, previous.top + self.y, previous.width(), previous.height(), 0x2000000 | 52);
+            Gfx::drawRect(*rt, previous.left + self.x, previous.top + self.y, previous.width(), previous.height(), 0x2000000 | 52);
         }
-        Gfx::drawRect(*ctx, next.left + self.x, next.top + self.y, next.width(), next.height(), 0x2000000 | 52);
+        Gfx::drawRect(*rt, next.left + self.x, next.top + self.y, next.width(), next.height(), 0x2000000 | 52);
 
-        self.draw(ctx);
+        self.draw(rt);
 
         if (EditorController::canGoBack())
         {
-            Gfx::drawRectInset(*ctx, previous.left + self.x + 1, previous.top + self.y + 1, previous.width() - 2, previous.height() - 2, self.getColour(WindowColour::secondary).u8(), 0x30);
+            Gfx::drawRectInset(*rt, previous.left + self.x + 1, previous.top + self.y + 1, previous.width() - 2, previous.height() - 2, self.getColour(WindowColour::secondary).u8(), 0x30);
         }
-        Gfx::drawRectInset(*ctx, next.left + self.x + 1, next.top + self.y + 1, next.width() - 2, next.height() - 2, self.getColour(WindowColour::secondary).u8(), 0x30);
+        Gfx::drawRectInset(*rt, next.left + self.x + 1, next.top + self.y + 1, next.width() - 2, next.height() - 2, self.getColour(WindowColour::secondary).u8(), 0x30);
 
-        Gfx::drawStringCentred(*ctx, (previous.right + next.left) / 2 + self.x, self.y + self.height - 12, self.getColour(WindowColour::tertiary).opaque().outline(), _stepNames[EditorController::getCurrentStep()]);
+        Gfx::drawStringCentred(*rt, (previous.right + next.left) / 2 + self.x, self.y + self.height - 12, self.getColour(WindowColour::tertiary).opaque().outline(), _stepNames[EditorController::getCurrentStep()]);
 
         if (EditorController::canGoBack())
         {
-            Gfx::drawImage(ctx, self.x + previous.left + 6, self.y + previous.top + 6, ImageIds::step_back);
+            Gfx::drawImage(rt, self.x + previous.left + 6, self.y + previous.top + 6, ImageIds::step_back);
             int x = (previous.left + 30 + previous.right) / 2;
             int y = previous.top + 6;
             auto textColour = self.getColour(WindowColour::secondary).opaque();
@@ -93,10 +93,10 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
             {
                 textColour = Colour::white;
             }
-            Gfx::drawStringCentred(*ctx, self.x + x, self.y + y, textColour, StringIds::editor_previous_step);
-            Gfx::drawStringCentred(*ctx, self.x + x, self.y + y + 10, textColour, _stepNames[EditorController::getPreviousStep()]);
+            Gfx::drawStringCentred(*rt, self.x + x, self.y + y, textColour, StringIds::editor_previous_step);
+            Gfx::drawStringCentred(*rt, self.x + x, self.y + y + 10, textColour, _stepNames[EditorController::getPreviousStep()]);
         }
-        Gfx::drawImage(ctx, self.x + next.right - 29, self.y + next.top + 4, ImageIds::step_forward);
+        Gfx::drawImage(rt, self.x + next.right - 29, self.y + next.top + 4, ImageIds::step_forward);
         int x = next.left + (next.width() - 31) / 2;
         int y = next.top + 6;
         auto textColour = self.getColour(WindowColour::secondary).opaque();
@@ -104,8 +104,8 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
         {
             textColour = Colour::white;
         }
-        Gfx::drawStringCentred(*ctx, self.x + x, self.y + y, textColour, StringIds::editor_next_step);
-        Gfx::drawStringCentred(*ctx, self.x + x, self.y + y + 10, textColour, _stepNames[EditorController::getNextStep()]);
+        Gfx::drawStringCentred(*rt, self.x + x, self.y + y, textColour, StringIds::editor_next_step);
+        Gfx::drawStringCentred(*rt, self.x + x, self.y + y + 10, textColour, _stepNames[EditorController::getNextStep()]);
     }
 
     // 0x0043D0ED

--- a/src/OpenLoco/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/Windows/ToolbarTop.cpp
@@ -91,7 +91,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     static void onMouseDown(Window& window, WidgetIndex_t widgetIndex);
     static void onDropdown(Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex);
     static void prepareDraw(Window& window);
-    static void draw(Window& window, Gfx::Context* context);
+    static void draw(Window& window, Gfx::RenderTarget* rt);
 
     // 0x00438B26
     void open()
@@ -736,9 +736,9 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     }
 
     // 0x00439DE4
-    static void draw(Window& window, Gfx::Context* context)
+    static void draw(Window& window, Gfx::RenderTarget* rt)
     {
-        Common::draw(window, context);
+        Common::draw(window, rt);
 
         const auto companyColour = CompanyManager::getPlayerCompanyColour();
 
@@ -772,10 +772,10 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                 bg_image++;
             }
 
-            Gfx::drawImage(context, x, y, fg_image);
+            Gfx::drawImage(rt, x, y, fg_image);
 
             y = window.widgets[Common::Widx::railroad_menu].top + window.y;
-            Gfx::drawImage(context, x, y, bg_image);
+            Gfx::drawImage(rt, x, y, bg_image);
         }
 
         {
@@ -802,10 +802,10 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                 bg_image++;
             }
 
-            Gfx::drawImage(context, x, y, fg_image);
+            Gfx::drawImage(rt, x, y, fg_image);
 
             y = window.widgets[Common::Widx::vehicles_menu].top + window.y;
-            Gfx::drawImage(context, x, y, bg_image);
+            Gfx::drawImage(rt, x, y, bg_image);
         }
 
         {
@@ -828,7 +828,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             if (Input::isDropdownActive(Ui::WindowType::topToolbar, Common::Widx::build_vehicles_menu))
                 fg_image++;
 
-            Gfx::drawImage(context, x, y, fg_image);
+            Gfx::drawImage(rt, x, y, fg_image);
         }
     }
 

--- a/src/OpenLoco/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/Windows/ToolbarTopCommon.cpp
@@ -35,10 +35,10 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     static loco_global<uint8_t[18], 0x0050A006> available_objects;
 
     // 0x00439DE4
-    void draw(Window& self, Gfx::Context* context)
+    void draw(Window& self, Gfx::RenderTarget* rt)
     {
         // Draw widgets.
-        self.draw(context);
+        self.draw(rt);
 
         const auto companyColour = CompanyManager::getPlayerCompanyColour();
 
@@ -73,10 +73,10 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
                 bgImage++;
             }
 
-            Gfx::drawImage(context, x, y, fgImage);
+            Gfx::drawImage(rt, x, y, fgImage);
 
             y = self.widgets[Widx::road_menu].top + self.y;
-            Gfx::drawImage(context, x, y, bgImage);
+            Gfx::drawImage(rt, x, y, bgImage);
         }
     }
 

--- a/src/OpenLoco/Windows/ToolbarTopCommon.h
+++ b/src/OpenLoco/Windows/ToolbarTopCommon.h
@@ -30,7 +30,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
         };
     }
 
-    void draw(Window& window, Gfx::Context* context);
+    void draw(Window& window, Gfx::RenderTarget* rt);
 
     void zoomMenuMouseDown(Window* window, WidgetIndex_t widgetIndex);
     void rotateMenuMouseDown(Window* window, WidgetIndex_t widgetIndex);

--- a/src/OpenLoco/Windows/TownList.cpp
+++ b/src/OpenLoco/Windows/TownList.cpp
@@ -64,7 +64,7 @@ namespace OpenLoco::Ui::Windows::TownList
         makeRemapWidget({ 96, 15 }, { 31, 27 }, WidgetType::tab, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_misc_buildings)
 
         static void prepareDraw(Window& self);
-        static void drawTabs(Window* self, Gfx::Context* context);
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
         static void initEvents();
         static void refreshTownList(Window* self);
@@ -140,10 +140,10 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A0F8
-        static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
         {
             auto shade = Colours::getShade(self.getColour(WindowColour::secondary).c(), 3);
-            Gfx::clearSingle(context, shade);
+            Gfx::clearSingle(rt, shade);
 
             uint16_t yPos = 0;
             for (uint16_t i = 0; i < self.var_83C; i++)
@@ -151,7 +151,7 @@ namespace OpenLoco::Ui::Windows::TownList
                 const auto townId = TownId(self.rowInfo[i]);
 
                 // Skip items outside of view, or irrelevant to the current filter.
-                if (yPos + rowHeight < context.y || yPos >= yPos + rowHeight + context.height || townId == TownId::null)
+                if (yPos + rowHeight < rt.y || yPos >= yPos + rowHeight + rt.height || townId == TownId::null)
                 {
                     yPos += rowHeight;
                     continue;
@@ -162,7 +162,7 @@ namespace OpenLoco::Ui::Windows::TownList
                 // Highlight selection.
                 if (townId == TownId(self.rowHover))
                 {
-                    Gfx::drawRect(context, 0, yPos, self.width, rowHeight, 0x2000030);
+                    Gfx::drawRect(rt, 0, yPos, self.width, rowHeight, 0x2000030);
                     text_colour_id = StringIds::wcolour2_stringid;
                 }
 
@@ -175,14 +175,14 @@ namespace OpenLoco::Ui::Windows::TownList
                     auto args = FormatArguments();
                     args.push(town->name);
 
-                    Gfx::drawStringLeftClipped(context, 0, yPos, 198, Colour::black, text_colour_id, &args);
+                    Gfx::drawStringLeftClipped(rt, 0, yPos, 198, Colour::black, text_colour_id, &args);
                 }
                 // Town Type
                 {
                     auto args = FormatArguments();
                     args.push(town->getTownSizeString());
 
-                    Gfx::drawStringLeftClipped(context, 200, yPos, 278, Colour::black, text_colour_id, &args);
+                    Gfx::drawStringLeftClipped(rt, 200, yPos, 278, Colour::black, text_colour_id, &args);
                 }
                 // Town Population
                 {
@@ -190,7 +190,7 @@ namespace OpenLoco::Ui::Windows::TownList
                     args.push(StringIds::int_32);
                     args.push(town->population);
 
-                    Gfx::drawStringLeftClipped(context, 280, yPos, 68, Colour::black, text_colour_id, &args);
+                    Gfx::drawStringLeftClipped(rt, 280, yPos, 68, Colour::black, text_colour_id, &args);
                 }
                 // Town Stations
                 {
@@ -198,17 +198,17 @@ namespace OpenLoco::Ui::Windows::TownList
                     args.push(StringIds::int_32);
                     args.push<int32_t>(town->num_stations);
 
-                    Gfx::drawStringLeftClipped(context, 350, yPos, 68, Colour::black, text_colour_id, &args);
+                    Gfx::drawStringLeftClipped(rt, 350, yPos, 68, Colour::black, text_colour_id, &args);
                 }
                 yPos += rowHeight;
             }
         }
 
         // 0x0049A0A7
-        static void draw(Ui::Window& self, Gfx::Context* context)
+        static void draw(Ui::Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
             auto args = FormatArguments();
             auto xPos = self.x + 4;
             auto yPos = self.y + self.height - 12;
@@ -219,7 +219,7 @@ namespace OpenLoco::Ui::Windows::TownList
                 args.push(StringIds::status_towns_plural);
             args.push(self.var_83C);
 
-            Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::black_stringid, &args);
+            Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x0049A27F
@@ -629,14 +629,14 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A627
-        static void draw(Ui::Window& self, Gfx::Context* context)
+        static void draw(Ui::Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
-            Gfx::drawStringLeft(*context, self.x + 3, self.y + self.widgets[widx::current_size].top + 1, Colour::black, StringIds::town_size_label);
+            Gfx::drawStringLeft(*rt, self.x + 3, self.y + self.widgets[widx::current_size].top + 1, Colour::black, StringIds::town_size_label);
 
-            Gfx::drawStringLeft(*context, self.x + 3, self.y + self.height - 13, Colour::black, StringIds::select_town_size);
+            Gfx::drawStringLeft(*rt, self.x + 3, self.y + self.height - 13, Colour::black, StringIds::select_town_size);
         }
 
         // 0x0049A675
@@ -844,10 +844,10 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A9C2
-        static void draw(Ui::Window& self, Gfx::Context* context)
+        static void draw(Ui::Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             auto buildingId = self.var_846;
 
@@ -861,7 +861,7 @@ namespace OpenLoco::Ui::Windows::TownList
 
             auto buildingObj = ObjectManager::get<BuildingObject>(buildingId);
 
-            Gfx::drawStringLeftClipped(*context, self.x + 3, self.y + self.height - 13, self.width - 19, Colour::black, StringIds::black_stringid, &buildingObj->name);
+            Gfx::drawStringLeftClipped(*rt, self.x + 3, self.y + self.height - 13, self.width - 19, Colour::black, StringIds::black_stringid, &buildingObj->name);
         }
 
         // 0x0049AB31
@@ -1177,10 +1177,10 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AA1C
-        static void drawScroll(Ui::Window& self, Gfx::Context& context, const uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
         {
             auto shade = Colours::getShade(self.getColour(WindowColour::secondary).c(), 3);
-            Gfx::clearSingle(context, shade);
+            Gfx::clearSingle(rt, shade);
 
             uint16_t xPos = 0;
             uint16_t yPos = 0;
@@ -1190,17 +1190,17 @@ namespace OpenLoco::Ui::Windows::TownList
                 {
                     if (self.rowInfo[i] == self.var_846)
                     {
-                        Gfx::drawRectInset(context, xPos, yPos, 112, 112, self.getColour(WindowColour::secondary).u8(), AdvancedColour::translucent_flag);
+                        Gfx::drawRectInset(rt, xPos, yPos, 112, 112, self.getColour(WindowColour::secondary).u8(), AdvancedColour::translucent_flag);
                     }
                 }
                 else
                 {
-                    Gfx::drawRectInset(context, xPos, yPos, 112, 112, self.getColour(WindowColour::secondary).u8(), (AdvancedColour::translucent_flag | AdvancedColour::outline_flag));
+                    Gfx::drawRectInset(rt, xPos, yPos, 112, 112, self.getColour(WindowColour::secondary).u8(), (AdvancedColour::translucent_flag | AdvancedColour::outline_flag));
                 }
 
                 auto buildingObj = ObjectManager::get<BuildingObject>(self.rowInfo[i]);
 
-                auto clipped = Gfx::clipContext(context, Ui::Rect(xPos + 1, yPos + 1, 110, 110));
+                auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(xPos + 1, yPos + 1, 110, 110));
                 if (clipped)
                 {
                     auto colour = *_buildingColour;
@@ -1482,7 +1482,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049B054
-        static void drawTabs(Window* self, Gfx::Context* context)
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
@@ -1491,7 +1491,7 @@ namespace OpenLoco::Ui::Windows::TownList
                 uint32_t imageId = skin->img;
                 imageId += InterfaceSkin::ImageIds::toolbar_menu_towns;
 
-                Widget::drawTab(self, context, imageId, widx::tab_town_list);
+                Widget::drawTab(self, rt, imageId, widx::tab_town_list);
             }
 
             // Build New Towns Tab
@@ -1520,7 +1520,7 @@ namespace OpenLoco::Ui::Windows::TownList
                 else
                     imageId += buildNewTownsImageIds[0];
 
-                Widget::drawTab(self, context, imageId, widx::tab_build_town);
+                Widget::drawTab(self, rt, imageId, widx::tab_build_town);
             }
 
             // Build New Buildings Tab
@@ -1549,7 +1549,7 @@ namespace OpenLoco::Ui::Windows::TownList
                 else
                     imageId += buildBuildingsImageIds[0];
 
-                Widget::drawTab(self, context, imageId, widx::tab_build_buildings);
+                Widget::drawTab(self, rt, imageId, widx::tab_build_buildings);
             }
 
             // Build New Misc Buildings Tab
@@ -1578,7 +1578,7 @@ namespace OpenLoco::Ui::Windows::TownList
                 else
                     imageId += buildMiscBuildingsImageIds[0];
 
-                Widget::drawTab(self, context, imageId, widx::tab_build_misc_buildings);
+                Widget::drawTab(self, rt, imageId, widx::tab_build_misc_buildings);
             }
         }
 

--- a/src/OpenLoco/Windows/TownWindow.cpp
+++ b/src/OpenLoco/Windows/TownWindow.cpp
@@ -60,7 +60,7 @@ namespace OpenLoco::Ui::Windows::Town
         static void update(Window& self);
         static void renameTownPrompt(Window* self, WidgetIndex_t widgetIndex);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
-        static void drawTabs(Window* self, Gfx::Context* context);
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt);
         static void initEvents();
     }
 
@@ -128,12 +128,12 @@ namespace OpenLoco::Ui::Windows::Town
         }
 
         // 0x00498FFE
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
-            self.drawViewports(context);
-            Widget::drawViewportCentreButton(context, &self, widx::centre_on_viewport);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
+            self.drawViewports(rt);
+            Widget::drawViewportCentreButton(rt, &self, widx::centre_on_viewport);
 
             auto town = TownManager::get(TownId(self.number));
 
@@ -145,7 +145,7 @@ namespace OpenLoco::Ui::Windows::Town
             const auto x = self.x + widget.left - 1;
             const auto y = self.y + widget.top - 1;
             const auto width = widget.width() - 1;
-            Gfx::drawStringLeftClipped(*context, x, y, width, Colour::black, StringIds::status_town_population, &args);
+            Gfx::drawStringLeftClipped(*rt, x, y, width, Colour::black, StringIds::status_town_population, &args);
         }
 
         // 0x00499079
@@ -390,12 +390,12 @@ namespace OpenLoco::Ui::Windows::Town
         }
 
         // 0x004994F9
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
-            auto clipped = Gfx::clipContext(*context, Ui::Rect(self.x, self.y + 44, self.width, self.height - 44));
+            auto clipped = Gfx::clipRenderTarget(*rt, Ui::Rect(self.x, self.y + 44, self.width, self.height - 44));
             if (!clipped)
                 return;
 
@@ -516,14 +516,14 @@ namespace OpenLoco::Ui::Windows::Town
         }
 
         // 0x004997F1
-        static void draw(Window& self, Gfx::Context* context)
+        static void draw(Window& self, Gfx::RenderTarget* rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             uint16_t xPos = self.x + 4;
             uint16_t yPos = self.y + 46;
-            Gfx::drawStringLeft(*context, xPos, yPos, Colour::black, StringIds::local_authority_ratings_transport_companies);
+            Gfx::drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::local_authority_ratings_transport_companies);
 
             xPos += 4;
             yPos += 14;
@@ -552,7 +552,7 @@ namespace OpenLoco::Ui::Windows::Town
                 args.push(rating);
                 args.push(rank);
 
-                Gfx::drawStringLeftClipped(*context, xPos, yPos, self.width - 12, Colour::black, StringIds::town_rating_company_percentage_rank, &args);
+                Gfx::drawStringLeftClipped(*rt, xPos, yPos, self.width - 12, Colour::black, StringIds::town_rating_company_percentage_rank, &args);
 
                 yPos += 10;
             }
@@ -713,14 +713,14 @@ namespace OpenLoco::Ui::Windows::Town
         }
 
         // 0x004999E1
-        static void drawTabs(Window* self, Gfx::Context* context)
+        static void drawTabs(Window* self, Gfx::RenderTarget* rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
             // Town tab
             {
                 const uint32_t imageId = skin->img + InterfaceSkin::ImageIds::toolbar_menu_towns;
-                Widget::drawTab(self, context, imageId, widx::tab_town);
+                Widget::drawTab(self, rt, imageId, widx::tab_town);
             }
 
             // Population tab
@@ -742,7 +742,7 @@ namespace OpenLoco::Ui::Windows::Town
                 else
                     imageId += populationTabImageIds[0];
 
-                Widget::drawTab(self, context, imageId, widx::tab_population);
+                Widget::drawTab(self, rt, imageId, widx::tab_population);
             }
 
             // Company ratings tab
@@ -772,7 +772,7 @@ namespace OpenLoco::Ui::Windows::Town
                 else
                     imageId += ratingsTabImageIds[0];
 
-                Widget::drawTab(self, context, imageId, widx::tab_company_ratings);
+                Widget::drawTab(self, rt, imageId, widx::tab_company_ratings);
             }
         }
 

--- a/src/OpenLoco/Windows/Tutorial.cpp
+++ b/src/OpenLoco/Windows/Tutorial.cpp
@@ -60,7 +60,7 @@ namespace OpenLoco::Ui::Windows::Tutorial
     }
 
     // 0x00439B4A
-    static void draw(Window& self, Gfx::Context* context)
+    static void draw(Window& self, Gfx::RenderTarget* rt)
     {
         static constexpr string_id titleStringIds[] = {
             StringIds::tutorial_1_title,
@@ -73,10 +73,10 @@ namespace OpenLoco::Ui::Windows::Tutorial
 
         auto& widget = self.widgets[Widx::frame];
         auto yPos = self.y + widget.top + 4;
-        Gfx::drawStringCentred(*context, self.x + widget.mid_x(), yPos, Colour::black, StringIds::tutorial_text, &args);
+        Gfx::drawStringCentred(*rt, self.x + widget.mid_x(), yPos, Colour::black, StringIds::tutorial_text, &args);
 
         yPos += 10;
-        Gfx::drawStringCentred(*context, self.x + widget.mid_x(), yPos, Colour::black, StringIds::tutorial_control, nullptr);
+        Gfx::drawStringCentred(*rt, self.x + widget.mid_x(), yPos, Colour::black, StringIds::tutorial_control, nullptr);
     }
 
     static void initEvents()

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -89,12 +89,12 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void event8(Window& self);
         static void event9(Window& self);
         static size_t getNumCars(Ui::Window* const self);
-        static void drawTabs(Window* const window, Gfx::Context* const context);
+        static void drawTabs(Window* const window, Gfx::RenderTarget* const rt);
         static void pickupToolUpdate(Window& self, const int16_t x, const int16_t y);
         static void pickupToolDown(Window& self, const int16_t x, const int16_t y);
         static void pickupToolAbort(Window& self);
         static size_t getNumCars(Ui::Window* const self);
-        static void drawTabs(Window* const window, Gfx::Context* const context);
+        static void drawTabs(Window* const window, Gfx::RenderTarget* const rt);
         static std::optional<Vehicles::Car> getCarFromScrollView(Window* const self, const int16_t y);
         static std::pair<uint32_t, string_id> getPickupImageIdandTooltip(const Vehicles::VehicleHead& head, const bool isPlaced);
     }
@@ -907,10 +907,10 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B226D
-        static void draw(Window& self, Gfx::Context* const context)
+        static void draw(Window& self, Gfx::RenderTarget* const rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             Widget& pickupButton = self.widgets[widx::pickup];
             if (pickupButton.type != WidgetType::none)
@@ -918,7 +918,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 if ((pickupButton.image & 0x20000000) != 0 && !self.isDisabled(widx::pickup))
                 {
                     Gfx::drawImage(
-                        context,
+                        rt,
                         self.x + pickupButton.left,
                         self.y + pickupButton.top,
                         Gfx::recolour(pickupButton.image, CompanyManager::getCompanyColour(self.owner)));
@@ -945,7 +945,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 }
 
                 Gfx::drawStringLeftClipped(
-                    *context,
+                    *rt,
                     self.x + self.widgets[widx::status].left - 1,
                     self.y + self.widgets[widx::status].top - 1,
                     self.widgets[widx::status].width() - 1,
@@ -958,27 +958,27 @@ namespace OpenLoco::Ui::Windows::Vehicle
             if (speedWidget.type != WidgetType::none)
             {
                 Gfx::drawImage(
-                    context,
+                    rt,
                     self.x + speedWidget.left,
                     self.y + speedWidget.top + 10,
                     Gfx::recolour(ImageIds::speed_control_track, self.getColour(WindowColour::secondary).c()));
 
                 Gfx::drawStringCentred(
-                    *context,
+                    *rt,
                     self.x + speedWidget.mid_x(),
                     self.y + speedWidget.top + 4,
                     Colour::black,
                     StringIds::tiny_power);
 
                 Gfx::drawStringCentred(
-                    *context,
+                    *rt,
                     self.x + speedWidget.mid_x(),
                     self.y + speedWidget.bottom - 10,
                     Colour::black,
                     StringIds::tiny_brake);
 
                 Gfx::drawImage(
-                    context,
+                    rt,
                     self.x + speedWidget.left + 1,
                     self.y + speedWidget.top + 57 - veh->var_6E,
                     Gfx::recolour(ImageIds::speed_control_thumb, self.getColour(WindowColour::secondary).c()));
@@ -986,8 +986,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             if (self.viewports[0] != nullptr)
             {
-                self.drawViewports(context);
-                Widget::drawViewportCentreButton(context, &self, widx::centreViewport);
+                self.drawViewports(rt);
+                Widget::drawViewportCentreButton(rt, &self, widx::centreViewport);
             }
             else if (Input::isToolActive(self.type, self.number))
             {
@@ -998,7 +998,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 origin.x = self.x + button.mid_x();
                 origin.y = self.y + button.mid_y();
                 Gfx::drawStringCentredWrapped(
-                    *context,
+                    *rt,
                     origin,
                     button.width() - 6,
                     Colour::black,
@@ -1495,10 +1495,10 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B3542
-        static void draw(Window& self, Gfx::Context* const context)
+        static void draw(Window& self, Gfx::RenderTarget* const rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             // TODO: identical to main tab (doesn't appear to do anything useful)
             if (self.widgets[widx::pickup].type != WidgetType::none)
@@ -1506,7 +1506,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 if ((self.widgets[widx::pickup].image & (1 << 29)) && !self.isDisabled(widx::pickup))
                 {
                     auto image = Gfx::recolour(self.widgets[widx::pickup].image, CompanyManager::getCompanyColour(self.owner));
-                    Gfx::drawImage(context, self.widgets[widx::pickup].left + self.x, self.widgets[widx::pickup].top + self.y, image);
+                    Gfx::drawImage(rt, self.widgets[widx::pickup].left + self.x, self.widgets[widx::pickup].top + self.y, image);
                 }
             }
 
@@ -1527,7 +1527,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 {
                     str = StringIds::vehicle_details_total_power_and_weight;
                 }
-                Gfx::drawStringLeftClipped(*context, pos.x, pos.y, self.width - 6, Colour::black, str, &args);
+                Gfx::drawStringLeftClipped(*rt, pos.x, pos.y, self.width - 6, Colour::black, str, &args);
             }
 
             {
@@ -1541,7 +1541,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 {
                     str = StringIds::vehicle_details_max_speed_and_rack_rail_and_reliability;
                 }
-                Gfx::drawStringLeftClipped(*context, pos.x, pos.y, self.width - 16, Colour::black, str, &args);
+                Gfx::drawStringLeftClipped(*rt, pos.x, pos.y, self.width - 16, Colour::black, str, &args);
             }
 
             {
@@ -1555,14 +1555,14 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     str = StringIds::vehicle_car_count_and_length;
                     args.push<uint32_t>(head->getCarCount());
                 }
-                Gfx::drawStringLeftClipped(*context, pos.x, pos.y, self.width - 16, Colour::black, str, &args);
+                Gfx::drawStringLeftClipped(*rt, pos.x, pos.y, self.width - 16, Colour::black, str, &args);
             }
         }
 
         // 0x004B36A3
-        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t i)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t i)
         {
-            Gfx::clearSingle(context, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
+            Gfx::clearSingle(rt, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
             auto head = Common::getVehicle(&self);
             if (head == nullptr)
             {
@@ -1585,7 +1585,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                         top = pos.y - 1;
                         carStr = StringIds::black_stringid;
                     }
-                    Gfx::fillRect(context, 0, top, self.width, bottom, 0x2000030);
+                    Gfx::fillRect(rt, 0, top, self.width, bottom, 0x2000030);
                 }
 
                 int16_t y = pos.y + (self.rowHeight - 22) / 2;
@@ -1596,21 +1596,21 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     al = 12;
                     ah = self.getColour(WindowColour::secondary).u8();
                 }
-                auto x = Common::sub_4B743B(al, ah, 0, y, car.front, &context);
+                auto x = Common::sub_4B743B(al, ah, 0, y, car.front, &rt);
 
                 auto vehicleObj = ObjectManager::get<VehicleObject>(car.front->objectId);
                 FormatArguments args{};
                 args.push(vehicleObj->name);
                 x += 2;
                 y = pos.y + (self.rowHeight / 2) - 6;
-                Gfx::drawStringLeft(context, x, y, Colour::black, carStr, &args);
+                Gfx::drawStringLeft(rt, x, y, Colour::black, carStr, &args);
 
                 pos.y += self.rowHeight;
             }
 
             if (EntityId(self.rowHover) == train.tail->id && _dragCarComponent != nullptr)
             {
-                Gfx::fillRect(context, 0, pos.y - 1, self.width, pos.y, 0x2000030);
+                Gfx::fillRect(rt, 0, pos.y - 1, self.width, pos.y, 0x2000030);
             }
         }
 
@@ -1819,10 +1819,10 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 004B3F0D
-        static void draw(Ui::Window& self, Gfx::Context* const context)
+        static void draw(Ui::Window& self, Gfx::RenderTarget* const rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             // draw total cargo
             char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
@@ -1834,18 +1834,18 @@ namespace OpenLoco::Ui::Windows::Vehicle
             head->generateCargoTotalString(buffer);
             FormatArguments args = {};
             args.push<string_id>(StringIds::buffer_1250);
-            Gfx::drawStringLeftClipped(*context, self.x + 3, self.y + self.height - 25, self.width - 15, Colour::black, StringIds::total_stringid, &args);
+            Gfx::drawStringLeftClipped(*rt, self.x + 3, self.y + self.height - 25, self.width - 15, Colour::black, StringIds::total_stringid, &args);
 
             // draw cargo capacity
             buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
             head->generateCargoCapacityString(buffer);
             args = {};
             args.push<string_id>(StringIds::buffer_1250);
-            Gfx::drawStringLeftClipped(*context, self.x + 3, self.y + self.height - 13, self.width - 15, Colour::black, StringIds::vehicle_capacity_stringid, &args);
+            Gfx::drawStringLeftClipped(*rt, self.x + 3, self.y + self.height - 13, self.width - 15, Colour::black, StringIds::vehicle_capacity_stringid, &args);
         }
 
         // based on 0x004B40C7
-        static void drawCargoText(Gfx::Context& context, const int16_t x, int16_t& y, const string_id strFormat, uint8_t cargoQty, uint8_t cargoType, StationId stationId)
+        static void drawCargoText(Gfx::RenderTarget& rt, const int16_t x, int16_t& y, const string_id strFormat, uint8_t cargoQty, uint8_t cargoType, StationId stationId)
         {
             if (cargoQty == 0)
             {
@@ -1861,14 +1861,14 @@ namespace OpenLoco::Ui::Windows::Vehicle
             args.push<uint32_t>(cargoQty);
             args.push(station->name);
             args.push(station->town);
-            Gfx::drawStringLeft(context, x, y, Colour::black, strFormat, &args);
+            Gfx::drawStringLeft(rt, x, y, Colour::black, strFormat, &args);
             y += 10;
         }
 
         // 004B3F62
-        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t i)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t i)
         {
-            Gfx::clearSingle(context, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
+            Gfx::clearSingle(rt, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
             auto* head = Common::getVehicle(&self);
             if (head == nullptr)
             {
@@ -1883,13 +1883,13 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 auto body = car.body;
                 if (front->id == EntityId(self.rowHover))
                 {
-                    Gfx::fillRect(context, 0, y, self.width, y + self.rowHeight - 1, 0x2000030);
+                    Gfx::fillRect(rt, 0, y, self.width, y + self.rowHeight - 1, 0x2000030);
                     strFormat = StringIds::wcolour2_stringid;
                 }
                 // Get width of the drawing
-                auto width = Common::sub_4B743B(1, 0, 0, y, front, &context);
+                auto width = Common::sub_4B743B(1, 0, 0, y, front, &rt);
                 // Actually draw it
-                width = Common::sub_4B743B(0, 0, 24 - width, (self.rowHeight - 22) / 2 + y, car.front, &context);
+                width = Common::sub_4B743B(0, 0, 24 - width, (self.rowHeight - 22) / 2 + y, car.front, &rt);
 
                 if (body->primaryCargo.type != 0xFF)
                 {
@@ -1901,14 +1901,14 @@ namespace OpenLoco::Ui::Windows::Vehicle
                         {
                             cargoTextHeight += 5;
                         }
-                        drawCargoText(context, width, cargoTextHeight, strFormat, body->primaryCargo.qty, body->primaryCargo.type, body->primaryCargo.townFrom);
-                        drawCargoText(context, width, cargoTextHeight, strFormat, front->secondaryCargo.qty, front->secondaryCargo.type, front->secondaryCargo.townFrom);
+                        drawCargoText(rt, width, cargoTextHeight, strFormat, body->primaryCargo.qty, body->primaryCargo.type, body->primaryCargo.townFrom);
+                        drawCargoText(rt, width, cargoTextHeight, strFormat, front->secondaryCargo.qty, front->secondaryCargo.type, front->secondaryCargo.townFrom);
                     }
                     else
                     {
                         FormatArguments args{};
                         args.push<string_id>(StringIds::cargo_empty);
-                        Gfx::drawStringLeft(context, width, cargoTextHeight + 5, Colour::black, strFormat, &args);
+                        Gfx::drawStringLeft(rt, width, cargoTextHeight + 5, Colour::black, strFormat, &args);
                     }
                 }
 
@@ -2203,10 +2203,10 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B576C
-        static void draw(Ui::Window& self, Gfx::Context* const context)
+        static void draw(Ui::Window& self, Gfx::RenderTarget* const rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             auto pos = Ui::Point(self.x + 4, self.y + 46);
 
@@ -2222,7 +2222,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 auto args = FormatArguments();
                 args.push<uint32_t>(veh1->lastIncome.day);
                 // Last income on: {DATE DMY}
-                Gfx::drawStringLeft(*context, pos.x, pos.y, Colour::black, StringIds::last_income_on_date, &args);
+                Gfx::drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::last_income_on_date, &args);
                 pos.y += 10;
                 for (int i = 0; i < 4; i++)
                 {
@@ -2241,7 +2241,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     args.push<uint16_t>(veh1->lastIncome.cargoAges[i]);
                     args.push<currency32_t>(veh1->lastIncome.cargoProfits[i]);
                     // {STRINGID} transported {INT16} blocks in {INT16} days = {CURRENCY32}
-                    Gfx::drawStringLeftWrapped(*context, pos.x + 4, pos.y, self.width - 12, Colour::black, StringIds::transported_blocks_in_days, &args);
+                    Gfx::drawStringLeftWrapped(*rt, pos.x + 4, pos.y, self.width - 12, Colour::black, StringIds::transported_blocks_in_days, &args);
 
                     // TODO: fix function to take pointer to offset
                     pos.y += 12;
@@ -2250,7 +2250,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             else
             {
                 // Last income: N/A"
-                Gfx::drawStringLeft(*context, pos.x, pos.y, Colour::black, StringIds::last_income_na);
+                Gfx::drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::last_income_na);
                 pos.y += 10;
             }
 
@@ -2261,7 +2261,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 // Last journey average speed: {VELOCITY}
                 auto args = FormatArguments();
                 args.push(head->lastAverageSpeed);
-                Gfx::drawStringLeft(*context, pos.x, pos.y, Colour::black, StringIds::last_journey_average_speed, &args);
+                Gfx::drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::last_journey_average_speed, &args);
                 pos.y += 10 + 5;
             }
 
@@ -2269,7 +2269,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 // Monthly Running Cost: {CURRENCY32}
                 auto args = FormatArguments();
                 args.push(head->calculateRunningCost());
-                Gfx::drawStringLeft(*context, pos.x, pos.y, Colour::black, StringIds::vehicle_monthly_running_cost, &args);
+                Gfx::drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::vehicle_monthly_running_cost, &args);
                 pos.y += 10;
             }
 
@@ -2278,7 +2278,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 auto args = FormatArguments();
                 auto monthlyProfit = (train.veh2->totalRecentProfit()) / 4;
                 args.push(monthlyProfit);
-                Gfx::drawStringLeft(*context, pos.x, pos.y, Colour::black, StringIds::vehicle_monthly_profit, &args);
+                Gfx::drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::vehicle_monthly_profit, &args);
                 pos.y += 10 + 5;
             }
 
@@ -2287,7 +2287,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 auto args = FormatArguments();
                 args.push(train.head->totalRefundCost);
                 pos.y = self.y + self.height - 14;
-                Gfx::drawStringLeft(*context, pos.x, pos.y, Colour::black, StringIds::sale_value_of_vehicle, &args);
+                Gfx::drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::sale_value_of_vehicle, &args);
             }
         }
 
@@ -3237,17 +3237,17 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4866
-        static void draw(Window& self, Gfx::Context* const context)
+        static void draw(Window& self, Gfx::RenderTarget* const rt)
         {
-            self.draw(context);
-            Common::drawTabs(&self, context);
+            self.draw(rt);
+            Common::drawTabs(&self, rt);
 
             if (Input::isToolActive(WindowType::vehicle, self.number))
             {
                 // Location at bottom left edge of window
                 Ui::Point loc{ static_cast<int16_t>(self.x + 3), static_cast<int16_t>(self.y + self.height - 13) };
 
-                Gfx::drawStringLeftClipped(*context, loc.x, loc.y, self.width - 14, Colour::black, StringIds::route_click_on_waypoint);
+                Gfx::drawStringLeftClipped(*rt, loc.x, loc.y, self.width - 14, Colour::black, StringIds::route_click_on_waypoint);
             }
         }
 
@@ -3331,25 +3331,25 @@ namespace OpenLoco::Ui::Windows::Vehicle
         };
 
         // 0x004B4A58 based on
-        static void sub_4B4A58(Window& self, Gfx::Context& context, const string_id strFormat, FormatArguments& args, Vehicles::Order& order, int16_t& y)
+        static void sub_4B4A58(Window& self, Gfx::RenderTarget& rt, const string_id strFormat, FormatArguments& args, Vehicles::Order& order, int16_t& y)
         {
             Ui::Point loc = { 8, static_cast<int16_t>(y - 1) };
-            Gfx::drawStringLeft(context, &loc, Colour::black, strFormat, &args);
+            Gfx::drawStringLeft(rt, &loc, Colour::black, strFormat, &args);
             if (order.hasFlag(Vehicles::OrderFlags::HasNumber))
             {
                 if (Input::isToolActive(self.type, self.number))
                 {
                     auto imageId = numberCircle[_113646A - 1];
-                    Gfx::drawImage(&context, loc.x + 3, loc.y + 1, Gfx::recolour(imageId, Colour::white));
+                    Gfx::drawImage(&rt, loc.x + 3, loc.y + 1, Gfx::recolour(imageId, Colour::white));
                 }
                 _113646A++;
             }
         }
 
         // 0x004B48BA
-        static void drawScroll(Window& self, Gfx::Context& context, const uint32_t i)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t i)
         {
-            Gfx::clearSingle(context, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
+            Gfx::clearSingle(rt, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
 
             auto head = Common::getVehicle(&self);
             if (head == nullptr)
@@ -3361,7 +3361,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             auto rowNum = 0;
             if (head->sizeOfOrderTable == 1)
             {
-                Gfx::drawStringLeft(context, 8, 0, Colour::black, StringIds::no_route_defined);
+                Gfx::drawStringLeft(rt, 8, 0, Colour::black, StringIds::no_route_defined);
                 rowNum++; // Used to move down the text
             }
 
@@ -3372,13 +3372,13 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 auto strFormat = StringIds::black_stringid;
                 if (self.var_842 == rowNum)
                 {
-                    Gfx::fillRect(context, 0, y, self.width, y + 9, enumValue(Colour::darkGreen));
+                    Gfx::fillRect(rt, 0, y, self.width, y + 9, enumValue(Colour::darkGreen));
                     strFormat = StringIds::white_stringid;
                 }
                 if (self.rowHover == rowNum)
                 {
                     strFormat = StringIds::wcolour2_stringid;
-                    Gfx::fillRect(context, 0, y, self.width, y + 9, 0x2000030);
+                    Gfx::fillRect(rt, 0, y, self.width, y + 9, 0x2000030);
                 }
 
                 FormatArguments args{};
@@ -3406,10 +3406,10 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     }
                 }
 
-                sub_4B4A58(self, context, strFormat, args, order, y);
+                sub_4B4A58(self, rt, strFormat, args, order, y);
                 if (head->currentOrder + head->orderTableOffset == order.getOffset())
                 {
-                    Gfx::drawStringLeft(context, 1, y - 1, Colour::black, StringIds::orders_current_order);
+                    Gfx::drawStringLeft(rt, 1, y - 1, Colour::black, StringIds::orders_current_order);
                 }
 
                 rowNum++;
@@ -3420,18 +3420,18 @@ namespace OpenLoco::Ui::Windows::Vehicle
             auto strFormat = StringIds::black_stringid;
             if (self.var_842 == rowNum)
             {
-                Gfx::fillRect(context, 0, loc.y, self.width, loc.y + lineHeight, enumValue(Colour::darkGreen));
+                Gfx::fillRect(rt, 0, loc.y, self.width, loc.y + lineHeight, enumValue(Colour::darkGreen));
                 strFormat = StringIds::white_stringid;
             }
             if (self.rowHover == rowNum)
             {
                 strFormat = StringIds::wcolour2_stringid;
-                Gfx::fillRect(context, 0, loc.y, self.width, loc.y + lineHeight, 0x2000030);
+                Gfx::fillRect(rt, 0, loc.y, self.width, loc.y + lineHeight, 0x2000030);
             }
 
             loc.y -= 1;
             auto args = FormatArguments::common(orderString[0]);
-            Gfx::drawStringLeft(context, &loc, Colour::black, strFormat, &args);
+            Gfx::drawStringLeft(rt, &loc, Colour::black, strFormat, &args);
         }
 
         static void initEvents()
@@ -4435,7 +4435,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // TODO: Move to a more appropriate file used by many windows
-        int16_t sub_4B743B(uint8_t al, uint8_t ah, int16_t cx, int16_t dx, Vehicles::VehicleBase* vehicle, Gfx::Context* const pDrawpixelinfo)
+        int16_t sub_4B743B(uint8_t al, uint8_t ah, int16_t cx, int16_t dx, Vehicles::VehicleBase* vehicle, Gfx::RenderTarget* const pDrawpixelinfo)
         {
             registers regs{};
             regs.al = al;
@@ -4486,7 +4486,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         };
 
         // 0x004B5F0D
-        static void drawTabs(Window* const self, Gfx::Context* const context)
+        static void drawTabs(Window* const self, Gfx::RenderTarget* const rt)
         {
             auto skin = OpenLoco::ObjectManager::get<InterfaceSkinObject>();
 
@@ -4506,7 +4506,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             Widget::drawTab(
                 self,
-                context,
+                rt,
                 Gfx::recolour(skin->img + mainTab.image + frame, CompanyManager::getCompanyColour(self->owner)),
                 widx::tabMain);
 
@@ -4517,7 +4517,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
             Widget::drawTab(
                 self,
-                context,
+                rt,
                 skin->img + InterfaceSkin::ImageIds::tab_wrench_frame0 + frame,
                 widx::tabDetails);
 
@@ -4528,7 +4528,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
             Widget::drawTab(
                 self,
-                context,
+                rt,
                 skin->img + InterfaceSkin::ImageIds::tab_cargo_delivered_frame0 + frame,
                 widx::tabCargo);
 
@@ -4539,7 +4539,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
             Widget::drawTab(
                 self,
-                context,
+                rt,
                 skin->img + InterfaceSkin::ImageIds::tab_routes_frame_0 + frame,
                 widx::tabRoute);
 
@@ -4550,7 +4550,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
             Widget::drawTab(
                 self,
-                context,
+                rt,
                 skin->img + InterfaceSkin::ImageIds::tab_finances_frame0 + frame,
                 widx::tabFinances);
         }

--- a/src/OpenLoco/openloco.vcxproj
+++ b/src/OpenLoco/openloco.vcxproj
@@ -56,6 +56,7 @@
     <ClCompile Include="GameState.cpp" />
     <ClCompile Include="Graphics\Colour.cpp" />
     <ClCompile Include="Graphics\Gfx.cpp" />
+    <ClCompile Include="Graphics\RenderTarget.cpp" />
     <ClCompile Include="Gui.cpp" />
     <ClCompile Include="Industry.cpp" />
     <ClCompile Include="IndustryManager.cpp" />
@@ -299,6 +300,7 @@
     <ClInclude Include="Graphics\Gfx.h" />
     <ClInclude Include="Graphics\ImageId.h" />
     <ClInclude Include="Graphics\ImageIds.h" />
+    <ClInclude Include="Graphics\RenderTarget.h" />
     <ClInclude Include="Gui.h" />
     <ClInclude Include="Industry.h" />
     <ClInclude Include="IndustryManager.h" />


### PR DESCRIPTION
I've renamed Context to RenderTarget as the name Context is a bit too arbitrary where in RenderTarget is a well established term to describe what this is, it currently carries a bit more state as needed such as the zoom level but that can be refactored one day.
Another reason to call it RenderTarget is that one day there might be another rendering engine which is not software based, the render target should become something that the renderer creates and should be a handle which the renderer interface can consume without leaking any implementation details.
I also moved it into a new TU to better separate it and make it easier to refactor later on as a handle as it currently forward declared type in Gfx.h

I'm also looking to make the renderer a bit more independent and also unify Drawing and Gfx under that and provide a better interface, the current SoftwareDrawingEngine class is just a small subset of the actual software rendering code and also has some window code in there, its a bit limited to what I can move around due to Interop reasons.