### PR TITLE
rename widget type wt_5 to slider

### DIFF
--- a/src/OpenLoco/Widget.cpp
+++ b/src/OpenLoco/Widget.cpp
@@ -97,7 +97,7 @@ namespace OpenLoco::Ui
                 assert(false); // Unused
                 break;
 
-            case WidgetType::wt_5:
+            case WidgetType::slider:
             case WidgetType::wt_6:
             case WidgetType::toolbarTab:
             case WidgetType::tab:

--- a/src/OpenLoco/Window.h
+++ b/src/OpenLoco/Window.h
@@ -33,7 +33,7 @@ namespace OpenLoco::Ui
         frame = 2,
         wt_3,
         wt_4,
-        wt_5,
+        slider,
         wt_6,
         toolbarTab = 7,
         tab = 8,

--- a/src/OpenLoco/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/Windows/CompanyFaceSelection.cpp
@@ -46,7 +46,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
         makeWidget({ 385, 2 }, { 13, 13 }, WidgetType::buttonWithImage, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
         makeWidget({ 0, 15 }, { 400, 257 }, WidgetType::panel, WindowColour::secondary),
         makeWidget({ 4, 19 }, { 188, 248 }, WidgetType::scrollview, WindowColour::secondary, Scrollbars::vertical, StringIds::tooltip_company_face_selection),
-        makeWidget({ 265, 23 }, { 66, 66 }, WidgetType::wt_5, WindowColour::secondary),
+        makeWidget({ 265, 23 }, { 66, 66 }, WidgetType::slider, WindowColour::secondary),
         widgetEnd(),
     };
 

--- a/src/OpenLoco/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/Windows/Construction/ConstructionTab.cpp
@@ -100,7 +100,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         makeWidget({ 81, 96 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::construction_slope_up, StringIds::tooltip_slope_up),
         makeWidget({ 105, 96 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::construction_steep_slope_up, StringIds::tooltip_steep_slope_up),
         makeDropdownWidgets({ 40, 123 }, { 58, 20 }, WidgetType::combobox, WindowColour::secondary, StringIds::empty, StringIds::tooltip_bridge_stats),
-        makeWidget({ 3, 145 }, { 132, 100 }, WidgetType::wt_5, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_construct),
+        makeWidget({ 3, 145 }, { 132, 100 }, WidgetType::slider, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_construct),
         makeWidget({ 6, 248 }, { 46, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::construction_remove, StringIds::tooltip_remove),
         makeWidget({ 57, 248 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::rotate_object, StringIds::rotate_90),
         widgetEnd(),
@@ -769,7 +769,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
         if (_constructionHover == 1)
         {
-            window->widgets[widx::construct].type = WidgetType::wt_5;
+            window->widgets[widx::construct].type = WidgetType::slider;
             window->widgets[widx::construct].tooltip = StringIds::tooltip_start_construction;
             window->widgets[widx::remove].type = WidgetType::none;
             window->widgets[widx::rotate_90].type = WidgetType::buttonWithImage;
@@ -976,7 +976,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
         if (_constructionHover == 1)
         {
-            window->widgets[widx::construct].type = WidgetType::wt_5;
+            window->widgets[widx::construct].type = WidgetType::slider;
             window->widgets[widx::construct].tooltip = StringIds::tooltip_start_construction;
             window->widgets[widx::remove].type = WidgetType::none;
             window->widgets[widx::rotate_90].type = WidgetType::buttonWithImage;

--- a/src/OpenLoco/Windows/News/News.cpp
+++ b/src/OpenLoco/Windows/News/News.cpp
@@ -814,7 +814,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
     namespace News2
     {
         Widget widgets[] = {
-            commonWidgets(360, 159, WidgetType::wt_5),
+            commonWidgets(360, 159, WidgetType::slider),
             widgetEnd(),
         };
     }

--- a/src/OpenLoco/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/Windows/ObjectSelectionWindow.cpp
@@ -88,7 +88,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         makeWidget({ 1, 1 }, { 598, 13 }, WidgetType::caption_25, WindowColour::primary, StringIds::title_object_selection),
         makeWidget({ 585, 2 }, { 13, 13 }, WidgetType::buttonWithImage, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
         makeWidget({ 0, 65 }, { 600, 333 }, WidgetType::panel, WindowColour::secondary),
-        makeWidget({ 3, 15 }, { 589, 50 }, WidgetType::wt_5, WindowColour::secondary),
+        makeWidget({ 3, 15 }, { 589, 50 }, WidgetType::slider, WindowColour::secondary),
         makeWidget({ 470, 20 }, { 122, 12 }, WidgetType::button, WindowColour::primary, StringIds::object_selection_advanced, StringIds::object_selection_advanced_tooltip),
         makeWidget({ 4, 68 }, { 288, 317 }, WidgetType::scrollview, WindowColour::secondary, Scrollbars::vertical),
         makeWidget({ 391, 68 }, { 114, 114 }, WidgetType::buttonWithImage, WindowColour::secondary),

--- a/src/OpenLoco/Windows/Options.cpp
+++ b/src/OpenLoco/Windows/Options.cpp
@@ -906,7 +906,7 @@ namespace OpenLoco::Ui::Windows::Options
             makeWidget({ 10, 64 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::music_controls_stop, StringIds::music_controls_stop_tip),
             makeWidget({ 34, 64 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::music_controls_play, StringIds::music_controls_play_tip),
             makeWidget({ 58, 64 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::music_controls_next, StringIds::music_controls_next_tip),
-            makeWidget({ 256, 64 }, { 109, 24 }, WidgetType::wt_5, WindowColour::secondary, Widget::kContentNull, StringIds::set_volume_tip),
+            makeWidget({ 256, 64 }, { 109, 24 }, WidgetType::slider, WindowColour::secondary, Widget::kContentNull, StringIds::set_volume_tip),
             makeDropdownWidgets({ 10, 93 }, { 346, 12 }, WidgetType::combobox, WindowColour::secondary, StringIds::arg2_stringid),
             makeWidget({ 183, 108 }, { 173, 12 }, WidgetType::button, WindowColour::secondary, StringIds::edit_music_selection, StringIds::edit_music_selection_tip),
             widgetEnd(),

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -239,7 +239,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             commonWidgets(265, 177, StringIds::stringid),
             makeWidget({ 3, 44 }, { 237, 120 }, WidgetType::viewport, WindowColour::secondary),
             makeWidget({ 3, 155 }, { 237, 21 }, WidgetType::wt_13, WindowColour::secondary),
-            makeWidget({ 240, 46 }, { 24, 115 }, WidgetType::wt_5, WindowColour::secondary),
+            makeWidget({ 240, 46 }, { 24, 115 }, WidgetType::slider, WindowColour::secondary),
             makeWidget({ 240, 44 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::red_flag, StringIds::tooltip_stop_start),
             makeWidget({ 240, 68 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::null, StringIds::tooltip_remove_from_track),
             makeWidget({ 240, 92 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::pass_signal, StringIds::tooltip_pass_signal_at_danger),
@@ -866,7 +866,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 if (CompanyManager::isPlayerCompany(head->owner))
                 {
                     viewportRight -= 27;
-                    self->widgets[widx::speedControl].type = WidgetType::wt_5;
+                    self->widgets[widx::speedControl].type = WidgetType::slider;
                 }
             }
 


### PR DESCRIPTION
The widget type `wt_5` is a slider, ie this
![image](https://user-images.githubusercontent.com/7483209/186102248-b00ddbdb-20cf-4e26-83d8-df0514e5416d.png)
