### PR TITLE
Fix #1612. Ambient audio no longer playing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 22.08+ (???)
 ------------------------------------------------------------------------
+- Fix: [#1612] Ambient audio no longer playing.
 - Fix: [#1613] Crash when viewing the Build Trains window with certain trains.
 - Fix: [#1614] Crash when ai picks up none existent vehicles.
 

--- a/src/OpenLoco/Audio/Channel.h
+++ b/src/OpenLoco/Audio/Channel.h
@@ -33,7 +33,7 @@ namespace OpenLoco::Audio
         void setPan(int32_t pan);
         void setFrequency(int32_t freq);
         bool isPlaying() const;
-        const OpenAL::Source& getSource() { return _source; }
-        const Attributes& getAttributes() { return _attributes; }
+        const OpenAL::Source& getSource() const { return _source; }
+        const Attributes& getAttributes() const { return _attributes; }
     };
 }


### PR DESCRIPTION
Mistake made when refactoring to reduce global usage and didn't end up
actually setting the variable. This removes all of the loco global usage
and replaces it with a normal global. This could be further worked on in future.