### PR TITLE
Fix 1614: Crash on pickup of none existent vehicles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 22.08+ (???)
 ------------------------------------------------------------------------
 - Fix: [#1613] Crash when viewing the Build Trains window with certain trains.
+- Fix: [#1614] Crash when ai picks up none existent vehicles.
 
 22.08 (2022-08-25)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/GameCommands/VehiclePickup.cpp
+++ b/src/OpenLoco/GameCommands/VehiclePickup.cpp
@@ -1,5 +1,6 @@
 #include "../Audio/Audio.h"
 #include "../Economy/Expenditures.h"
+#include "../Entities/EntityManager.h"
 #include "../Interop/Interop.hpp"
 #include "../Types.hpp"
 #include "../Utility/Prng.hpp"
@@ -27,8 +28,12 @@ namespace OpenLoco::GameCommands
     {
         GameCommands::setExpenditureType(ExpenditureType::TrainRunningCosts);
 
-        auto train = Vehicles::Vehicle(headId);
-        auto* head = train.head;
+        auto* head = EntityManager::get<Vehicles::VehicleHead>(headId);
+        if (head == nullptr)
+        {
+            return FAILURE;
+        }
+        auto train = Vehicles::Vehicle(*head);
         auto* veh2 = train.veh2;
 
         GameCommands::setPosition(veh2->position);


### PR DESCRIPTION
Unsure why the ai is picking up a none existent vehicle but this at least stops it crashing
