### PR TITLE
Yet another wrap string issue fixed.

### DIFF
--- a/src/OpenLoco/Graphics/Gfx.cpp
+++ b/src/OpenLoco/Graphics/Gfx.cpp
@@ -1336,6 +1336,13 @@ namespace OpenLoco::Gfx
                 {
                     // wrap.push_back(startLine); TODO: refactor to return pointers to line starts
                     maxWidth = std::max(maxWidth, lineWidth);
+                    if (startLine == wordStart && *ptr != '\0')
+                    {
+                        // Warning! Not loco string argument safe assumes no one/two/four argument strings.
+                        // TODO: Implement loco string strlen!
+                        memmove(ptr + 1, ptr, strlen(ptr) + 1);
+                        *ptr++ = '\0';
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
When the string needs to be wrapped but there are no words to wrap on it would move the pointer into uninitialised memory instead of shifting the memory by 1. Note this still has issues as its not locoString argument safe