### PR TITLE
Introduce locoStrlen and locoStrcpy to handle args

### DIFF
--- a/DEVELOPMENTLOG.md
+++ b/DEVELOPMENTLOG.md
@@ -1,5 +1,8 @@
 # OpenLoco version 22.10+ (???)
 
+## Add Loco String Functions [#1642]
+Internally locomotion uses its own form of strings. These strings can have inline parameters and arguments or arguments passed as a seperate variable. To acheive this the game assumes that all text is a C-string, mostly ASCII (7bit) and uses some of the spare bits for argument indication (sentinals). This causes some havoc with trying to support non-Latin languages as we ideally need to move to UTF-8. The arguments vary from 1-4 bytes of information and crucially they might have 0 as one of those bytes. This potential 0 means that all C-string functions strcat, strcpy, strlen may work incorrectly and not understand the string. Therefore we now have locoStrlen, locoStrcpy to replace them. Eventually we will require to rework all string handling so that arguments are safely encoded in (hopefully) UTF-8 but that is a long way off.
+
 # OpenLoco version 22.10 (2022-10-09)
 
 ## Change Company Face Game Command [#1656]

--- a/src/OpenLoco/Graphics/Gfx.cpp
+++ b/src/OpenLoco/Graphics/Gfx.cpp
@@ -357,7 +357,7 @@ namespace OpenLoco::Gfx
 
                 case ControlCodes::newline:
                 case ControlCodes::newlineSmaller:
-                    continue;
+                    break;
 
                 case ControlCodes::Font::small:
                     fontSpriteBase = Font::small;
@@ -381,6 +381,11 @@ namespace OpenLoco::Gfx
                 case ControlCodes::windowColour2:
                 case ControlCodes::windowColour3:
                 case ControlCodes::windowColour4:
+                    break;
+
+                case ControlCodes::newlineXY:
+                    width = *str++;
+                    str++;
                     break;
 
                 case ControlCodes::inlineSpriteStr:

--- a/src/OpenLoco/Graphics/Gfx.cpp
+++ b/src/OpenLoco/Graphics/Gfx.cpp
@@ -312,7 +312,7 @@ namespace OpenLoco::Gfx
             }
             else
             {
-                strcpy(string, bestString.c_str());
+                StringManager::locoStrcpy(string, bestString.c_str());
                 return getStringWidth(string);
             }
         }
@@ -1338,9 +1338,9 @@ namespace OpenLoco::Gfx
                     maxWidth = std::max(maxWidth, lineWidth);
                     if (startLine == wordStart && *ptr != '\0')
                     {
-                        // Warning! Not loco string argument safe assumes no one/two/four argument strings.
-                        // TODO: Implement loco string strlen!
-                        memmove(ptr + 1, ptr, strlen(ptr) + 1);
+                        // Shuffle the string forward by one to make space for line ending
+                        std::copy_backward(ptr, ptr + StringManager::locoStrlen(ptr) + 1, ptr + 1);
+                        // Insert line ending
                         *ptr++ = '\0';
                     }
                 }
@@ -1348,6 +1348,7 @@ namespace OpenLoco::Gfx
                 {
                     // wrap.push_back(startLine); TODO: refactor to return pointers to line starts
                     maxWidth = std::max(maxWidth, lastWordLineWith);
+                    // Insert line ending instead of space character
                     *wordStart = '\0';
                     ptr = wordStart + 1;
                 }

--- a/src/OpenLoco/Localisation/StringManager.cpp
+++ b/src/OpenLoco/Localisation/StringManager.cpp
@@ -271,6 +271,10 @@ namespace OpenLoco::StringManager
     // Loco string argument safe strlen
     size_t locoStrlen(const char* buffer)
     {
+        if (buffer == nullptr)
+        {
+            return 0;
+        }
         auto* ptr = buffer;
         while (*ptr != '\0')
         {
@@ -293,6 +297,10 @@ namespace OpenLoco::StringManager
 
     char* locoStrcpy(char* dest, const char* src)
     {
+        if (src == nullptr)
+        {
+            return dest;
+        }
         char* ret = dest;
         while (*src != '\0')
         {

--- a/src/OpenLoco/Localisation/StringManager.h
+++ b/src/OpenLoco/Localisation/StringManager.h
@@ -150,5 +150,7 @@ namespace OpenLoco::StringManager
     std::pair<string_id, string_id> monthToString(MonthId month);
     int32_t internalLengthToComma1DP(const int32_t length);
     size_t locoStrlen(const char* buffer);
+    size_t locoStrlenS(const char* buffer, std::size_t size);
     char* locoStrcpy(char* dest, const char* src);
+    char* locoStrcpyS(char* dest, std::size_t destSize, const char* src, std::size_t srcSize);
 }

--- a/src/OpenLoco/Localisation/StringManager.h
+++ b/src/OpenLoco/Localisation/StringManager.h
@@ -149,4 +149,6 @@ namespace OpenLoco::StringManager
     string_id fromTownName(string_id stringId);
     std::pair<string_id, string_id> monthToString(MonthId month);
     int32_t internalLengthToComma1DP(const int32_t length);
+    size_t locoStrlen(const char* buffer);
+    char* locoStrcpy(char* dest, const char* src);
 }

--- a/src/OpenLoco/Objects/VehicleObject.cpp
+++ b/src/OpenLoco/Objects/VehicleObject.cpp
@@ -76,7 +76,7 @@ namespace OpenLoco
 
         getCargoString(buffer);
 
-        if (strlen(buffer) != 0)
+        if (StringManager::locoStrlen(buffer) != 0)
         {
             Gfx::drawStringLeftWrapped(rt, rowPosition.x, rowPosition.y, width - 4, Colour::black, StringIds::buffer_1250);
         }

--- a/src/OpenLoco/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/Ui/ViewportInteraction.cpp
@@ -189,7 +189,7 @@ namespace OpenLoco::Ui::ViewportInteraction
         *buffer = 0;
         industry->getStatusString(buffer);
         auto args = FormatArguments::mapToolTip();
-        if (std::strlen(buffer) != 0)
+        if (StringManager::locoStrlen(buffer) != 0)
         {
             args.push(StringIds::wcolour3_stringid_2);
             args.push(industry->name);

--- a/src/OpenLoco/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/Windows/CompanyWindow.cpp
@@ -2332,7 +2332,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
             *buffer_2039++ = static_cast<char>(ControlCodes::Colour::black);
             char* scenarioDetailsString = getGameState().scenarioDetails;
-            strcpy(buffer_2039, scenarioDetailsString);
+            StringManager::locoStrcpy(buffer_2039, scenarioDetailsString);
 
             int16_t y = self.y + 47;
             // for example: "Provide the transport services on this little island" for "Boulder Breakers" scenario

--- a/src/OpenLoco/Windows/Vehicle.cpp
+++ b/src/OpenLoco/Windows/Vehicle.cpp
@@ -1278,7 +1278,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
 
             char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_337));
-            if (strlen(buffer) != 0)
+            if (StringManager::locoStrlen(buffer) != 0)
             {
                 if (self.widgets[widx::carList].tooltip == tooltipFormat && self.var_85C == enumValue(tooltipContent))
                 {


### PR DESCRIPTION
Lots of places are incorrectly handling inline string arguments potentially miss copying or getting the wrong length of strings.

~~There are still a few places using the stdlib ones that i need to investigate so this isn't ready just yet.~~