### PR TITLE
Fix Vehicle Crash for Acquire Assets cheat.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 22.09+ (???)
 ------------------------------------------------------------------------
 - Fix: [#1237] Long entity (company) names may be cut-off incorrectly.
+- Fix: [#1650] Acquire all company assets cheat causes some Trains and Trams to crash
 
 22.09 (2022-09-04)
 ------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 22.09+ (???)
 ------------------------------------------------------------------------
 - Fix: [#1237] Long entity (company) names may be cut-off incorrectly.
-- Fix: [#1650] Acquire all company assets cheat causes some Trains and Trams to crash
+- Fix: [#1650] Acquire all company assets cheat may cause some trains and trams to crash.
 
 22.09 (2022-09-04)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/GameCommands/Cheat.cpp
+++ b/src/OpenLoco/GameCommands/Cheat.cpp
@@ -34,7 +34,7 @@ namespace OpenLoco::GameCommands
                 if (roadElement != nullptr)
                 {
                     // check to verify that roadElement is owned by the target company
-                    if (roadElement->owner != targetCompanyId)
+                    if (roadElement->owner() != targetCompanyId)
                         continue;
 
                     roadElement->setOwner(ourCompanyId);
@@ -45,7 +45,7 @@ namespace OpenLoco::GameCommands
                 if (trackElement != nullptr)
                 {
                     // check to verify that the trackElement is owned by the target company
-                    if (trackElement->owner != targetCompanyId)
+                    if (trackElement->owner() != targetCompanyId)
                         continue;
 
                     trackElement->setOwner(ourCompanyId);

--- a/src/OpenLoco/GameCommands/Cheat.cpp
+++ b/src/OpenLoco/GameCommands/Cheat.cpp
@@ -34,7 +34,7 @@ namespace OpenLoco::GameCommands
                 if (roadElement != nullptr)
                 {
                     // check to verify that roadElement is owned by the target company
-                    if (roadElement.owner != targetCompanyId)
+                    if (roadElement->owner != targetCompanyId)
                         continue;
 
                     roadElement->setOwner(ourCompanyId);
@@ -45,7 +45,7 @@ namespace OpenLoco::GameCommands
                 if (trackElement != nullptr)
                 {
                     // check to verify that the trackElement is owned by the target company
-                    if (trackElement.owner != targetCompanyId)
+                    if (trackElement->owner != targetCompanyId)
                         continue;
 
                     trackElement->setOwner(ourCompanyId);

--- a/src/OpenLoco/GameCommands/Cheat.cpp
+++ b/src/OpenLoco/GameCommands/Cheat.cpp
@@ -33,6 +33,10 @@ namespace OpenLoco::GameCommands
                 auto* roadElement = element.as<RoadElement>();
                 if (roadElement != nullptr)
                 {
+                    // check to verify that roadElement is owned by the target company
+                    if (roadElement.owner != targetCompanyId)
+                        continue;
+
                     roadElement->setOwner(ourCompanyId);
                     continue;
                 }
@@ -40,6 +44,10 @@ namespace OpenLoco::GameCommands
                 auto* trackElement = element.as<TrackElement>();
                 if (trackElement != nullptr)
                 {
+                    // check to verify that the trackElement is owned by the target company
+                    if (trackElement.owner != targetCompanyId)
+                        continue;
+
                     trackElement->setOwner(ourCompanyId);
                     continue;
                 }

--- a/src/OpenLoco/GameCommands/Cheat.cpp
+++ b/src/OpenLoco/GameCommands/Cheat.cpp
@@ -33,17 +33,19 @@ namespace OpenLoco::GameCommands
                 auto* roadElement = element.as<RoadElement>();
                 if (roadElement != nullptr)
                 {
-                    // check to verify that roadElement is owned by the target company
+                    // Check to verify that roadElement is owned by the target company
                     if (roadElement->owner() == targetCompanyId)
                         roadElement->setOwner(ourCompanyId);
+                    continue;
                 }
 
                 auto* trackElement = element.as<TrackElement>();
                 if (trackElement != nullptr)
                 {
-                    // check to verify that the trackElement is owned by the target company.
+                    // Check to verify that the trackElement is owned by the target company.
                     if (trackElement->owner() == targetCompanyId)
                         trackElement->setOwner(ourCompanyId);
+                    continue;
                 }
             }
 

--- a/src/OpenLoco/GameCommands/Cheat.cpp
+++ b/src/OpenLoco/GameCommands/Cheat.cpp
@@ -34,22 +34,16 @@ namespace OpenLoco::GameCommands
                 if (roadElement != nullptr)
                 {
                     // check to verify that roadElement is owned by the target company
-                    if (roadElement->owner() != targetCompanyId)
-                        continue;
-
-                    roadElement->setOwner(ourCompanyId);
-                    continue;
+                    if (roadElement->owner() == targetCompanyId)
+                        roadElement->setOwner(ourCompanyId);
                 }
 
                 auto* trackElement = element.as<TrackElement>();
                 if (trackElement != nullptr)
                 {
-                    // check to verify that the trackElement is owned by the target company
-                    if (trackElement->owner() != targetCompanyId)
-                        continue;
-
-                    trackElement->setOwner(ourCompanyId);
-                    continue;
+                    // check to verify that the trackElement is owned by the target company.
+                    if (trackElement->owner() == targetCompanyId)
+                        trackElement->setOwner(ourCompanyId);
                 }
             }
 


### PR DESCRIPTION
This Pull Request adds a check for ownership of Road and Track elements into the acquireAssets function, this makes sure that only the assets for the target company is acquired, preventing vehicles from crashing for other companies because of being on tracks not owned by them.

this should fix #1650 

this currently is a work in progress and needs testing