### PR TITLE
Raise filename length limit back to 200 chars

### DIFF
--- a/src/OpenLoco/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/Windows/PromptBrowseWindow.cpp
@@ -112,9 +112,8 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         }
         Utility::strcpy_safe(_filter, filter);
 
-        auto inputSize = StringManager::kUserStringSize - 1;
         changeDirectory(directory.make_preferred());
-        inputSession = Ui::TextInput::InputSession(baseName, inputSize);
+        inputSession = Ui::TextInput::InputSession(baseName, 200);
 
         initEvents();
 


### PR DESCRIPTION
Something I missed while reviewing #1651. I've raised the limit back to 200 chars, for now. I'd prefer to use a constant from `std::filesystem`, but I'm not aware of such a limit.