### PR TITLE
Add writeLocoCall to interop

### DIFF
--- a/src/OpenLoco/Interop/Hook.cpp
+++ b/src/OpenLoco/Interop/Hook.cpp
@@ -231,6 +231,16 @@ namespace OpenLoco::Interop
         writeMemory(address, data, sizeof(data));
     }
 
+    void writeLocoCall(uint32_t address, uint32_t fnAddress)
+    {
+        uint8_t data[5] = { 0 };
+        data[0] = 0xE8; // CALL
+
+        WRITE_ADDRESS_STRICTALIAS(&data[1], fnAddress - address - 5);
+
+        writeMemory(address, data, sizeof(data));
+    }
+
     static void* _smallHooks;
     static uint8_t* _offset;
 

--- a/src/OpenLoco/Interop/Interop.hpp
+++ b/src/OpenLoco/Interop/Interop.hpp
@@ -412,6 +412,7 @@ namespace OpenLoco::Interop
     void registerHook(uintptr_t address, hook_function function);
     void writeRet(uint32_t address);
     void writeJmp(uint32_t address, void* fn);
+    void writeLocoCall(uint32_t address, uint32_t fnAddress);
     void writeNop(uint32_t address, size_t count);
     void hookDump(uint32_t address, void* fn);
     void hookLib(uint32_t address, void* fn);


### PR DESCRIPTION
Required for my double hook.

```cpp
        // Cheeky hook as this is hooking tryCreateNewIndustriesMonthly which is not used in vanilla anymore
        // and then modifying callers to findRandomNewIndustryLocation allowing us to use both vanilla and new function
        registerHook(
            0x00459659,
            [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                registers backup = regs;
                uint8_t indObjId = regs.dl;

                auto res = findRandomNewIndustryLocation(indObjId);
                if (res.has_value())
                {
                    backup.ax = res->x;
                    backup.cx = res->y;
                }
                else
                {
                    backup.ax = -1;
                }
                regs = backup;
                return 0;
            });
        // Relocate calls to findRandomNewIndustryLocation to tryCreateNewIndustriesMonthly which is
        // hooked to point to our findRandomNewIndustryLocation
        writeLocoCall(0x0045994B, 0x00459659);
        writeLocoCall(0x004597A0, 0x00459659);
```