### PR TITLE
Use the correct cap on fast square root

### DIFF
--- a/src/OpenLoco/Math/Vector.cpp
+++ b/src/OpenLoco/Math/Vector.cpp
@@ -9,7 +9,7 @@ namespace OpenLoco::Math::Vector
     uint16_t fastSquareRoot(uint32_t distance)
     {
         uint8_t i = 10;
-        for (; distance > 4096; --i, distance >>= 2)
+        for (; distance >= 4096; --i, distance >>= 2)
             ;
 
         return _vehicle_arr_500B50[(distance & 0xFFE) >> 1] >> i;


### PR DESCRIPTION
Found this whilst trying to get industryManger3 to not diverge. I thought it would break my 1000 and 10000 tick saves but they are still fine hence why this is a standalone PR.