### PR TITLE
Fix #1598: Cargo delivery payment calculation goes out of bounds

### DIFF
--- a/src/OpenLoco/Economy/Economy.cpp
+++ b/src/OpenLoco/Economy/Economy.cpp
@@ -71,7 +71,7 @@ namespace OpenLoco::Economy
                 continue;
             }
 
-            for (uint16_t numDays = 2; numDays <= 122; ++numDays)
+            for (uint16_t numDays = 2; numDays < 122; ++numDays)
             {
                 _deliveredCargoPayment[cargoItem][(numDays / 2) - 1] = CompanyManager::calculateDeliveredCargoPayment(cargoItem, 100, 10, numDays);
             }

--- a/src/OpenLoco/Economy/Economy.cpp
+++ b/src/OpenLoco/Economy/Economy.cpp
@@ -71,7 +71,7 @@ namespace OpenLoco::Economy
                 continue;
             }
 
-            for (uint16_t numDays = 2; numDays < 122; ++numDays)
+            for (uint16_t numDays = 2; numDays < 122; numDays += 2)
             {
                 _deliveredCargoPayment[cargoItem][(numDays / 2) - 1] = CompanyManager::calculateDeliveredCargoPayment(cargoItem, 100, 10, numDays);
             }


### PR DESCRIPTION
This addresses the issue described in #1598. Going back to the disassembly it is clear 61 (ours: 122) should be used as an exclusive maximum. Note the snippet below uses `jb` and not `jbe`.
```
.text:0043762A                 cmp     edx, 61
.text:0043762D                 jb      short loc_43760B
```

I don't think this warrants a changelog entry. Even though the code ended up going over boundaries, this would only have mattered for the last cargo object, and even then, the elements directly after this array are:
```
.data:009C68F8 _deliveredCargoPayment dd 780h dup(?)   ; DATA XREF: ui__company_list__event_6_draw+74↑o
.data:009C86F8 zoom_ticks      dd ?                    ; DATA XREF: gui_init+7E↑w
.data:009C86FC _tutorialOffset dd ?                    ; DATA XREF: show_tutorial+D3↑w
```

Interestingly the function was introduced by itself in #733, then in CompanyList.cpp, and only later moved to Economy.cpp.