### PR TITLE
Refactor remaining window functions to use references

### DIFF
--- a/src/OpenLoco/Input/ShortcutManager.cpp
+++ b/src/OpenLoco/Input/ShortcutManager.cpp
@@ -164,11 +164,11 @@ namespace OpenLoco::Input::ShortcutManager
     // 0x004BF0FE
     static void zoomViewOut()
     {
-        Window* main = WindowManager::getMainWindow();
+        Window& main = WindowManager::getMainWindow();
         if (main == nullptr)
             return;
 
-        main->viewportZoomOut(false);
+        main.viewportZoomOut(false);
         TownManager::updateLabels();
         StationManager::updateLabels();
     }
@@ -176,11 +176,11 @@ namespace OpenLoco::Input::ShortcutManager
     // 0x004BF115
     static void zoomViewIn()
     {
-        Window* main = WindowManager::getMainWindow();
+        Window& main = WindowManager::getMainWindow();
         if (main == nullptr)
             return;
 
-        main->viewportZoomIn(false);
+        main.viewportZoomIn(false);
         TownManager::updateLabels();
         StationManager::updateLabels();
     }
@@ -188,11 +188,11 @@ namespace OpenLoco::Input::ShortcutManager
     // 0x004BF12C
     static void rotateView()
     {
-        Window* main = WindowManager::getMainWindow();
+        Window& main = WindowManager::getMainWindow();
         if (main == nullptr)
             return;
 
-        main->viewportRotateRight();
+        main.viewportRotateRight();
         TownManager::updateLabels();
         StationManager::updateLabels();
         Windows::MapWindow::centerOnViewPoint();
@@ -234,9 +234,9 @@ namespace OpenLoco::Input::ShortcutManager
         if (window == nullptr)
             return;
 
-        auto viewport = WindowManager::getMainWindow()->viewports[0];
-        viewport->flags ^= ViewportFlags::underground_view;
-        window->invalidate();
+        auto viewport = WindowManager::getMainWindow().viewports[0];
+        viewport.flags ^= ViewportFlags::underground_view;
+        window.invalidate();
     }
 
     // 0x004BF194
@@ -246,9 +246,9 @@ namespace OpenLoco::Input::ShortcutManager
         if (window == nullptr)
             return;
 
-        auto viewport = WindowManager::getMainWindow()->viewports[0];
-        viewport->flags ^= ViewportFlags::hide_foreground_tracks_roads;
-        window->invalidate();
+        auto viewport = WindowManager::getMainWindow().viewports[0];
+        viewport.flags ^= ViewportFlags::hide_foreground_tracks_roads;
+        window.invalidate();
     }
 
     // 0x004BF19E
@@ -258,9 +258,9 @@ namespace OpenLoco::Input::ShortcutManager
         if (window == nullptr)
             return;
 
-        auto viewport = WindowManager::getMainWindow()->viewports[0];
-        viewport->flags ^= ViewportFlags::hide_foreground_scenery_buildings;
-        window->invalidate();
+        auto viewport = WindowManager::getMainWindow().viewports[0];
+        viewport.flags ^= ViewportFlags::hide_foreground_scenery_buildings;
+        window.invalidate();
     }
 
     // 0x004BF1A8
@@ -270,9 +270,9 @@ namespace OpenLoco::Input::ShortcutManager
         if (window == nullptr)
             return;
 
-        auto viewport = WindowManager::getMainWindow()->viewports[0];
-        viewport->flags ^= ViewportFlags::height_marks_on_land;
-        window->invalidate();
+        auto viewport = WindowManager::getMainWindow().viewports[0];
+        viewport.flags ^= ViewportFlags::height_marks_on_land;
+        window.invalidate();
     }
 
     // 0x004BF1B2
@@ -282,9 +282,9 @@ namespace OpenLoco::Input::ShortcutManager
         if (window == nullptr)
             return;
 
-        auto viewport = WindowManager::getMainWindow()->viewports[0];
-        viewport->flags ^= ViewportFlags::height_marks_on_tracks_roads;
-        window->invalidate();
+        auto viewport = WindowManager::getMainWindow().viewports[0];
+        viewport.flags ^= ViewportFlags::height_marks_on_tracks_roads;
+        window.invalidate();
     }
 
     // 0x004BF1BC
@@ -294,9 +294,9 @@ namespace OpenLoco::Input::ShortcutManager
         if (window == nullptr)
             return;
 
-        auto viewport = WindowManager::getMainWindow()->viewports[0];
-        viewport->flags ^= ViewportFlags::one_way_direction_arrows;
-        window->invalidate();
+        auto viewport = WindowManager::getMainWindow().viewports[0];
+        viewport.flags ^= ViewportFlags::one_way_direction_arrows;
+        window.invalidate();
     }
 
     // 0x004BF1C6

--- a/src/OpenLoco/Ui/ScrollView.cpp
+++ b/src/OpenLoco/Ui/ScrollView.cpp
@@ -24,9 +24,9 @@ namespace OpenLoco::Ui::ScrollView
 
     // 0x004C87E1
     // regs.bp: deltaX
-    static void horizontalFollow(Ui::Window* const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex, const size_t scrollIndex, const int16_t deltaX)
+    static void horizontalFollow(Ui::Window& const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex, const size_t scrollIndex, const int16_t deltaX)
     {
-        ScrollArea& scrollArea = w->scrollAreas[scrollIndex];
+        ScrollArea& scrollArea = w.scrollAreas[scrollIndex];
         scrollArea.flags |= ScrollFlags::hscrollbarThumbPressed;
 
         uint16_t trackWidth = widget->width() - 2 - thumbSize - thumbSize;
@@ -55,14 +55,14 @@ namespace OpenLoco::Ui::ScrollView
         scrollArea.contentOffsetX = std::clamp<int16_t>(newOffset, 0, maxOffset);
 
         ScrollView::updateThumbs(w, widgetIndex);
-        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+        WindowManager::invalidateWidget(w.type, w.number, widgetIndex);
     }
 
     // 0x004C8898
     // regs.bp: deltaY
-    static void verticalFollow(Ui::Window* const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex, const size_t scrollIndex, const int16_t deltaY)
+    static void verticalFollow(Ui::Window& const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex, const size_t scrollIndex, const int16_t deltaY)
     {
-        ScrollArea& scrollArea = w->scrollAreas[scrollIndex];
+        ScrollArea& scrollArea = w.scrollAreas[scrollIndex];
         scrollArea.flags |= ScrollFlags::vscrollbarThumbPressed;
 
         uint16_t trackHeight = widget->height() - 2 - thumbSize - thumbSize;
@@ -91,14 +91,14 @@ namespace OpenLoco::Ui::ScrollView
         scrollArea.contentOffsetY = std::clamp<int16_t>(newOffset, 0, maxOffset);
 
         ScrollView::updateThumbs(w, widgetIndex);
-        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+        WindowManager::invalidateWidget(w.type, w.number, widgetIndex);
     }
 
     // 0x004C8CFD
     // regs.bp: deltaX
-    void horizontalDragFollow(Ui::Window* const w, Ui::Widget* const widget, const WidgetIndex_t dragWidgetIndex, const size_t dragScrollIndex, const int16_t deltaX)
+    void horizontalDragFollow(Ui::Window& const w, Ui::Widget* const widget, const WidgetIndex_t dragWidgetIndex, const size_t dragScrollIndex, const int16_t deltaX)
     {
-        ScrollArea& scrollArea = w->scrollAreas[dragScrollIndex];
+        ScrollArea& scrollArea = w.scrollAreas[dragScrollIndex];
         if ((scrollArea.flags & ScrollFlags::hscrollbarVisible) == 0)
         {
             return;
@@ -130,15 +130,15 @@ namespace OpenLoco::Ui::ScrollView
         scrollArea.contentOffsetX = std::clamp<int16_t>(newOffset, 0, maxOffset);
 
         ScrollView::updateThumbs(w, dragWidgetIndex);
-        WindowManager::invalidateWidget(w->type, w->number, dragWidgetIndex);
+        WindowManager::invalidateWidget(w.type, w.number, dragWidgetIndex);
     }
 
     // 0x004C8E2E
     // regs.bp: deltaY
     // possible extraction of common functionality in verticalDragFollow, horizontalDragFollow, verticalFollow, horizontalFollow
-    void verticalDragFollow(Ui::Window* const w, Ui::Widget* const widget, const WidgetIndex_t dragWidgetIndex, const size_t dragScrollIndex, const int16_t deltaY)
+    void verticalDragFollow(Ui::Window& const w, Ui::Widget* const widget, const WidgetIndex_t dragWidgetIndex, const size_t dragScrollIndex, const int16_t deltaY)
     {
-        ScrollArea& scrollArea = w->scrollAreas[dragScrollIndex];
+        ScrollArea& scrollArea = w.scrollAreas[dragScrollIndex];
         if ((scrollArea.flags & ScrollFlags::vscrollbarVisible) == 0)
         {
             return;
@@ -170,16 +170,16 @@ namespace OpenLoco::Ui::ScrollView
         scrollArea.contentOffsetY = std::clamp<int16_t>(newOffset, 0, maxOffset);
 
         ScrollView::updateThumbs(w, dragWidgetIndex);
-        WindowManager::invalidateWidget(w->type, w->number, dragWidgetIndex);
+        WindowManager::invalidateWidget(w.type, w.number, dragWidgetIndex);
     }
 
     // 0x004C8EF0
     // Note: Original function returns a scrollAreaOffset not an index
-    GetPartResult getPart(Ui::Window* window, Ui::Widget* widget, int16_t x, int16_t y)
+    GetPartResult getPart(Ui::Window& window, Ui::Widget* widget, int16_t x, int16_t y)
     {
         GetPartResult res{ { x, y }, ScrollPart::none, 0 };
 
-        for (const auto* winWidget = window->widgets; winWidget != widget; winWidget++)
+        for (const auto* winWidget = window.widgets; winWidget != widget; winWidget++)
         {
             if (winWidget->type == WidgetType::scrollview)
             {
@@ -189,11 +189,11 @@ namespace OpenLoco::Ui::ScrollView
 
         res.index = std::min<size_t>(res.index, Window::kMaxScrollAreas - 1);
 
-        const auto& scroll = window->scrollAreas[res.index];
-        auto right = widget->right + window->x;
-        auto left = widget->left + window->x;
-        auto top = widget->top + window->y;
-        auto bottom = widget->bottom + window->y;
+        const auto& scroll = window.scrollAreas[res.index];
+        auto right = widget->right + window.x;
+        auto left = widget->left + window.x;
+        auto top = widget->top + window.y;
+        auto bottom = widget->bottom + window.y;
 
         if ((scroll.flags & ScrollFlags::hscrollbarVisible)
             && y >= (bottom - barWidth))
@@ -295,130 +295,130 @@ namespace OpenLoco::Ui::ScrollView
     }
 
     // 0x004CA1ED
-    void updateThumbs(Window* window, WidgetIndex_t widgetIndex)
+    void updateThumbs(Window& window, WidgetIndex_t widgetIndex)
     {
         registers regs;
 
         regs.esi = X86Pointer(window);
-        regs.ebx = window->getScrollDataIndex(widgetIndex) * sizeof(ScrollArea);
-        regs.edi = X86Pointer(&window->widgets[widgetIndex]);
+        regs.ebx = window.getScrollDataIndex(widgetIndex) * sizeof(ScrollArea);
+        regs.edi = X86Pointer(&window.widgets[widgetIndex]);
         call(0x4CA1ED, regs);
     }
 
     // 0x004C894F
-    static void hButtonLeft(Ui::Window* const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
+    static void hButtonLeft(Ui::Window& const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
     {
-        w->scrollAreas[scrollAreaIndex].flags |= ScrollFlags::hscrollbarLeftPressed;
-        w->scrollAreas[scrollAreaIndex].contentOffsetX = std::max(w->scrollAreas[scrollAreaIndex].contentOffsetX - buttonClickStep, 0);
+        w.scrollAreas[scrollAreaIndex].flags |= ScrollFlags::hscrollbarLeftPressed;
+        w.scrollAreas[scrollAreaIndex].contentOffsetX = std::max(w.scrollAreas[scrollAreaIndex].contentOffsetX - buttonClickStep, 0);
         ScrollView::updateThumbs(w, widgetIndex);
-        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+        WindowManager::invalidateWidget(w.type, w.number, widgetIndex);
     }
 
     // 0x004C89AE
-    static void hButtonRight(Ui::Window* const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
+    static void hButtonRight(Ui::Window& const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
     {
-        w->scrollAreas[scrollAreaIndex].flags |= ScrollFlags::hscrollbarRightPressed;
-        int16_t trackWidth = w->widgets[widgetIndex].width() - 2;
-        if ((w->scrollAreas[scrollAreaIndex].flags & ScrollFlags::vscrollbarVisible) != 0)
+        w.scrollAreas[scrollAreaIndex].flags |= ScrollFlags::hscrollbarRightPressed;
+        int16_t trackWidth = w.widgets[widgetIndex].width() - 2;
+        if ((w.scrollAreas[scrollAreaIndex].flags & ScrollFlags::vscrollbarVisible) != 0)
         {
             trackWidth -= barWidth;
         }
-        int16_t widgetContentWidth = std::max(w->scrollAreas[scrollAreaIndex].contentWidth - trackWidth, 0);
-        w->scrollAreas[scrollAreaIndex].contentOffsetX = std::min<int16_t>(w->scrollAreas[scrollAreaIndex].contentOffsetX + buttonClickStep, widgetContentWidth);
+        int16_t widgetContentWidth = std::max(w.scrollAreas[scrollAreaIndex].contentWidth - trackWidth, 0);
+        w.scrollAreas[scrollAreaIndex].contentOffsetX = std::min<int16_t>(w.scrollAreas[scrollAreaIndex].contentOffsetX + buttonClickStep, widgetContentWidth);
         ScrollView::updateThumbs(w, widgetIndex);
-        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+        WindowManager::invalidateWidget(w.type, w.number, widgetIndex);
     }
 
     // 0x004C8A36
-    static void hTrackLeft(Ui::Window* const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
+    static void hTrackLeft(Ui::Window& const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
     {
-        int16_t trackWidth = w->widgets[widgetIndex].width() - 2;
-        if ((w->scrollAreas[scrollAreaIndex].flags & ScrollFlags::vscrollbarVisible) != 0)
+        int16_t trackWidth = w.widgets[widgetIndex].width() - 2;
+        if ((w.scrollAreas[scrollAreaIndex].flags & ScrollFlags::vscrollbarVisible) != 0)
         {
             trackWidth -= barWidth;
         }
-        w->scrollAreas[scrollAreaIndex].contentOffsetX = std::max(w->scrollAreas[scrollAreaIndex].contentOffsetX - trackWidth, 0);
+        w.scrollAreas[scrollAreaIndex].contentOffsetX = std::max(w.scrollAreas[scrollAreaIndex].contentOffsetX - trackWidth, 0);
         ScrollView::updateThumbs(w, widgetIndex);
-        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+        WindowManager::invalidateWidget(w.type, w.number, widgetIndex);
     }
 
     // 0x004C8AA6
-    static void hTrackRight(Ui::Window* const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
+    static void hTrackRight(Ui::Window& const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
     {
-        int16_t trackWidth = w->widgets[widgetIndex].width() - 2;
-        if ((w->scrollAreas[scrollAreaIndex].flags & ScrollFlags::vscrollbarVisible) != 0)
+        int16_t trackWidth = w.widgets[widgetIndex].width() - 2;
+        if ((w.scrollAreas[scrollAreaIndex].flags & ScrollFlags::vscrollbarVisible) != 0)
         {
             trackWidth -= barWidth;
         }
-        int16_t widgetContentWidth = std::max(w->scrollAreas[scrollAreaIndex].contentWidth - trackWidth, 0);
-        w->scrollAreas[scrollAreaIndex].contentOffsetX = std::min<int16_t>(w->scrollAreas[scrollAreaIndex].contentOffsetX + trackWidth, widgetContentWidth);
+        int16_t widgetContentWidth = std::max(w.scrollAreas[scrollAreaIndex].contentWidth - trackWidth, 0);
+        w.scrollAreas[scrollAreaIndex].contentOffsetX = std::min<int16_t>(w.scrollAreas[scrollAreaIndex].contentOffsetX + trackWidth, widgetContentWidth);
         ScrollView::updateThumbs(w, widgetIndex);
-        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+        WindowManager::invalidateWidget(w.type, w.number, widgetIndex);
     }
 
-    void verticalNudgeUp(Ui::Window* const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
+    void verticalNudgeUp(Ui::Window& const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
     {
-        w->scrollAreas[scrollAreaIndex].contentOffsetY = std::max(w->scrollAreas[scrollAreaIndex].contentOffsetY - buttonClickStep, 0);
+        w.scrollAreas[scrollAreaIndex].contentOffsetY = std::max(w.scrollAreas[scrollAreaIndex].contentOffsetY - buttonClickStep, 0);
         ScrollView::updateThumbs(w, widgetIndex);
-        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+        WindowManager::invalidateWidget(w.type, w.number, widgetIndex);
     }
 
     // 0x004C8B26
-    static void vButtonTop(Ui::Window* const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
+    static void vButtonTop(Ui::Window& const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
     {
-        w->scrollAreas[scrollAreaIndex].flags |= ScrollFlags::vscrollbarUpPressed;
+        w.scrollAreas[scrollAreaIndex].flags |= ScrollFlags::vscrollbarUpPressed;
         verticalNudgeUp(w, scrollAreaIndex, widgetIndex);
     }
 
-    void verticalNudgeDown(Ui::Window* const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
+    void verticalNudgeDown(Ui::Window& const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
     {
-        int16_t trackHeight = w->widgets[widgetIndex].height() - 2;
-        if ((w->scrollAreas[scrollAreaIndex].flags & ScrollFlags::hscrollbarVisible) != 0)
+        int16_t trackHeight = w.widgets[widgetIndex].height() - 2;
+        if ((w.scrollAreas[scrollAreaIndex].flags & ScrollFlags::hscrollbarVisible) != 0)
         {
             trackHeight -= barWidth;
         }
-        int16_t widgetContentHeight = std::max(w->scrollAreas[scrollAreaIndex].contentHeight - trackHeight, 0);
-        w->scrollAreas[scrollAreaIndex].contentOffsetY = std::min<int16_t>(w->scrollAreas[scrollAreaIndex].contentOffsetY + buttonClickStep, widgetContentHeight);
+        int16_t widgetContentHeight = std::max(w.scrollAreas[scrollAreaIndex].contentHeight - trackHeight, 0);
+        w.scrollAreas[scrollAreaIndex].contentOffsetY = std::min<int16_t>(w.scrollAreas[scrollAreaIndex].contentOffsetY + buttonClickStep, widgetContentHeight);
         ScrollView::updateThumbs(w, widgetIndex);
-        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+        WindowManager::invalidateWidget(w.type, w.number, widgetIndex);
     }
 
     // 0x004C8B85
-    static void vButtonBottom(Ui::Window* const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
+    static void vButtonBottom(Ui::Window& const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
     {
-        w->scrollAreas[scrollAreaIndex].flags |= ScrollFlags::vscrollbarDownPressed;
+        w.scrollAreas[scrollAreaIndex].flags |= ScrollFlags::vscrollbarDownPressed;
         verticalNudgeDown(w, scrollAreaIndex, widgetIndex);
     }
 
     // 0x004C8C0D
-    static void vTrackTop(Ui::Window* const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
+    static void vTrackTop(Ui::Window& const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
     {
-        int16_t trackHeight = w->widgets[widgetIndex].height() - 2;
-        if ((w->scrollAreas[scrollAreaIndex].flags & ScrollFlags::hscrollbarVisible) != 0)
+        int16_t trackHeight = w.widgets[widgetIndex].height() - 2;
+        if ((w.scrollAreas[scrollAreaIndex].flags & ScrollFlags::hscrollbarVisible) != 0)
         {
             trackHeight -= barWidth;
         }
-        w->scrollAreas[scrollAreaIndex].contentOffsetY = std::max(w->scrollAreas[scrollAreaIndex].contentOffsetY - trackHeight, 0);
+        w.scrollAreas[scrollAreaIndex].contentOffsetY = std::max(w.scrollAreas[scrollAreaIndex].contentOffsetY - trackHeight, 0);
         ScrollView::updateThumbs(w, widgetIndex);
-        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+        WindowManager::invalidateWidget(w.type, w.number, widgetIndex);
     }
 
     // 0x004C8C7D
-    static void vTrackBottom(Ui::Window* const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
+    static void vTrackBottom(Ui::Window& const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex)
     {
-        int16_t trackHeight = w->widgets[widgetIndex].height() - 2;
-        if ((w->scrollAreas[scrollAreaIndex].flags & ScrollFlags::hscrollbarVisible) != 0)
+        int16_t trackHeight = w.widgets[widgetIndex].height() - 2;
+        if ((w.scrollAreas[scrollAreaIndex].flags & ScrollFlags::hscrollbarVisible) != 0)
         {
             trackHeight -= barWidth;
         }
-        int16_t widgetContentHeight = std::max(w->scrollAreas[scrollAreaIndex].contentHeight - trackHeight, 0);
-        w->scrollAreas[scrollAreaIndex].contentOffsetY = std::min<int16_t>(w->scrollAreas[scrollAreaIndex].contentOffsetY + trackHeight, widgetContentHeight);
+        int16_t widgetContentHeight = std::max(w.scrollAreas[scrollAreaIndex].contentHeight - trackHeight, 0);
+        w.scrollAreas[scrollAreaIndex].contentOffsetY = std::min<int16_t>(w.scrollAreas[scrollAreaIndex].contentOffsetY + trackHeight, widgetContentHeight);
         ScrollView::updateThumbs(w, widgetIndex);
-        WindowManager::invalidateWidget(w->type, w->number, widgetIndex);
+        WindowManager::invalidateWidget(w.type, w.number, widgetIndex);
     }
 
     // 0x004C8689
-    void scrollLeftBegin(const int16_t x, const int16_t y, Ui::Window* const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex)
+    void scrollLeftBegin(const int16_t x, const int16_t y, Ui::Window& const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex)
     {
         auto res = getPart(w, widget, x, y);
 
@@ -426,11 +426,11 @@ namespace OpenLoco::Ui::ScrollView
         setCurrentScrollIndex(res.index);
 
         // Not implemented for any window
-        // window->call_22()
+        // window.call_22()
         switch (res.area)
         {
             case Ui::ScrollView::ScrollPart::view:
-                w->callScrollMouseDown(res.scrollviewLoc.x, res.scrollviewLoc.y, static_cast<uint8_t>(res.index));
+                w.callScrollMouseDown(res.scrollviewLoc.x, res.scrollviewLoc.y, static_cast<uint8_t>(res.index));
                 break;
             case Ui::ScrollView::ScrollPart::hscrollbarButtonLeft:
                 hButtonLeft(w, res.index, widgetIndex);
@@ -462,7 +462,7 @@ namespace OpenLoco::Ui::ScrollView
     }
 
     // Based on 0x004C8689
-    void scrollModalRight(const int16_t x, const int16_t y, Ui::Window* const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex)
+    void scrollModalRight(const int16_t x, const int16_t y, Ui::Window& const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex)
     {
         auto res = getPart(w, widget, x, y);
 
@@ -471,7 +471,7 @@ namespace OpenLoco::Ui::ScrollView
 
         if (res.area == Ui::ScrollView::ScrollPart::view)
         {
-            w->callScrollMouseDown(res.scrollviewLoc.x, res.scrollviewLoc.y, static_cast<uint8_t>(res.index));
+            w.callScrollMouseDown(res.scrollviewLoc.x, res.scrollviewLoc.y, static_cast<uint8_t>(res.index));
         }
     }
 
@@ -487,12 +487,12 @@ namespace OpenLoco::Ui::ScrollView
         constexpr uint16_t horizontalFlags = ScrollFlags::hscrollbarThumbPressed | ScrollFlags::hscrollbarLeftPressed | ScrollFlags::hscrollbarRightPressed;
         constexpr uint16_t verticalFlags = ScrollFlags::vscrollbarThumbPressed | ScrollFlags::vscrollbarUpPressed | ScrollFlags::vscrollbarDownPressed;
 
-        window->scrollAreas[scrollAreaIndex].flags &= ~(verticalFlags | horizontalFlags);
+        window.scrollAreas[scrollAreaIndex].flags &= ~(verticalFlags | horizontalFlags);
         WindowManager::invalidateWidget(type, number, widgetIndex);
     }
 
     // 0x004C7236
-    void scrollLeftContinue(const int16_t x, const int16_t y, Ui::Window* const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex)
+    void scrollLeftContinue(const int16_t x, const int16_t y, Ui::Window& const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex)
     {
         auto scrollIndex = getCurrentScrollIndex();
         if (_currentScrollArea == ScrollView::ScrollPart::hscrollbarThumb)
@@ -516,14 +516,14 @@ namespace OpenLoco::Ui::ScrollView
             auto res = getPart(w, widget, x, y);
             if (res.area != _currentScrollArea)
             {
-                clearPressedButtons(w->type, w->number, widgetIndex);
+                clearPressedButtons(w.type, w.number, widgetIndex);
                 return;
             }
 
             switch (res.area)
             {
                 case ScrollPart::view: // 0x004C729A
-                    w->callScrollMouseDrag(res.scrollviewLoc.x, res.scrollviewLoc.y, static_cast<uint8_t>(res.index));
+                    w.callScrollMouseDrag(res.scrollviewLoc.x, res.scrollviewLoc.y, static_cast<uint8_t>(res.index));
                     break;
 
                 case ScrollPart::hscrollbarButtonLeft:

--- a/src/OpenLoco/Ui/ScrollView.h
+++ b/src/OpenLoco/Ui/ScrollView.h
@@ -43,14 +43,14 @@ namespace OpenLoco::Ui::ScrollView
         ScrollPart area;
         size_t index;
     };
-    GetPartResult getPart(Ui::Window* window, Ui::Widget* widget, int16_t x, int16_t y);
-    void updateThumbs(Window* window, WidgetIndex_t widgetIndex);
-    void scrollLeftBegin(const int16_t x, const int16_t y, Ui::Window* const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex);
-    void scrollLeftContinue(const int16_t x, const int16_t y, Ui::Window* const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex);
-    void scrollModalRight(const int16_t x, const int16_t y, Ui::Window* const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex);
+    GetPartResult getPart(Ui::Window& window, Ui::Widget* widget, int16_t x, int16_t y);
+    void updateThumbs(Window& window, WidgetIndex_t widgetIndex);
+    void scrollLeftBegin(const int16_t x, const int16_t y, Ui::Window& const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex);
+    void scrollLeftContinue(const int16_t x, const int16_t y, Ui::Window& const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex);
+    void scrollModalRight(const int16_t x, const int16_t y, Ui::Window& const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex);
     void clearPressedButtons(const WindowType type, const WindowNumber_t number, const WidgetIndex_t widgetIndex);
-    void horizontalDragFollow(Ui::Window* const w, Ui::Widget* const widget, const WidgetIndex_t dragWidgetIndex, const size_t dragScrollIndex, const int16_t deltaX);
-    void verticalDragFollow(Ui::Window* const w, Ui::Widget* const widget, const WidgetIndex_t dragWidgetIndex, const size_t dragScrollIndex, const int16_t deltaY);
-    void verticalNudgeUp(Ui::Window* const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex);
-    void verticalNudgeDown(Ui::Window* const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex);
+    void horizontalDragFollow(Ui::Window& const w, Ui::Widget* const widget, const WidgetIndex_t dragWidgetIndex, const size_t dragScrollIndex, const int16_t deltaX);
+    void verticalDragFollow(Ui::Window& const w, Ui::Widget* const widget, const WidgetIndex_t dragWidgetIndex, const size_t dragScrollIndex, const int16_t deltaY);
+    void verticalNudgeUp(Ui::Window& const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex);
+    void verticalNudgeDown(Ui::Window& const w, const size_t scrollAreaIndex, const WidgetIndex_t widgetIndex);
 }

--- a/src/OpenLoco/Windows/Cheats.cpp
+++ b/src/OpenLoco/Windows/Cheats.cpp
@@ -52,7 +52,7 @@ namespace OpenLoco::Ui::Windows::Cheats
 
         constexpr uint64_t enabledWidgets = (1 << Widx::close_button) | (1 << Widx::tab_finances) | (1 << Widx::tab_companies) | (1 << Widx::tab_vehicles) | (1 << Widx::tab_towns);
 
-        static void drawTabs(Ui::Window* const self, Gfx::RenderTarget* const rt)
+        static void drawTabs(Ui::Window& const self, Gfx::RenderTarget* const rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
@@ -78,8 +78,8 @@ namespace OpenLoco::Ui::Windows::Cheats
                 };
 
                 uint32_t imageId = skin->img;
-                if (self->currentTab == Widx::tab_finances - Widx::tab_finances)
-                    imageId += financesTabImageIds[(self->frameNo / 2) % std::size(financesTabImageIds)];
+                if (self.currentTab == Widx::tab_finances - Widx::tab_finances)
+                    imageId += financesTabImageIds[(self.frameNo / 2) % std::size(financesTabImageIds)];
                 else
                     imageId += financesTabImageIds[0];
 
@@ -106,8 +106,8 @@ namespace OpenLoco::Ui::Windows::Cheats
                 };
 
                 uint32_t imageId = skin->img;
-                if (self->currentTab == Widx::tab_vehicles - Widx::tab_finances)
-                    imageId += vehiclesTabImageIds[(self->frameNo / 2) % std::size(vehiclesTabImageIds)];
+                if (self.currentTab == Widx::tab_vehicles - Widx::tab_finances)
+                    imageId += vehiclesTabImageIds[(self.frameNo / 2) % std::size(vehiclesTabImageIds)];
                 else
                     imageId += vehiclesTabImageIds[0];
 
@@ -126,7 +126,7 @@ namespace OpenLoco::Ui::Windows::Cheats
             }
         }
 
-        static void switchTab(Window* self, WidgetIndex_t widgetIndex);
+        static void switchTab(Window& self, WidgetIndex_t widgetIndex);
     }
 
     namespace Finances
@@ -848,7 +848,7 @@ namespace OpenLoco::Ui::Windows::Cheats
 
     static void initEvents();
 
-    Window* open()
+    Window& open()
     {
         auto window = WindowManager::bringToFront(WindowType::cheats);
         if (window != nullptr)
@@ -896,28 +896,28 @@ namespace OpenLoco::Ui::Windows::Cheats
         };
         // clang-format on
 
-        static void switchTab(Window* self, WidgetIndex_t widgetIndex)
+        static void switchTab(Window& self, WidgetIndex_t widgetIndex)
         {
-            self->currentTab = widgetIndex - Widx::tab_finances;
-            self->frameNo = 0;
+            self.currentTab = widgetIndex - Widx::tab_finances;
+            self.frameNo = 0;
 
-            auto tabInfo = tabInformationByTabOffset[self->currentTab];
+            auto tabInfo = tabInformationByTabOffset[self.currentTab];
 
-            self->enabledWidgets = *tabInfo.enabledWidgets;
-            self->holdableWidgets = tabInfo.holdableWidgets != nullptr ? *tabInfo.holdableWidgets : 0;
-            self->eventHandlers = tabInfo.events;
-            self->activatedWidgets = 0;
-            self->widgets = tabInfo.widgets;
-            self->disabledWidgets = 0;
+            self.enabledWidgets = *tabInfo.enabledWidgets;
+            self.holdableWidgets = tabInfo.holdableWidgets != nullptr ? *tabInfo.holdableWidgets : 0;
+            self.eventHandlers = tabInfo.events;
+            self.activatedWidgets = 0;
+            self.widgets = tabInfo.widgets;
+            self.disabledWidgets = 0;
 
-            self->invalidate();
+            self.invalidate();
 
-            self->setSize(tabInfo.kWindowSize);
-            self->callOnResize();
-            self->callPrepareDraw();
-            self->initScrollWidgets();
-            self->invalidate();
-            self->moveInsideScreenEdges();
+            self.setSize(tabInfo.kWindowSize);
+            self.callOnResize();
+            self.callPrepareDraw();
+            self.initScrollWidgets();
+            self.invalidate();
+            self.moveInsideScreenEdges();
         }
     }
 

--- a/src/OpenLoco/Windows/CompanyList.cpp
+++ b/src/OpenLoco/Windows/CompanyList.cpp
@@ -89,11 +89,11 @@ namespace OpenLoco::Ui::Windows::CompanyList
         static void onMouseUp(Window& self, WidgetIndex_t widgetIndex);
         static void onUpdate(Window& self);
         static void prepareDraw(Window& self);
-        static void switchTab(Window* self, WidgetIndex_t widgetIndex);
-        static void refreshCompanyList(Window* self);
-        static void drawTabs(Window* self, Gfx::RenderTarget* rt);
-        static void drawGraph(Window* self, Gfx::RenderTarget* rt);
-        static void drawGraphAndLegend(Window* self, Gfx::RenderTarget* rt);
+        static void switchTab(Window& self, WidgetIndex_t widgetIndex);
+        static void refreshCompanyList(Window& self);
+        static void drawTabs(Window& self, Gfx::RenderTarget* rt);
+        static void drawGraph(Window& self, Gfx::RenderTarget* rt);
+        static void drawGraphAndLegend(Window& self, Gfx::RenderTarget* rt);
         static void initEvents();
     }
 
@@ -251,7 +251,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00437AE2
-        static void updateCompanyList(Window* self)
+        static void updateCompanyList(Window& self)
         {
             CompanyId chosenCompany = CompanyId::null;
 
@@ -266,7 +266,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     continue;
                 }
 
-                if (getOrder(SortMode(self->sortMode), company, *CompanyManager::get(chosenCompany)))
+                if (getOrder(SortMode(self.sortMode), company, *CompanyManager::get(chosenCompany)))
                 {
                     chosenCompany = company.id();
                 }
@@ -278,30 +278,30 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 CompanyManager::get(chosenCompany)->challengeFlags |= CompanyFlags::sorted;
 
-                if (chosenCompany != CompanyId(self->rowInfo[self->rowCount]))
+                if (chosenCompany != CompanyId(self.rowInfo[self.rowCount]))
                 {
-                    self->rowInfo[self->rowCount] = enumValue(chosenCompany);
+                    self.rowInfo[self.rowCount] = enumValue(chosenCompany);
                     shouldInvalidate = true;
                 }
 
-                self->rowCount++;
-                if (self->rowCount > self->var_83C)
+                self.rowCount++;
+                if (self.rowCount > self.var_83C)
                 {
-                    self->var_83C = self->rowCount;
+                    self.var_83C = self.rowCount;
                     shouldInvalidate = true;
                 }
 
                 if (shouldInvalidate)
                 {
-                    self->invalidate();
+                    self.invalidate();
                 }
             }
             else
             {
-                if (self->var_83C != self->rowCount)
+                if (self.var_83C != self.rowCount)
                 {
-                    self->var_83C = self->rowCount;
-                    self->invalidate();
+                    self.var_83C = self.rowCount;
+                    self.invalidate();
                 }
 
                 Common::refreshCompanyList(self);
@@ -537,16 +537,16 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00436198
-        static void tabReset(Window* self)
+        static void tabReset(Window& self)
         {
-            self->minWidth = kMinWindowSize.width;
-            self->minHeight = kMinWindowSize.height;
-            self->maxWidth = kMaxWindowSize.width;
-            self->maxHeight = kMaxWindowSize.height;
-            self->width = kWindowSize.width;
-            self->height = kWindowSize.height;
-            self->var_83C = 0;
-            self->rowHover = -1;
+            self.minWidth = kMinWindowSize.width;
+            self.minHeight = kMinWindowSize.height;
+            self.maxWidth = kMaxWindowSize.width;
+            self.maxHeight = kMaxWindowSize.height;
+            self.width = kWindowSize.width;
+            self.height = kWindowSize.height;
+            self.var_83C = 0;
+            self.rowHover = -1;
             Common::refreshCompanyList(self);
         }
 
@@ -569,7 +569,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
     }
 
     // 0x00435BC8
-    Window* open()
+    Window& open()
     {
         auto window = WindowManager::bringToFront(WindowType::companyList);
 
@@ -702,14 +702,14 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x004361D8
-        static void tabReset(Window* self)
+        static void tabReset(Window& self)
         {
-            self->minWidth = kWindowSize.width;
-            self->minHeight = kWindowSize.height;
-            self->maxWidth = kWindowSize.width;
-            self->maxHeight = kWindowSize.height;
-            self->width = kWindowSize.width;
-            self->height = kWindowSize.height;
+            self.minWidth = kWindowSize.width;
+            self.minHeight = kWindowSize.height;
+            self.maxWidth = kWindowSize.width;
+            self.maxHeight = kWindowSize.height;
+            self.width = kWindowSize.width;
+            self.height = kWindowSize.height;
         }
 
         static void initEvents()
@@ -793,14 +793,14 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00436201
-        static void tabReset(Window* self)
+        static void tabReset(Window& self)
         {
-            self->minWidth = kWindowSize.width;
-            self->minHeight = kWindowSize.height;
-            self->maxWidth = kWindowSize.width;
-            self->maxHeight = kWindowSize.height;
-            self->width = kWindowSize.width;
-            self->height = kWindowSize.height;
+            self.minWidth = kWindowSize.width;
+            self.minHeight = kWindowSize.height;
+            self.maxWidth = kWindowSize.width;
+            self.maxHeight = kWindowSize.height;
+            self.width = kWindowSize.width;
+            self.height = kWindowSize.height;
         }
 
         static void initEvents()
@@ -884,14 +884,14 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00436227
-        static void tabReset(Window* self)
+        static void tabReset(Window& self)
         {
-            self->minWidth = kWindowSize.width;
-            self->minHeight = kWindowSize.height;
-            self->maxWidth = kWindowSize.width;
-            self->maxHeight = kWindowSize.height;
-            self->width = kWindowSize.width;
-            self->height = kWindowSize.height;
+            self.minWidth = kWindowSize.width;
+            self.minHeight = kWindowSize.height;
+            self.maxWidth = kWindowSize.width;
+            self.maxHeight = kWindowSize.height;
+            self.width = kWindowSize.width;
+            self.height = kWindowSize.height;
         }
 
         static void initEvents()
@@ -975,14 +975,14 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x0043624D
-        static void tabReset(Window* self)
+        static void tabReset(Window& self)
         {
-            self->minWidth = kWindowSize.width;
-            self->minHeight = kWindowSize.height;
-            self->maxWidth = kWindowSize.width;
-            self->maxHeight = kWindowSize.height;
-            self->width = kWindowSize.width;
-            self->height = kWindowSize.height;
+            self.minWidth = kWindowSize.width;
+            self.minHeight = kWindowSize.height;
+            self.maxWidth = kWindowSize.width;
+            self.maxHeight = kWindowSize.height;
+            self.width = kWindowSize.width;
+            self.height = kWindowSize.height;
         }
 
         static void initEvents()
@@ -1015,7 +1015,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00437949
-        static void drawGraphLegend(Window* self, Gfx::RenderTarget* rt, int16_t x, int16_t y)
+        static void drawGraphLegend(Window& self, Gfx::RenderTarget* rt, int16_t x, int16_t y)
         {
             auto cargoCount = 0;
             for (uint8_t i = 0; i < ObjectManager::getMaxObjects(ObjectType::cargo); i++)
@@ -1028,12 +1028,12 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 auto palette = Colours::getShade(colour, 6);
                 auto stringId = StringIds::small_black_string;
 
-                if (self->var_854 & (1 << cargoCount))
+                if (self.var_854 & (1 << cargoCount))
                 {
                     stringId = StringIds::small_white_string;
                 }
 
-                if (!(self->var_854 & (1 << cargoCount)) || !(_word_9C68C7 & (1 << 2)))
+                if (!(self.var_854 & (1 << cargoCount)) || !(_word_9C68C7 & (1 << 2)))
                 {
                     Gfx::fillRect(*rt, x, y + 3, x + 4, y + 7, palette);
                 }
@@ -1135,7 +1135,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x004379F2
-        static void setLegendHover(Window* self, int16_t x, int16_t y)
+        static void setLegendHover(Window& self, int16_t x, int16_t y)
         {
             uint32_t selectedCargo = 0;
             if (!Input::hasFlag(Input::Flags::flag5))
@@ -1164,27 +1164,27 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     }
                 }
             }
-            if (self->var_854 != selectedCargo)
+            if (self.var_854 != selectedCargo)
             {
                 // TODO: var_854 is 16 bits but selectedCargo is 32 bits. Only the first 15 cargo types can be selected.
-                self->var_854 = selectedCargo;
-                self->invalidate();
+                self.var_854 = selectedCargo;
+                self.invalidate();
             }
-            if (self->var_854 != 0)
+            if (self.var_854 != 0)
             {
-                self->invalidate();
+                self.invalidate();
             }
         }
 
         // 0x00436273
-        static void tabReset(Window* self)
+        static void tabReset(Window& self)
         {
-            self->minWidth = kWindowSize.width;
-            self->minHeight = kWindowSize.height;
-            self->maxWidth = kWindowSize.width;
-            self->maxHeight = kWindowSize.height;
-            self->width = kWindowSize.width;
-            self->height = kWindowSize.height;
+            self.minWidth = kWindowSize.width;
+            self.minHeight = kWindowSize.height;
+            self.maxWidth = kWindowSize.width;
+            self.maxHeight = kWindowSize.height;
+            self.width = kWindowSize.width;
+            self.height = kWindowSize.height;
             Economy::buildDeliveredCargoPaymentsTable();
         }
 
@@ -1326,7 +1326,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x004378BA
-        static void setLegendHover(Window* self, int16_t x, int16_t y)
+        static void setLegendHover(Window& self, int16_t x, int16_t y)
         {
             uint32_t selectedCompany = 0;
             if (!Input::hasFlag(Input::Flags::flag5))
@@ -1349,14 +1349,14 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     }
                 }
             }
-            if (self->var_854 != selectedCompany)
+            if (self.var_854 != selectedCompany)
             {
-                self->var_854 = selectedCompany;
-                self->invalidate();
+                self.var_854 = selectedCompany;
+                self.invalidate();
             }
-            if (self->var_854 != 0)
+            if (self.var_854 != 0)
             {
-                self->invalidate();
+                self.invalidate();
             }
         }
 
@@ -1420,26 +1420,26 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x004360FA
-        static void switchTab(Window* self, WidgetIndex_t widgetIndex)
+        static void switchTab(Window& self, WidgetIndex_t widgetIndex)
         {
-            if (Input::isToolActive(self->type, self->number))
+            if (Input::isToolActive(self.type, self.number))
                 Input::toolCancel();
 
-            self->currentTab = widgetIndex - widx::tab_company_list;
-            self->frameNo = 0;
-            self->flags &= ~(WindowFlags::flag_16);
+            self.currentTab = widgetIndex - widx::tab_company_list;
+            self.frameNo = 0;
+            self.flags &= ~(WindowFlags::flag_16);
 
-            self->viewportRemove(0);
+            self.viewportRemove(0);
 
             const auto& tabInfo = tabInformationByTabOffset[widgetIndex - widx::tab_company_list];
 
-            self->enabledWidgets = tabInfo.enabledWidgets;
-            self->holdableWidgets = 0;
-            self->eventHandlers = tabInfo.events;
-            self->activatedWidgets = 0;
-            self->widgets = tabInfo.widgets;
+            self.enabledWidgets = tabInfo.enabledWidgets;
+            self.holdableWidgets = 0;
+            self.eventHandlers = tabInfo.events;
+            self.activatedWidgets = 0;
+            self.widgets = tabInfo.widgets;
 
-            self->invalidate();
+            self.invalidate();
 
             switch (widgetIndex)
             {
@@ -1463,15 +1463,15 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     break;
             }
 
-            self->callOnResize();
-            self->callPrepareDraw();
-            self->initScrollWidgets();
-            self->invalidate();
-            self->moveInsideScreenEdges();
+            self.callOnResize();
+            self.callPrepareDraw();
+            self.initScrollWidgets();
+            self.invalidate();
+            self.moveInsideScreenEdges();
         }
 
         // 0x00437637
-        static void drawTabs(Window* self, Gfx::RenderTarget* rt)
+        static void drawTabs(Window& self, Gfx::RenderTarget* rt)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
@@ -1497,12 +1497,12 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 };
 
                 uint32_t imageId = skin->img;
-                if (self->currentTab == widx::tab_performance - widx::tab_company_list)
-                    imageId += performanceImageIds[(self->frameNo / 4) % std::size(performanceImageIds)];
+                if (self.currentTab == widx::tab_performance - widx::tab_company_list)
+                    imageId += performanceImageIds[(self.frameNo / 4) % std::size(performanceImageIds)];
                 else
                     imageId += performanceImageIds[0];
 
-                imageId = Gfx::recolour(imageId, self->getColour(WindowColour::secondary).c());
+                imageId = Gfx::recolour(imageId, self.getColour(WindowColour::secondary).c());
 
                 Widget::drawTab(self, rt, imageId, widx::tab_performance);
             }
@@ -1521,12 +1521,12 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 };
 
                 uint32_t imageId = skin->img;
-                if (self->currentTab == widx::tab_cargo_units - widx::tab_company_list)
-                    imageId += cargoUnitsImageIds[(self->frameNo / 4) % std::size(cargoUnitsImageIds)];
+                if (self.currentTab == widx::tab_cargo_units - widx::tab_company_list)
+                    imageId += cargoUnitsImageIds[(self.frameNo / 4) % std::size(cargoUnitsImageIds)];
                 else
                     imageId += cargoUnitsImageIds[0];
 
-                imageId = Gfx::recolour(imageId, self->getColour(WindowColour::secondary).c());
+                imageId = Gfx::recolour(imageId, self.getColour(WindowColour::secondary).c());
 
                 Widget::drawTab(self, rt, imageId, widx::tab_cargo_units);
             }
@@ -1545,12 +1545,12 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 };
 
                 uint32_t imageId = skin->img;
-                if (self->currentTab == widx::tab_cargo_distance - widx::tab_company_list)
-                    imageId += cargoDistanceImageIds[(self->frameNo / 4) % std::size(cargoDistanceImageIds)];
+                if (self.currentTab == widx::tab_cargo_distance - widx::tab_company_list)
+                    imageId += cargoDistanceImageIds[(self.frameNo / 4) % std::size(cargoDistanceImageIds)];
                 else
                     imageId += cargoDistanceImageIds[0];
 
-                imageId = Gfx::recolour(imageId, self->getColour(WindowColour::secondary).c());
+                imageId = Gfx::recolour(imageId, self.getColour(WindowColour::secondary).c());
 
                 Widget::drawTab(self, rt, imageId, widx::tab_cargo_distance);
             }
@@ -1569,19 +1569,19 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 };
 
                 uint32_t imageId = skin->img;
-                if (self->currentTab == widx::tab_values - widx::tab_company_list)
-                    imageId += companyValuesImageIds[(self->frameNo / 4) % std::size(companyValuesImageIds)];
+                if (self.currentTab == widx::tab_values - widx::tab_company_list)
+                    imageId += companyValuesImageIds[(self.frameNo / 4) % std::size(companyValuesImageIds)];
                 else
                     imageId += companyValuesImageIds[0];
 
-                imageId = Gfx::recolour(imageId, self->getColour(WindowColour::secondary).c());
+                imageId = Gfx::recolour(imageId, self.getColour(WindowColour::secondary).c());
 
                 Widget::drawTab(self, rt, imageId, widx::tab_values);
 
-                if (!(self->isDisabled(widx::tab_values)))
+                if (!(self.isDisabled(widx::tab_values)))
                 {
-                    auto x = self->widgets[widx::tab_values].left + self->x + 28;
-                    auto y = self->widgets[widx::tab_values].top + self->y + 14 + 1;
+                    auto x = self.widgets[widx::tab_values].left + self.x + 28;
+                    auto y = self.widgets[widx::tab_values].top + self.y + 14 + 1;
                     Gfx::drawStringRight(*rt, x, y, Colour::black, StringIds::currency_symbol);
                 }
             }
@@ -1594,10 +1594,10 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 Widget::drawTab(self, rt, imageId, widx::tab_payment_rates);
 
-                if (!(self->isDisabled(widx::tab_payment_rates)))
+                if (!(self.isDisabled(widx::tab_payment_rates)))
                 {
-                    auto x = self->widgets[widx::tab_payment_rates].left + self->x + 28;
-                    auto y = self->widgets[widx::tab_payment_rates].top + self->y + 14 + 1;
+                    auto x = self.widgets[widx::tab_payment_rates].left + self.x + 28;
+                    auto y = self.widgets[widx::tab_payment_rates].top + self.y + 14 + 1;
                     Gfx::drawStringRight(*rt, x, y, Colour::black, StringIds::currency_symbol);
                 }
             }
@@ -1607,16 +1607,16 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 uint32_t imageId = skin->img;
                 imageId += InterfaceSkin::ImageIds::tab_awards;
 
-                imageId = Gfx::recolour(imageId, self->getColour(WindowColour::secondary).c());
+                imageId = Gfx::recolour(imageId, self.getColour(WindowColour::secondary).c());
 
                 Widget::drawTab(self, rt, imageId, widx::tab_speed_records);
             }
         }
 
         // 0x00437AB6
-        static void refreshCompanyList(Window* self)
+        static void refreshCompanyList(Window& self)
         {
-            self->rowCount = 0;
+            self.rowCount = 0;
 
             for (auto& company : CompanyManager::companies())
             {
@@ -1625,7 +1625,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x004CF824
-        static void drawGraph(Window* self, Gfx::RenderTarget* rt)
+        static void drawGraph(Window& self, Gfx::RenderTarget* rt)
         {
             registers regs;
             regs.esi = X86Pointer(self);
@@ -1634,7 +1634,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00437810
-        static void drawGraphLegend(Window* self, Gfx::RenderTarget* rt, int16_t x, int16_t y)
+        static void drawGraphLegend(Window& self, Gfx::RenderTarget* rt, int16_t x, int16_t y)
         {
             auto companyCount = 0;
             for (auto& company : CompanyManager::companies())
@@ -1643,12 +1643,12 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 auto colour = Colours::getShade(companyColour, 6);
                 auto stringId = StringIds::small_black_string;
 
-                if (self->var_854 & (1 << companyCount))
+                if (self.var_854 & (1 << companyCount))
                 {
                     stringId = StringIds::small_white_string;
                 }
 
-                if (!(self->var_854 & (1 << companyCount)) || !(_word_9C68C7 & (1 << 2)))
+                if (!(self.var_854 & (1 << companyCount)) || !(_word_9C68C7 & (1 << 2)))
                 {
                     Gfx::fillRect(*rt, x, y + 3, x + 4, y + 7, colour);
                 }
@@ -1664,7 +1664,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x004365E4
-        static void drawGraphAndLegend(Window* self, Gfx::RenderTarget* rt)
+        static void drawGraphAndLegend(Window& self, Gfx::RenderTarget* rt)
         {
             auto totalMonths = (getCurrentYear() * 12) + static_cast<uint16_t>(getCurrentMonth());
 
@@ -1674,10 +1674,10 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             Common::drawGraph(self, rt);
 
-            if (self->var_854 != 0)
+            if (self.var_854 != 0)
             {
                 auto i = 0;
-                auto bitScan = Utility::bitScanForward(self->var_854);
+                auto bitScan = Utility::bitScanForward(self.var_854);
                 while (bitScan != _graphItemId[i] && bitScan != -1)
                 {
                     i++;
@@ -1693,8 +1693,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 Common::drawGraph(self, rt);
             }
 
-            auto x = self->width + self->x - 104;
-            auto y = self->y + 52;
+            auto x = self.width + self.x - 104;
+            auto y = self.y + 52;
 
             Common::drawGraphLegend(self, rt, x, y);
         }


### PR DESCRIPTION
This is in reference to Issue #1590 which is for the refactoring of window functions to utilize references as opposed to pointers. Once discovering that many of these conversions have already been made, I decided to review any sub functions that are taking in window pointers. I changed a total of 5 files to use window references instead of pointers. These files are:
- ShortcutManager.cpp
- ScrollView.cpp
- ScrollView.h
- Cheats.cpp
- CompanyList.cpp