### PR TITLE
Add giant screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 22.09+ (???)
 ------------------------------------------------------------------------
 - Feature: [#1608] Added character limit label in text input windows.
-- Feature: [#1666] Allow the saving of giant (full-map) screenshots.
+- Feature: [#1666] Allow saving giant (full map) screenshots.
 - Change: [#1623] Title screen music volume is now bound to the music volume setting.
 - Fix: [#1237] Long entity (company) names may be cut-off incorrectly.
 - Fix: [#1650] Acquire all company assets cheat may cause some trains and trams to crash.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 22.09+ (???)
 ------------------------------------------------------------------------
 - Feature: [#1608] Added character limit label in text input windows.
+- Feature: [#1666] Allow the saving of giant (full-map) screenshots.
 - Change: [#1623] Title screen music volume is now bound to the music volume setting.
 - Fix: [#1237] Long entity (company) names may be cut-off incorrectly.
 - Fix: [#1650] Acquire all company assets cheat may cause some trains and trams to crash.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2316,3 +2316,4 @@ strings:
   2261: "{NEWLINE}{COLOUR WINDOW_2} Length: {COLOUR BLACK}{INT32_1DP} tile(s)"
   2262: "{NEWLINE}Length:  {INT32_1DP} tile(s)"
   2263: "{COLOUR WINDOW_2}{UINT16}/{UINT16}"
+  2264: "Giant screenshot"

--- a/src/OpenLoco/Input.h
+++ b/src/OpenLoco/Input.h
@@ -102,6 +102,8 @@ namespace OpenLoco::Input
     void setMapSelectionFlags(uint8_t flags);
     void resetMapSelectionFlag(uint8_t flags);
 
+    void triggerScreenshotCountdown(int8_t numTicks, uint8_t type);
+
     void handleKeyboard();
     void handleMouse(int16_t x, int16_t y, MouseButton button);
     MouseButton getLastKnownButtonState();

--- a/src/OpenLoco/Input.h
+++ b/src/OpenLoco/Input.h
@@ -29,6 +29,13 @@ namespace OpenLoco::Input
         scrollRight,       // 9
     };
 
+    // TODO: move this
+    enum class ScreenshotType : uint8_t
+    {
+        regular = 0,
+        giant = 1,
+    };
+
     namespace Flags
     {
         constexpr uint32_t widgetPressed = 1 << 0;
@@ -102,7 +109,7 @@ namespace OpenLoco::Input
     void setMapSelectionFlags(uint8_t flags);
     void resetMapSelectionFlag(uint8_t flags);
 
-    void triggerScreenshotCountdown(int8_t numTicks, uint8_t type);
+    void triggerScreenshotCountdown(int8_t numTicks, ScreenshotType type);
 
     void handleKeyboard();
     void handleMouse(int16_t x, int16_t y, MouseButton button);

--- a/src/OpenLoco/Input/Keyboard.cpp
+++ b/src/OpenLoco/Input/Keyboard.cpp
@@ -51,6 +51,8 @@ namespace OpenLoco::Input
     static loco_global<uint8_t[256], 0x01140740> _keyboardState;
     static loco_global<uint8_t, 0x011364A4> _editingShortcutIndex;
 
+    static uint8_t _screenshotType = 0;
+
     static const std::pair<std::string, std::function<void()>> kCheats[] = {
         { "DRIVER", loc_4BECDE },
         { "SHUNT", loc_4BED04 },
@@ -479,6 +481,12 @@ namespace OpenLoco::Input
         Input::setFlag(Flags::viewportScrolling);
     }
 
+    void triggerScreenshotCountdown(int8_t numTicks, uint8_t type)
+    {
+        _screenshotCountdown = numTicks;
+        _screenshotType = type;
+    }
+
     // 0x004BE92A
     void handleKeyboard()
     {
@@ -489,7 +497,12 @@ namespace OpenLoco::Input
             {
                 try
                 {
-                    std::string fileName = saveScreenshot();
+                    std::string fileName;
+                    if (_screenshotType != 0)
+                        fileName = saveGiantScreenshot();
+                    else
+                        fileName = saveScreenshot();
+
                     *((const char**)(&_commonFormatArgs[0])) = fileName.c_str();
                     Windows::showError(StringIds::screenshot_saved_as, StringIds::null, false);
                 }

--- a/src/OpenLoco/Input/Keyboard.cpp
+++ b/src/OpenLoco/Input/Keyboard.cpp
@@ -51,7 +51,7 @@ namespace OpenLoco::Input
     static loco_global<uint8_t[256], 0x01140740> _keyboardState;
     static loco_global<uint8_t, 0x011364A4> _editingShortcutIndex;
 
-    static uint8_t _screenshotType = 0;
+    static ScreenshotType _screenshotType = ScreenshotType::regular;
 
     static const std::pair<std::string, std::function<void()>> kCheats[] = {
         { "DRIVER", loc_4BECDE },
@@ -481,7 +481,7 @@ namespace OpenLoco::Input
         Input::setFlag(Flags::viewportScrolling);
     }
 
-    void triggerScreenshotCountdown(int8_t numTicks, uint8_t type)
+    void triggerScreenshotCountdown(int8_t numTicks, ScreenshotType type)
     {
         _screenshotCountdown = numTicks;
         _screenshotType = type;
@@ -498,7 +498,7 @@ namespace OpenLoco::Input
                 try
                 {
                     std::string fileName;
-                    if (_screenshotType != 0)
+                    if (_screenshotType == ScreenshotType::giant)
                         fileName = saveGiantScreenshot();
                     else
                         fileName = saveScreenshot();

--- a/src/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/Localisation/StringIds.h
@@ -1827,4 +1827,5 @@ namespace OpenLoco::StringIds
     constexpr string_id stats_length = 2261;
     constexpr string_id vehicle_details_tooltip_length = 2262;
     constexpr string_id num_characters_left_int_int = 2263;
+    constexpr string_id menu_giant_screenshot = 2264;
 }

--- a/src/OpenLoco/Ui/Screenshot.cpp
+++ b/src/OpenLoco/Ui/Screenshot.cpp
@@ -133,14 +133,8 @@ namespace OpenLoco::Input
         return prepareSaveScreenshot(rt);
     }
 
-    std::string saveGiantScreenshot()
+    static Ui::Viewport createGiantViewport(const uint16_t resolutionWidth, const uint16_t resolutionHeight, const uint8_t zoomLevel)
     {
-        const auto& main = WindowManager::getMainWindow();
-        const auto zoomLevel = main->viewports[0]->zoom;
-
-        const uint16_t resolutionWidth = ((Map::kMapColumns * 32 * 2) >> zoomLevel) + 8;
-        const uint16_t resolutionHeight = ((Map::kMapRows * 32 * 1) >> zoomLevel) + 128;
-
         Ui::Viewport viewport{};
         viewport.width = resolutionWidth;
         viewport.height = resolutionHeight;
@@ -159,6 +153,19 @@ namespace OpenLoco::Input
         auto pos = viewport.centre2dCoordinates({ centreX, centreY, z });
         viewport.viewX = pos.x;
         viewport.viewY = pos.y;
+
+        return viewport;
+    }
+
+    std::string saveGiantScreenshot()
+    {
+        const auto& main = WindowManager::getMainWindow();
+        const auto zoomLevel = main->viewports[0]->zoom;
+
+        const uint16_t resolutionWidth = ((Map::kMapColumns * 32 * 2) >> zoomLevel) + 8;
+        const uint16_t resolutionHeight = ((Map::kMapRows * 32 * 1) >> zoomLevel) + 128;
+
+        Ui::Viewport viewport = createGiantViewport(resolutionWidth, resolutionHeight, zoomLevel);
 
         // Ensure sprites appear regardless of rotation
         EntityManager::resetSpatialIndex();

--- a/src/OpenLoco/Ui/Screenshot.cpp
+++ b/src/OpenLoco/Ui/Screenshot.cpp
@@ -154,34 +154,12 @@ namespace OpenLoco::Input
 
         const uint16_t centreX = (Map::kMapColumns / 2) * 32 + 16;
         const uint16_t centreY = (Map::kMapRows / 2) * 32 + 16;
-
         const uint16_t z = Map::TileManager::getHeight({ centreX, centreY }).landHeight;
         const auto rotation = main->viewports[0]->getRotation();
-        uint16_t x = 0, y = 0;
 
-        // TODO: I think we have a function for this already?
-        switch (rotation)
-        {
-            case 0:
-                x = centreY - centreX;
-                y = ((centreX + centreY) / 2) - z;
-                break;
-            case 1:
-                x = -centreY - centreX;
-                y = ((-centreX + centreY) / 2) - z;
-                break;
-            case 2:
-                x = -centreY + centreX;
-                y = ((-centreX - centreY) / 2) - z;
-                break;
-            case 3:
-                x = centreY + centreX;
-                y = ((centreX - centreY) / 2) - z;
-                break;
-        }
-
-        viewport.viewX = x - ((viewport.viewWidth << zoomLevel) / 2);
-        viewport.viewY = y - ((viewport.viewHeight << zoomLevel) / 2);
+        auto pos = Map::gameToScreen({ centreX, centreY, z }, rotation);
+        viewport.viewX = pos.x;
+        viewport.viewY = pos.y;
 
         // Ensure sprites appear regardless of rotation
         EntityManager::resetSpatialIndex();

--- a/src/OpenLoco/Ui/Screenshot.cpp
+++ b/src/OpenLoco/Ui/Screenshot.cpp
@@ -173,14 +173,14 @@ namespace OpenLoco::Input
                 break;
         }
 
-        viewport.x = x - ((viewport.viewWidth << zoomLevel) / 2);
-        viewport.y = y - ((viewport.viewHeight << zoomLevel) / 2);
+        viewport.viewX = x - ((viewport.viewWidth << zoomLevel) / 2);
+        viewport.viewY = y - ((viewport.viewHeight << zoomLevel) / 2);
 
         // Ensure sprites appear regardless of rotation
         // TODO: what is the OpenLoco equivalent?
         // reset_all_sprite_quadrant_placements();
 
-        Gfx::RenderTarget rt;
+        Gfx::RenderTarget rt{};
         rt.bits = static_cast<uint8_t*>(malloc(resolutionWidth * resolutionHeight));
         if (!rt.bits)
             return nullptr;

--- a/src/OpenLoco/Ui/Screenshot.cpp
+++ b/src/OpenLoco/Ui/Screenshot.cpp
@@ -199,8 +199,9 @@ namespace OpenLoco::Input
         rt.zoomLevel = 0;
 
         viewport.render(&rt);
+        auto fileName = prepareSaveScreenshot(rt);
         free(rt.bits);
 
-        return prepareSaveScreenshot(rt);
+        return fileName;
     }
 }

--- a/src/OpenLoco/Ui/Screenshot.cpp
+++ b/src/OpenLoco/Ui/Screenshot.cpp
@@ -152,9 +152,9 @@ namespace OpenLoco::Input
         viewport.pad_11 = 0;
         viewport.flags = 0;
 
-        const uint16_t centreX = (Map::kMapColumns / 2) * 32 + 16;
-        const uint16_t centreY = (Map::kMapRows / 2) * 32 + 16;
-        const uint16_t z = Map::TileManager::getHeight({ centreX, centreY }).landHeight;
+        const coord_t centreX = (Map::kMapColumns / 2) * 32 + 16;
+        const coord_t centreY = (Map::kMapRows / 2) * 32 + 16;
+        const coord_t z = Map::TileManager::getHeight({ centreX, centreY }).landHeight;
         const auto rotation = main->viewports[0]->getRotation();
 
         auto pos = Map::gameToScreen({ centreX, centreY, z }, rotation);

--- a/src/OpenLoco/Ui/Screenshot.cpp
+++ b/src/OpenLoco/Ui/Screenshot.cpp
@@ -146,8 +146,8 @@ namespace OpenLoco::Input
         viewport.height = resolutionHeight;
         viewport.x = 0;
         viewport.y = 0;
-        viewport.viewWidth = viewport.width;
-        viewport.viewHeight = viewport.height;
+        viewport.viewWidth = viewport.width << zoomLevel;
+        viewport.viewHeight = viewport.height << zoomLevel;
         viewport.zoom = zoomLevel;
         viewport.pad_11 = 0;
         viewport.flags = 0;
@@ -155,9 +155,8 @@ namespace OpenLoco::Input
         const coord_t centreX = (Map::kMapColumns / 2) * 32 + 16;
         const coord_t centreY = (Map::kMapRows / 2) * 32 + 16;
         const coord_t z = Map::TileManager::getHeight({ centreX, centreY }).landHeight;
-        const auto rotation = main->viewports[0]->getRotation();
 
-        auto pos = Map::gameToScreen({ centreX, centreY, z }, rotation);
+        auto pos = viewport.centre2dCoordinates({ centreX, centreY, z });
         viewport.viewX = pos.x;
         viewport.viewY = pos.y;
 

--- a/src/OpenLoco/Ui/Screenshot.cpp
+++ b/src/OpenLoco/Ui/Screenshot.cpp
@@ -126,7 +126,13 @@ namespace OpenLoco::Input
         return fileName;
     }
 
-    static std::string saveGiantScreenshot()
+    std::string saveScreenshot()
+    {
+        auto& rt = Gfx::getScreenRT();
+        return prepareSaveScreenshot(rt);
+    }
+
+    std::string saveGiantScreenshot()
     {
         const auto& main = WindowManager::getMainWindow();
         const auto zoomLevel = main->viewports[0]->zoom;
@@ -196,18 +202,5 @@ namespace OpenLoco::Input
         free(rt.bits);
 
         return prepareSaveScreenshot(rt);
-    }
-
-    std::string saveScreenshot()
-    {
-        // TODO: remove hack and just call saveGiantScreenshot from Ui
-        bool giant = true;
-        if (!giant)
-        {
-            auto& rt = Gfx::getScreenRT();
-            return prepareSaveScreenshot(rt);
-        }
-        else
-            return saveGiantScreenshot();
     }
 }

--- a/src/OpenLoco/Ui/Screenshot.cpp
+++ b/src/OpenLoco/Ui/Screenshot.cpp
@@ -1,4 +1,5 @@
 #include "Screenshot.h"
+#include "../Entities/EntityManager.h"
 #include "../Graphics/Gfx.h"
 #include "../Interop/Interop.hpp"
 #include "../Localisation/StringIds.h"
@@ -183,8 +184,7 @@ namespace OpenLoco::Input
         viewport.viewY = y - ((viewport.viewHeight << zoomLevel) / 2);
 
         // Ensure sprites appear regardless of rotation
-        // TODO: what is the OpenLoco equivalent?
-        // reset_all_sprite_quadrant_placements();
+        EntityManager::resetSpatialIndex();
 
         Gfx::RenderTarget rt{};
         rt.bits = static_cast<uint8_t*>(malloc(resolutionWidth * resolutionHeight));

--- a/src/OpenLoco/Ui/Screenshot.h
+++ b/src/OpenLoco/Ui/Screenshot.h
@@ -4,4 +4,5 @@
 namespace OpenLoco::Input
 {
     std::string saveScreenshot();
+    std::string saveGiantScreenshot();
 }

--- a/src/OpenLoco/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/Windows/ToolbarTop.cpp
@@ -244,11 +244,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                 break;
 
             case LoadSaveDropdownId::screenshot:
-                Input::triggerScreenshotCountdown(10, 0);
+                Input::triggerScreenshotCountdown(10, Input::ScreenshotType::regular);
                 break;
 
             case LoadSaveDropdownId::giantScreenshot:
-                Input::triggerScreenshotCountdown(10, 1);
+                Input::triggerScreenshotCountdown(10, Input::ScreenshotType::giant);
                 break;
 
             case LoadSaveDropdownId::server:

--- a/src/OpenLoco/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/Windows/ToolbarTop.cpp
@@ -78,6 +78,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         about,
         options,
         screenshot,
+        giantScreenshot,
         server,
         quitToMenu,
         quitToDesktop
@@ -135,7 +136,8 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                      .separator()
                      .item(LoadSaveDropdownId::about, StringIds::menu_about)
                      .item(LoadSaveDropdownId::options, StringIds::options)
-                     .item(LoadSaveDropdownId::screenshot, StringIds::menu_screenshot);
+                     .item(LoadSaveDropdownId::screenshot, StringIds::menu_screenshot)
+                     .item(LoadSaveDropdownId::giantScreenshot, StringIds::menu_giant_screenshot);
 
         auto& newConfig = Config::getNew();
         if (newConfig.network.enabled)
@@ -202,12 +204,6 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             Error::open(StringIds::error_game_save_failed, StringIds::null);
     }
 
-    static void takeScreenshot()
-    {
-        loco_global<uint8_t, 0x00508F16> _screenshotCountdown;
-        _screenshotCountdown = 10;
-    }
-
     static void startOrCloseServer()
     {
         if (isNetworked())
@@ -248,7 +244,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                 break;
 
             case LoadSaveDropdownId::screenshot:
-                takeScreenshot();
+                Input::triggerScreenshotCountdown(10, 0);
+                break;
+
+            case LoadSaveDropdownId::giantScreenshot:
+                Input::triggerScreenshotCountdown(10, 1);
                 break;
 
             case LoadSaveDropdownId::server:

--- a/src/OpenLoco/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/Windows/ToolbarTopAlt.cpp
@@ -117,9 +117,10 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
         Dropdown::add(3, StringIds::menu_about);
         Dropdown::add(4, StringIds::options);
         Dropdown::add(5, StringIds::menu_screenshot);
-        Dropdown::add(6, 0);
-        Dropdown::add(7, StringIds::menu_quit_to_menu);
-        Dropdown::add(8, StringIds::menu_exit_openloco);
+        Dropdown::add(6, StringIds::menu_giant_screenshot);
+        Dropdown::add(7, 0);
+        Dropdown::add(8, StringIds::menu_quit_to_menu);
+        Dropdown::add(9, StringIds::menu_exit_openloco);
         Dropdown::showBelow(window, widgetIndex, 9, 0);
         Dropdown::setHighlightedItem(1);
     }
@@ -163,18 +164,19 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
                 break;
 
             case 5:
-            {
-                loco_global<uint8_t, 0x00508F16> _screenshotCountdown;
-                _screenshotCountdown = 10;
+                Input::triggerScreenshotCountdown(10, 0);
                 break;
-            }
 
-            case 7:
+            case 6:
+                Input::triggerScreenshotCountdown(10, 1);
+                break;
+
+            case 8:
                 // Return to title screen
                 GameCommands::do_21(0, 1);
                 break;
 
-            case 8:
+            case 9:
                 // Exit to desktop
                 GameCommands::do_21(0, 2);
                 break;

--- a/src/OpenLoco/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/Windows/ToolbarTopAlt.cpp
@@ -164,11 +164,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
                 break;
 
             case 5:
-                Input::triggerScreenshotCountdown(10, 0);
+                Input::triggerScreenshotCountdown(10, Input::ScreenshotType::regular);
                 break;
 
             case 6:
-                Input::triggerScreenshotCountdown(10, 1);
+                Input::triggerScreenshotCountdown(10, Input::ScreenshotType::giant);
                 break;
 
             case 8:


### PR DESCRIPTION
This PR introduces the ability to save the entire map as one giant screenshot. Living up to their name, these screenshots are 24,586×12,416 pixels, netting about 30MB each.

