### PR TITLE
Remove specific interop utility string functions

### DIFF
--- a/src/OpenLoco/Environment.cpp
+++ b/src/OpenLoco/Environment.cpp
@@ -178,7 +178,7 @@ namespace OpenLoco::Environment
     template<typename T>
     static void setDirectory(T& buffer, fs::path path)
     {
-        Utility::strcpy_safe(buffer, path.make_preferred().u8string().c_str());
+        Utility::strlcpy(buffer, path.make_preferred().u8string().c_str(), buffer.size());
     }
 
     void autoCreateDirectory(const fs::path& path)

--- a/src/OpenLoco/Graphics/PaletteMap.cpp
+++ b/src/OpenLoco/Graphics/PaletteMap.cpp
@@ -5,6 +5,7 @@
 #include "ImageIds.h"
 #include <algorithm>
 #include <cassert>
+#include <cstring>
 #include <numeric>
 
 using namespace OpenLoco::Interop;

--- a/src/OpenLoco/Interop/Interop.hpp
+++ b/src/OpenLoco/Interop/Interop.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "../Utility/String.hpp"
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -419,28 +418,4 @@ namespace OpenLoco::Interop
 
     void registerHooks();
     void loadSections();
-}
-
-// these safe string function convenience overloads are located in this header, rather than in Utility/String.hpp,
-// so that Utility/String.hpp doesn't needlessly have to include this header just for the definition of loco_global
-// (and so that we don't have to use type traits SFINAE template wizardry to get around not having the definition available)
-namespace OpenLoco::Utility
-{
-    template<size_t TCount, uintptr_t TAddress>
-    void strcpy_safe(OpenLoco::Interop::loco_global<char[TCount], TAddress>& dest, const char* src)
-    {
-        (void)strlcpy(dest, src, dest.size());
-    }
-
-    template<size_t TCount, uintptr_t TAddress>
-    void strcat_safe(OpenLoco::Interop::loco_global<char[TCount], TAddress>& dest, const char* src)
-    {
-        (void)strlcat(dest, src, dest.size());
-    }
-
-    template<size_t TCount, uintptr_t TAddress, typename... Args>
-    int sprintf_safe(OpenLoco::Interop::loco_global<char[TCount], TAddress>& dest, const char* fmt, Args&&... args)
-    {
-        return std::snprintf(dest, TCount, fmt, std::forward<Args>(args)...);
-    }
 }

--- a/src/OpenLoco/Network/NetworkConnection.cpp
+++ b/src/OpenLoco/Network/NetworkConnection.cpp
@@ -1,6 +1,7 @@
 #include "NetworkConnection.h"
 #include "../Console.h"
 #include "../Platform/Platform.h"
+#include <cstring>
 
 using namespace OpenLoco::Network;
 

--- a/src/OpenLoco/Objects/ObjectIndex.cpp
+++ b/src/OpenLoco/Objects/ObjectIndex.cpp
@@ -8,6 +8,7 @@
 #include "../Ui/ProgressBar.h"
 #include "../Utility/Numeric.hpp"
 #include "../Utility/Stream.hpp"
+#include "../Utility/String.hpp"
 #include "ObjectManager.h"
 #include <cstdint>
 #include <fstream>

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -68,6 +68,7 @@
 #include "Ui/ProgressBar.h"
 #include "Ui/WindowManager.h"
 #include "Utility/Numeric.hpp"
+#include "Utility/String.hpp"
 #include "ViewportManager.h"
 
 #pragma warning(disable : 4611) // interaction between '_setjmp' and C++ object destruction is non - portable

--- a/src/OpenLoco/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/Windows/PromptBrowseWindow.cpp
@@ -110,7 +110,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         {
             *_fileType = BrowseFileType::landscape;
         }
-        Utility::strcpy_safe(_filter, filter);
+        Utility::strlcpy(_filter, filter, _filter.size());
 
         changeDirectory(directory.make_preferred());
         inputSession = Ui::TextInput::InputSession(baseName, 200);

--- a/src/OpenLoco/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/Windows/TitleMenu.cpp
@@ -20,6 +20,7 @@
 #include "../Ui.h"
 #include "../Ui/Dropdown.h"
 #include "../Ui/WindowManager.h"
+#include "../Utility/String.hpp"
 #include "../ViewportManager.h"
 #include "../Widget.h"
 #include <string_view>


### PR DESCRIPTION
They were barely used and it simplifies the header