### PR TITLE
Update CMake usage in README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,20 +105,16 @@ Note: The game can currently only be built for 32-bit architectures.
 
 Either open the OpenLoco folder in VS 2022 or build using cmake with the following commands.
 
-1. Run `mkdir build`
-2. Run `cd build`
-3. Run `cmake .. -A Win32 "-DCMAKE_TOOLCHAIN_FILE=<vcpkg_root>/scripts/buildsystems/vcpkg.cmake"`
-4. Run `cmake --build .`
+1. Run `cmake -S . -B build -A Win32 "-DCMAKE_TOOLCHAIN_FILE=<vcpkg_root>/scripts/buildsystems/vcpkg.cmake"`
+2. Run `cmake --build build`
 
 ### Linux:
 Due to issues with yaml-cpp package, for Linux we bundle our own copy via git submodule. Make sure you have cloned repository recursively.
 
 The standard CMake build procedure is to install the required libraries, then:
 ```
-mkdir build
-cd build
-CXXFLAGS="-m32" cmake .. -G Ninja # remember the usual cmake options, e.g. -DCMAKE_BUILD_TYPE=RelWithDebInfo
-ninja
+CXXFLAGS="-m32" cmake -S . -B build -G Ninja # remember the usual cmake options, e.g. -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build
 ```
 
 Note that installing some packages can be problematic on desktop AMD64 distributions, you can use our docker images for compilation.


### PR DESCRIPTION
CMake 3.14.0 released in March 2019 [1] added the command line config options `-S <source-dir>` and `-B <build-dir>` and the build argument `--build <build-dir>` [2]. These options are universally valid independent of the build system used (`make`, `nmake`, `ninja`, `MSBuild`,...), making the provided CMake commands more generic.

As reference Ubuntu 20.04 ships the CMake 3.16.3 [3] version.

- [1] https://gitlab.kitware.com/cmake/cmake/-/tags/v3.14.0
- [2] https://cmake.org/cmake/help/v3.14/release/3.14.html#command-line
- [3] https://packages.ubuntu.com/focal/cmake