### PR TITLE
add #pragma once to header without it

### DIFF
--- a/src/OpenLoco/Drawing/FPSCounter.h
+++ b/src/OpenLoco/Drawing/FPSCounter.h
@@ -1,3 +1,5 @@
+#pragma once
+
 namespace OpenLoco::Drawing
 {
     void drawFPS();

--- a/src/OpenLoco/GameCommands/Cheat.h
+++ b/src/OpenLoco/GameCommands/Cheat.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 
 namespace OpenLoco::GameCommands

--- a/src/OpenLoco/Localisation/LanguageFiles.h
+++ b/src/OpenLoco/Localisation/LanguageFiles.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 
 namespace OpenLoco::Localisation

--- a/src/OpenLoco/Localisation/Languages.h
+++ b/src/OpenLoco/Localisation/Languages.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <string>
 #include <vector>
 

--- a/src/OpenLoco/Localisation/Unicode.h
+++ b/src/OpenLoco/Localisation/Unicode.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 
 namespace OpenLoco::Localisation

--- a/src/OpenLoco/Map/QuarterTile.h
+++ b/src/OpenLoco/Map/QuarterTile.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 
 namespace OpenLoco::Map

--- a/src/OpenLoco/Map/Track/Track.h
+++ b/src/OpenLoco/Map/Track/Track.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "../../Types.hpp"
 #include "../Map.hpp"
 #include <utility>

--- a/src/OpenLoco/Map/Tree.h
+++ b/src/OpenLoco/Map/Tree.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "Map.hpp"
 #include <optional>
 

--- a/src/OpenLoco/Ui/Cursor.h
+++ b/src/OpenLoco/Ui/Cursor.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cassert>
 #include <cstdint>
 #include <cstdio>

--- a/src/OpenLoco/Ui/Dropdown.h
+++ b/src/OpenLoco/Ui/Dropdown.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "../Company.h"
 #include "../Core/Optional.hpp"
 #include "../Graphics/Colour.h"

--- a/src/OpenLoco/Ui/Screenshot.h
+++ b/src/OpenLoco/Ui/Screenshot.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 #include <string>
 

--- a/src/OpenLoco/Ui/ScrollView.h
+++ b/src/OpenLoco/Ui/ScrollView.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "../Interop/Interop.hpp"
 #include "../Window.h"
 

--- a/src/OpenLoco/Ui/TextInput.h
+++ b/src/OpenLoco/Ui/TextInput.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "../Graphics/Gfx.h"
 
 #include <cstdint>

--- a/src/OpenLoco/Utility/Yaml.hpp
+++ b/src/OpenLoco/Utility/Yaml.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifdef _WIN32
 // Ignore warnings generated from yaml-cpp
 #pragma warning(push)


### PR DESCRIPTION
I noticed that some of the headers are missing `#pragma once`. This PR adds it to the remaining headers