### PR TITLE
Fix prng naming to follow coding style

### DIFF
--- a/src/OpenLoco/GameCommands/VehiclePickup.cpp
+++ b/src/OpenLoco/GameCommands/VehiclePickup.cpp
@@ -11,7 +11,7 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Vehicles
 {
-    static loco_global<Utility::prng, 0x00525E20> _prng;
+    static loco_global<Utility::Prng, 0x00525E20> _prng;
 
     // 0x0048B15B
     void playPickupSound(Vehicles::Vehicle2* veh2)

--- a/src/OpenLoco/GameState.h
+++ b/src/OpenLoco/GameState.h
@@ -17,8 +17,8 @@ namespace OpenLoco
 #pragma pack(push, 1)
     struct GameState
     {
-        Utility::prng rng;                                                       // 0x000000 (0x00525E18)
-        Utility::prng unkRng;                                                    // 0x000008 (0x00525E20)
+        Utility::Prng rng;                                                       // 0x000000 (0x00525E18)
+        Utility::Prng unkRng;                                                    // 0x000008 (0x00525E20)
         uint32_t flags;                                                          // 0x000010 (0x00525E28)
         uint32_t currentDay;                                                     // 0x000014 (0x00525E2C)
         uint16_t dayCounter;                                                     // 0x000018 (0x00525E30)
@@ -72,7 +72,7 @@ namespace OpenLoco
         uint8_t lastMiscBuildingOption;                                          // 0x0001B1 (0x00525FC9)
         uint8_t lastWallOption;                                                  // 0x0001B2 (0x00525FCA)
         uint8_t var_1B3;                                                         // 0x0001B3 (0x00525FCB)
-        Utility::prng var_1B4;                                                   // 0x0001B4 (0x00525FCC)
+        Utility::Prng var_1B4;                                                   // 0x0001B4 (0x00525FCC)
         char scenarioFileName[256];                                              // 0x0001BC (0x00525FD4)
         char scenarioName[64];                                                   // 0x0002BC (0x005260D4)
         char scenarioDetails[256];                                               // 0x0002FC (0x00526114)

--- a/src/OpenLoco/Industry.cpp
+++ b/src/OpenLoco/Industry.cpp
@@ -541,12 +541,12 @@ namespace OpenLoco
 
         const auto* indObj = ObjectManager::get<IndustryObject>(objectId);
 
-        std::optional<Utility::prng> is23prng;
+        std::optional<Utility::Prng> is23prng;
         if (indObj->flags & IndustryObjectFlags::unk23) // Livestock use this
         {
             is23prng = prng;
         }
-        std::optional<Utility::prng> is27prng;
+        std::optional<Utility::Prng> is27prng;
         if (indObj->flags & IndustryObjectFlags::unk27) // Skislope use this
         {
             // Vanilla mistake here didn't set the prng! It would just recycle from a previous unk23 caller

--- a/src/OpenLoco/Industry.h
+++ b/src/OpenLoco/Industry.h
@@ -35,7 +35,7 @@ namespace OpenLoco
         coord_t x;                  // 0x02
         coord_t y;                  // 0x04
         uint16_t flags;             // 0x06
-        Utility::prng prng;         // 0x08
+        Utility::Prng prng;         // 0x08
         uint8_t objectId;           // 0x10
         uint8_t under_construction; // 0x11 (0xFF = Finished)
         uint16_t pad_12;

--- a/src/OpenLoco/Map/WaveManager.cpp
+++ b/src/OpenLoco/Map/WaveManager.cpp
@@ -16,7 +16,7 @@ namespace OpenLoco::Map::WaveManager
     using namespace OpenLoco::Interop;
     using namespace OpenLoco::Ui;
 
-    static loco_global<Utility::prng, 0x00525E20> _prng; // not the gPrng
+    static loco_global<Utility::Prng, 0x00525E20> _prng; // not the gPrng
 
     const static Pos2 _offsets[4] = {
         Pos2(+32, 0),

--- a/src/OpenLoco/OpenLoco.cpp
+++ b/src/OpenLoco/OpenLoco.cpp
@@ -114,7 +114,7 @@ namespace OpenLoco
         return version;
     }
 
-    Utility::prng& gPrng()
+    Utility::Prng& gPrng()
     {
         return getGameState().rng;
     }

--- a/src/OpenLoco/OpenLoco.h
+++ b/src/OpenLoco/OpenLoco.h
@@ -22,7 +22,7 @@ namespace OpenLoco
     std::string getVersionInfo();
 
     void* hInstance();
-    Utility::prng& gPrng();
+    Utility::Prng& gPrng();
     void initialiseViewports();
     void simulateGame(const fs::path& path, int32_t ticks);
 

--- a/src/OpenLoco/Scenario.cpp
+++ b/src/OpenLoco/Scenario.cpp
@@ -404,7 +404,7 @@ namespace OpenLoco::Scenario
         if (!load(path))
             return false;
 
-        gameState.rng = Utility::prng(Platform::getTime() ^ oldRng.srand_0(), oldRng.srand_1());
+        gameState.rng = Utility::Prng(Platform::getTime() ^ oldRng.srand_0(), oldRng.srand_1());
         std::strncpy(gameState.scenarioFileName, path.u8string().c_str(), std::size(gameState.scenarioFileName) - 1);
         start();
     }

--- a/src/OpenLoco/Town.h
+++ b/src/OpenLoco/Town.h
@@ -34,7 +34,7 @@ namespace OpenLoco
         coord_t y;                    // 0x04
         uint16_t flags;               // 0x06
         LabelFrame labelFrame;        // 0x08
-        Utility::prng prng;           // 0x28
+        Utility::Prng prng;           // 0x28
         uint32_t population;          // 0x30
         uint32_t populationCapacity;  // 0x34
         int16_t numBuildings;         // 0x38

--- a/src/OpenLoco/Tutorial.cpp
+++ b/src/OpenLoco/Tutorial.cpp
@@ -137,7 +137,7 @@ namespace OpenLoco::Tutorial
 
         // Set fixed rng seed
         auto& gameState = getGameState();
-        gameState.rng = Utility::prng(0x12345678, 0x9ABCDEF0);
+        gameState.rng = Utility::Prng(0x12345678, 0x9ABCDEF0);
 
         // Start the scenario
         Scenario::start();

--- a/src/OpenLoco/Utility/Prng.hpp
+++ b/src/OpenLoco/Utility/Prng.hpp
@@ -6,7 +6,7 @@
 namespace OpenLoco::Utility
 {
 #pragma pack(push, 1)
-    struct prng
+    struct Prng
     {
     private:
         uint32_t _srand_0{};
@@ -16,11 +16,11 @@ namespace OpenLoco::Utility
         uint32_t srand_0() { return _srand_0; }
         uint32_t srand_1() { return _srand_1; }
 
-        prng()
+        Prng()
         {
         }
 
-        prng(uint32_t s0, uint32_t s1)
+        Prng(uint32_t s0, uint32_t s1)
             : _srand_0(s0)
             , _srand_1(s1)
         {

--- a/src/OpenLoco/Windows/IndustryList.cpp
+++ b/src/OpenLoco/Windows/IndustryList.cpp
@@ -32,7 +32,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
     static loco_global<IndustryId, 0x00E0C3C9> _industryLastPlacedId;
     static loco_global<uint8_t, 0x00E0C3DA> _industryGhostType;
     static loco_global<IndustryId, 0x00E0C3DB> _industryGhostId;
-    static loco_global<Utility::prng, 0x00525E20> _prng;
+    static loco_global<Utility::Prng, 0x00525E20> _prng;
     static loco_global<uint32_t, 0x00E0C394> _dword_E0C394;
     static loco_global<uint32_t, 0x00E0C398> _dword_E0C398;
 


### PR DESCRIPTION
Really this should be in Core as well not Utility but its a pain to move with all the CMake outstanding PRs