### PR TITLE
Refactor scenario options window

### DIFF
--- a/src/OpenLoco/src/Input.h
+++ b/src/OpenLoco/src/Input.h
@@ -133,6 +133,7 @@ namespace OpenLoco::Input
     uint16_t getTooltipTimeout();
     void setTooltipTimeout(uint16_t tooltipTimeout);
 
+    uint16_t getClickRepeatTicks();
     void setClickRepeatTicks(uint16_t ticks);
 
     bool isRightMouseButtonDown();

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -2112,6 +2112,11 @@ namespace OpenLoco::Input
         _tooltipTimeout = tooltipTimeout;
     }
 
+    uint16_t getClickRepeatTicks()
+    {
+        return _clickRepeatTicks;
+    }
+
     void setClickRepeatTicks(uint16_t ticks)
     {
         _clickRepeatTicks = ticks;

--- a/src/OpenLoco/src/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Windows/Cheats.cpp
@@ -6,6 +6,7 @@
 #include "../Graphics/Colour.h"
 #include "../Graphics/Gfx.h"
 #include "../Graphics/ImageIds.h"
+#include "../Input.h"
 #include "../Localisation/FormatArguments.hpp"
 #include "../Localisation/StringIds.h"
 #include "../Localisation/StringManager.h"
@@ -367,22 +368,21 @@ namespace OpenLoco::Ui::Windows::Cheats
 
         static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
         {
-            static loco_global<uint16_t, 0x00523376> _clickRepeatTicks;
-
             currency32_t cashStepSize{};
             int32_t timeStepSize{};
+            uint16_t clickRepeatTicks = Input::getClickRepeatTicks();
 
-            if (*_clickRepeatTicks < 100)
+            if (clickRepeatTicks < 100)
             {
                 cashStepSize = 1'000;
                 timeStepSize = 1;
             }
-            else if (*_clickRepeatTicks < 200)
+            else if (clickRepeatTicks < 200)
             {
                 cashStepSize = 10'000;
                 timeStepSize = 10;
             }
-            else if (*_clickRepeatTicks < 300)
+            else if (clickRepeatTicks < 300)
             {
                 cashStepSize = 100'000;
                 timeStepSize = 100;

--- a/src/OpenLoco/src/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Windows/CompanyWindow.cpp
@@ -1934,8 +1934,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         // 0x0043383E
         static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
         {
-            static loco_global<uint16_t, 0x00523376> _clickRepeatTicks;
-
             switch (widgetIndex)
             {
                 case Common::widx::company_select:
@@ -1949,7 +1947,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                         return;
 
                     GameCommands::ChangeLoanArgs args{};
-                    args.newLoan = std::max<currency32_t>(0, company->currentLoan - calculateStepSize(*_clickRepeatTicks));
+                    args.newLoan = std::max<currency32_t>(0, company->currentLoan - calculateStepSize(Input::getClickRepeatTicks()));
 
                     GameCommands::setErrorTitle(StringIds::cant_pay_back_loan);
                     GameCommands::doCommand(args, GameCommands::Flags::apply);
@@ -1959,7 +1957,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 case widx::loan_increase:
                 {
                     GameCommands::ChangeLoanArgs args{};
-                    args.newLoan = CompanyManager::get(CompanyId(self.number))->currentLoan + calculateStepSize(*_clickRepeatTicks);
+                    args.newLoan = CompanyManager::get(CompanyId(self.number))->currentLoan + calculateStepSize(Input::getClickRepeatTicks());
 
                     GameCommands::setErrorTitle(StringIds::cant_borrow_any_more_money);
                     GameCommands::doCommand(args, GameCommands::Flags::apply);

--- a/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
@@ -34,7 +34,6 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     static loco_global<uint8_t, 0x00522091> _byte_522091;
     static loco_global<uint8_t, 0x00522092> _byte_522092;
 
-    static loco_global<uint16_t, 0x00523376> _clickRepeatTicks;
     static loco_global<uint32_t, 0x00523394> _toolWidgetIndex;
 
     static loco_global<Map::Pos3, 0x00F24942> _constructionArrowPos;
@@ -1721,14 +1720,14 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
             case widx::construct:
             {
-                if (*_clickRepeatTicks >= 40)
+                if (Input::getClickRepeatTicks() >= 40)
                     constructTrack(&self, widgetIndex);
                 break;
             }
 
             case widx::remove:
             {
-                if (*_clickRepeatTicks >= 40)
+                if (Input::getClickRepeatTicks() >= 40)
                     removeTrack(&self, widgetIndex);
                 break;
             }

--- a/src/OpenLoco/src/Windows/Options.cpp
+++ b/src/OpenLoco/src/Windows/Options.cpp
@@ -1066,12 +1066,11 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         static loco_global<int16_t, 0x005233A4> _5233A4;
-        static loco_global<uint16_t, 0x00523376> _clickRepeatTicks;
 
         // 0x004C072A
         static void volumeMouseDown(Window* w)
         {
-            _clickRepeatTicks = 31;
+            Input::setClickRepeatTicks(31);
 
             int x = _5233A4 - w->x - w->widgets[Widx::volume].left - 10;
             x = std::clamp(x, 0, 80);

--- a/src/OpenLoco/src/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioOptions.cpp
@@ -433,6 +433,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
                 case Scenario::ObjectiveType::performanceIndex:
                     args.push<int16_t>(Scenario::getObjective().performanceIndex * 10);
+                    args.skip(2);
                     widgets[widx::objective_value].text = StringIds::challenge_performance_index;
                     break;
 

--- a/src/OpenLoco/src/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioOptions.cpp
@@ -25,7 +25,6 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
     static constexpr Ui::Size kCompaniesWindowSize = { 366, 327 };
     static constexpr Ui::Size kOtherWindowSize = { 366, 217 };
 
-    static loco_global<uint16_t, 0x00523376> _clickRepeatTicks;
     static loco_global<uint16_t[10], 0x0112C826> _commonFormatArgs;
 
     namespace Common
@@ -270,11 +269,12 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                         case Scenario::ObjectiveType::cargoDelivery:
                         {
                             uint16_t stepSize{};
-                            if (*_clickRepeatTicks < 100)
+                            uint16_t clickRepeatTicks = Input::getClickRepeatTicks();
+                            if (clickRepeatTicks < 100)
                                 stepSize = 100;
-                            else if (*_clickRepeatTicks >= 100)
+                            else if (clickRepeatTicks >= 100)
                                 stepSize = 1000;
-                            else if (*_clickRepeatTicks >= 200)
+                            else if (clickRepeatTicks >= 200)
                                 stepSize = 10000;
 
                             // Round off cargo to the nearest multiple of the step size.
@@ -309,11 +309,12 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                         case Scenario::ObjectiveType::cargoDelivery:
                         {
                             uint16_t stepSize{};
-                            if (*_clickRepeatTicks < 100)
+                            uint16_t clickRepeatTicks = Input::getClickRepeatTicks();
+                            if (clickRepeatTicks < 100)
                                 stepSize = 100;
-                            else if (*_clickRepeatTicks >= 100)
+                            else if (clickRepeatTicks >= 100)
                                 stepSize = 1000;
-                            else if (*_clickRepeatTicks >= 200)
+                            else if (clickRepeatTicks >= 200)
                                 stepSize = 10000;
 
                             // Round off cargo to the nearest multiple of the step size.


### PR DESCRIPTION
Some minor refactor work, primarily focussed on removing globals from the scenario options window.

* Use GameState in ScenarioOptions window
* Replace _commonFormatArgs with FormatArguments in scenario options
* Remove references to clickRepeatTicks outside of MouseInput.cpp