### PR TITLE
Fix #1676, #1702. Scenario list crash/hang on new scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 22.10+ (???)
 ------------------------------------------------------------------------
 - Feature: [#1696] Display filename in object selection window.
+- Fix: [#1676] Crash when viewing newly created scenarios in scenario list.
 - Fix: [#1680] Title music plays in scenario editor.
 - Fix: [#1711] Crash on linux when config folder for OpenLoco is not manually created.
 - Fix: [#1720] Crash when indexing object files that fail validation.

--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -90,7 +90,7 @@ namespace OpenLoco::EditorController
         gameState.numberOfIndustries = options.numberOfIndustries;
         options.objective = Scenario::getObjective();
         options.objectiveDeliveredCargo = ObjectManager::getHeader(LoadedObjectHandle{ ObjectType::cargo, options.objective.deliveredCargoType });
-        options.currency = ObjectManager::getHeader(LoadedObjectHandle{ ObjectType::currency, options.objective.deliveredCargoType });
+        options.currency = ObjectManager::getHeader(LoadedObjectHandle{ ObjectType::currency, 0 });
     }
 
     // 0x0043EE25


### PR DESCRIPTION
Mistake made in implementation of the editorcontroller meant that invalid currency objects were set as the currency of a scenario meta details. This would cause the game to unload the currency object which would change the layout of image data set for water object which would cause invalid offsets to be set in the palette table which would cause the image draw functions to behave oddly causing crashs or infinite loops.