### PR TITLE
Optionally disable town growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#175, #938] Allow modifying object selection in-game (cheat menu).
 - Feature: [#1664] Allow modifying scenario options in-game (cheat menu).
+- Feature: [#1736] Allow disabling town renewal/expansion/growth (options menu).
 - Fix: [#1727] Starting loan is not displayed properly in scenario options.
 - Change: [#1736] The miscellaneous options tab has been redesigned to reduce clutter.
 

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2323,3 +2323,5 @@ strings:
   2268: "Gameplay tweaks"
   2269: "Preferred owner"
   2270: "Autosave preferences"
+  2271: "Disable town expansion"
+  2272: "{SMALLFONT}{COLOUR BLACK}When enabled, towns will not renew or expand over time"

--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -182,6 +182,8 @@ namespace OpenLoco::Config
             _newConfig.cheatsMenuEnabled = config["cheats_menu_enabled"].as<bool>();
         if (config["companyAIDisabled"])
             _newConfig.companyAIDisabled = config["companyAIDisabled"].as<bool>();
+        if (config["townGrowthDisabled"])
+            _newConfig.townGrowthDisabled = config["townGrowthDisabled"].as<bool>();
         if (config["scale_factor"])
             _newConfig.scaleFactor = config["scale_factor"].as<float>();
         if (config["zoom_to_cursor"])
@@ -265,6 +267,7 @@ namespace OpenLoco::Config
         node["trainsReverseAtSignals"] = _newConfig.trainsReverseAtSignals;
         node["cheats_menu_enabled"] = _newConfig.cheatsMenuEnabled;
         node["companyAIDisabled"] = _newConfig.companyAIDisabled;
+        node["townGrowthDisabled"] = _newConfig.townGrowthDisabled;
         node["scale_factor"] = _newConfig.scaleFactor;
         node["zoom_to_cursor"] = _newConfig.zoomToCursor;
         node["autosave_frequency"] = _newConfig.autosaveFrequency;

--- a/src/OpenLoco/src/Config.h
+++ b/src/OpenLoco/src/Config.h
@@ -172,6 +172,7 @@ namespace OpenLoco::Config
         bool breakdownsDisabled = false;
         bool trainsReverseAtSignals = true;
         bool companyAIDisabled = false;
+        bool townGrowthDisabled = false;
         float scaleFactor = 1.0f;
         bool zoomToCursor = true;
         int32_t autosaveFrequency = 1;

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1837,6 +1837,8 @@ namespace OpenLoco::StringIds
     constexpr string_id gameplay_tweaks = 2268;
     constexpr string_id preferred_owner = 2269;
     constexpr string_id autosave_preferences = 2270;
+    constexpr string_id disableTownExpansion = 2271;
+    constexpr string_id disableTownExpansion_tip = 2272;
 
     constexpr string_id temporary_object_load_str_0 = 8192;
     constexpr string_id temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Town.cpp
+++ b/src/OpenLoco/src/Town.cpp
@@ -1,4 +1,5 @@
 #include "Town.h"
+#include "Config.h"
 #include "Interop/Interop.hpp"
 #include "Localisation/StringIds.h"
 #include "OpenLoco.h"
@@ -24,6 +25,9 @@ namespace OpenLoco
     void Town::update()
     {
         recalculateSize();
+
+        if (Config::get().townGrowthDisabled)
+            return;
 
         static constexpr std::array<uint8_t, 12> kBuildSpeedToGrowthPerTick = { 0, 1, 3, 5, 7, 9, 12, 16, 22, 0, 0, 0 };
         auto growthPerTick = kBuildSpeedToGrowthPerTick[this->buildSpeed];

--- a/src/OpenLoco/src/Windows/Options.cpp
+++ b/src/OpenLoco/src/Windows/Options.cpp
@@ -1906,7 +1906,7 @@ namespace OpenLoco::Ui::Windows::Options
 
     namespace Misc
     {
-        static constexpr Ui::Size kWindowSize = { 420, 251 };
+        static constexpr Ui::Size kWindowSize = { 420, 266 };
 
         namespace Widx
         {
@@ -1917,6 +1917,7 @@ namespace OpenLoco::Ui::Windows::Options
                 disable_vehicle_breakdowns,
                 trainsReverseAtSignals,
                 disableAICompanies,
+                disableTownExpansion,
                 groupPreferredOwnerName,
                 use_preferred_owner_name,
                 change_btn,
@@ -1930,28 +1931,29 @@ namespace OpenLoco::Ui::Windows::Options
             };
         }
 
-        static constexpr uint64_t enabledWidgets = Common::enabledWidgets | (1 << Misc::Widx::enableCheatsToolbarButton) | (1 << Misc::Widx::disable_vehicle_breakdowns) | (1 << Widx::trainsReverseAtSignals) | (1 << Widx::disableAICompanies) | (1 << Misc::Widx::use_preferred_owner_name) | (1 << Misc::Widx::change_btn) | (1 << Misc::Widx::export_plugin_objects) | (1 << Misc::Widx::autosave_frequency_btn) | (1 << Misc::Widx::autosave_amount) | (1 << Misc::Widx::autosave_amount_down_btn) | (1 << Misc::Widx::autosave_amount_up_btn);
+        static constexpr uint64_t enabledWidgets = Common::enabledWidgets | (1 << Widx::enableCheatsToolbarButton) | (1 << Widx::disable_vehicle_breakdowns) | (1 << Widx::trainsReverseAtSignals) | (1 << Widx::disableAICompanies) | (1 << Widx::disableAICompanies) | (1 << Widx::use_preferred_owner_name) | (1 << Widx::change_btn) | (1 << Widx::export_plugin_objects) | (1 << Widx::disableTownExpansion) | (1 << Widx::autosave_amount) | (1 << Widx::autosave_amount_down_btn) | (1 << Widx::autosave_amount_up_btn);
 
         static Widget _widgets[] = {
             common_options_widgets(kWindowSize, StringIds::options_title_miscellaneous),
 
             // Cheats group
-            makeWidget({ 4, 49 }, { 412, 78 }, WidgetType::groupbox, WindowColour::secondary, StringIds::gameplay_tweaks),
+            makeWidget({ 4, 49 }, { 412, 93 }, WidgetType::groupbox, WindowColour::secondary, StringIds::gameplay_tweaks),
             makeWidget({ 10, 64 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::option_cheat_menu_enable, StringIds::tooltip_option_cheat_menu_enable),
             makeWidget({ 10, 79 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disable_vehicle_breakdowns),
             makeWidget({ 10, 94 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::trainsReverseAtSignals),
             makeWidget({ 10, 109 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disableAICompanies, StringIds::disableAICompanies_tip),
+            makeWidget({ 10, 124 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disableTownExpansion, StringIds::disableTownExpansion_tip),
 
             // Preferred owner name group
-            makeWidget({ 4, 130 }, { 412, 47 }, WidgetType::groupbox, WindowColour::secondary, StringIds::preferred_owner),
-            makeWidget({ 10, 145 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::use_preferred_owner_name, StringIds::use_preferred_owner_name_tip),
-            makeWidget({ 335, 159 }, { 75, 12 }, WidgetType::button, WindowColour::secondary, StringIds::change),
+            makeWidget({ 4, 145 }, { 412, 47 }, WidgetType::groupbox, WindowColour::secondary, StringIds::preferred_owner),
+            makeWidget({ 10, 160 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::use_preferred_owner_name, StringIds::use_preferred_owner_name_tip),
+            makeWidget({ 335, 174 }, { 75, 12 }, WidgetType::button, WindowColour::secondary, StringIds::change),
 
             // Save options group
-            makeWidget({ 4, 181 }, { 412, 65 }, WidgetType::groupbox, WindowColour::secondary, StringIds::autosave_preferences),
-            makeDropdownWidgets({ 250, 197 }, { 156, 12 }, WidgetType::combobox, WindowColour::secondary, StringIds::empty),
-            makeStepperWidgets({ 250, 212 }, { 156, 12 }, WidgetType::textbox, WindowColour::secondary, StringIds::empty),
-            makeWidget({ 10, 228 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::export_plugin_objects, StringIds::export_plugin_objects_tip),
+            makeWidget({ 4, 196 }, { 412, 65 }, WidgetType::groupbox, WindowColour::secondary, StringIds::autosave_preferences),
+            makeDropdownWidgets({ 250, 212 }, { 156, 12 }, WidgetType::combobox, WindowColour::secondary, StringIds::empty),
+            makeStepperWidgets({ 250, 227 }, { 156, 12 }, WidgetType::textbox, WindowColour::secondary, StringIds::empty),
+            makeWidget({ 10, 243 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::export_plugin_objects, StringIds::export_plugin_objects_tip),
             widgetEnd(),
         };
 
@@ -1966,6 +1968,7 @@ namespace OpenLoco::Ui::Windows::Options
         static void disableVehicleBreakdownsMouseUp(Window* w);
         static void trainsReverseAtSignalsMouseUp(Window* w);
         static void disableAICompaniesMouseUp(Window* w);
+        static void disableTownExpansionMouseUp(Window* w);
         static void exportPluginObjectsMouseUp(Window* w);
 
         // 0x004C11B7
@@ -2004,6 +2007,11 @@ namespace OpenLoco::Ui::Windows::Options
                 w.activatedWidgets |= (1 << Widx::disableAICompanies);
             else
                 w.activatedWidgets &= ~(1 << Widx::disableAICompanies);
+
+            if (Config::get().townGrowthDisabled)
+                w.activatedWidgets |= (1 << Widx::disableTownExpansion);
+            else
+                w.activatedWidgets &= ~(1 << Widx::disableTownExpansion);
 
             w.activatedWidgets &= ~(1 << Widx::export_plugin_objects);
             if (Config::get().old.flags & Config::Flags::exportObjectsWithSaves)
@@ -2196,6 +2204,10 @@ namespace OpenLoco::Ui::Windows::Options
                     disableAICompaniesMouseUp(&w);
                     break;
 
+                case Widx::disableTownExpansion:
+                    disableTownExpansionMouseUp(&w);
+                    break;
+
                 case Widx::export_plugin_objects:
                     exportPluginObjectsMouseUp(&w);
                     break;
@@ -2328,6 +2340,14 @@ namespace OpenLoco::Ui::Windows::Options
         {
             auto& cfg = OpenLoco::Config::get();
             cfg.companyAIDisabled = !cfg.companyAIDisabled;
+            Config::write();
+            w->invalidate();
+        }
+
+        static void disableTownExpansionMouseUp(Window* w)
+        {
+            auto& cfg = OpenLoco::Config::get();
+            cfg.townGrowthDisabled = !cfg.townGrowthDisabled;
             Config::write();
             w->invalidate();
         }


### PR DESCRIPTION
This adds the option to disable town renewal/expansion/growth, intended as a QoL feature for sandbox players.

- [x] Currently depends on/contains #1736, which should be reviewed first.

![Screenshot (3)](https://user-images.githubusercontent.com/604665/207673196-0937521b-28b4-4a59-a7a5-6f3803dd8e6c.png)