### PR TITLE
Revamp the miscellaneous options tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Feature: [#175, #938] Allow modifying object selection in-game (cheat menu).
 - Feature: [#1664] Allow modifying scenario options in-game (cheat menu).
 - Fix: [#1727] Starting loan is not displayed properly in scenario options.
+- Change: [#1736] The miscellaneous options tab has been redesigned to reduce clutter.
 
 22.11 (2022-11-20)
 ------------------------------------------------------------------------

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2322,4 +2322,4 @@ strings:
   2267: "Object selection"
   2268: "Gameplay tweaks"
   2269: "Preferred owner"
-  2269: "Autosave preferences"
+  2270: "Autosave preferences"

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2320,3 +2320,6 @@ strings:
   2265: "{COLOUR WINDOW_2} Filename: {COLOUR BLACK}{STRINGID}"
   2266: "Scenario options"
   2267: "Object selection"
+  2268: "Gameplay tweaks"
+  2269: "Preferred owner"
+  2269: "Autosave preferences"

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1854,5 +1854,5 @@ namespace OpenLoco::StringIds
     constexpr string_id object_strings_begin = 8208;
     constexpr string_id gameplay_tweaks = 2268;
     constexpr string_id preferred_owner = 2269;
-    constexpr string_id autosave_preferences = 2269;
+    constexpr string_id autosave_preferences = 2270;
 }

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1852,4 +1852,7 @@ namespace OpenLoco::StringIds
     constexpr string_id temporary_object_load_str_14 = 8206;
     constexpr string_id temporary_object_load_str_15 = 8207;
     constexpr string_id object_strings_begin = 8208;
+    constexpr string_id gameplay_tweaks = 2268;
+    constexpr string_id preferred_owner = 2269;
+    constexpr string_id autosave_preferences = 2269;
 }

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1834,6 +1834,9 @@ namespace OpenLoco::StringIds
     constexpr string_id object_selection_filename = 2265;
     constexpr string_id open_scenario_options = 2266;
     constexpr string_id open_object_selection = 2267;
+    constexpr string_id gameplay_tweaks = 2268;
+    constexpr string_id preferred_owner = 2269;
+    constexpr string_id autosave_preferences = 2270;
 
     constexpr string_id temporary_object_load_str_0 = 8192;
     constexpr string_id temporary_object_load_str_1 = 8193;
@@ -1852,7 +1855,4 @@ namespace OpenLoco::StringIds
     constexpr string_id temporary_object_load_str_14 = 8206;
     constexpr string_id temporary_object_load_str_15 = 8207;
     constexpr string_id object_strings_begin = 8208;
-    constexpr string_id gameplay_tweaks = 2268;
-    constexpr string_id preferred_owner = 2269;
-    constexpr string_id autosave_preferences = 2270;
 }

--- a/src/OpenLoco/src/Windows/Options.cpp
+++ b/src/OpenLoco/src/Windows/Options.cpp
@@ -25,13 +25,6 @@
 
 using namespace OpenLoco::Interop;
 
-namespace OpenLoco::StringIds
-{
-    constexpr string_id gameplay_tweaks = 2268;
-    constexpr string_id preferred_owner = 2269;
-    constexpr string_id autosave_preferences = 2269;
-}
-
 namespace OpenLoco::Ui::Windows::Options
 {
     static void tabOnMouseUp(Window* w, WidgetIndex_t wi);

--- a/src/OpenLoco/src/Windows/Options.cpp
+++ b/src/OpenLoco/src/Windows/Options.cpp
@@ -25,6 +25,13 @@
 
 using namespace OpenLoco::Interop;
 
+namespace OpenLoco::StringIds
+{
+    constexpr string_id gameplay_tweaks = 2268;
+    constexpr string_id preferred_owner = 2269;
+    constexpr string_id autosave_preferences = 2269;
+}
+
 namespace OpenLoco::Ui::Windows::Options
 {
     static void tabOnMouseUp(Window* w, WidgetIndex_t wi);
@@ -1906,24 +1913,27 @@ namespace OpenLoco::Ui::Windows::Options
 
     namespace Misc
     {
-        static constexpr Ui::Size kWindowSize = { 420, 189 };
+        static constexpr Ui::Size kWindowSize = { 420, 251 };
 
         namespace Widx
         {
             enum
             {
-                enableCheatsToolbarButton = 10,
+                groupCheats = 10,
+                enableCheatsToolbarButton,
                 disable_vehicle_breakdowns,
                 trainsReverseAtSignals,
                 disableAICompanies,
+                groupPreferredOwnerName,
                 use_preferred_owner_name,
                 change_btn,
-                export_plugin_objects,
+                groupSaveOptions,
                 autosave_frequency,
                 autosave_frequency_btn,
                 autosave_amount,
                 autosave_amount_down_btn,
                 autosave_amount_up_btn,
+                export_plugin_objects,
             };
         }
 
@@ -1931,15 +1941,24 @@ namespace OpenLoco::Ui::Windows::Options
 
         static Widget _widgets[] = {
             common_options_widgets(kWindowSize, StringIds::options_title_miscellaneous),
-            makeWidget({ 10, 49 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::option_cheat_menu_enable, StringIds::tooltip_option_cheat_menu_enable),
-            makeWidget({ 10, 64 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disable_vehicle_breakdowns),
-            makeWidget({ 10, 79 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::trainsReverseAtSignals),
-            makeWidget({ 10, 94 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disableAICompanies, StringIds::disableAICompanies_tip),
-            makeWidget({ 10, 109 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::use_preferred_owner_name, StringIds::use_preferred_owner_name_tip),
-            makeWidget({ 335, 124 }, { 75, 12 }, WidgetType::button, WindowColour::secondary, StringIds::change),
-            makeWidget({ 10, 139 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::export_plugin_objects, StringIds::export_plugin_objects_tip),
-            makeDropdownWidgets({ 250, 154 }, { 156, 12 }, WidgetType::combobox, WindowColour::secondary, StringIds::empty),
-            makeStepperWidgets({ 250, 169 }, { 156, 12 }, WidgetType::textbox, WindowColour::secondary, StringIds::empty),
+
+            // Cheats group
+            makeWidget({ 4, 49 }, { 412, 78 }, WidgetType::groupbox, WindowColour::secondary, StringIds::gameplay_tweaks),
+            makeWidget({ 10, 64 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::option_cheat_menu_enable, StringIds::tooltip_option_cheat_menu_enable),
+            makeWidget({ 10, 79 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disable_vehicle_breakdowns),
+            makeWidget({ 10, 94 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::trainsReverseAtSignals),
+            makeWidget({ 10, 109 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disableAICompanies, StringIds::disableAICompanies_tip),
+
+            // Preferred owner name group
+            makeWidget({ 4, 130 }, { 412, 47 }, WidgetType::groupbox, WindowColour::secondary, StringIds::preferred_owner),
+            makeWidget({ 10, 145 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::use_preferred_owner_name, StringIds::use_preferred_owner_name_tip),
+            makeWidget({ 335, 159 }, { 75, 12 }, WidgetType::button, WindowColour::secondary, StringIds::change),
+
+            // Save options group
+            makeWidget({ 4, 181 }, { 412, 65 }, WidgetType::groupbox, WindowColour::secondary, StringIds::autosave_preferences),
+            makeDropdownWidgets({ 250, 197 }, { 156, 12 }, WidgetType::combobox, WindowColour::secondary, StringIds::empty),
+            makeStepperWidgets({ 250, 212 }, { 156, 12 }, WidgetType::textbox, WindowColour::secondary, StringIds::empty),
+            makeWidget({ 10, 228 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::export_plugin_objects, StringIds::export_plugin_objects_tip),
             widgetEnd(),
         };
 
@@ -2038,9 +2057,9 @@ namespace OpenLoco::Ui::Windows::Options
 
             FormatArguments args = {};
             args.push(StringIds::buffer_2039);
-            Gfx::drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::change_btn].top + 1, Colour::black, StringIds::wcolour2_preferred_owner_name, &args);
+            Gfx::drawStringLeft(*rt, w.x + 24, w.y + w.widgets[Widx::change_btn].top + 1, Colour::black, StringIds::wcolour2_preferred_owner_name, &args);
 
-            auto y = w.y + w.widgets[Widx::autosave_frequency].top + 1;
+            auto y = w.y + w.widgets[Widx::autosave_frequency].top;
             drawStringLeft(*rt, w.x + 10, y, Colour::black, StringIds::autosave_frequency, nullptr);
 
             auto freq = Config::get().autosaveFrequency;
@@ -2059,7 +2078,7 @@ namespace OpenLoco::Ui::Windows::Options
             }
             drawDropdownContent(&w, rt, Widx::autosave_frequency, stringId, freq);
 
-            y = w.y + w.widgets[Widx::autosave_amount].top + 1;
+            y = w.y + w.widgets[Widx::autosave_amount].top;
             drawStringLeft(*rt, w.x + 10, y, Colour::black, StringIds::autosave_amount, nullptr);
 
             auto scale = Config::get().autosaveAmount;


### PR DESCRIPTION
This PR reorganises the miscellaneous options tab, grouping relevant options into boxes, reducing visual clutter.

Before:
![Screenshot](https://user-images.githubusercontent.com/604665/207670313-5fcf5bb5-95cb-4445-bb50-83af8fd44e59.png)

After:
![Screenshot (2)](https://user-images.githubusercontent.com/604665/207671137-805b7f4d-5290-4a09-834c-84cab78824eb.png)
