### PR TITLE
Introduce enum flags

### DIFF
--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -1,16 +1,17 @@
 set(public_files
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/BitSet.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/EnumFlags.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/FileSystem.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/LocoFixedVector.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/Prng.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/Span.hpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/EnumFlags.hpp"
 )
 
 set(private_files
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Prng.cpp")
 
 set(test_files
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/EnumFlagsTests.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/PrngTests.cpp"
 )
 

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -3,7 +3,9 @@ set(public_files
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/FileSystem.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/LocoFixedVector.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/Prng.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/Span.hpp")
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/Span.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/EnumFlags.hpp"
+)
 
 set(private_files
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Prng.cpp")

--- a/src/Core/include/OpenLoco/Core/EnumFlags.hpp
+++ b/src/Core/include/OpenLoco/Core/EnumFlags.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+
+namespace OpenLoco::Core
+{
+
+#define OPENLOCO_ENABLE_ENUM_OPERATORS(ENM)                                                                                 \
+    static_assert(std::is_unsigned_v<std::underlying_type_t<ENM>> == true, "Underlying enum type must be unsignd");         \
+    inline constexpr ENM operator|(const ENM a, const ENM b) noexcept                                                       \
+    {                                                                                                                       \
+        return static_cast<ENM>(static_cast<std::underlying_type_t<ENM>>(a) | static_cast<std::underlying_type_t<ENM>>(b)); \
+    }                                                                                                                       \
+    inline constexpr ENM operator|=(ENM& a, const ENM b) noexcept                                                           \
+    {                                                                                                                       \
+        a = static_cast<ENM>(static_cast<std::underlying_type_t<ENM>>(a) | static_cast<std::underlying_type_t<ENM>>(b));    \
+        return a;                                                                                                           \
+    }                                                                                                                       \
+    inline constexpr ENM operator^(const ENM a, const ENM b) noexcept                                                       \
+    {                                                                                                                       \
+        return static_cast<ENM>(static_cast<std::underlying_type_t<ENM>>(a) ^ static_cast<std::underlying_type_t<ENM>>(b)); \
+    }                                                                                                                       \
+    inline constexpr ENM operator^=(ENM& a, const ENM b) noexcept                                                           \
+    {                                                                                                                       \
+        a = static_cast<ENM>(static_cast<std::underlying_type_t<ENM>>(a) ^ static_cast<std::underlying_type_t<ENM>>(b));    \
+        return a;                                                                                                           \
+    }                                                                                                                       \
+    inline constexpr ENM operator&(const ENM a, const ENM b) noexcept                                                       \
+    {                                                                                                                       \
+        return static_cast<ENM>(static_cast<std::underlying_type_t<ENM>>(a) & static_cast<std::underlying_type_t<ENM>>(b)); \
+    }                                                                                                                       \
+    inline constexpr ENM operator&=(ENM& a, const ENM b) noexcept                                                           \
+    {                                                                                                                       \
+        a = static_cast<ENM>(static_cast<std::underlying_type_t<ENM>>(a) & static_cast<std::underlying_type_t<ENM>>(b));    \
+        return a;                                                                                                           \
+    }                                                                                                                       \
+    inline constexpr ENM operator~(const ENM a) noexcept                                                                    \
+    {                                                                                                                       \
+        return static_cast<ENM>(~static_cast<std::underlying_type_t<ENM>>(a));                                              \
+    }
+
+}

--- a/src/Core/include/OpenLoco/Core/EnumFlags.hpp
+++ b/src/Core/include/OpenLoco/Core/EnumFlags.hpp
@@ -8,6 +8,7 @@ namespace OpenLoco::Core
 
 #define OPENLOCO_ENABLE_ENUM_OPERATORS(ENM)                                                                                 \
     static_assert(std::is_unsigned_v<std::underlying_type_t<ENM>> == true, "Underlying enum type must be unsignd");         \
+    static_assert(static_cast<std::underlying_type_t<ENM>>(ENM::none) == 0U, "Enum must have a none value");                \
     inline constexpr ENM operator|(const ENM a, const ENM b) noexcept                                                       \
     {                                                                                                                       \
         return static_cast<ENM>(static_cast<std::underlying_type_t<ENM>>(a) | static_cast<std::underlying_type_t<ENM>>(b)); \

--- a/src/Core/tests/EnumFlagsTests.cpp
+++ b/src/Core/tests/EnumFlagsTests.cpp
@@ -1,0 +1,64 @@
+#include <OpenLoco/Core/EnumFlags.hpp>
+#include <gtest/gtest.h>
+
+enum class TestFlags : std::uint32_t
+{
+    none = 0,
+    a = 1U << 0,
+    b = 1U << 2,
+    c = 1U << 4,
+    d = 1U << 8,
+    e = 1U << 16,
+    f = 1U << 24,
+    g = 1U << 31,
+};
+OPENLOCO_ENABLE_ENUM_OPERATORS(TestFlags);
+
+TEST(EnumFlagsTest, operatorOr)
+{
+    constexpr TestFlags flags = TestFlags::a | TestFlags::c | TestFlags::d | TestFlags::g;
+    constexpr auto value = static_cast<std::underlying_type_t<TestFlags>>(flags);
+    ASSERT_EQ(value, 0b1000'0000'0000'0000'0000'0001'0001'0001);
+}
+
+TEST(EnumFlagsTest, operatorAnd)
+{
+    constexpr TestFlags flags = (TestFlags::a | TestFlags::c | TestFlags::d | TestFlags::g) & TestFlags::c;
+    constexpr auto value = static_cast<std::underlying_type_t<TestFlags>>(flags);
+    ASSERT_EQ(value, 0b0000'0000'0000'0000'0000'0000'0001'0000);
+}
+
+TEST(EnumFlagsTest, operatorXor)
+{
+    constexpr TestFlags flags = (TestFlags::a | TestFlags::c | TestFlags::d) ^ (TestFlags::a | TestFlags::c | TestFlags::d) ^ TestFlags::f;
+    constexpr auto value = static_cast<std::underlying_type_t<TestFlags>>(flags);
+    ASSERT_EQ(value, 0b0000'0001'0000'0000'0000'0000'0000'0000);
+}
+
+TEST(EnumFlagsTest, operatorOrInplace)
+{
+    TestFlags flags = TestFlags::none;
+    flags |= TestFlags::a;
+    flags |= TestFlags::c;
+    flags |= TestFlags::d;
+    flags |= TestFlags::g;
+    auto value = static_cast<std::underlying_type_t<TestFlags>>(flags);
+    ASSERT_EQ(value, 0b1000'0000'0000'0000'0000'0001'0001'0001);
+}
+
+TEST(EnumFlagsTest, operatorAndInplace)
+{
+    TestFlags flags = (TestFlags::a | TestFlags::c | TestFlags::d | TestFlags::g);
+    flags &= TestFlags::c;
+    auto value = static_cast<std::underlying_type_t<TestFlags>>(flags);
+    ASSERT_EQ(value, 0b0000'0000'0000'0000'0000'0000'0001'0000);
+}
+
+TEST(EnumFlagsTest, operatorXorInplace)
+{
+    TestFlags flags = (TestFlags::a | TestFlags::c | TestFlags::d);
+    flags ^= (TestFlags::a | TestFlags::c | TestFlags::d);
+    flags ^= TestFlags::f;
+    auto value = static_cast<std::underlying_type_t<TestFlags>>(flags);
+    ASSERT_EQ(value, 0b0000'0001'0000'0000'0000'0000'0000'0000);
+}

--- a/src/OpenLoco/src/Company.cpp
+++ b/src/OpenLoco/src/Company.cpp
@@ -298,7 +298,8 @@ namespace OpenLoco
             Ui::WindowManager::invalidate(Ui::WindowType::company, enumValue(id()));
         }
 
-        if (challengeFlags & (CompanyFlags::challengeBeatenByOpponent | CompanyFlags::challengeCompleted | CompanyFlags::challengeFailed))
+        constexpr auto requiredFlags = CompanyFlags::challengeBeatenByOpponent | CompanyFlags::challengeCompleted | CompanyFlags::challengeFailed;
+        if ((challengeFlags & requiredFlags) != CompanyFlags::none)
         {
             return;
         }

--- a/src/OpenLoco/src/Company.cpp
+++ b/src/OpenLoco/src/Company.cpp
@@ -167,7 +167,7 @@ namespace OpenLoco
 
         callThinkFunc2();
 
-        if (headquartersX != -1 || (challengeFlags & CompanyFlags::bankrupt) || ((challengeFlags & CompanyFlags::unk0) == 0))
+        if (headquartersX != -1 || (challengeFlags & CompanyFlags::bankrupt) != CompanyFlags::none || (challengeFlags & CompanyFlags::unk0) == CompanyFlags::none)
         {
             return;
         }
@@ -433,7 +433,7 @@ namespace OpenLoco
 
     void Company::updateLoanAutorepay()
     {
-        if (currentLoan > 0 && cash > 0 && ((challengeFlags & CompanyFlags::autopayLoan) != 0))
+        if (currentLoan > 0 && cash > 0 && ((challengeFlags & CompanyFlags::autopayLoan) != CompanyFlags::none))
         {
             GameCommands::ChangeLoanArgs args{};
             args.newLoan = currentLoan - std::max<currency32_t>(0, std::min<currency32_t>(currentLoan, cash.asInt64()));
@@ -703,7 +703,7 @@ namespace OpenLoco
             return;
         }
 
-        if (challengeFlags & CompanyFlags::bankrupt)
+        if ((challengeFlags & CompanyFlags::bankrupt) != CompanyFlags::none)
         {
             bool hasAssets = false;
             for (auto& unk : var_4A8)

--- a/src/OpenLoco/src/Company.h
+++ b/src/OpenLoco/src/Company.h
@@ -4,6 +4,7 @@
 #include "Economy/Expenditures.h"
 #include "Map/Map.hpp"
 #include "Types.hpp"
+#include <OpenLoco/Core/EnumFlags.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -11,19 +12,21 @@
 
 namespace OpenLoco
 {
-    namespace CompanyFlags
+    enum class CompanyFlags : uint32_t
     {
-        constexpr uint32_t unk0 = (1 << 0);                      // 0x01
-        constexpr uint32_t sorted = (1 << 3);                    // 0x08
-        constexpr uint32_t increasedPerformance = (1 << 4);      // 0x10
-        constexpr uint32_t decreasedPerformance = (1 << 5);      // 0x20
-        constexpr uint32_t challengeCompleted = (1 << 6);        // 0x40
-        constexpr uint32_t challengeFailed = (1 << 7);           // 0x80
-        constexpr uint32_t challengeBeatenByOpponent = (1 << 8); // 0x100
-        constexpr uint32_t bankrupt = (1 << 9);                  // 0x200
-        constexpr uint32_t autopayLoan = (1 << 31);              // 0x80000000 new for OpenLoco
-    }
-
+        none = 0U,
+        unk0 = (1U << 0),                      // 0x01
+        sorted = (1U << 3),                    // 0x08
+        increasedPerformance = (1U << 4),      // 0x10
+        decreasedPerformance = (1U << 5),      // 0x20
+        challengeCompleted = (1U << 6),        // 0x40
+        challengeFailed = (1U << 7),           // 0x80
+        challengeBeatenByOpponent = (1U << 8), // 0x100
+        bankrupt = (1U << 9),                  // 0x200
+        autopayLoan = (1U << 31),              // 0x80000000 new for OpenLoco
+    };
+    OPENLOCO_ENABLE_ENUM_OPERATORS(CompanyFlags);
+    
     enum class CorporateRating
     {
         platelayer,           // 0 - 9.9%

--- a/src/OpenLoco/src/Company.h
+++ b/src/OpenLoco/src/Company.h
@@ -26,7 +26,7 @@ namespace OpenLoco
         autopayLoan = (1U << 31),              // 0x80000000 new for OpenLoco
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(CompanyFlags);
-    
+
     enum class CorporateRating
     {
         platelayer,           // 0 - 9.9%

--- a/src/OpenLoco/src/Company.h
+++ b/src/OpenLoco/src/Company.h
@@ -107,7 +107,7 @@ namespace OpenLoco
         static_assert(sizeof(unk4A8) == 0x8C);
         string_id name;
         string_id ownerName;
-        uint32_t challengeFlags;          // 0x04
+        CompanyFlags challengeFlags;      // 0x04
         currency48_t cash;                // 0x08
         currency32_t currentLoan;         // 0x0E
         uint32_t updateCounter;           // 0x12

--- a/src/OpenLoco/src/CompanyManager.cpp
+++ b/src/OpenLoco/src/CompanyManager.cpp
@@ -390,7 +390,7 @@ namespace OpenLoco::CompanyManager
             return StringIds::company_status_empty;
         }
 
-        if (company->challengeFlags & CompanyFlags::bankrupt)
+        if ((company->challengeFlags & CompanyFlags::bankrupt) != CompanyFlags::none)
             return StringIds::company_status_bankrupt;
 
         const string_id observationStatusStrings[] = {

--- a/src/OpenLoco/src/S5/S5.h
+++ b/src/OpenLoco/src/S5/S5.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "CompanyManager.h"
 #include "EditorController.h"
 #include "Engine/Limits.h"
 #include "Objects/Object.h"
@@ -165,7 +166,7 @@ namespace OpenLoco::S5
         uint8_t challengeProgress;           // 0x246
         std::byte pad_247;                   // 0x247
         uint8_t image[250 * 200];            // 0x248
-        uint32_t challengeFlags;             // 0xC598 (from [company.challenge_flags])
+        CompanyFlags challengeFlags;         // 0xC598 (from [company.challenge_flags])
         std::byte pad_C59C[0xC618 - 0xC59C]; // 0xC59C
     };
 #pragma pack(pop)
@@ -176,7 +177,7 @@ namespace OpenLoco::S5
     {
         uint16_t name;                 // 0x0000
         uint16_t ownerName;            // 0x0002
-        uint32_t challengeFlags;       // 0x0004
+        CompanyFlags challengeFlags;   // 0x0004
         uint8_t cash[6];               // 0x0008
         uint32_t currentLoan;          // 0x000E
         uint32_t updateCounter;        // 0x0012

--- a/src/OpenLoco/src/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Windows/CompanyList.cpp
@@ -257,7 +257,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             for (auto& company : CompanyManager::companies())
             {
-                if ((company.challengeFlags & CompanyFlags::sorted) != 0)
+                if ((company.challengeFlags & CompanyFlags::sorted) != CompanyFlags::none)
                     continue;
 
                 if (chosenCompany == CompanyId::null)
@@ -506,11 +506,11 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 auto performanceStringId = StringIds::performance_index;
 
-                if ((company->challengeFlags & CompanyFlags::increasedPerformance) && (company->challengeFlags & CompanyFlags::decreasedPerformance))
+                if ((company->challengeFlags & CompanyFlags::increasedPerformance) != CompanyFlags::none && (company->challengeFlags & CompanyFlags::decreasedPerformance) != CompanyFlags::none)
                 {
                     performanceStringId = StringIds::performance_index_decrease;
 
-                    if (company->challengeFlags & CompanyFlags::increasedPerformance)
+                    if ((company->challengeFlags & CompanyFlags::increasedPerformance) != CompanyFlags::none)
                     {
                         performanceStringId = StringIds::performance_index_increase;
                     }

--- a/src/OpenLoco/src/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Windows/CompanyWindow.cpp
@@ -773,11 +773,11 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 formatPerformanceIndex(company->performanceIndex, args);
 
                 string_id formatId = StringIds::company_details_performance;
-                if (company->challengeFlags & CompanyFlags::decreasedPerformance)
+                if ((company->challengeFlags & CompanyFlags::decreasedPerformance) != CompanyFlags::none)
                 {
                     formatId = StringIds::company_details_performance_decreasing;
                 }
-                else if (company->challengeFlags & CompanyFlags::increasedPerformance)
+                else if ((company->challengeFlags & CompanyFlags::increasedPerformance) != CompanyFlags::none)
                 {
                     formatId = StringIds::company_details_performance_increasing;
                 }
@@ -1639,7 +1639,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 self.widgets[widx::loan_increase].type = WidgetType::button;
                 self.widgets[widx::loan_autopay].type = WidgetType::checkbox;
 
-                if ((company->challengeFlags & CompanyFlags::autopayLoan) != 0)
+                if ((company->challengeFlags & CompanyFlags::autopayLoan) != CompanyFlags::none)
                 {
                     self.activatedWidgets |= (1ULL << Finances::widx::loan_autopay);
                 }
@@ -1751,7 +1751,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 auto args = FormatArguments::common(company->cash);
 
                 auto cashFormat = StringIds::cash_positive;
-                if ((company->challengeFlags & CompanyFlags::bankrupt) != 0)
+                if ((company->challengeFlags & CompanyFlags::bankrupt) != CompanyFlags::none)
                     cashFormat = StringIds::cash_bankrupt;
                 if (company->cash.var_04 < 0)
                     cashFormat = StringIds::cash_negative;
@@ -2349,7 +2349,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             Company* playerCompany = CompanyManager::getPlayerCompany();
 
-            if ((playerCompany->challengeFlags & CompanyFlags::challengeCompleted) != 0)
+            if ((playerCompany->challengeFlags & CompanyFlags::challengeCompleted) != CompanyFlags::none)
             {
                 uint16_t years = Scenario::getObjectiveProgress().completedChallengeInMonths / 12;
                 uint16_t months = Scenario::getObjectiveProgress().completedChallengeInMonths % 12;
@@ -2359,13 +2359,13 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 return;
             }
 
-            if ((playerCompany->challengeFlags & CompanyFlags::challengeFailed) != 0)
+            if ((playerCompany->challengeFlags & CompanyFlags::challengeFailed) != CompanyFlags::none)
             {
                 Gfx::drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::failed_you_failed_to_complete_the_challenge);
                 return;
             }
 
-            if ((playerCompany->challengeFlags & CompanyFlags::challengeBeatenByOpponent) != 0)
+            if ((playerCompany->challengeFlags & CompanyFlags::challengeBeatenByOpponent) != CompanyFlags::none)
             {
                 uint16_t years = Scenario::getObjectiveProgress().completedChallengeInMonths / 12;
                 uint16_t months = Scenario::getObjectiveProgress().completedChallengeInMonths % 12;

--- a/src/OpenLoco/src/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/src/Windows/PlayerInfoPanel.cpp
@@ -222,7 +222,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
         auto x = window.x + frame.width() / 2 + 12;
         {
             auto companyValueString = StringIds::player_info_bankrupt;
-            if (!(playerCompany->challengeFlags & CompanyFlags::bankrupt))
+            if ((playerCompany->challengeFlags & CompanyFlags::bankrupt) == CompanyFlags::none)
             {
                 if (static_cast<int16_t>(playerCompany->cash.var_04) < 0)
                 {
@@ -248,11 +248,11 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
         {
             auto performanceString = StringIds::player_info_performance;
 
-            if (playerCompany->challengeFlags & CompanyFlags::increasedPerformance)
+            if ((playerCompany->challengeFlags & CompanyFlags::increasedPerformance) != CompanyFlags::none)
             {
                 performanceString = StringIds::player_info_performance_increase;
             }
-            else if (playerCompany->challengeFlags & (CompanyFlags::decreasedPerformance))
+            else if ((playerCompany->challengeFlags & CompanyFlags::decreasedPerformance) != CompanyFlags::none)
             {
                 performanceString = StringIds::player_info_performance_decrease;
             }

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -478,14 +478,14 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
 
         // Challenge progress
         auto flags = saveInfo.challengeFlags;
-        if (!(flags & CompanyFlags::challengeBeatenByOpponent))
+        if ((flags & CompanyFlags::challengeBeatenByOpponent) == CompanyFlags::none)
         {
             auto stringId = StringIds::window_browse_challenge_completed;
             int16_t progress = 0;
-            if (!(flags & CompanyFlags::challengeCompleted))
+            if ((flags & CompanyFlags::challengeCompleted) == CompanyFlags::none)
             {
                 stringId = StringIds::window_browse_challenge_failed;
-                if (!(flags & CompanyFlags::challengeFailed))
+                if ((flags & CompanyFlags::challengeFailed) == CompanyFlags::none)
                 {
                     stringId = StringIds::window_browse_challenge_progress;
                     progress = saveInfo.challengeProgress;

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -332,15 +332,15 @@ namespace OpenLoco::Ui::Windows::TimePanel
 
         auto playerCompany = CompanyManager::get(CompanyManager::getControllingId());
 
-        if ((playerCompany->challengeFlags & CompanyFlags::challengeCompleted) != 0)
+        if ((playerCompany->challengeFlags & CompanyFlags::challengeCompleted) != CompanyFlags::none)
         {
             args.push(StringIds::challenge_completed);
         }
-        else if ((playerCompany->challengeFlags & CompanyFlags::challengeFailed) != 0)
+        else if ((playerCompany->challengeFlags & CompanyFlags::challengeFailed) != CompanyFlags::none)
         {
             args.push(StringIds::challenge_failed);
         }
-        else if ((playerCompany->challengeFlags & CompanyFlags::challengeBeatenByOpponent) != 0)
+        else if ((playerCompany->challengeFlags & CompanyFlags::challengeBeatenByOpponent) != CompanyFlags::none)
         {
             args.push(StringIds::empty);
         }


### PR DESCRIPTION
This is a proposal to use enum flags for actual flags. OPENLOCO_ENABLE_ENUM_FLAGS just implements all the operators. The main benefit is that its a strong type and can't be accidentally mixed with another flag, the other benefit is that the debugger will now correctly show all flags with a name.

I changed CompanyFlags to use this to have some example code, should probably rename challengeFlags to companyFlags or just flags for the Company struct.