### PR TITLE
Close #1698: improve Locomotion folder prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Feature: [#1745] Add cheat to instantly win any scenario/challenge.
 - Fix: [#528] Snow rendering issue with Steam provided Locomotion.
 - Fix: [#1750] Scenario index is not updated when in-game language changes.
+- Change: [#1698] The prompts asking to locate the Locomotion install folder have been improved.
 
 22.12 (2022-12-22)
 ------------------------------------------------------------------------


### PR DESCRIPTION
This PR improves the OpenLoco 'onboarding experience' by making the Locomotion folder prompts more verbose and user-friendly. I'll let the screenshots below speak for themselves.

NB: the screenshots were taken on Linux. SDL popups do not look particularly nice on Linux; I'm sure they look nicer on Windows and macOS.

#### After
![Screenshot_20230123_201416](https://user-images.githubusercontent.com/604665/214130258-49b03afb-2c3d-47ea-8f75-fb18f2a3c488.png)
![Screenshot_20230123_201710](https://user-images.githubusercontent.com/604665/214130262-091d4f95-c9f4-4cdf-bb66-8f9a9ed08ddc.png)

#### Before
![Screenshot_20230123_201904](https://user-images.githubusercontent.com/604665/214130266-3e90f1f4-9dcf-49c0-852f-f0fba49a3968.png)
![Screenshot_20230123_201910](https://user-images.githubusercontent.com/604665/214130269-a508514c-f229-493b-a2de-b01ca451aa49.png)

Closes #1698