### PR TITLE
Fix address comment for toolDragEnd

### DIFF
--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -1027,7 +1027,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             }
         }
 
-        // 0x004BC701activatedWidgets
+        // 0x004BC701
         static void toolDragEnd(Window& self, const WidgetIndex_t widgetIndex)
         {
             if (widgetIndex == Common::widx::panel)


### PR DESCRIPTION
The parser doesn't quite like this and it seems to be an accidental change, see https://github.com/OpenLoco/OpenLoco/commit/7380c4b4492ac76cd4022dba559b405962f0cc01#diff-aaae0c8d1a0b580bbfaad30e86c4c3f9d72ac4f65b93271fdfe300b7d8f9102aR1023
