### PR TITLE
Performance improvement for debug builds, fix possible UB

### DIFF
--- a/src/Interop/include/OpenLoco/Interop/Interop.hpp
+++ b/src/Interop/include/OpenLoco/Interop/Interop.hpp
@@ -127,15 +127,12 @@ namespace OpenLoco::Interop
 #endif
 #endif
 
-    constexpr uintptr_t remapAddress(uintptr_t locoAddress)
-    {
-        return kGoodPlaceForDataSegment - 0x008A4000 + locoAddress;
-    }
-
     template<uint32_t TAddress, typename T>
     constexpr T& addr()
     {
-        return *((T*)remapAddress(TAddress));
+        constexpr auto ptrAddr = kGoodPlaceForDataSegment - 0x008A4000 + TAddress;
+        // We use std::launder to prevent the compiler from doing optimizations that lead to undefined behavior.
+        return *std::launder(reinterpret_cast<T*>(ptrAddr));
     }
 
     /**


### PR DESCRIPTION
Since debug builds disable inlining entirely each call to addr would also lead to remapAddress calls, since the addresses are all const we can just compute the address within addr with constexpr, this makes very little difference code wise but spares us with all the pointless calls. I also added std::launder, it was sort of made for this purpose to specify the lifetime of an object that comes from some memory address, this acts as optimization barrier and avoids possible undefined behavior. Also instead of a C cast it uses reinterpret_cast which is the correct way to go about this.