### PR TITLE
Move thirdparty part in CMakeLists root to thirdparty CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,15 +69,19 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 set(DEBUG_LEVEL 0 CACHE STRING "Select debug level for compilation. Use value in range 0–3.")
 list(APPEND COMMON_COMPILE_OPTIONS -DDEBUG=${DEBUG_LEVEL})
 
+# Display source files nicely in IDEs
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+# System dependencies
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
+
+# Thirdparty dependencies
+include(thirdparty/CMakeLists.txt)
 
 if (${OPENLOCO_BUILD_TESTS})
     enable_testing()
 endif()
-
-# Display source files nicely in IDEs
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Handle creating the rct2 text and data files on OS X and Linux
 if (UNIX)
@@ -131,7 +135,6 @@ if (UNIX)
     endif ()
 endif()
 
-include(thirdparty/CMakeLists.txt)
 add_subdirectory(src)
 
 if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,37 +71,9 @@ list(APPEND COMMON_COMPILE_OPTIONS -DDEBUG=${DEBUG_LEVEL})
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
+
 if (${OPENLOCO_BUILD_TESTS})
-    find_package(GTest REQUIRED)
     enable_testing()
-endif()
-find_package(SDL2 REQUIRED CONFIG)
-if (TARGET SDL2::SDL2-static)
-    set(SDL2_LIB SDL2::SDL2-static)
-elseif (TARGET SDL2::SDL2)
-    set(SDL2_LIB SDL2::SDL2)
-else ()
-    # Even though we asked for SDL2 from a configure mode which would have SDL2 targets
-    # it appears we have been given a raw module mode SDL2 so create a wrapper library
-    # then we can treat it just like a normal configure mode target
-    add_library(SDL2_WRAPPER INTERFACE)
-    target_link_libraries(SDL2_WRAPPER INTERFACE ${SDL2_LIBRARIES})
-    target_include_directories(SDL2_WRAPPER INTERFACE ${SDL2_INCLUDE_DIRS})
-    set(SDL2_LIB SDL2_WRAPPER)
-endif()
-
-find_package(PNG REQUIRED)
-if (NOT APPLE AND NOT MSVC)
-    pkg_check_modules(OPENAL REQUIRED openal)
-else()
-    find_package(OpenAL CONFIG REQUIRED)
-    set(OPENAL_LIBRARIES OpenAL::OpenAL)
-endif()
-
-# breakpad is also required
-if (MSVC)
-    find_package(unofficial-breakpad CONFIG REQUIRED)
-    set(BREAKPAD_LIBRARIES unofficial::breakpad::libbreakpad unofficial::breakpad::libbreakpad_client)
 endif()
 
 # Display source files nicely in IDEs

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -38,3 +38,36 @@ if ( NOT span-lite_FOUND )
     # Group all the ThirdParty items under a ThirdParty folder in IDEs
     set_target_properties(span-lite PROPERTIES FOLDER "ThirdParty")
 endif()
+
+if (${OPENLOCO_BUILD_TESTS})
+    find_package(GTest REQUIRED)
+endif()
+
+find_package(SDL2 REQUIRED CONFIG)
+if (TARGET SDL2::SDL2-static)
+    set(SDL2_LIB SDL2::SDL2-static)
+elseif (TARGET SDL2::SDL2)
+    set(SDL2_LIB SDL2::SDL2)
+else ()
+    # Even though we asked for SDL2 from a configure mode which would have SDL2 targets
+    # it appears we have been given a raw module mode SDL2 so create a wrapper library
+    # then we can treat it just like a normal configure mode target
+    add_library(SDL2_WRAPPER INTERFACE)
+    target_link_libraries(SDL2_WRAPPER INTERFACE ${SDL2_LIBRARIES})
+    target_include_directories(SDL2_WRAPPER INTERFACE ${SDL2_INCLUDE_DIRS})
+    set(SDL2_LIB SDL2_WRAPPER)
+endif()
+
+find_package(PNG REQUIRED)
+if (NOT APPLE AND NOT MSVC)
+    pkg_check_modules(OPENAL REQUIRED openal)
+else()
+    find_package(OpenAL CONFIG REQUIRED)
+    set(OPENAL_LIBRARIES OpenAL::OpenAL)
+endif()
+
+# breakpad is also required
+if (MSVC)
+    find_package(unofficial-breakpad CONFIG REQUIRED)
+    set(BREAKPAD_LIBRARIES unofficial::breakpad::libbreakpad unofficial::breakpad::libbreakpad_client)
+endif()


### PR DESCRIPTION
I think this makes more sense, now all thirdparty stuff is at one place we need to manage. Was trying to add spdlog to test it out and noticed it was a bit scattered.