### PR TITLE
Apply edge scroll only when the window has input focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix: [#1763] Title music does not stop when unchecked in options window.
 - Fix: [#1772] Toggling edge scrolling option does not work.
 - Fix: [#1798] Memory leak when resizing the window.
+- Change: [#1823] Prevent edge scroll if the window has no input focus.
 
 23.01 (2023-01-25)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -386,6 +386,9 @@ namespace OpenLoco::Input
 
     static void edgeScroll()
     {
+        if (!Ui::hasInputFocus())
+            return;
+
         if (Tutorial::state() != Tutorial::State::none)
             return;
 

--- a/src/OpenLoco/src/Ui.cpp
+++ b/src/OpenLoco/src/Ui.cpp
@@ -1049,4 +1049,11 @@ namespace OpenLoco::Ui
 
         setWindowScaling(newScaleFactor);
     }
+
+    bool hasInputFocus()
+    {
+        const uint32_t windowFlags = SDL_GetWindowFlags(window);
+        return (windowFlags & SDL_WINDOW_INPUT_FOCUS) != 0;
+    }
+
 }

--- a/src/OpenLoco/src/Ui.h
+++ b/src/OpenLoco/src/Ui.h
@@ -142,6 +142,7 @@ namespace OpenLoco::Ui
     void minimalHandleInput();
     void setWindowScaling(float newScaleFactor);
     void adjustWindowScale(float adjust_by);
+    bool hasInputFocus();
 
     namespace ViewportInteraction
     {


### PR DESCRIPTION
This annoyed me quite a bit, it should only scroll when the window has actually input focus.