### PR TITLE
Add search/filter functionality to object selection window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 23.01+ (???)
 ------------------------------------------------------------------------
+- Feature: [#1837]: Add search/filter functionality to object selection window.
 - Fix: [#1763] Title music does not stop when unchecked in options window.
 - Fix: [#1772] Toggling edge scrolling option does not work.
 - Fix: [#1798] Memory leak when resizing the window.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2326,3 +2326,4 @@ strings:
   2271: "Disable town expansion"
   2272: "{SMALLFONT}{COLOUR BLACK}When enabled, towns will not renew or expand over time"
   2273: "Complete scenario challenge"
+  2274: "Clear"

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -342,6 +342,13 @@ namespace OpenLoco::Input
                 }
             }
 
+            ti = WindowManager::find(WindowType::objectSelection);
+            if (ti != nullptr)
+            {
+                Ui::Windows::ObjectSelectionWindow::handleInput(nextKey->charCode, nextKey->keyCode);
+                continue;
+            }
+
             ti = WindowManager::find(WindowType::editKeyboardShortcut);
             if (ti != nullptr)
             {

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -345,6 +345,9 @@ namespace OpenLoco::Input
             ti = WindowManager::find(WindowType::objectSelection);
             if (ti != nullptr)
             {
+                if (tryShortcut(Shortcut::screenshot, nextKey->keyCode, _keyModifier))
+                    continue;
+
                 Ui::Windows::ObjectSelectionWindow::handleInput(nextKey->charCode, nextKey->keyCode);
                 continue;
             }

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1840,6 +1840,7 @@ namespace OpenLoco::StringIds
     constexpr string_id disableTownExpansion = 2271;
     constexpr string_id disableTownExpansion_tip = 2272;
     constexpr string_id completeChallenge = 2273;
+    constexpr string_id clearInput = 2274;
 
     constexpr string_id temporary_object_load_str_0 = 8192;
     constexpr string_id temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Ui/TextInput.cpp
+++ b/src/OpenLoco/src/Ui/TextInput.cpp
@@ -136,6 +136,14 @@ namespace OpenLoco::Ui::TextInput
         xOffset = std::clamp<int16_t>(xOffset, minOffset, maxOffset);
     }
 
+    void InputSession::clearInput()
+    {
+        buffer.clear();
+        cursorPosition = 0;
+        cursorFrame = 0;
+        xOffset = 0;
+    }
+
     // 0x004CEBFB
     void InputSession::sanitizeInput()
     {

--- a/src/OpenLoco/src/Ui/TextInput.cpp
+++ b/src/OpenLoco/src/Ui/TextInput.cpp
@@ -14,7 +14,7 @@ namespace OpenLoco::Ui::TextInput
     {
         if ((charCode >= SDLK_SPACE && charCode < SDLK_DELETE) || (charCode >= 159 && charCode <= 255))
         {
-            if (buffer.length() == inputLenLimit)
+            if (inputLenLimit > 0 && buffer.length() == inputLenLimit)
             {
                 return false;
             }

--- a/src/OpenLoco/src/Ui/TextInput.h
+++ b/src/OpenLoco/src/Ui/TextInput.h
@@ -30,6 +30,7 @@ namespace OpenLoco::Ui::TextInput
         bool handleInput(uint32_t charCode, uint32_t keyCode);
         bool needsReoffsetting(int16_t containerWidth);
         void calculateTextOffset(int16_t containerWidth);
+        void clearInput();
         void sanitizeInput();
     };
 }

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -263,6 +263,7 @@ namespace OpenLoco::Ui::Windows
     {
         Window* open();
         bool tryCloseWindow();
+        void handleInput(uint32_t charCode, uint32_t keyCode);
     }
 
     namespace Options

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -261,7 +261,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x00472BBC
-    static ObjectManager::ObjIndexPair sub_472BBC(Window* self)
+    static ObjectManager::ObjIndexPair getFirstAvailableSelectedObject(Window* self)
     {
         const auto objects = ObjectManager::getAvailableObjects(static_cast<ObjectType>(self->currentTab));
 
@@ -316,7 +316,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         repositionTargetTab(window, ObjectType::region);
         ObjectManager::freeTemporaryObject();
 
-        auto objIndex = sub_472BBC(window);
+        auto objIndex = getFirstAvailableSelectedObject(window);
         if (objIndex.index != -1)
         {
             window->rowHover = objIndex.index;
@@ -868,7 +868,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                     self.object = nullptr;
                     self.scrollAreas[0].contentWidth = 0;
                     ObjectManager::freeTemporaryObject();
-                    auto objIndex = sub_472BBC(&self);
+                    auto objIndex = getFirstAvailableSelectedObject(&self);
 
                     if (objIndex.index != -1)
                     {

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -688,7 +688,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static void drawSearchBox(Window& self, Gfx::RenderTarget* rt)
     {
         char* textBuffer = (char*)StringManager::getString(StringIds::buffer_2039);
-        strcpy(textBuffer, inputSession.buffer.c_str());
+        strncpy(textBuffer, inputSession.buffer.c_str(), 256);
 
         auto& widget = widgets[widx::textInput];
         auto clipped = Gfx::clipRenderTarget(*rt, Ui::Rect(widget.left + 1 + self.x, widget.top + 1 + self.y, widget.width() - 2, widget.height() - 2));
@@ -1167,7 +1167,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     void handleInput(uint32_t charCode, uint32_t keyCode)
     {
-        auto w = WindowManager::find(WindowType::objectSelection);
+        auto* w = WindowManager::find(WindowType::objectSelection);
         if (w == nullptr)
             return;
 

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -120,11 +120,17 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         uint8_t row;
     };
 
+    enum class Visibility
+    {
+        hidden = 0,
+        shown = 1,
+    };
+
     struct TabObjectEntry
     {
         ObjectManager::ObjectIndexId index;
         ObjectManager::ObjectIndexEntry object;
-        bool visible;
+        Visibility display;
     };
 
     static loco_global<char[2], 0x005045F8> _strCheckmark;
@@ -287,7 +293,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         {
             if (pattern.empty())
             {
-                entry.visible = true;
+                entry.display = Visibility::shown;
                 _numVisibleObjectsListed++;
                 continue;
             }
@@ -298,9 +304,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             const bool containsName = contains(name, pattern);
             const bool containsFileName = contains(filename, pattern);
 
-            entry.visible = containsName || containsFileName;
+            entry.display = containsName || containsFileName ? Visibility::shown : Visibility::hidden;
 
-            if (entry.visible)
+            if (entry.display == Visibility::shown)
                 _numVisibleObjectsListed++;
         }
     }
@@ -313,7 +319,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         _tabObjectList.reserve(objects.size());
         for (auto [index, object] : objects)
         {
-            auto entry = TabObjectEntry{ index, object, true };
+            auto entry = TabObjectEntry{ index, object, Visibility::shown };
             _tabObjectList.emplace_back(std::move(entry));
         }
 
@@ -830,7 +836,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         int y = 0;
         for (auto& entry : _tabObjectList)
         {
-            if (!entry.visible)
+            if (entry.display == Visibility::hidden)
                 continue;
 
             Drawing::RectInsetFlags flags = Drawing::RectInsetFlags::colourLight | Drawing::RectInsetFlags::fillDarker | Drawing::RectInsetFlags::borderInset;
@@ -997,7 +1003,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     {
         for (auto& entry : _tabObjectList)
         {
-            if (!entry.visible)
+            if (entry.display == Visibility::hidden)
                 continue;
 
             y -= kRowHeight;

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -268,8 +268,33 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         repositionTargetTab(self, firstTabIndex);
     }
 
+    static bool contains(const std::string_view& a, const std::string_view& b)
+    {
+        return std::search(a.begin(), a.end(), b.begin(), b.end(), [](char a, char b) {
+                   return tolower(a) == tolower(b);
+               })
+            != a.end();
+    }
+
     static void applyFilterToObjectList()
     {
+        std::string_view pattern = inputSession.buffer.c_str();
+        for (auto& entry : _tabObjectList)
+        {
+            if (pattern.empty())
+            {
+                entry.visible = true;
+                continue;
+            }
+
+            const std::string_view name = entry.object._name;
+            const std::string_view filename = entry.object._filename;
+
+            const bool containsName = contains(name, pattern);
+            const bool containsFileName = contains(filename, pattern);
+
+            entry.visible = containsName || containsFileName;
+        }
     }
 
     static void populateTabObjectList(ObjectType objectType)

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -155,6 +155,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         tabArea,
         advancedButton,
         textInput,
+        clearButton,
         scrollview,
         objectImage,
     };
@@ -166,7 +167,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         makeWidget({ 0, 65 }, { 600, 333 }, WidgetType::panel, WindowColour::secondary),
         makeWidget({ 3, 15 }, { 589, 50 }, WidgetType::wt_6, WindowColour::secondary),
         makeWidget({ 470, 20 }, { 122, 12 }, WidgetType::button, WindowColour::primary, StringIds::object_selection_advanced, StringIds::object_selection_advanced_tooltip),
-        makeWidget({ 4, 68 }, { 288, 14 }, WidgetType::textbox, WindowColour::secondary),
+        makeWidget({ 4, 68 }, { 246, 14 }, WidgetType::textbox, WindowColour::secondary),
+        makeWidget({ 254, 68 }, { 38, 14 }, WidgetType::button, WindowColour::secondary, StringIds::clearInput),
         makeWidget({ 4, 85 }, { 288, 300 }, WidgetType::scrollview, WindowColour::secondary, Scrollbars::vertical),
         makeWidget({ 391, 68 }, { 114, 114 }, WidgetType::buttonWithImage, WindowColour::secondary),
         widgetEnd(),
@@ -357,7 +359,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         window = WindowManager::createWindowCentred(WindowType::objectSelection, { kWindowSize }, WindowFlags::none, &_events);
         window->widgets = widgets;
-        window->enabledWidgets = (1ULL << widx::closeButton) | (1ULL << widx::tabArea) | (1ULL << widx::advancedButton);
+        window->enabledWidgets = (1ULL << widx::closeButton) | (1ULL << widx::tabArea) | (1ULL << widx::advancedButton) | (1ULL << widx::clearButton);
         window->initScrollWidgets();
         window->frameNo = 0;
         window->rowHover = -1;
@@ -964,6 +966,13 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 self.invalidate();
 
                 break;
+            }
+
+            case widx::clearButton:
+            {
+                inputSession.clearInput();
+                applyFilterToObjectList();
+                self.invalidate();
             }
         }
     }

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -281,7 +281,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     static void applyFilterToObjectList()
     {
-        std::string_view pattern = inputSession.buffer.c_str();
+        std::string_view pattern = inputSession.buffer;
         _numVisibleObjectsListed = 0;
         for (auto& entry : _tabObjectList)
         {

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -130,7 +130,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static loco_global<uint16_t[33], 0x00112C181> _tabObjectCounts;
 
     // 0x0112C21C
-    static TabPosition _tabInformation[36];
+    static TabPosition _tabPositions[36];
 
     static Ui::TextInput::InputSession inputSession;
 
@@ -169,13 +169,13 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static void rotateTabs(uint8_t newStartPosition)
     {
         auto isSentinel = [](auto& entry) { return entry.index == 0xFF; };
-        auto sentinelPos = std::find_if(std::begin(_tabInformation), std::end(_tabInformation), isSentinel);
+        auto sentinelPos = std::find_if(std::begin(_tabPositions), std::end(_tabPositions), isSentinel);
 
-        std::rotate(std::begin(_tabInformation), std::begin(_tabInformation) + newStartPosition, sentinelPos);
+        std::rotate(std::begin(_tabPositions), std::begin(_tabPositions) + newStartPosition, sentinelPos);
 
-        for (uint8_t i = 0; _tabInformation[i].index != 0xFF; i++)
+        for (uint8_t i = 0; _tabPositions[i].index != 0xFF; i++)
         {
-            _tabInformation[i].row = i < kPrimaryTabRowCapacity ? 0 : 1;
+            _tabPositions[i].row = i < kPrimaryTabRowCapacity ? 0 : 1;
         }
     }
 
@@ -183,20 +183,20 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static void repositionTargetTab(Window* self, ObjectType targetTab)
     {
         self->currentTab = enumValue(targetTab);
-        for (auto i = 0U; i < std::size(_tabInformation); i++)
+        for (auto i = 0U; i < std::size(_tabPositions); i++)
         {
             // Ended up in a position without info? Reassign positions first.
-            if (_tabInformation[i].index == 0xFF)
+            if (_tabPositions[i].index == 0xFF)
             {
                 self->var_856 |= (1 << 0);
                 assignTabPositions(self);
                 return;
             }
 
-            if (_tabInformation[i].index == enumValue(targetTab))
+            if (_tabPositions[i].index == enumValue(targetTab))
             {
                 // Found current tab, and its in bottom row? No change required
-                if (_tabInformation[i].row == 0)
+                if (_tabPositions[i].row == 0)
                     return;
                 // Otherwise, we'll rotate the tabs around, such that this one is in the bottom row
                 else
@@ -239,8 +239,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 continue;
 
             // Assign tab position
-            _tabInformation[tabPos].index = static_cast<uint8_t>(currentType);
-            _tabInformation[tabPos].row = currentRow;
+            _tabPositions[tabPos].index = static_cast<uint8_t>(currentType);
+            _tabPositions[tabPos].row = currentRow;
             tabPos++;
 
             // Distribute tabs over two rows -- ensure there's capacity left in current row
@@ -254,9 +254,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         }
 
         // Add a marker to denote the last tab
-        _tabInformation[tabPos].index = 0xFF;
+        _tabPositions[tabPos].index = 0xFF;
 
-        const auto firstTabIndex = ObjectType(_tabInformation[0].index);
+        const auto firstTabIndex = ObjectType(_tabPositions[0].index);
         repositionTargetTab(self, firstTabIndex);
     }
 
@@ -373,25 +373,25 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         {
             auto xPos = x + (row * kRowOffsetX);
             auto yPos = y - (row * kRowOffsetY);
-            for (auto index = 0; _tabInformation[index].index != 0xFF; index++)
+            for (auto index = 0; _tabPositions[index].index != 0xFF; index++)
             {
-                if (_tabInformation[index].row != row)
+                if (_tabPositions[index].row != row)
                     continue;
 
                 auto image = Gfx::recolour(ImageIds::tab, self->getColour(WindowColour::secondary).c());
-                if (_tabInformation[index].index == self->currentTab)
+                if (_tabPositions[index].index == self->currentTab)
                 {
                     image = Gfx::recolour(ImageIds::selected_tab, self->getColour(WindowColour::secondary).c());
                     drawingCtx.drawImage(rt, xPos, yPos, image);
 
-                    image = Gfx::recolour(_tabDisplayInfo[_tabInformation[index].index].image, Colour::mutedSeaGreen);
+                    image = Gfx::recolour(_tabDisplayInfo[_tabPositions[index].index].image, Colour::mutedSeaGreen);
                     drawingCtx.drawImage(rt, xPos, yPos, image);
                 }
                 else
                 {
                     drawingCtx.drawImage(rt, xPos, yPos, image);
 
-                    image = Gfx::recolour(_tabDisplayInfo[_tabInformation[index].index].image, Colour::mutedSeaGreen);
+                    image = Gfx::recolour(_tabDisplayInfo[_tabPositions[index].index].image, Colour::mutedSeaGreen);
                     drawingCtx.drawImage(rt, xPos, yPos, image);
 
                     image = Gfx::recolourTranslucent(ImageIds::tab, ExtColour::unk33);
@@ -843,16 +843,16 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                     auto xPos = x + (row * kRowOffsetX);
                     auto yPos = y - (row * kRowOffsetY);
 
-                    for (int i = 0; _tabInformation[i].index != 0xFF; i++)
+                    for (int i = 0; _tabPositions[i].index != 0xFF; i++)
                     {
-                        if (_tabInformation[i].row != row)
+                        if (_tabPositions[i].row != row)
                             continue;
 
                         if (_52334A >= xPos && _52334C >= yPos)
                         {
                             if (_52334A < xPos + 31 && yPos + 27 > _52334C)
                             {
-                                clickedTab = _tabInformation[i].index;
+                                clickedTab = _tabPositions[i].index;
                                 break;
                             }
                         }
@@ -895,7 +895,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                     const ObjectTabFlags tabFlags = _tabDisplayInfo[currentTab].flags;
                     if ((tabFlags & ObjectTabFlags::advanced) != ObjectTabFlags::none)
                     {
-                        currentTab = _tabInformation[0].index;
+                        currentTab = _tabPositions[0].index;
                     }
                 }
                 repositionTargetTab(&self, static_cast<ObjectType>(currentTab));

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -310,6 +310,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         _tabObjectList.clear();
 
         const auto objects = ObjectManager::getAvailableObjects(objectType);
+        _tabObjectList.reserve(objects.size());
         for (auto [index, object] : objects)
         {
             auto entry = TabObjectEntry{ index, object, true };

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -123,8 +123,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static loco_global<char[2], 0x005045F8> _strCheckmark;
     static loco_global<uint8_t*, 0x50D144> _objectSelection;
 
-    static loco_global<uint16_t, 0x0052334A> _52334A;
-    static loco_global<uint16_t, 0x0052334C> _52334C;
+    static loco_global<uint16_t, 0x0052334A> _mousePosX;
+    static loco_global<uint16_t, 0x0052334C> _mousePosY;
 
     // _tabObjectCounts can be integrated after implementing sub_473A95
     static loco_global<uint16_t[33], 0x00112C181> _tabObjectCounts;
@@ -848,9 +848,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                         if (_tabPositions[i].row != row)
                             continue;
 
-                        if (_52334A >= xPos && _52334C >= yPos)
+                        if (_mousePosX >= xPos && _mousePosY >= yPos)
                         {
-                            if (_52334A < xPos + 31 && yPos + 27 > _52334C)
+                            if (_mousePosX < xPos + 31 && yPos + 27 > _mousePosY)
                             {
                                 clickedTab = _tabPositions[i].index;
                                 break;

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -981,6 +981,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     {
         for (auto& entry : _tabObjectList)
         {
+            if (!entry.visible)
+                continue;
+
             y -= kRowHeight;
             if (y < 0)
             {

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -314,7 +314,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         for (auto [index, object] : objects)
         {
             auto entry = TabObjectEntry{ index, object, true };
-            _tabObjectList.emplace_back(entry);
+            _tabObjectList.emplace_back(std::move(entry));
         }
 
         applyFilterToObjectList();

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -121,7 +121,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     };
 
     static loco_global<char[2], 0x005045F8> _strCheckmark;
-    static loco_global<uint8_t*, 0x50D144> _50D144;
+    static loco_global<uint8_t*, 0x50D144> _objectSelection;
 
     static loco_global<uint16_t, 0x0052334A> _52334A;
     static loco_global<uint16_t, 0x0052334C> _52334C;
@@ -267,7 +267,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         for (auto [index, object] : objects)
         {
-            if (_50D144[index] & (1 << 0))
+            if (_objectSelection[index] & (1 << 0))
             {
                 return { static_cast<int16_t>(index), object };
             }
@@ -787,7 +787,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 }
             }
 
-            if (_50D144[i] & (1 << 0))
+            if (_objectSelection[i] & (1 << 0))
             {
                 auto x = 2;
                 drawingCtx.setCurrentFontSpriteBase(Font::m2);
@@ -799,7 +799,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
                 auto checkColour = self.getColour(WindowColour::secondary).opaque();
 
-                if (_50D144[i] & 0x1C)
+                if (_objectSelection[i] & 0x1C)
                 {
                     checkColour = checkColour.inset();
                 }
@@ -984,9 +984,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         if (ObjectManager::getMaxObjects(type) == 1)
         {
-            if (!(_50D144[index] & (1 << 0)))
+            if (!(_objectSelection[index] & (1 << 0)))
             {
-                auto [oldIndex, oldObject] = ObjectManager::getActiveObject(type, _50D144);
+                auto [oldIndex, oldObject] = ObjectManager::getActiveObject(type, _objectSelection);
 
                 if (oldIndex != -1)
                 {
@@ -997,7 +997,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         auto bx = 0;
 
-        if (!(_50D144[index] & (1 << 0)))
+        if (!(_objectSelection[index] & (1 << 0)))
         {
             bx |= (1 << 0);
         }
@@ -1025,7 +1025,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             auto objects = ObjectManager::getAvailableObjects(type);
             for (auto [i, object] : objects)
             {
-                if (!(_50D144[i] & (1 << 0)))
+                if (!(_objectSelection[i] & (1 << 0)))
                 {
                     ObjectManager::unload(*object._header);
                 }
@@ -1041,7 +1041,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             auto objects = ObjectManager::getAvailableObjects(type);
             for (auto [i, object] : objects)
             {
-                if (_50D144[i] & (1 << 0))
+                if (_objectSelection[i] & (1 << 0))
                 {
                     if (!ObjectManager::findObjectHandle(*object._header))
                     {

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -139,6 +139,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     // 0x0112C21C
     static TabPosition _tabPositions[36];
     static std::vector<TabObjectEntry> _tabObjectList;
+    static uint16_t _numVisibleObjectsListed;
 
     static Ui::TextInput::InputSession inputSession;
 
@@ -279,11 +280,13 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static void applyFilterToObjectList()
     {
         std::string_view pattern = inputSession.buffer.c_str();
+        _numVisibleObjectsListed = 0;
         for (auto& entry : _tabObjectList)
         {
             if (pattern.empty())
             {
                 entry.visible = true;
+                _numVisibleObjectsListed++;
                 continue;
             }
 
@@ -294,6 +297,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             const bool containsFileName = contains(filename, pattern);
 
             entry.visible = containsName || containsFileName;
+
+            if (entry.visible)
+                _numVisibleObjectsListed++;
         }
     }
 
@@ -965,7 +971,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     // 0x004738ED
     static void getScrollSize(Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
     {
-        *scrollHeight = _tabObjectCounts[self.currentTab] * kRowHeight;
+        *scrollHeight = _numVisibleObjectsListed * kRowHeight;
     }
 
     // 0x00473900

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -705,9 +705,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         // Draw search box cursor, blinking
         if ((inputSession.cursorFrame % 32) < 16)
         {
-            // We the string again to figure out where the cursor should go; position.x will be adjusted
+            // We draw the string again to figure out where the cursor should go; position.x will be adjusted
             textBuffer[inputSession.cursorPosition] = '\0';
-            Ui::Point position = { inputSession.xOffset, 1 };
+            position = { inputSession.xOffset, 1 };
             drawingCtx.drawStringLeft(*clipped, &position, Colour::black, StringIds::black_stringid, &args);
             drawingCtx.fillRect(*clipped, position.x, position.y, position.x, position.y + 9, Colours::getShade(self.getColour(WindowColour::secondary).c(), 9), Drawing::RectFlags::none);
         }


### PR DESCRIPTION
This PR introduces search/filter functionality to the object selection window, performing case-insensitive string matching on the visible name and object filenames.

Matches by visible name:
![Unnamed (1)](https://user-images.githubusercontent.com/604665/219135963-cec35d7a-47be-4d9b-af86-3435b6a7a287.png)

Or by object filename:
![Unnamed (2)](https://user-images.githubusercontent.com/604665/219135979-ae8ede33-e520-4af3-b775-78932437ab1d.png)
