### PR TITLE
Decouple UI

### DIFF
--- a/src/OpenLoco/src/Drawing/FPSCounter.cpp
+++ b/src/OpenLoco/src/Drawing/FPSCounter.cpp
@@ -54,7 +54,7 @@ namespace OpenLoco::Drawing
 
         // Draw text
         const int stringWidth = drawingCtx.getStringWidth(buffer);
-        const auto x = Ui::width() / 2 - (stringWidth / 2);
+        const auto x = Ui::unscaledWidth() / 2 - (stringWidth / 2);
         const auto y = 2;
         drawingCtx.drawString(rt, x, y, Colour::black, buffer);
 

--- a/src/OpenLoco/src/Drawing/SoftwareDrawingEngine.cpp
+++ b/src/OpenLoco/src/Drawing/SoftwareDrawingEngine.cpp
@@ -279,7 +279,9 @@ namespace OpenLoco::Drawing
         rt.zoomLevel = 0;
 
         // TODO: Remove main window and draw that independent from UI.
-
+        auto* viewport = Ui::WindowManager::getMainViewport();
+        viewport->render(&rt);
+        
         // Draw UI.
         Ui::WindowManager::render(rt, rect);
     }

--- a/src/OpenLoco/src/Drawing/SoftwareDrawingEngine.h
+++ b/src/OpenLoco/src/Drawing/SoftwareDrawingEngine.h
@@ -54,8 +54,15 @@ namespace OpenLoco::Drawing
 
         SDL_Window* _window{};
         SDL_Palette* _palette{};
+
         SDL_Surface* _screenSurface{};
         SDL_Surface* _screenRGBASurface{};
+
+        SDL_Surface* _screenUiSurface{};
+        SDL_Surface* _screenUiRGBASurface{};
+
+        SDL_Surface* _finalSurface{};
+
         SoftwareDrawingContext _ctx;
     };
 }

--- a/src/OpenLoco/src/Graphics/RenderTarget.cpp
+++ b/src/OpenLoco/src/Graphics/RenderTarget.cpp
@@ -6,7 +6,8 @@ using namespace OpenLoco::Interop;
 namespace OpenLoco::Gfx
 {
     static loco_global<RenderTarget, 0x0050B884> _screenRT;
-
+    static RenderTarget _screenUiRT;
+    
     Ui::Rect RenderTarget::getDrawableRect() const
     {
         auto zoom = zoomLevel;
@@ -25,6 +26,11 @@ namespace OpenLoco::Gfx
     RenderTarget& getScreenRT()
     {
         return _screenRT;
+    }
+
+    RenderTarget& getScreenUiRT()
+    {
+        return _screenUiRT;
     }
 
     // 0x004CEC50

--- a/src/OpenLoco/src/Graphics/RenderTarget.h
+++ b/src/OpenLoco/src/Graphics/RenderTarget.h
@@ -27,7 +27,8 @@ namespace OpenLoco::Gfx
 #pragma pack(pop)
 
     RenderTarget& getScreenRT();
-
+    RenderTarget& getScreenUiRT();
+    
     std::optional<Gfx::RenderTarget> clipRenderTarget(const Gfx::RenderTarget& src, const Ui::Rect& newRect);
 
 }

--- a/src/OpenLoco/src/Gui.cpp
+++ b/src/OpenLoco/src/Gui.cpp
@@ -53,8 +53,8 @@ namespace OpenLoco::Gui
     // 0x004392BD
     void resize()
     {
-        const int32_t uiWidth = Ui::width();
-        const int32_t uiHeight = Ui::height();
+        const int32_t uiWidth = Ui::unscaledWidth();
+        const int32_t uiHeight = Ui::unscaledHeight();
 
         auto window = WindowManager::getMainWindow();
         if (window)

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -2250,8 +2250,8 @@ namespace OpenLoco::Input
             }
 
             // 0x004C6FE4
-            x = std::clamp<uint16_t>(x, 0, Ui::width() - 1);
-            y = std::clamp<uint16_t>(y, 0, Ui::height() - 1);
+            x = std::clamp<uint16_t>(x, 0, Ui::unscaledWidth() - 1);
+            y = std::clamp<uint16_t>(y, 0, Ui::unscaledHeight() - 1);
             return button;
         }
         else

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -317,6 +317,7 @@ namespace OpenLoco
         Gui::init();
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
         drawingCtx.clear(Gfx::getScreenRT(), 0x0A0A0A0A);
+        drawingCtx.clear(Gfx::getScreenUiRT(), 0x00000000);
     }
 
     static void loadFile(const fs::path& path)
@@ -736,6 +737,10 @@ namespace OpenLoco
 
     static void tickLogic(int32_t count)
     {
+        auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
+        // drawingCtx.clear(Gfx::getScreenRT(), 0x0A0A0A0A);
+        drawingCtx.clear(Gfx::getScreenUiRT(), 0x0);
+        
         for (int32_t i = 0; i < count; i++)
         {
             tickLogic();

--- a/src/OpenLoco/src/Ui.cpp
+++ b/src/OpenLoco/src/Ui.cpp
@@ -102,6 +102,16 @@ namespace OpenLoco::Ui
     }
 #endif // _WIN32
 
+    int32_t unscaledWidth()
+    {
+        return width() * Config::get().scaleFactor;
+    }
+
+    int32_t unscaledHeight()
+    {
+        return height() * Config::get().scaleFactor;
+    }
+
     int32_t width()
     {
         return _screenInfo->width;
@@ -496,7 +506,7 @@ namespace OpenLoco::Ui
                     break;
                 case SDL_MOUSEMOTION:
                 {
-                    auto scaleFactor = Config::get().scaleFactor;
+                    auto scaleFactor = 1; // Config::get().scaleFactor;
                     auto x = static_cast<int32_t>(e.motion.x / scaleFactor);
                     auto y = static_cast<int32_t>(e.motion.y / scaleFactor);
                     auto xrel = static_cast<int32_t>(e.motion.xrel / scaleFactor);
@@ -509,7 +519,7 @@ namespace OpenLoco::Ui
                     break;
                 case SDL_MOUSEBUTTONDOWN:
                 {
-                    auto scaleFactor = Config::get().scaleFactor;
+                    auto scaleFactor = 1; // Config::get().scaleFactor;
                     const auto x = static_cast<int32_t>(e.button.x / scaleFactor);
                     const auto y = static_cast<int32_t>(e.button.y / scaleFactor);
                     addr<0x00525324, int32_t>() = 1;
@@ -530,7 +540,7 @@ namespace OpenLoco::Ui
                 }
                 case SDL_MOUSEBUTTONUP:
                 {
-                    auto scaleFactor = Config::get().scaleFactor;
+                    auto scaleFactor = 1; // Config::get().scaleFactor;
                     const auto x = static_cast<int32_t>(e.button.x / scaleFactor);
                     const auto y = static_cast<int32_t>(e.button.y / scaleFactor);
                     addr<0x00525324, int32_t>() = 1;

--- a/src/OpenLoco/src/Ui.h
+++ b/src/OpenLoco/src/Ui.h
@@ -113,6 +113,9 @@ namespace OpenLoco::Ui
 
     void* hwnd();
 
+    int32_t unscaledWidth();
+    int32_t unscaledHeight();
+    
     int32_t width();
     int32_t height();
     bool dirtyBlocksInitialised();

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -872,10 +872,10 @@ namespace OpenLoco::Ui::WindowManager
         if (position.y < 28)
             return false;
 
-        if (position.x + size.width > Ui::width())
+        if (position.x + size.width > Ui::unscaledWidth())
             return false;
 
-        if (position.y + size.height > Ui::width())
+        if (position.y + size.height > Ui::unscaledWidth())
             return false;
 
         for (Ui::Window* w = &_windows[0]; w != _windowsEnd; w++)
@@ -905,8 +905,8 @@ namespace OpenLoco::Ui::WindowManager
         uint32_t flags,
         WindowEventList* events)
     {
-        origin.x = std::clamp<decltype(origin.x)>(origin.x, 0, std::max(0, Ui::width() - size.width));
-        origin.y = std::clamp<decltype(origin.y)>(origin.y, 28, std::max(28, Ui::height() - size.height));
+        origin.x = std::clamp<decltype(origin.x)>(origin.x, 0, std::max(0, Ui::unscaledWidth() - size.width));
+        origin.y = std::clamp<decltype(origin.y)>(origin.y, 28, std::max(28, Ui::unscaledHeight() - size.height));
 
         return createWindow(type, origin, size, flags, events);
     }

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -2152,12 +2152,15 @@ namespace OpenLoco::Ui::WindowManager
 
     void render(Gfx::RenderTarget& rt, const Rect& rect)
     {
+        auto* mainWnd = getMainWindow();
         for (size_t i = 0; i < count(); i++)
         {
             auto w = get(i);
-
-            if (w->isTranslucent())
+            if (w == mainWnd)
                 continue;
+
+            // if (w->isTranslucent())
+            // continue;
 
             if (rect.right() <= w->x || rect.bottom() <= w->y)
                 continue;

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -1463,8 +1463,8 @@ namespace OpenLoco::Ui::Windows::MapWindow
         if (_lastMapWindowFlags != 0)
         {
             size = _lastMapWindowSize;
-            size.width = std::clamp<uint16_t>(size.width, 350, Ui::width());
-            size.height = std::clamp<uint16_t>(size.height, 272, Ui::height() - 56);
+            size.width = std::clamp<uint16_t>(size.width, 350, Ui::unscaledWidth());
+            size.height = std::clamp<uint16_t>(size.height, 272, Ui::unscaledHeight() - 56);
         }
 
         window = WindowManager::createWindow(WindowType::map, size, 0, &events);

--- a/src/OpenLoco/src/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Windows/MessageWindow.cpp
@@ -316,7 +316,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         if (window == nullptr)
         {
             int16_t y = 29;
-            int16_t x = Ui::width() - 366;
+            int16_t x = Ui::unscaledWidth() - 366;
             Ui::Point origin = { x, y };
 
             window = WindowManager::createWindow(

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -88,7 +88,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
 
         auto window = WindowManager::createWindow(
             WindowType::timeToolbar,
-            Ui::Point(Ui::width() - kWindowSize.width, Ui::height() - kWindowSize.height),
+            Ui::Point(Ui::unscaledWidth() - kWindowSize.width, Ui::unscaledHeight() - kWindowSize.height),
             Ui::Size(kWindowSize.width, kWindowSize.height),
             Ui::WindowFlags::stickToFront | Ui::WindowFlags::transparent | Ui::WindowFlags::noBackground,
             &_events);

--- a/src/OpenLoco/src/Windows/TitleExit.cpp
+++ b/src/OpenLoco/src/Windows/TitleExit.cpp
@@ -43,7 +43,7 @@ namespace OpenLoco::Ui::Windows::TitleExit
 
         auto window = OpenLoco::Ui::WindowManager::createWindow(
             WindowType::titleExit,
-            Ui::Point(Ui::width() - kWindowSize.width, Ui::height() - kWindowSize.height),
+            Ui::Point(Ui::unscaledWidth() - kWindowSize.width, Ui::unscaledHeight() - kWindowSize.height),
             kWindowSize,
             WindowFlags::stickToFront | WindowFlags::transparent | WindowFlags::noBackground | WindowFlags::flag_6,
             &_events);

--- a/src/OpenLoco/src/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Windows/TitleMenu.cpp
@@ -166,7 +166,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
 
         auto window = OpenLoco::Ui::WindowManager::createWindow(
             WindowType::titleMenu,
-            Ui::Point((Ui::width() - kWW) / 2, Ui::height() - kWH - 25),
+            Ui::Point((Ui::unscaledWidth() - kWW) / 2, Ui::unscaledHeight() - kWH - 25),
             { kWW, kWH },
             WindowFlags::stickToFront | WindowFlags::transparent | WindowFlags::noBackground | WindowFlags::flag_6,
             &_events);

--- a/src/OpenLoco/src/Windows/ToolbarBottomEditor.cpp
+++ b/src/OpenLoco/src/Windows/ToolbarBottomEditor.cpp
@@ -131,8 +131,8 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
     {
         initEvents();
 
-        Ui::Point origin = Ui::Point(0, Ui::height() - kWindowHeight);
-        Ui::Size windowSize = Ui::Size(Ui::width(), kWindowHeight);
+        Ui::Point origin = Ui::Point(0, Ui::unscaledHeight() - kWindowHeight);
+        Ui::Size windowSize = Ui::Size(Ui::unscaledWidth(), kWindowHeight);
         auto window = WindowManager::createWindow(
             WindowType::editorToolbar,
             origin,

--- a/src/OpenLoco/src/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Windows/ToolbarTop.cpp
@@ -110,7 +110,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         auto window = WindowManager::createWindow(
             WindowType::topToolbar,
             { 0, 0 },
-            Ui::Size(Ui::width(), 28),
+            Ui::Size(Ui::unscaledWidth(), 28),
             WindowFlags::stickToFront | WindowFlags::transparent | WindowFlags::noBackground,
             &_events);
         window->widgets = _widgets;
@@ -921,7 +921,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         else
             window.widgets[Common::Widx::port_menu].type = WidgetType::none;
 
-        uint32_t x = std::max(640, Ui::width()) - 1;
+        uint32_t x = std::max(640, Ui::unscaledWidth()) - 1;
         Common::rightAlignTabs(&window, x, { Common::Widx::towns_menu, Common::Widx::stations_menu, Common::Widx::vehicles_menu });
         x -= 11;
         Common::rightAlignTabs(&window, x, { Common::Widx::build_vehicles_menu });

--- a/src/OpenLoco/src/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Windows/ToolbarTopAlt.cpp
@@ -87,7 +87,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
         auto window = WindowManager::createWindow(
             WindowType::topToolbar,
             { 0, 0 },
-            Ui::Size(Ui::width(), 28),
+            Ui::Size(Ui::unscaledWidth(), 28),
             WindowFlags::stickToFront | WindowFlags::transparent | WindowFlags::noBackground,
             &_events);
         window->widgets = _widgets;
@@ -285,7 +285,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
     // 0x0043D2F3
     static void prepareDraw(Window& window)
     {
-        uint32_t x = std::max(640, Ui::width()) - 1;
+        uint32_t x = std::max(640, Ui::unscaledWidth()) - 1;
 
         Common::rightAlignTabs(&window, x, { Common::Widx::towns_menu });
         x -= 11;


### PR DESCRIPTION
A very crude proof of concept, while doing this it revealed quite a few things that should be addressed to properly support this.
1. We need to separate the UI resolution from the resolution at where we render the game at, basically we have to separate the context between drawing a viewport and UI, both can have different resolutions.
2. We should not store the mouse coordinates scaled, UI requires to be unscaled while for in-game we have to apply the scale before to compensate for different render resolution.
3. The main window acted as a way to clear the pixels for where no windows is, there is a specific draw order, this poc requires to clear that in every tick causing odd flickering, I have to yet fully figure out whats causing this. 
4. The invalidation doesn't properly work with the separate UI space, UI is currently always cleared each tick, world space also has invalidation issues, this is due to how the invalidation grid works, this should be probably kept at UI resolution and then we need to transform UI to screen to check what regions are dirty.
5. UI code has to rely on UI resolution rather than render resolution, those two things require to be separated, i've added a quick and dirty unscaledWidth/unscaledHeight function to make this work.

This PR acts more as a reference to where the problems are at.