### PR TITLE
Drop jammy builds for C++20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [g++, clang++]
-        distro: [focal, jammy]
+        distro: [focal]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
C++20 requires at least GCC10, while jammy has GCC9