### PR TITLE
Fix company sort order by status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: [#1772] Toggling edge scrolling option does not work.
 - Fix: [#1798] Memory leak when resizing the window.
 - Fix: [#1842] Track, Road and Dock objects incorrectly unloaded causing packing issues.
+- Fix: [#1853] Company list not sorted properly by status.
 - Change: [#1823] Prevent edge scroll if the window has no input focus.
 
 23.01 (2023-01-25)

--- a/src/OpenLoco/src/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Windows/CompanyList.cpp
@@ -207,7 +207,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             char rhsString[256] = { 0 };
             {
                 auto args = FormatArguments();
-                auto statusString = CompanyManager::getOwnerStatus(lhs.id(), args);
+                auto statusString = CompanyManager::getOwnerStatus(rhs.id(), args);
                 StringManager::formatString(rhsString, statusString, &args);
             }
 


### PR DESCRIPTION
While tinkering with the warnings I discovered this. This would have never made it if the warnings were not disabled for unused variables.

Closes #1853