### PR TITLE
Warning overhaul

### DIFF
--- a/cmake/OpenLocoUtility.cmake
+++ b/cmake/OpenLocoUtility.cmake
@@ -58,13 +58,8 @@ function(loco_target_compile_link_flags TARGET)
         /W4                      # Warning level 4
                                  # Poke holes in W4 due to our interop code
         /wd4068                  #   4068: unknown pragma
-        /wd4091                  #   4091: 'keyword' : ignored on left of 'type' when no variable is declared
-        /wd4100                  #   4100: 'identifier' : unreferenced formal parameter
-        /wd4132                  #   4132: 'object' : const object should be initialized
         /wd4200                  #   4200: nonstandard extension used : zero-sized array in struct/union
         /wd4201                  #   4201: nonstandard extension used : nameless struct/union
-        /wd4204                  #   4204: nonstandard extension used : non-constant aggregate initializer
-        /wd4206                  #   4206: nonstandard extension used : translation unit is empty
         /wd4221                  #   4221: nonstandard extension used : 'identifier' : cannot be initialized using address of automatic variable
         /wd4244                  #   4244: 'argument' : conversion from 'type1' to 'type2', possible loss of data
         /wd4245                  #   4245: 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch

--- a/cmake/OpenLocoUtility.cmake
+++ b/cmake/OpenLocoUtility.cmake
@@ -60,7 +60,6 @@ function(loco_target_compile_link_flags TARGET)
         /wd4068                  #   4068: unknown pragma
         /wd4200                  #   4200: nonstandard extension used : zero-sized array in struct/union
         /wd4201                  #   4201: nonstandard extension used : nameless struct/union
-        /wd4221                  #   4221: nonstandard extension used : 'identifier' : cannot be initialized using address of automatic variable
         /wd4244                  #   4244: 'argument' : conversion from 'type1' to 'type2', possible loss of data
         /wd4245                  #   4245: 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch
     )

--- a/cmake/OpenLocoUtility.cmake
+++ b/cmake/OpenLocoUtility.cmake
@@ -69,7 +69,6 @@ function(loco_target_compile_link_flags TARGET)
         -fstrict-aliasing
         -Wall
         -Wextra
-        -Wno-unused-parameter
         -Wtype-limits
         $<$<BOOL:${STRICT}>:-Werror>         # Warnings are errors (STRICT ONLY)
 

--- a/src/Console/src/Console.cpp
+++ b/src/Console/src/Console.cpp
@@ -25,7 +25,7 @@ namespace OpenLoco::Console
         va_end(args);
     }
 
-    void logVerbose(const char* format, ...)
+    void logVerbose([[maybe_unused]] const char* format, ...)
     {
 #ifdef VERBOSE
         va_list args;

--- a/src/Interop/src/Hook.cpp
+++ b/src/Interop/src/Hook.cpp
@@ -31,7 +31,7 @@ namespace OpenLoco::Interop
     *(data + 2) = ((addr)&0x00ff0000) >> 16;  \
     *(data + 3) = ((addr)&0xff000000) >> 24;
 
-    static bool hookFunc(uintptr_t address, uintptr_t hookAddress, int32_t stacksize)
+    static bool hookFunc(uintptr_t address, uintptr_t hookAddress, [[maybe_unused]] int32_t stacksize)
     {
         int32_t i = 0;
         uint8_t data[kHookByteCount] = { 0 };

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -411,7 +411,7 @@ namespace OpenLoco::Audio
         }
     }
 
-    static int32_t calculateVolumeFromViewport(SoundId id, const Map::Pos3& mpos, const Viewport& viewport)
+    static int32_t calculateVolumeFromViewport([[maybe_unused]] SoundId id, const Map::Pos3& mpos, const Viewport& viewport)
     {
         auto volume = 0;
         auto zVol = 0;

--- a/src/OpenLoco/src/Company.cpp
+++ b/src/OpenLoco/src/Company.cpp
@@ -70,7 +70,7 @@ namespace OpenLoco
         call(0x00431035, regs);
     }
 
-    static void nullsub_3(Company* company)
+    static void nullsub_3([[maybe_unused]] Company* company)
     {
     }
 
@@ -95,7 +95,7 @@ namespace OpenLoco
         call(0x004311E7, regs);
     }
 
-    static void nullsub_4(Company* company)
+    static void nullsub_4([[maybe_unused]] Company* company)
     {
     }
 

--- a/src/OpenLoco/src/Entities/EntityTweener.cpp
+++ b/src/OpenLoco/src/Entities/EntityTweener.cpp
@@ -35,7 +35,7 @@ namespace OpenLoco
     {
         restore();
         reset();
-        PopulateEntities<EntityListType::misc>(_entities, _prePos, [](auto* ent) { return true; });
+        PopulateEntities<EntityListType::misc>(_entities, _prePos, [](auto*) { return true; });
         PopulateEntities<EntityListType::vehicle>(_entities, _prePos, [](auto* ent) {
             const auto* vehicle = ent->template asBase<Vehicles::VehicleBase>();
             if (vehicle == nullptr)

--- a/src/OpenLoco/src/GameCommands/GameCommands.h
+++ b/src/OpenLoco/src/GameCommands/GameCommands.h
@@ -1681,7 +1681,7 @@ namespace OpenLoco::GameCommands
         static constexpr auto command = GameCommand::applyFreeCashCheat;
 
         ApplyFreeCashCheatArgs() = default;
-        explicit ApplyFreeCashCheatArgs(const registers& regs)
+        explicit ApplyFreeCashCheatArgs(const registers&)
         {
         }
 

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -1109,7 +1109,7 @@ namespace OpenLoco::Input
     }
 
     // 0x004C7722
-    static void stateResizing(MouseButton button, int16_t x, int16_t y, Ui::Window* window, Ui::Widget* widget, Ui::WidgetIndex_t widgetIndex)
+    static void stateResizing(MouseButton button, int16_t x, int16_t y, Ui::Window* window, [[maybe_unused]] Ui::Widget* widget, [[maybe_unused]] Ui::WidgetIndex_t widgetIndex)
     {
         auto w = WindowManager::find(_dragWindowType, _dragWindowNumber);
         if (w == nullptr)
@@ -1217,7 +1217,7 @@ namespace OpenLoco::Input
     }
 
     // 0x004C7903
-    static void statePositioningWindow(MouseButton button, int16_t x, int16_t y, Ui::Window* window, Ui::Widget* widget, Ui::WidgetIndex_t widgetIndex)
+    static void statePositioningWindow(MouseButton button, int16_t x, int16_t y, [[maybe_unused]] Ui::Window* window, [[maybe_unused]] Ui::Widget* widget, [[maybe_unused]] Ui::WidgetIndex_t widgetIndex)
     {
         auto w = WindowManager::find(_dragWindowType, _dragWindowNumber);
         if (w == nullptr)

--- a/src/OpenLoco/src/Interop/Hooks.cpp
+++ b/src/OpenLoco/src/Interop/Hooks.cpp
@@ -72,7 +72,7 @@ static void STDCALL fn_40447f()
 }
 
 FORCE_ALIGN_ARG_POINTER
-static void STDCALL fn_404b68(int a0, int a1, int a2, int a3)
+static void STDCALL fn_404b68(int, int, int, int)
 {
     STUB();
     return;
@@ -114,7 +114,7 @@ static uint32_t STDCALL lib_timeGetTime()
 
 // typedef bool (CALLBACK *LPDSENUMCALLBACKA)(LPGUID, char*, char*, void*);
 FORCE_ALIGN_ARG_POINTER
-static long STDCALL fn_DirectSoundEnumerateA(void* pDSEnumCallback, void* pContext)
+static long STDCALL fn_DirectSoundEnumerateA(void*, void*)
 {
     STUB();
     return 0;
@@ -144,7 +144,7 @@ static void STDCALL fn_407b26()
 /// region Progress bar
 
 FORCE_ALIGN_ARG_POINTER
-static void CDECL fn_4080bb(char* lpWindowName, uint32_t a1)
+static void CDECL fn_4080bb(char*, uint32_t)
 {
     Console::log("Create progress bar");
 }
@@ -402,7 +402,7 @@ static uint32_t STDCALL lib_WriteFile(
     char* buffer,
     size_t nNumberOfBytesToWrite,
     uint32_t* lpNumberOfBytesWritten,
-    uintptr_t lpOverlapped)
+    uintptr_t)
 {
     *lpNumberOfBytesWritten = fwrite(buffer, 1, nNumberOfBytesToWrite, hFile);
     Console::logVerbose("WriteFile(%s)", buffer);
@@ -423,11 +423,11 @@ FORCE_ALIGN_ARG_POINTER
 static int32_t STDCALL lib_CreateFileA(
     char* lpFileName,
     uint32_t dwDesiredAccess,
-    uint32_t dwShareMode,
-    uintptr_t lpSecurityAttributes,
+    uint32_t,
+    uintptr_t,
     uint32_t dwCreationDisposition,
-    uint32_t dwFlagsAndAttributes,
-    uintptr_t hTemplateFile)
+    uint32_t,
+    uintptr_t)
 {
     Console::logVerbose("CreateFile(%s, 0x%x, 0x%x)", lpFileName, dwDesiredAccess, dwCreationDisposition);
 

--- a/src/OpenLoco/src/Interop/Hooks.cpp
+++ b/src/OpenLoco/src/Interop/Hooks.cpp
@@ -298,13 +298,13 @@ FORCE_ALIGN_ARG_POINTER
 }
 
 FORCE_ALIGN_ARG_POINTER
-[[maybe_unused]] static void CDECL fnc1(int i1)
+[[maybe_unused]] static void CDECL fnc1(int)
 {
     STUB();
 }
 
 FORCE_ALIGN_ARG_POINTER
-[[maybe_unused]] static void CDECL fnc2(int i1, int i2)
+[[maybe_unused]] static void CDECL fnc2(int, int)
 {
     STUB();
 }
@@ -316,13 +316,13 @@ FORCE_ALIGN_ARG_POINTER
 }
 
 FORCE_ALIGN_ARG_POINTER
-[[maybe_unused]] static void STDCALL fn1(int i1)
+[[maybe_unused]] static void STDCALL fn1(int)
 {
     return;
 }
 
 FORCE_ALIGN_ARG_POINTER
-[[maybe_unused]] static void STDCALL fn2(int i1, int i2)
+[[maybe_unused]] static void STDCALL fn2(int, int)
 {
     STUB();
 }
@@ -590,13 +590,13 @@ static void registerAudioHooks()
     writeRet(0x00404B40);
     registerHook(
         0x0048A18C,
-        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             Audio::updateSounds();
             return 0;
         });
     registerHook(
         0x00489C6A,
-        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             Audio::stopVehicleNoise();
             return 0;
         });
@@ -660,7 +660,7 @@ void OpenLoco::Interop::registerHooks()
     // Replace Ui::update() with our own
     registerHook(
         0x004524C1,
-        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             Ui::update();
             return 0;
         });
@@ -675,7 +675,7 @@ void OpenLoco::Interop::registerHooks()
 
     registerHook(
         0x00407231,
-        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             OpenLoco::Input::sub_407231();
             return 0;
         });
@@ -715,7 +715,7 @@ void OpenLoco::Interop::registerHooks()
 
     registerHook(
         0x00438A6C,
-        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             Gui::init();
             return 0;
         });
@@ -805,7 +805,7 @@ void OpenLoco::Interop::registerHooks()
 
     registerHook(
         0x004392BD,
-        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             Gui::resize();
             return 0;
         });

--- a/src/OpenLoco/src/Interop/Hooks.cpp
+++ b/src/OpenLoco/src/Interop/Hooks.cpp
@@ -590,13 +590,13 @@ static void registerAudioHooks()
     writeRet(0x00404B40);
     registerHook(
         0x0048A18C,
-        []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             Audio::updateSounds();
             return 0;
         });
     registerHook(
         0x00489C6A,
-        []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             Audio::stopVehicleNoise();
             return 0;
         });
@@ -660,7 +660,7 @@ void OpenLoco::Interop::registerHooks()
     // Replace Ui::update() with our own
     registerHook(
         0x004524C1,
-        []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             Ui::update();
             return 0;
         });
@@ -675,7 +675,7 @@ void OpenLoco::Interop::registerHooks()
 
     registerHook(
         0x00407231,
-        []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             OpenLoco::Input::sub_407231();
             return 0;
         });
@@ -715,7 +715,7 @@ void OpenLoco::Interop::registerHooks()
 
     registerHook(
         0x00438A6C,
-        []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             Gui::init();
             return 0;
         });

--- a/src/OpenLoco/src/Localisation/StringManager.cpp
+++ b/src/OpenLoco/src/Localisation/StringManager.cpp
@@ -732,7 +732,7 @@ namespace OpenLoco::StringManager
         return formatString(buffer, id, wrapped);
     }
 
-    char* formatString(char* buffer, size_t bufferLen, string_id id, const void* args)
+    char* formatString(char* buffer, [[maybe_unused]] size_t bufferLen, string_id id, const void* args)
     {
         return formatString(buffer, id, args);
     }

--- a/src/OpenLoco/src/Main.cpp
+++ b/src/OpenLoco/src/Main.cpp
@@ -11,7 +11,7 @@
  */
 // Hack to trick mingw into thinking we forward-declared this function.
 extern "C" __declspec(dllexport) int StartOpenLoco(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow);
-extern "C" __declspec(dllexport) int StartOpenLoco(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
+extern "C" __declspec(dllexport) int StartOpenLoco([[maybe_unused]] HINSTANCE hInstance, [[maybe_unused]] HINSTANCE hPrevInstance, LPSTR lpCmdLine, [[maybe_unused]] int nCmdShow)
 {
     return OpenLoco::main(lpCmdLine);
 }

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -202,7 +202,7 @@ namespace OpenLoco::Map
                     {
                         const auto randAnim = _E0C3D4[(numAnimations * (rand & 0xFF)) / 256];
                         const auto newVar6_3F = randAnim | (1 << 5) | (var_6_003F() & 0xC);
-                        applyToMultiTile(*this, loc, isMultiTile, [newVar6_3F](IndustryElement& elIndustry, const Map::Pos2& pos) {
+                        applyToMultiTile(*this, loc, isMultiTile, [newVar6_3F](IndustryElement& elIndustry, [[maybe_unused]] const Map::Pos2& pos) {
                             elIndustry.setVar_6_003F(newVar6_3F);
                         });
                         AnimationManager::createAnimation(4, loc, baseZ());

--- a/src/OpenLoco/src/Map/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator.cpp
@@ -46,7 +46,7 @@ namespace OpenLoco::Map::MapGenerator
         int32_t const height;
         int32_t const pitch;
 
-        HeightMap(int32_t width, int32_t height, int32_t pitch, [[maybe_unused]] uint8_t baseHeight)
+        HeightMap(int32_t width, int32_t height, int32_t pitch)
             : _height(width * pitch)
             , width(width)
             , height(height)
@@ -756,7 +756,7 @@ namespace OpenLoco::Map::MapGenerator
 
         {
             // Should be 384x384 (but generateLandscape goes out of bounds?)
-            HeightMap heightMap(512, 512, 512, options.minLandHeight);
+            HeightMap heightMap(512, 512, 512);
 
             generateHeightMap(options, heightMap);
             updateProgress(17);

--- a/src/OpenLoco/src/Map/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator.cpp
@@ -46,7 +46,7 @@ namespace OpenLoco::Map::MapGenerator
         int32_t const height;
         int32_t const pitch;
 
-        HeightMap(int32_t width, int32_t height, int32_t pitch, uint8_t baseHeight)
+        HeightMap(int32_t width, int32_t height, int32_t pitch, [[maybe_unused]] uint8_t baseHeight)
             : _height(width * pitch)
             , width(width)
             , height(height)
@@ -416,7 +416,7 @@ namespace OpenLoco::Map::MapGenerator
     }
 
     // 0x004C4BD7
-    static void generateWater(HeightMap& heightMap)
+    static void generateWater([[maybe_unused]] HeightMap& heightMap)
     {
         static loco_global<uint16_t, 0x00525FB2> _seaLevel;
 
@@ -557,7 +557,7 @@ namespace OpenLoco::Map::MapGenerator
         _heightMap = nullptr;
     }
 
-    static void generateTerrainNull(HeightMap& heightMap, uint8_t surfaceStyle) {}
+    static void generateTerrainNull([[maybe_unused]] HeightMap& heightMap, [[maybe_unused]] uint8_t surfaceStyle) {}
 
     using GenerateTerrainFunc = void (*)(HeightMap&, uint8_t);
     static const GenerateTerrainFunc _generateFuncs[] = {

--- a/src/OpenLoco/src/Network/NetworkBase.cpp
+++ b/src/OpenLoco/src/Network/NetworkBase.cpp
@@ -78,7 +78,7 @@ void NetworkBase::onUpdate()
 {
 }
 
-void NetworkBase::onReceivePacket(IUdpSocket& socket, std::unique_ptr<INetworkEndpoint> endpoint, const Packet& packet)
+void NetworkBase::onReceivePacket(IUdpSocket&, std::unique_ptr<INetworkEndpoint>, const Packet&)
 {
 }
 

--- a/src/OpenLoco/src/Network/NetworkClient.cpp
+++ b/src/OpenLoco/src/Network/NetworkClient.cpp
@@ -128,7 +128,7 @@ bool NetworkClient::hasTimedOut() const
     return false;
 }
 
-void NetworkClient::onReceivePacket(IUdpSocket& socket, std::unique_ptr<INetworkEndpoint> endpoint, const Packet& packet)
+void NetworkClient::onReceivePacket([[maybe_unused]] IUdpSocket& socket, std::unique_ptr<INetworkEndpoint> endpoint, const Packet& packet)
 {
     // TODO do we really need the check, it is possible but unlikely
     //      for something else to hijack the UDP client port

--- a/src/OpenLoco/src/Network/NetworkConnection.cpp
+++ b/src/OpenLoco/src/Network/NetworkConnection.cpp
@@ -181,7 +181,7 @@ std::optional<Packet> NetworkConnection::takeNextPacket()
     }
 }
 
-void NetworkConnection::logPacket(const Packet& packet, bool sent, bool resend)
+void NetworkConnection::logPacket([[maybe_unused]] const Packet& packet, [[maybe_unused]] bool sent, [[maybe_unused]] bool resend)
 {
 #if defined(DEBUG)
 #ifdef LOG_PACKETS

--- a/src/OpenLoco/src/Network/NetworkServer.cpp
+++ b/src/OpenLoco/src/Network/NetworkServer.cpp
@@ -187,7 +187,7 @@ void NetworkServer::onReceiveSendChatMessagePacket(Client& client, const SendCha
     _chatMessageQueue.push({ client.id, std::string(packet.getText()) });
 }
 
-void NetworkServer::onReceiveGameCommandPacket(Client& client, const GameCommandPacket& packet)
+void NetworkServer::onReceiveGameCommandPacket([[maybe_unused]] Client& client, const GameCommandPacket& packet)
 {
     queueGameCommand(packet.company, packet.regs);
 }

--- a/src/OpenLoco/src/Objects/TreeObject.cpp
+++ b/src/OpenLoco/src/Objects/TreeObject.cpp
@@ -107,7 +107,7 @@ namespace OpenLoco
     }
 
     // 0x004BE144
-    void TreeObject::load(const LoadedObjectHandle& handle, stdx::span<const std::byte> data, ObjectManager::DependentObjects*)
+    void TreeObject::load(const LoadedObjectHandle& handle, [[maybe_unused]] stdx::span<const std::byte> data, ObjectManager::DependentObjects*)
     {
         Interop::registers regs;
         regs.esi = Interop::X86Pointer(this);

--- a/src/OpenLoco/src/Objects/VehicleObject.cpp
+++ b/src/OpenLoco/src/Objects/VehicleObject.cpp
@@ -308,7 +308,7 @@ namespace OpenLoco
     }
 
     // 0x004B841B
-    void VehicleObject::load(const LoadedObjectHandle& handle, stdx::span<const std::byte> data, ObjectManager::DependentObjects* dependencies)
+    void VehicleObject::load(const LoadedObjectHandle& handle, [[maybe_unused]] stdx::span<const std::byte> data, ObjectManager::DependentObjects* dependencies)
     {
         Interop::registers regs;
         regs.esi = Interop::X86Pointer(this);

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -530,7 +530,7 @@ namespace OpenLoco
                 // This address is where those routines jump back to to end the tick prematurely
                 registerHook(
                     0x0046AD71,
-                    []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                    [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                         longjmp(tickJump, 1);
                     });
 

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -530,7 +530,7 @@ namespace OpenLoco
                 // This address is where those routines jump back to to end the tick prematurely
                 registerHook(
                     0x0046AD71,
-                    [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                    []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                         longjmp(tickJump, 1);
                     });
 

--- a/src/OpenLoco/src/Paint/Paint.cpp
+++ b/src/OpenLoco/src/Paint/Paint.cpp
@@ -549,10 +549,7 @@ namespace OpenLoco::Paint
     }
 
     template<uint8_t>
-    static bool checkBoundingBox(const PaintStructBoundBox& initialBBox, const PaintStructBoundBox& currentBBox)
-    {
-        return false;
-    }
+    static bool checkBoundingBox(const PaintStructBoundBox& initialBBox, const PaintStructBoundBox& currentBBox);
 
     template<>
     bool checkBoundingBox<0>(const PaintStructBoundBox& initialBBox, const PaintStructBoundBox& currentBBox)

--- a/src/OpenLoco/src/Paint/PaintStation.cpp
+++ b/src/OpenLoco/src/Paint/PaintStation.cpp
@@ -224,7 +224,7 @@ namespace OpenLoco::Paint
     }
 
     // 0x00411AC6
-    static void paintTrainStationStyle0DiagonalTrack0NE(PaintSession& session, const Map::StationElement& elStation, const ImageId imageBase, const ImageId imageTranslucentBase)
+    static void paintTrainStationStyle0DiagonalTrack0NE(PaintSession& session, const Map::StationElement& elStation, const ImageId imageBase, [[maybe_unused]] const ImageId imageTranslucentBase)
     {
         const Map::Pos3 heightOffset(0, 0, elStation.baseHeight());
         Map::Pos3 bbOffset = Map::Pos3{ 2, 2, 8 } + heightOffset;
@@ -252,13 +252,13 @@ namespace OpenLoco::Paint
     }
 
     // 0x00411BA6
-    static void paintTrainStationStyle0DiagonalTrack2NE(PaintSession& session, const Map::StationElement& elStation, const ImageId imageBase, const ImageId imageTranslucentBase)
+    static void paintTrainStationStyle0DiagonalTrack2NE([[maybe_unused]] PaintSession& session, [[maybe_unused]] const Map::StationElement& elStation, [[maybe_unused]] const ImageId imageBase, [[maybe_unused]] const ImageId imageTranslucentBase)
     {
         return;
     }
 
     // 0x00411BA8
-    static void paintTrainStationStyle0DiagonalTrack3NE(PaintSession& session, const Map::StationElement& elStation, const ImageId imageBase, const ImageId imageTranslucentBase)
+    static void paintTrainStationStyle0DiagonalTrack3NE(PaintSession& session, const Map::StationElement& elStation, const ImageId imageBase, [[maybe_unused]] const ImageId imageTranslucentBase)
     {
         const Map::Pos3 heightOffset(0, 0, elStation.baseHeight());
         Map::Pos3 bbOffset = Map::Pos3{ 2, 2, 8 } + heightOffset;
@@ -267,13 +267,13 @@ namespace OpenLoco::Paint
     }
 
     // 0x00411BEB
-    static void paintTrainStationStyle0DiagonalTrack0SE(PaintSession& session, const Map::StationElement& elStation, const ImageId imageBase, const ImageId imageTranslucentBase)
+    static void paintTrainStationStyle0DiagonalTrack0SE([[maybe_unused]] PaintSession& session, [[maybe_unused]] const Map::StationElement& elStation, [[maybe_unused]] const ImageId imageBase, [[maybe_unused]] const ImageId imageTranslucentBase)
     {
         return;
     }
 
     // 0x00411BED
-    static void paintTrainStationStyle0DiagonalTrack1SE(PaintSession& session, const Map::StationElement& elStation, const ImageId imageBase, const ImageId imageTranslucentBase)
+    static void paintTrainStationStyle0DiagonalTrack1SE(PaintSession& session, const Map::StationElement& elStation, const ImageId imageBase, [[maybe_unused]] const ImageId imageTranslucentBase)
     {
         const Map::Pos3 heightOffset(0, 0, elStation.baseHeight());
         Map::Pos3 bbOffset = Map::Pos3{ 28, 34, 8 } + heightOffset;
@@ -282,7 +282,7 @@ namespace OpenLoco::Paint
     }
 
     // 0x00411C30
-    static void paintTrainStationStyle0DiagonalTrack2SE(PaintSession& session, const Map::StationElement& elStation, const ImageId imageBase, const ImageId imageTranslucentBase)
+    static void paintTrainStationStyle0DiagonalTrack2SE(PaintSession& session, const Map::StationElement& elStation, const ImageId imageBase, [[maybe_unused]] const ImageId imageTranslucentBase)
     {
         const Map::Pos3 heightOffset(0, 0, elStation.baseHeight());
         Map::Pos3 bbOffset = Map::Pos3{ 34, 28, 8 } + heightOffset;
@@ -350,7 +350,7 @@ namespace OpenLoco::Paint
     }
 
     // 0x004D78EC
-    static void paintTrainStationStyle0(PaintSession& session, const Map::StationElement& elStation, const uint8_t trackId, const uint8_t sequenceIndex, const ImageId imageBase, const ImageId imageGlassBase)
+    static void paintTrainStationStyle0(PaintSession& session, const Map::StationElement& elStation, const uint8_t trackId, [[maybe_unused]] const uint8_t sequenceIndex, const ImageId imageBase, const ImageId imageGlassBase)
     {
         switch (trackId)
         {

--- a/src/OpenLoco/src/Paint/PaintTile.cpp
+++ b/src/OpenLoco/src/Paint/PaintTile.cpp
@@ -92,31 +92,31 @@ namespace OpenLoco::Paint
     }
 
     // 0x004792E7 streetlights?
-    static void sub_4792E7(PaintSession& session)
+    static void sub_4792E7([[maybe_unused]] PaintSession& session)
     {
         call(0x004792E7);
     }
 
     // 0x0046748F
-    static void sub_46748F(PaintSession& session)
+    static void sub_46748F([[maybe_unused]] PaintSession& session)
     {
         call(0x0046748F);
     }
 
     // 0x0045CA67
-    static void sub_45CA67(PaintSession& session)
+    static void sub_45CA67([[maybe_unused]] PaintSession& session)
     {
         call(0x0045CA67);
     }
 
     // 0x0045CC1B
-    static void sub_45CC1B(PaintSession& session)
+    static void sub_45CC1B([[maybe_unused]] PaintSession& session)
     {
         call(0x0045CC1B);
     }
 
     // 0x0042AC9C
-    static bool sub_42AC9C(PaintSession& session)
+    static bool sub_42AC9C([[maybe_unused]] PaintSession& session)
     {
         registers regs;
         call(0x0042AC9C, regs);
@@ -124,7 +124,7 @@ namespace OpenLoco::Paint
     }
 
     // 0x004656BF
-    static void paintSurface(PaintSession& session, Map::SurfaceElement& elSurface)
+    static void paintSurface([[maybe_unused]] PaintSession& session, Map::SurfaceElement& elSurface)
     {
         registers regs;
         regs.esi = X86Pointer(&elSurface);
@@ -133,7 +133,7 @@ namespace OpenLoco::Paint
     }
 
     // 0x0042C6C4
-    static void paintBuilding(PaintSession& session, Map::BuildingElement& elBuilding)
+    static void paintBuilding([[maybe_unused]] PaintSession& session, Map::BuildingElement& elBuilding)
     {
         registers regs;
         regs.esi = X86Pointer(&elBuilding);
@@ -143,7 +143,7 @@ namespace OpenLoco::Paint
     }
 
     // 0x004C3D7C
-    static void paintWall(PaintSession& session, Map::WallElement& elWall)
+    static void paintWall([[maybe_unused]] PaintSession& session, Map::WallElement& elWall)
     {
         registers regs;
         regs.esi = X86Pointer(&elWall);
@@ -153,7 +153,7 @@ namespace OpenLoco::Paint
     }
 
     // 0x004759A6
-    static void paintRoad(PaintSession& session, Map::RoadElement& elRoad)
+    static void paintRoad([[maybe_unused]] PaintSession& session, Map::RoadElement& elRoad)
     {
         registers regs;
         regs.esi = X86Pointer(&elRoad);

--- a/src/OpenLoco/src/Title.cpp
+++ b/src/OpenLoco/src/Title.cpp
@@ -219,11 +219,11 @@ namespace OpenLoco::Title
 
             auto& command = *_sequenceIterator++;
             std::visit(overloaded{
-                           [](WaitStep step) {
+                           []([[maybe_unused]] WaitStep step) {
                                // This loop slightly deviates from the original, subtract 1 tick to make up for it.
                                _waitCounter = step.duration - 1;
                            },
-                           [](ReloadStep step) {
+                           []([[maybe_unused]] ReloadStep step) {
                                reload();
                            },
                            [](MoveStep step) {
@@ -241,7 +241,7 @@ namespace OpenLoco::Title
                                    }
                                }
                            },
-                           [](RotateStep step) {
+                           []([[maybe_unused]] RotateStep step) {
                                if (Game::hasFlags(GameStateFlags::tileManagerLoaded))
                                {
                                    auto main = Ui::WindowManager::getMainWindow();
@@ -251,7 +251,7 @@ namespace OpenLoco::Title
                                    }
                                }
                            },
-                           [](ResetStep step) {
+                           []([[maybe_unused]] ResetStep step) {
                                _sequenceIterator = _titleSequence.begin();
                            },
                        },
@@ -271,13 +271,13 @@ namespace OpenLoco::Title
     {
         registerHook(
             0x0046AD7D,
-            [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 start();
                 return 0;
             });
         registerHook(
             0x004442C4,
-            [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 loadTitle();
                 return 0;
             });

--- a/src/OpenLoco/src/Title.cpp
+++ b/src/OpenLoco/src/Title.cpp
@@ -271,13 +271,13 @@ namespace OpenLoco::Title
     {
         registerHook(
             0x0046AD7D,
-            []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 start();
                 return 0;
             });
         registerHook(
             0x004442C4,
-            []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 loadTitle();
                 return 0;
             });

--- a/src/OpenLoco/src/TownManager.cpp
+++ b/src/OpenLoco/src/TownManager.cpp
@@ -221,7 +221,7 @@ namespace OpenLoco::TownManager
     {
         registerHook(
             0x00497348,
-            [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 resetBuildingsInfluence();
                 return 0;
             });

--- a/src/OpenLoco/src/Ui.cpp
+++ b/src/OpenLoco/src/Ui.cpp
@@ -342,7 +342,7 @@ namespace OpenLoco::Ui
     {
     }
 
-    static void positionChanged(int32_t x, int32_t y)
+    static void positionChanged([[maybe_unused]] int32_t x, [[maybe_unused]] int32_t y)
     {
         auto displayIndex = SDL_GetWindowDisplayIndex(window);
 

--- a/src/OpenLoco/src/Ui/Dropdown.cpp
+++ b/src/OpenLoco/src/Ui/Dropdown.cpp
@@ -182,7 +182,7 @@ namespace OpenLoco::Ui::Dropdown
         }
 
         // 0x00494BF6
-        static void sub_494BF6(Window* self, Gfx::RenderTarget* rt, string_id stringId, int16_t x, int16_t y, int16_t width, AdvancedColour colour, FormatArguments args)
+        static void sub_494BF6([[maybe_unused]] Window* self, Gfx::RenderTarget* rt, string_id stringId, int16_t x, int16_t y, int16_t width, AdvancedColour colour, FormatArguments args)
         {
             StringManager::formatString(_byte_112CC04, stringId, &args);
 
@@ -197,7 +197,7 @@ namespace OpenLoco::Ui::Dropdown
         }
 
         // 0x004CD00E
-        static void draw(Window& self, Gfx::RenderTarget* rt)
+        static void draw([[maybe_unused]] Window& self, Gfx::RenderTarget* rt)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 

--- a/src/OpenLoco/src/Ui/ScrollView.cpp
+++ b/src/OpenLoco/src/Ui/ScrollView.cpp
@@ -462,7 +462,7 @@ namespace OpenLoco::Ui::ScrollView
     }
 
     // Based on 0x004C8689
-    void scrollModalRight(const int16_t x, const int16_t y, Ui::Window* const w, Ui::Widget* const widget, const WidgetIndex_t widgetIndex)
+    void scrollModalRight(const int16_t x, const int16_t y, Ui::Window* const w, Ui::Widget* const widget, [[maybe_unused]] const WidgetIndex_t widgetIndex)
     {
         auto res = getPart(w, widget, x, y);
 

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -99,7 +99,7 @@ namespace OpenLoco::Ui::WindowManager
 
         registerHook(
             0x0043CB9F,
-            [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 Windows::TitleMenu::editorInit();
 
                 return 0;
@@ -397,7 +397,7 @@ namespace OpenLoco::Ui::WindowManager
 
         registerHook(
             0x004CD3D0,
-            [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 dispatchUpdateAll();
                 return 0;
             });

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -99,7 +99,7 @@ namespace OpenLoco::Ui::WindowManager
 
         registerHook(
             0x0043CB9F,
-            []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 Windows::TitleMenu::editorInit();
 
                 return 0;
@@ -397,7 +397,7 @@ namespace OpenLoco::Ui::WindowManager
 
         registerHook(
             0x004CD3D0,
-            []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 dispatchUpdateAll();
                 return 0;
             });

--- a/src/OpenLoco/src/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/CreateVehicle.cpp
@@ -121,7 +121,7 @@ namespace OpenLoco::Vehicles
     }
 
     // 0x004AE8F1, 0x004AEA9E
-    static VehicleBogie* createBogie(const EntityId head, const uint16_t vehicleTypeId, const VehicleObject& vehObject, const uint8_t bodyNumber, VehicleBase* const lastVeh, const ColourScheme colourScheme)
+    static VehicleBogie* createBogie(const EntityId head, const uint16_t vehicleTypeId, [[maybe_unused]] const VehicleObject& vehObject, const uint8_t bodyNumber, VehicleBase* const lastVeh, const ColourScheme colourScheme)
     {
         auto newBogie = createVehicleThing<VehicleBogie>();
         newBogie->owner = _updatingCompanyId;

--- a/src/OpenLoco/src/Widget.cpp
+++ b/src/OpenLoco/src/Widget.cpp
@@ -40,7 +40,7 @@ namespace OpenLoco::Ui
     void draw_14(Gfx::RenderTarget* rt, Widget* widget, AdvancedColour colour, bool disabled, int16_t x, int16_t y, string_id string);
 
     // 0x004CF3EB
-    static void drawStationNameBackground(Gfx::RenderTarget* rt, const Window* window, const Widget* widget, int16_t x, int16_t y, AdvancedColour colour, int16_t width)
+    static void drawStationNameBackground(Gfx::RenderTarget* rt, [[maybe_unused]] const Window* window, [[maybe_unused]] const Widget* widget, int16_t x, int16_t y, AdvancedColour colour, int16_t width)
     {
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
         drawingCtx.drawImage(rt, x - 4, y, Gfx::recolour(ImageIds::curved_border_left_medium, colour.c()));
@@ -227,7 +227,7 @@ namespace OpenLoco::Ui
         drawingCtx.drawImage(rt, x, y, image);
     }
 
-    void Widget::sub_4CADE8(Gfx::RenderTarget* rt, const Window* window, AdvancedColour colour, bool enabled, bool disabled, bool activated)
+    void Widget::sub_4CADE8(Gfx::RenderTarget* rt, const Window* window, AdvancedColour colour, [[maybe_unused]] bool enabled, bool disabled, bool activated)
     {
         Ui::Point placeForImage(left + window->x, top + window->y);
         const bool isColourSet = image & Widget::kImageIdColourSet;
@@ -297,7 +297,7 @@ namespace OpenLoco::Ui
     }
 
     // 0x004CAAB9
-    void Widget::drawFrame(Gfx::RenderTarget* rt, const Window* window, Drawing::RectInsetFlags flags, AdvancedColour colour)
+    void Widget::drawFrame(Gfx::RenderTarget* rt, const Window* window, [[maybe_unused]] Drawing::RectInsetFlags flags, AdvancedColour colour)
     {
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
         auto clipped = Gfx::clipRenderTarget(*rt, Ui::Rect(left + window->x, top + window->y, right - left, 41));
@@ -374,7 +374,7 @@ namespace OpenLoco::Ui
     }
 
     // 0x004CABFE
-    void Widget::drawTab(Gfx::RenderTarget* rt, const Window* window, Drawing::RectInsetFlags flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
+    void Widget::drawTab(Gfx::RenderTarget* rt, const Window* window, [[maybe_unused]] Drawing::RectInsetFlags flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
     {
         if (content == kContentNull)
         {
@@ -452,7 +452,7 @@ namespace OpenLoco::Ui
     }
 
     // 0x004CAC5F
-    void Widget::drawButtonWithColour(Gfx::RenderTarget* rt, const Window* window, Drawing::RectInsetFlags flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered)
+    void Widget::drawButtonWithColour(Gfx::RenderTarget* rt, const Window* window, [[maybe_unused]] Drawing::RectInsetFlags flags, AdvancedColour colour, bool enabled, [[maybe_unused]] bool disabled, bool activated, bool hovered)
     {
         if (content == kContentNull)
         {
@@ -484,7 +484,7 @@ namespace OpenLoco::Ui
     }
 
     // 0x004CB164
-    void Widget::drawButton(Gfx::RenderTarget* rt, const Window* window, Drawing::RectInsetFlags flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
+    void Widget::drawButton(Gfx::RenderTarget* rt, const Window* window, Drawing::RectInsetFlags flags, AdvancedColour colour, [[maybe_unused]] bool enabled, [[maybe_unused]] bool disabled, bool activated)
     {
         int l = window->x + left;
         int r = window->x + right;
@@ -501,7 +501,7 @@ namespace OpenLoco::Ui
     }
 
     // 0x004CB1BE
-    void Widget::draw_13(Gfx::RenderTarget* rt, const Window* window, Drawing::RectInsetFlags flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
+    void Widget::draw_13(Gfx::RenderTarget* rt, const Window* window, [[maybe_unused]] Drawing::RectInsetFlags flags, AdvancedColour colour, [[maybe_unused]] bool enabled, bool disabled, bool activated)
     {
         if (content == kContentNull)
         {
@@ -533,7 +533,7 @@ namespace OpenLoco::Ui
     }
 
     // 0x004CB21D
-    void draw_11_c(Gfx::RenderTarget* rt, const Window* window, Widget* widget, AdvancedColour colour, bool disabled, int16_t x, int16_t y, string_id string)
+    void draw_11_c(Gfx::RenderTarget* rt, const Window* window, Widget* widget, AdvancedColour colour, bool disabled, [[maybe_unused]] int16_t x, int16_t y, string_id string)
     {
         colour = colour.opaque();
         if (disabled)
@@ -564,7 +564,7 @@ namespace OpenLoco::Ui
     }
 
     // 0x4CB2D6
-    void Widget::draw_15(Gfx::RenderTarget* rt, const Window* window, Drawing::RectInsetFlags flags, AdvancedColour colour, bool disabled)
+    void Widget::draw_15(Gfx::RenderTarget* rt, const Window* window, [[maybe_unused]] Drawing::RectInsetFlags flags, AdvancedColour colour, bool disabled)
     {
         if (content == kContentNull || content == kContentUnk)
         {
@@ -611,7 +611,7 @@ namespace OpenLoco::Ui
     }
 
     // 0x004CA750
-    void Widget::draw_23_caption(Gfx::RenderTarget* rt, const Window* window, Drawing::RectInsetFlags flags, AdvancedColour colour)
+    void Widget::draw_23_caption(Gfx::RenderTarget* rt, const Window* window, [[maybe_unused]] Drawing::RectInsetFlags flags, AdvancedColour colour)
     {
         char stringBuffer[512];
         stringBuffer[0] = ControlCodes::Colour::black;
@@ -633,7 +633,7 @@ namespace OpenLoco::Ui
     }
 
     // 0x004CA7F6
-    void Widget::draw_24_caption(Gfx::RenderTarget* rt, const Window* window, Drawing::RectInsetFlags flags, AdvancedColour colour)
+    void Widget::draw_24_caption(Gfx::RenderTarget* rt, const Window* window, [[maybe_unused]] Drawing::RectInsetFlags flags, [[maybe_unused]] AdvancedColour colour)
     {
         char stringBuffer[512];
         stringBuffer[0] = ControlCodes::windowColour1;
@@ -652,7 +652,7 @@ namespace OpenLoco::Ui
     }
 
     // 0x004CA88B
-    void Widget::draw_25_caption(Gfx::RenderTarget* rt, const Window* window, Drawing::RectInsetFlags flags, AdvancedColour colour)
+    void Widget::draw_25_caption(Gfx::RenderTarget* rt, const Window* window, [[maybe_unused]] Drawing::RectInsetFlags flags, [[maybe_unused]] AdvancedColour colour)
     {
         char stringBuffer[512];
         stringBuffer[0] = ControlCodes::Colour::white;
@@ -670,7 +670,7 @@ namespace OpenLoco::Ui
         drawingCtx.drawString(*rt, x, window->y + top + 1, AdvancedColour(Colour::black).outline(), stringBuffer);
     }
 
-    static void draw_hscroll(Gfx::RenderTarget* rt, const Window* window, Widget* widget, Drawing::RectInsetFlags flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered, int16_t scrollview_index)
+    static void draw_hscroll(Gfx::RenderTarget* rt, const Window* window, Widget* widget, Drawing::RectInsetFlags flags, AdvancedColour colour, [[maybe_unused]] bool enabled, [[maybe_unused]] bool disabled, [[maybe_unused]] bool activated, [[maybe_unused]] bool hovered, int16_t scrollview_index)
     {
         const auto* scroll_area = &window->scrollAreas[scrollview_index];
 
@@ -736,7 +736,7 @@ namespace OpenLoco::Ui
         // popa
     }
 
-    static void draw_vscroll(Gfx::RenderTarget* rt, const Window* window, Widget* widget, Drawing::RectInsetFlags flags, AdvancedColour colour, bool enabled, bool disabled, bool activated, bool hovered, int16_t scrollview_index)
+    static void draw_vscroll(Gfx::RenderTarget* rt, const Window* window, Widget* widget, Drawing::RectInsetFlags flags, AdvancedColour colour, [[maybe_unused]] bool enabled, [[maybe_unused]] bool disabled, [[maybe_unused]] bool activated, [[maybe_unused]] bool hovered, int16_t scrollview_index)
     {
         const auto* scroll_area = &window->scrollAreas[scrollview_index];
 
@@ -879,7 +879,7 @@ namespace OpenLoco::Ui
     }
 
     // 0x004CB00B
-    void Widget::draw_27_checkbox(Gfx::RenderTarget* rt, const Window* window, Drawing::RectInsetFlags flags, AdvancedColour colour, bool enabled, bool disabled, bool activated)
+    void Widget::draw_27_checkbox(Gfx::RenderTarget* rt, const Window* window, Drawing::RectInsetFlags flags, AdvancedColour colour, bool enabled, [[maybe_unused]] bool disabled, bool activated)
     {
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
         if (enabled)
@@ -902,7 +902,7 @@ namespace OpenLoco::Ui
     }
 
     // 0x004CB080
-    void Widget::draw_27_label(Gfx::RenderTarget* rt, const Window* window, Drawing::RectInsetFlags flags, AdvancedColour colour, bool disabled)
+    void Widget::draw_27_label(Gfx::RenderTarget* rt, const Window* window, [[maybe_unused]] Drawing::RectInsetFlags flags, AdvancedColour colour, bool disabled)
     {
         if (content == kContentNull)
         {

--- a/src/OpenLoco/src/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Windows/BuildVehicle.cpp
@@ -733,7 +733,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     }
 
     // 0x4C37B9
-    static void getScrollSize(Ui::Window& window, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
     {
         *scrollHeight = window.var_83C * window.rowHeight;
     }
@@ -786,7 +786,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     }
 
     // 0x4C3802
-    static void onScrollMouseOver(Ui::Window& window, int16_t x, int16_t y, uint8_t scroll_index)
+    static void onScrollMouseOver(Ui::Window& window, [[maybe_unused]] int16_t x, int16_t y, uint8_t scroll_index)
     {
         if (scroll_index != scrollIdx::vehicle_selection)
         {
@@ -851,7 +851,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     }
 
     // 0x4C37CB
-    static Ui::CursorId cursor(Window& window, int16_t widgetIdx, int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId cursor(Window& window, int16_t widgetIdx, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
     {
         if (widgetIdx != widx::scrollview_vehicle_selection)
         {

--- a/src/OpenLoco/src/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Windows/CompanyFaceSelection.cpp
@@ -112,7 +112,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x004352A4
-    static void onClose(Window& self)
+    static void onClose([[maybe_unused]] Window& self)
     {
         ObjectManager::freeTemporaryObject();
     }
@@ -129,7 +129,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x4352BB
-    static void getScrollSize(Window& self, const uint32_t scrollIndex, uint16_t* const scrollWidth, uint16_t* const scrollHeight)
+    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint16_t* const scrollWidth, uint16_t* const scrollHeight)
     {
         *scrollHeight = _numberCompetitorObjects * kRowHeight;
     }
@@ -161,7 +161,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x00435314
-    static void scrollMouseDown(Window& self, const int16_t x, const int16_t y, const uint8_t scroll_index)
+    static void scrollMouseDown(Window& self, [[maybe_unused]] const int16_t x, const int16_t y, [[maybe_unused]] const uint8_t scroll_index)
     {
         const auto objRow = getObjectFromSelection(y);
 
@@ -180,7 +180,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x004352C7
-    static void scrollMouseOver(Window& self, const int16_t x, const int16_t y, const uint8_t scroll_index)
+    static void scrollMouseOver(Window& self, [[maybe_unused]] const int16_t x, const int16_t y, [[maybe_unused]] const uint8_t scroll_index)
     {
         auto objRow = getObjectFromSelection(y);
         if (self.rowHover == objRow.rowIndex)
@@ -203,7 +203,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x4352B1
-    static std::optional<FormatArguments> tooltip(Window& self, const WidgetIndex_t)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, const WidgetIndex_t)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_list);
@@ -259,7 +259,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x00435152
-    static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+    static void drawScroll(Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
     {
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
         drawingCtx.clearSingle(rt, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));

--- a/src/OpenLoco/src/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Windows/CompanyList.cpp
@@ -195,7 +195,6 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00437BE1
-        // FIXME: rhs is not used.
         static bool orderByStatus(const OpenLoco::Company& lhs, const OpenLoco::Company& rhs)
         {
             char lhsString[256] = { 0 };

--- a/src/OpenLoco/src/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Windows/CompanyList.cpp
@@ -195,6 +195,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00437BE1
+        // FIXME: rhs is not used.
         static bool orderByStatus(const OpenLoco::Company& lhs, const OpenLoco::Company& rhs)
         {
             char lhsString[256] = { 0 };
@@ -345,13 +346,13 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00436321
-        static void getScrollSize(Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
         {
             *scrollHeight = self.var_83C * kRowHeight;
         }
 
         // 0x004363A0
-        static void onScrollMouseDown(Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+        static void onScrollMouseDown(Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             uint16_t currentRow = y / kRowHeight;
             if (currentRow > self.var_83C)
@@ -365,7 +366,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00436361
-        static void onScrollMouseOver(Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+        static void onScrollMouseOver(Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             self.flags &= ~(WindowFlags::notScrollView);
 
@@ -383,7 +384,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x004362B6
-        static std::optional<FormatArguments> tooltip(Window& self, WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_company_list);
@@ -391,7 +392,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x0043632C
-        static Ui::CursorId cursor(Window& self, int16_t widgetIdx, int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, int16_t widgetIdx, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
         {
             if (widgetIdx != widx::scrollview)
                 return fallback;
@@ -452,7 +453,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00435EA7
-        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 

--- a/src/OpenLoco/src/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Windows/CompanyWindow.cpp
@@ -971,7 +971,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432CA1
-        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             Map::TileManager::mapInvalidateSelectionRect();
             Input::resetMapSelectionFlag(Input::MapSelectionFlags::enable);
@@ -1007,7 +1007,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         // regs.dx = widgetIndex;
         // regs.ax = mouseX;
         // regs.bx = mouseY;
-        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t mouseX, const int16_t mouseY)
+        static void onToolDown([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t mouseX, const int16_t mouseY)
         {
             removeHeadquarterGhost();
 
@@ -1027,7 +1027,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432D7A
-        static void onToolAbort(Window& self, const WidgetIndex_t widgetIndex)
+        static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex)
         {
             removeHeadquarterGhost();
             Ui::Windows::hideGridlines();
@@ -1874,7 +1874,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x0043361E
-        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -2030,14 +2030,14 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x0043386F
-        static void getScrollSize(Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, uint16_t* scrollWidth, [[maybe_unused]] uint16_t* scrollHeight)
         {
             const auto& company = CompanyManager::get(CompanyId(self.number));
             *scrollWidth = company->numExpenditureMonths * expenditureColumnWidth;
         }
 
         // 0x00433887
-        static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_list);

--- a/src/OpenLoco/src/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Windows/Construction/Common.cpp
@@ -984,7 +984,7 @@ namespace OpenLoco::Ui::Windows::Construction
         }
 
         // 0x0049DD14
-        void onClose(Window& self)
+        void onClose([[maybe_unused]] Window& self)
         {
             removeConstructionGhosts();
             WindowManager::viewportSetVisibility(WindowManager::ViewportVisibility::reset);

--- a/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
@@ -304,7 +304,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049F92D
-    static void constructTrack(Window* self, WidgetIndex_t widgetIndex)
+    static void constructTrack([[maybe_unused]] Window* self, [[maybe_unused]] WidgetIndex_t widgetIndex)
     {
         if (_trackType & (1 << 7))
         {
@@ -486,7 +486,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x004A0121
-    static void removeTrack(Window* self, WidgetIndex_t widgetIndex)
+    static void removeTrack([[maybe_unused]] Window* self, [[maybe_unused]] WidgetIndex_t widgetIndex)
     {
         if (_trackType & (1 << 7))
         {
@@ -1734,7 +1734,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049D4EA
-    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void onDropdown([[maybe_unused]] Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (widgetIndex == widx::bridge_dropdown)
         {
@@ -2391,7 +2391,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049DC8C
-    static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::construct)
         {
@@ -2473,7 +2473,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049DC97
-    static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::construct)
             return;
@@ -2489,7 +2489,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049D4F5
-    static Ui::CursorId cursor(Window& self, int16_t widgetIndex, int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId cursor([[maybe_unused]] Window& self, int16_t widgetIndex, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
     {
         if (widgetIndex == widx::bridge || widgetIndex == widx::bridge_dropdown)
             Input::setTooltipTimeout(2000);

--- a/src/OpenLoco/src/Windows/Construction/OverheadTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/OverheadTab.cpp
@@ -326,7 +326,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
     }
 
     // 0x0049EC20
-    static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::image)
         {

--- a/src/OpenLoco/src/Windows/Construction/SignalTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/SignalTab.cpp
@@ -250,7 +250,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
     }
 
     // 0x0049E75A
-    static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::single_direction && widgetIndex != widx::both_directions)
         {

--- a/src/OpenLoco/src/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/StationTab.cpp
@@ -541,7 +541,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     }
 
     // 0x0049E42C
-    static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::image)
         {

--- a/src/OpenLoco/src/Windows/DragVehiclePart.cpp
+++ b/src/OpenLoco/src/Windows/DragVehiclePart.cpp
@@ -49,7 +49,7 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
     }
 
     // 0x004B62FE
-    static Ui::CursorId cursor(Window& self, const int16_t widgetIdx, const int16_t x, const int16_t y, const Ui::CursorId fallback)
+    static Ui::CursorId cursor(Window& self, [[maybe_unused]] const int16_t widgetIdx, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y, [[maybe_unused]] const Ui::CursorId fallback)
     {
         self.height = 0; // Set to zero so that skipped in window find
         Vehicle::Details::scrollDrag(Input::getScrollLastLocation());
@@ -57,7 +57,7 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
         return CursorId::dragHand;
     }
 
-    static void onMove(Window& self, const int16_t x, const int16_t y)
+    static void onMove(Window& self, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
     {
         self.height = 0; // Set to zero so that skipped in window find
         Vehicle::Details::scrollDragEnd(Input::getScrollLastLocation());

--- a/src/OpenLoco/src/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Windows/IndustryList.cpp
@@ -186,7 +186,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458172
-        static void onScrollMouseDown(Ui::Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+        static void onScrollMouseDown(Ui::Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             uint16_t currentRow = y / kRowHeight;
             if (currentRow > self.var_83C)
@@ -200,7 +200,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458140
-        static void onScrollMouseOver(Ui::Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+        static void onScrollMouseOver(Ui::Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             self.flags &= ~(WindowFlags::notScrollView);
 
@@ -367,7 +367,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00457EE8
-        static std::optional<FormatArguments> tooltip(Ui::Window& self, WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_industry_list);
@@ -375,13 +375,13 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458108
-        static void getScrollSize(Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
         {
             *scrollHeight = kRowHeight * self.var_83C;
         }
 
         // 0x00457D2A
-        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -451,7 +451,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458113
-        static Ui::CursorId cursor(Window& self, int16_t widgetIdx, int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, int16_t widgetIdx, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
         {
             if (widgetIdx != widx::scrollview)
                 return fallback;
@@ -724,7 +724,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458966
-        static void onScrollMouseDown(Ui::Window& self, int16_t x, int16_t y, uint8_t scrollIndex)
+        static void onScrollMouseDown(Ui::Window& self, int16_t x, int16_t y, [[maybe_unused]] uint8_t scrollIndex)
         {
             int16_t xPos = (x / kRowHeight);
             int16_t yPos = (y / kRowHeight) * 5;
@@ -751,7 +751,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458721
-        static void onScrollMouseOver(Ui::Window& self, int16_t x, int16_t y, uint8_t scrollIndex)
+        static void onScrollMouseOver(Ui::Window& self, int16_t x, int16_t y, [[maybe_unused]] uint8_t scrollIndex)
         {
             auto index = getRowIndex(x, y);
             uint16_t rowInfo = 0xFFFF;
@@ -885,7 +885,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458455
-        static std::optional<FormatArguments> tooltip(Ui::Window& self, WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_new_industry_list);
@@ -893,7 +893,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x004586EA
-        static void getScrollSize(Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
         {
             *scrollHeight = (4 + self.var_83C) / 5;
             if (*scrollHeight == 0)
@@ -902,7 +902,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458352
-        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -1020,7 +1020,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x0045848A
-        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, int16_t x, const int16_t y)
+        static void onToolUpdate(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, int16_t x, const int16_t y)
         {
             Map::TileManager::mapInvalidateSelectionRect();
             Input::resetMapSelectionFlag(Input::MapSelectionFlags::enable);
@@ -1054,7 +1054,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x0045851F
-        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, int16_t x, const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, int16_t x, const int16_t y)
         {
             removeIndustryGhost();
             auto placementArgs = getIndustryPlacementArgsFromCursor(x, y);
@@ -1073,7 +1073,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x004585AD
-        static void onToolAbort(Window& self, const WidgetIndex_t widgetIndex)
+        static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex)
         {
             removeIndustryGhost();
             Ui::Windows::hideGridlines();

--- a/src/OpenLoco/src/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Windows/KeyboardShortcuts.cpp
@@ -153,7 +153,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     }
 
     // 0x004BE72C
-    static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+    static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
     {
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -230,13 +230,13 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     }
 
     // 0x004BE84E
-    static void getScrollSize(Ui::Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
     {
         *scrollHeight = self.rowCount * kRowHeight;
     }
 
     // 0x004BE853
-    static void onScrollMouseOver(Ui::Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+    static void onScrollMouseOver(Ui::Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         auto row = y / kRowHeight;
 
@@ -251,7 +251,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     }
 
     // 0x004BE87B
-    static void onScrollMouseDown(Ui::Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+    static void onScrollMouseDown(Ui::Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         auto row = y / kRowHeight;
 

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -428,7 +428,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         };
 
         // 0x0043E01C
-        static void drawScroll(Ui::Window& window, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& window, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -467,7 +467,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E2AC
-        static void getScrollSize(Ui::Window& window, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
         {
             *scrollHeight = 0;
 
@@ -634,7 +634,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E1CF
-        static void scrollMouseDown(Window& window, int16_t xPos, int16_t yPos, uint8_t scrollIndex)
+        static void scrollMouseDown(Window& window, int16_t xPos, int16_t yPos, [[maybe_unused]] uint8_t scrollIndex)
         {
             int16_t landIndex = scrollPosToLandIndex(xPos, yPos);
             if (landIndex == -1)
@@ -675,7 +675,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E2A2
-        static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_list);

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -374,7 +374,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046B9E7
-    static void getScrollSize(Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
     {
         self.callPrepareDraw();
         *scrollWidth = kMapColumns * 2;
@@ -394,7 +394,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046B97C
-    static void scrollMouseDown(Window& self, int16_t x, int16_t y, uint8_t scrollIndex)
+    static void scrollMouseDown([[maybe_unused]] Window& self, int16_t x, int16_t y, [[maybe_unused]] uint8_t scrollIndex)
     {
         auto pos = mapWindowPosToLocation({ x, y });
 
@@ -402,7 +402,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046B946
-    static std::optional<FormatArguments> tooltip(Window& self, WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_map);
@@ -1377,7 +1377,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046B806
-    static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+    static void drawScroll(Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
     {
         if (!Game::hasFlags(GameStateFlags::tileManagerLoaded))
             return;

--- a/src/OpenLoco/src/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Windows/MessageWindow.cpp
@@ -136,13 +136,13 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042A871
-        static void getScrollSize(Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
         {
             *scrollHeight = _messageCount * messageHeight;
         }
 
         // 0x0042A8B9
-        static void scrollMouseDown(Ui::Window& self, int16_t x, int16_t y, uint8_t scrollIndex)
+        static void scrollMouseDown(Ui::Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scrollIndex)
         {
             auto messageIndex = y / messageHeight;
 
@@ -174,7 +174,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042A87C
-        static void scrollMouseOver(Ui::Window& self, int16_t x, int16_t y, uint8_t scrollIndex)
+        static void scrollMouseOver(Ui::Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scrollIndex)
         {
             self.flags &= ~(WindowFlags::notScrollView);
 
@@ -192,7 +192,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042A70C
-        static std::optional<FormatArguments> tooltip(Ui::Window& self, WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_message_list);
@@ -216,7 +216,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042A5D7
-        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
         {
             auto colour = Colours::getShade(self.getColour(WindowColour::secondary).c(), 4);
 
@@ -468,7 +468,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042AAAC
-        static void onDropdown(Window& self, Ui::WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown([[maybe_unused]] Window& self, Ui::WidgetIndex_t widgetIndex, int16_t itemIndex)
         {
             switch (widgetIndex)
             {

--- a/src/OpenLoco/src/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/src/Windows/MusicSelection.cpp
@@ -99,7 +99,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     }
 
     // 0x004C1663
-    static void drawScroll(Ui::Window& window, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+    static void drawScroll(Ui::Window& window, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
     {
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -136,7 +136,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     }
 
     // 0x004C176C
-    static void getScrollSize(Ui::Window& window, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
     {
         *scrollHeight = kRowHeight * Audio::kNumMusicTracks;
     }
@@ -153,7 +153,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     }
 
     // 0x004C1799
-    static void onScrollMouseDown(Ui::Window& window, int16_t x, int16_t y, uint8_t scroll_index)
+    static void onScrollMouseDown(Ui::Window& window, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         uint16_t currentTrack = y / kRowHeight;
         if (currentTrack > window.rowCount)
@@ -179,7 +179,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     }
 
     // 0x004C1771
-    static void onScrollMouseOver(Ui::Window& window, int16_t x, int16_t y, uint8_t scroll_index)
+    static void onScrollMouseOver(Ui::Window& window, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         uint16_t currentTrack = y / kRowHeight;
         if (currentTrack > window.rowCount || currentTrack == window.rowHover)
@@ -201,7 +201,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     }
 
     // 0x004C1762
-    static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_list);

--- a/src/OpenLoco/src/Windows/NetworkStatus.cpp
+++ b/src/OpenLoco/src/Windows/NetworkStatus.cpp
@@ -80,7 +80,7 @@ namespace OpenLoco::Ui::Windows::NetworkStatus
         Gfx::invalidateScreen();
     }
 
-    static void onClose(Ui::Window& window)
+    static void onClose([[maybe_unused]] Ui::Window& window)
     {
         if (_cbClose)
         {
@@ -98,7 +98,7 @@ namespace OpenLoco::Ui::Windows::NetworkStatus
         }
     }
 
-    static void prepareDraw(Window& self)
+    static void prepareDraw([[maybe_unused]] Window& self)
     {
         StringManager::setString(StringIds::buffer_1250, _text.c_str());
     }

--- a/src/OpenLoco/src/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Windows/News/News.cpp
@@ -35,7 +35,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
         WindowEventList events;
 
         // 0x00429BB7
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp([[maybe_unused]] Window& self, WidgetIndex_t widgetIndex)
         {
             switch (widgetIndex)
             {

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -327,7 +327,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x00472BBC
-    static ObjectManager::ObjIndexPair getFirstAvailableSelectedObject(Window* self)
+    static ObjectManager::ObjIndexPair getFirstAvailableSelectedObject([[maybe_unused]] Window* self)
     {
         for (auto& entry : _tabObjectList)
         {
@@ -985,13 +985,13 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x004738ED
-    static void getScrollSize(Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
     {
         *scrollHeight = _numVisibleObjectsListed * kRowHeight;
     }
 
     // 0x00473900
-    static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_object_list);
@@ -999,7 +999,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x00472B54
-    static ObjectManager::ObjIndexPair getObjectFromSelection(Window* self, int16_t& y)
+    static ObjectManager::ObjIndexPair getObjectFromSelection([[maybe_unused]] Window* self, int16_t& y)
     {
         for (auto& entry : _tabObjectList)
         {
@@ -1017,7 +1017,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x0047390A
-    static void onScrollMouseOver(Ui::Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+    static void onScrollMouseOver(Ui::Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         auto objIndex = getObjectFromSelection(&self, y);
 
@@ -1047,7 +1047,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x00473948
-    static void onScrollMouseDown(Ui::Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+    static void onScrollMouseDown(Ui::Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         auto objIndex = getObjectFromSelection(&self, y);
         auto index = objIndex.index;
@@ -1138,7 +1138,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x004739DD
-    static void onClose(Window& self)
+    static void onClose([[maybe_unused]] Window& self)
     {
         unloadUnselectedObjects();
         editorLoadSelectedObjects();

--- a/src/OpenLoco/src/Windows/Options.cpp
+++ b/src/OpenLoco/src/Windows/Options.cpp
@@ -42,7 +42,7 @@ namespace OpenLoco::Ui::Windows::Options
     static loco_global<void*, 0x011364A0> __11364A0;
     static loco_global<uint16_t, 0x0112C185> _112C185;
 
-    static void onClose(Window& w)
+    static void onClose([[maybe_unused]] Window& w)
     {
         free(__11364A0);
     }
@@ -317,7 +317,7 @@ namespace OpenLoco::Ui::Windows::Options
 #pragma mark - Construction Marker (Widget 19)
 
         // 0x004BFE2E
-        static void constructionMarkerMouseDown(Window* w, WidgetIndex_t wi)
+        static void constructionMarkerMouseDown(Window* w, [[maybe_unused]] WidgetIndex_t wi)
         {
             Widget dropdown = w->widgets[Widx::construction_marker];
             Dropdown::show(w->x + dropdown.left, w->y + dropdown.top, dropdown.width() - 4, dropdown.height(), w->getColour(WindowColour::secondary), 2, 0x80);
@@ -345,7 +345,7 @@ namespace OpenLoco::Ui::Windows::Options
 #pragma mark - Vehicle zoom (Widget 15)
 
         // 0x004BFEBE
-        static void vehicleZoomMouseDown(Window* w, WidgetIndex_t wi)
+        static void vehicleZoomMouseDown(Window* w, [[maybe_unused]] WidgetIndex_t wi)
         {
             Widget dropdown = w->widgets[Widx::vehicles_min_scale];
             Dropdown::show(w->x + dropdown.left, w->y + dropdown.top, dropdown.width() - 4, dropdown.height(), w->getColour(WindowColour::secondary), 4, 0x80);
@@ -375,7 +375,7 @@ namespace OpenLoco::Ui::Windows::Options
 #pragma mark - Station names minimum scale (Widget 17)
 
         // 0x004BFF72
-        static void stationNamesScaleMouseDown(Window* w, WidgetIndex_t wi)
+        static void stationNamesScaleMouseDown(Window* w, [[maybe_unused]] WidgetIndex_t wi)
         {
             Widget dropdown = w->widgets[Widx::station_names_min_scale];
             Dropdown::show(w->x + dropdown.left, w->y + dropdown.top, dropdown.width() - 4, dropdown.height(), w->getColour(WindowColour::secondary), 4, 0x80);
@@ -418,7 +418,7 @@ namespace OpenLoco::Ui::Windows::Options
         }
 #endif
 
-        static void screenModeMouseDown(Window* w, WidgetIndex_t wi)
+        static void screenModeMouseDown(Window* w, [[maybe_unused]] WidgetIndex_t wi)
         {
             Widget dropdown = w->widgets[Widx::screen_mode];
             Dropdown::show(w->x + dropdown.left, w->y + dropdown.top, dropdown.width() - 4, dropdown.height(), w->getColour(WindowColour::secondary), 3, 0x80);
@@ -431,7 +431,7 @@ namespace OpenLoco::Ui::Windows::Options
             Dropdown::setItemSelected(selection);
         }
 
-        static void screenModeDropdown(Window* w, int16_t selection)
+        static void screenModeDropdown([[maybe_unused]] Window* w, int16_t selection)
         {
             if (selection == -1)
                 return;
@@ -448,7 +448,7 @@ namespace OpenLoco::Ui::Windows::Options
 #pragma mark - Resolution dropdown (Widget 11)
 
         // 0x004C0026
-        static void resolutionMouseDown(Window* w, WidgetIndex_t wi)
+        static void resolutionMouseDown(Window* w, [[maybe_unused]] WidgetIndex_t wi)
         {
             std::vector<Resolution> resolutions = getFullscreenResolutions();
 
@@ -465,7 +465,7 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C00F4
-        static void resolutionDropdown(Window* w, int16_t index)
+        static void resolutionDropdown([[maybe_unused]] Window* w, int16_t index)
         {
             if (index == -1)
                 return;
@@ -475,7 +475,7 @@ namespace OpenLoco::Ui::Windows::Options
 
 #pragma mark -
 
-        static void displayScaleMouseDown(Window* w, WidgetIndex_t wi, float adjust_by)
+        static void displayScaleMouseDown([[maybe_unused]] Window* w, [[maybe_unused]] WidgetIndex_t wi, float adjust_by)
         {
             OpenLoco::Ui::adjustWindowScale(adjust_by);
         }
@@ -1681,7 +1681,7 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C0FB3
-        static void distanceSpeedDropdown(Window* w, int16_t ax)
+        static void distanceSpeedDropdown([[maybe_unused]] Window* w, int16_t ax)
         {
             if (ax == -1)
                 return;
@@ -1718,7 +1718,7 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C106C
-        static void heightsLabelsDropdown(Window* w, int16_t ax)
+        static void heightsLabelsDropdown([[maybe_unused]] Window* w, int16_t ax)
         {
             if (ax == -1)
                 return;

--- a/src/OpenLoco/src/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/src/Windows/PlayerInfoPanel.cpp
@@ -273,7 +273,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     }
 
     // 0x004395A4
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex)
     {
         switch (widgetIndex)
         {
@@ -298,7 +298,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     }
 
     // 0x004395BC
-    static void onDropdown(Window& w, WidgetIndex_t widgetIndex, int16_t item_index)
+    static void onDropdown([[maybe_unused]] Window& w, WidgetIndex_t widgetIndex, int16_t item_index)
     {
         switch (widgetIndex)
         {
@@ -321,7 +321,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     }
 
     // 0x004395DE
-    static Ui::CursorId onCursor(Ui::Window& window, int16_t widgetIndex, int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId onCursor([[maybe_unused]] Ui::Window& window, int16_t widgetIndex, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
     {
         switch (widgetIndex)
         {
@@ -334,7 +334,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     }
 
     // 0x004395F5
-    static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex)
     {
         FormatArguments args{};
         switch (widgetIndex)

--- a/src/OpenLoco/src/Windows/ProgressBar.cpp
+++ b/src/OpenLoco/src/Windows/ProgressBar.cpp
@@ -88,7 +88,7 @@ namespace OpenLoco::Ui::Windows::ProgressBar
     }
 
     // 0x004CF78A
-    static void prepareDraw(Window& self)
+    static void prepareDraw([[maybe_unused]] Window& self)
     {
         char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
         strncpy(buffer, _captionString.c_str(), 256);

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -216,13 +216,13 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x004464A1
-    static void getScrollSize(Ui::Window& window, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
     {
         *scrollHeight = window.rowHeight * static_cast<uint16_t>(_files.size());
     }
 
     // 0x004464F7
-    static void onScrollMouseDown(Window& self, int16_t x, int16_t y, uint8_t scrollIndex)
+    static void onScrollMouseDown(Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scrollIndex)
     {
         auto index = size_t(y / self.rowHeight);
         if (index >= _files.size())
@@ -260,7 +260,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x004464B1
-    static void onScrollMouseOver(Window& self, int16_t x, int16_t y, uint8_t scrollIndex)
+    static void onScrollMouseOver(Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scrollIndex)
     {
         if (WindowManager::getCurrentModalType() != WindowType::fileBrowserPrompt)
             return;
@@ -278,7 +278,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x004467D7
-    static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_list);
@@ -573,7 +573,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x00446314
-    static void drawScroll(Ui::Window& window, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+    static void drawScroll(Ui::Window& window, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
     {
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 

--- a/src/OpenLoco/src/Windows/PromptOkCancelWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptOkCancelWindow.cpp
@@ -91,7 +91,7 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
     }
 
     // 0x00447125
-    void handleInput(uint32_t charCode, uint32_t keyCode)
+    void handleInput([[maybe_unused]] uint32_t charCode, uint32_t keyCode)
     {
         auto window = WindowManager::find(WindowType::confirmationPrompt);
         if (window == nullptr)
@@ -102,7 +102,7 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
     }
 
     // 0x00447093
-    static void prepareDraw(Window& self)
+    static void prepareDraw([[maybe_unused]] Window& self)
     {
         // Prepare description string for drawing.
         char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));

--- a/src/OpenLoco/src/Windows/PromptSaveWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptSaveWindow.cpp
@@ -110,7 +110,7 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
     }
 
     // 0x0043C3F4
-    static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex)
+    static void onMouseUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex)
     {
         switch (widgetIndex)
         {
@@ -136,7 +136,7 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
     }
 
     // 0x0043C577
-    static void onClose(Window& self)
+    static void onClose([[maybe_unused]] Window& self)
     {
         unsetPauseFlag(2);
         Audio::unpauseSound();

--- a/src/OpenLoco/src/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioSelect.cpp
@@ -463,7 +463,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     }
 
     // 0x00443F32
-    static void onScrollMouseDown(Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+    static void onScrollMouseDown(Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         auto scenarioCount = ScenarioManager::getScenarioCountByCategory(self.currentTab);
 
@@ -489,7 +489,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     }
 
     // 0x00443FB2
-    static void onScrollMouseOver(Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+    static void onScrollMouseOver(Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         auto scenarioCount = ScenarioManager::getScenarioCountByCategory(self.currentTab);
 
@@ -510,7 +510,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     }
 
     // 0x00444001
-    static std::optional<FormatArguments> tooltip(Window& self, WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_scenario_list);

--- a/src/OpenLoco/src/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Windows/StationList.cpp
@@ -361,7 +361,7 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x004919A4
-    static Ui::CursorId cursor(Window& window, int16_t widgetIdx, int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId cursor(Window& window, int16_t widgetIdx, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
     {
         if (widgetIdx != widx::scrollview)
             return fallback;
@@ -448,7 +448,7 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x0049157F
-    static void drawScroll(Ui::Window& window, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+    static void drawScroll(Ui::Window& window, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
     {
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -665,7 +665,7 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x00491A0C
-    static void onScrollMouseDown(Ui::Window& window, int16_t x, int16_t y, uint8_t scroll_index)
+    static void onScrollMouseDown(Ui::Window& window, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         uint16_t currentRow = y / kRowHeight;
         if (currentRow > window.var_83C)
@@ -679,7 +679,7 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x004919D1
-    static void onScrollMouseOver(Ui::Window& window, int16_t x, int16_t y, uint8_t scroll_index)
+    static void onScrollMouseOver(Ui::Window& window, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         window.flags &= ~(WindowFlags::notScrollView);
 
@@ -711,13 +711,13 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x00491999
-    static void getScrollSize(Ui::Window& window, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
     {
         *scrollHeight = kRowHeight * window.var_83C;
     }
 
     // 0x00491841
-    static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_station_list);

--- a/src/OpenLoco/src/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Windows/StationWindow.cpp
@@ -444,7 +444,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EB64
-        static void getScrollSize(Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
         {
             auto station = StationManager::get(StationId(self.number));
             *scrollHeight = 0;
@@ -460,7 +460,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EB4F
-        static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_cargo_list);
@@ -468,7 +468,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048E986
-        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
             drawingCtx.clearSingle(rt, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
@@ -643,7 +643,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EE4A
-        static void getScrollSize(Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
         {
             auto station = StationManager::get(StationId(self.number));
             *scrollHeight = 0;
@@ -655,7 +655,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EE73
-        static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_ratings_list);
@@ -676,7 +676,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048ED2F
-        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
             drawingCtx.clearSingle(rt, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -228,7 +228,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void removeTreeGhost();
 
         // 0x004BBB0A
-        static void onClose(Window& self)
+        static void onClose([[maybe_unused]] Window& self)
         {
             removeTreeGhost();
             Ui::Windows::hideGridlines();
@@ -477,7 +477,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBB15
-        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -515,7 +515,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBB20
-        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -577,7 +577,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBEC1
-        static void getScrollSize(Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
         {
             *scrollHeight = (self.var_83C + 8) / 9;
             if (*scrollHeight == 0)
@@ -591,7 +591,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBF3B
-        static void scrollMouseDown(Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+        static void scrollMouseDown(Window& self, int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             int16_t xPos = (x / kColumnWidth);
             int16_t yPos = (y / kRowHeight) * 5;
@@ -620,7 +620,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBEF8
-        static void scrollMouseOver(Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+        static void scrollMouseOver(Window& self, int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             auto index = getRowIndex(x, y);
             uint16_t rowInfo = y;
@@ -639,7 +639,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBB00
-        static std::optional<FormatArguments> tooltip(Window& self, WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_trees_list);
@@ -763,7 +763,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BB982
-        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -922,7 +922,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static WindowEventList events;
 
         // 0x004BC671
-        static void onClose(Window& self)
+        static void onClose([[maybe_unused]] Window& self)
         {
             Ui::Windows::hideGridlines();
         }
@@ -970,7 +970,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC677
-        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             Map::TileManager::mapInvalidateSelectionRect();
             Input::resetMapSelectionFlag(Input::MapSelectionFlags::enable);
@@ -1008,7 +1008,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC689
-        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
                 return;
@@ -1016,7 +1016,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC682
-        static void toolDragContinue(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void toolDragContinue([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
                 return;
@@ -1029,7 +1029,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC701
-        static void toolDragEnd(Window& self, const WidgetIndex_t widgetIndex)
+        static void toolDragEnd([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex)
         {
             if (widgetIndex == Common::widx::panel)
             {
@@ -1119,7 +1119,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static WindowEventList events;
 
         // 0x004BC9D1
-        static void onClose(Window& self)
+        static void onClose([[maybe_unused]] Window& self)
         {
             Ui::Windows::hideGridlines();
         }
@@ -1314,7 +1314,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             WindowManager::invalidate(WindowType::terraform, 0);
         }
 
-        static void onPaintToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onPaintToolUpdate([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             Map::TileManager::mapInvalidateSelectionRect();
             Input::resetMapSelectionFlag(Input::MapSelectionFlags::enable);
@@ -1339,7 +1339,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             }
         }
 
-        static void onAdjustLandToolUpdate(const OpenLoco::Ui::WidgetIndex_t& widgetIndex, const int16_t& x, const int16_t& y)
+        static void onAdjustLandToolUpdate([[maybe_unused]] const OpenLoco::Ui::WidgetIndex_t& widgetIndex, const int16_t& x, const int16_t& y)
         {
             uint16_t xPos = 0;
 
@@ -1428,7 +1428,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC9ED
-        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
         {
             switch (widgetIndex)
             {
@@ -1445,7 +1445,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC9E2
-        static void toolDragContinue(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void toolDragContinue([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             switch (widgetIndex)
             {
@@ -1507,7 +1507,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCA5D
-        static void toolDragEnd(Window& self, const WidgetIndex_t widgetIndex)
+        static void toolDragEnd([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex)
         {
             switch (widgetIndex)
             {
@@ -1635,7 +1635,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static WindowEventList events;
 
         // 0x004BCDAE
-        static void onClose(Window& self)
+        static void onClose([[maybe_unused]] Window& self)
         {
             Ui::Windows::hideGridlines();
         }
@@ -1698,7 +1698,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCDB4
-        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
                 return;
@@ -1741,7 +1741,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCDCA
-        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
                 return;
@@ -1770,7 +1770,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCDBF
-        static void toolDragContinue(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void toolDragContinue([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
                 return;
@@ -1818,7 +1818,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCDE8
-        static void toolDragEnd(Window& self, const WidgetIndex_t widgetIndex)
+        static void toolDragEnd([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex)
         {
             if (widgetIndex == Common::widx::panel)
             {
@@ -1981,7 +1981,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void removeWallGhost();
 
         // 0x004BC21C
-        static void onClose(Window& self)
+        static void onClose([[maybe_unused]] Window& self)
         {
             removeWallGhost();
             Ui::Windows::hideGridlines();
@@ -2153,7 +2153,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC227
-        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -2187,7 +2187,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC232
-        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -2206,7 +2206,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC359
-        static void getScrollSize(Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
         {
             *scrollHeight = (self.var_83C + 9) / 10;
             if (*scrollHeight == 0)
@@ -2220,7 +2220,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC3D3
-        static void scrollMouseDown(Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+        static void scrollMouseDown(Window& self, int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             int16_t xPos = (x / 40);
             int16_t yPos = (y / kRowHeight) * 10;
@@ -2246,7 +2246,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC390
-        static void scrollMouseOver(Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+        static void scrollMouseOver(Window& self, int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             auto index = getRowIndex(x, y);
             uint16_t rowInfo = 0xFFFF;
@@ -2266,7 +2266,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC212
-        static std::optional<FormatArguments> tooltip(Window& self, WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_walls_list);
@@ -2309,7 +2309,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC11C
-        static void drawScroll(Window& self, Gfx::RenderTarget& rt, uint32_t scrollIndex)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] uint32_t scrollIndex)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 

--- a/src/OpenLoco/src/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Windows/TextInputWindow.cpp
@@ -208,7 +208,7 @@ namespace OpenLoco::Ui::Windows::TextInput
      *
      * @param window @<esi>
      */
-    static void prepareDraw(Ui::Window& window)
+    static void prepareDraw([[maybe_unused]] Ui::Window& window)
     {
         _widgets[Widx::title].text = _title;
         memcpy(_commonFormatArgs, _formatArgs, 16);

--- a/src/OpenLoco/src/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Windows/TileInspector.cpp
@@ -361,7 +361,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         }
     }
 
-    static void scrollMouseDown(Window& self, const int16_t x, const int16_t y, const uint8_t scrollIndex)
+    static void scrollMouseDown(Window& self, [[maybe_unused]] const int16_t x, const int16_t y, [[maybe_unused]] const uint8_t scrollIndex)
     {
         auto index = y / self.rowHeight;
         if (index >= self.rowCount)
@@ -375,7 +375,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         }
     }
 
-    static void scrollMouseOver(Window& self, const int16_t x, const int16_t y, const uint8_t scrollIndex)
+    static void scrollMouseOver(Window& self, [[maybe_unused]] const int16_t x, const int16_t y, [[maybe_unused]] const uint8_t scrollIndex)
     {
         auto index = y / self.rowHeight;
         if (index >= self.rowCount)
@@ -433,7 +433,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         *scrollHeight = self.rowCount * self.rowHeight;
     }
 
-    static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::panel)
             return;
@@ -466,7 +466,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         self.invalidate();
     }
 
-    static void onClose(Window& self)
+    static void onClose([[maybe_unused]] Window& self)
     {
         Input::toolCancel();
     }

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -109,7 +109,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x004396A4
-    static void prepareDraw(Window& window)
+    static void prepareDraw([[maybe_unused]] Window& window)
     {
         _widgets[Widx::inner_frame].type = WidgetType::none;
         _widgets[Widx::pause_btn].image = Gfx::recolour(ImageIds::speed_pause);
@@ -204,7 +204,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x004398FB
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex)
     {
         switch (widgetIndex)
         {
@@ -253,7 +253,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x0043A72F
-    static void mapDropdown(Window* self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void mapDropdown(Window* self, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -304,7 +304,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x00439944
-    static Ui::CursorId onCursor(Ui::Window& self, int16_t widgetIdx, int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId onCursor([[maybe_unused]] Ui::Window& self, int16_t widgetIdx, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
     {
         switch (widgetIdx)
         {
@@ -317,7 +317,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x00439955
-    static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex)
     {
         FormatArguments args{};
         switch (widgetIndex)
@@ -370,7 +370,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x00439A15
-    static void textInput(Window& w, WidgetIndex_t widgetIndex, const char* str)
+    static void textInput([[maybe_unused]] Window& w, WidgetIndex_t widgetIndex, const char* str)
     {
         switch (widgetIndex)
         {

--- a/src/OpenLoco/src/Windows/TitleExit.cpp
+++ b/src/OpenLoco/src/Windows/TitleExit.cpp
@@ -83,7 +83,7 @@ namespace OpenLoco::Ui::Windows::TitleExit
     }
 
     // 0x00439268
-    static void onMouseUp(Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex)
     {
         if (Intro::isActive())
         {

--- a/src/OpenLoco/src/Windows/TitleLogo.cpp
+++ b/src/OpenLoco/src/Windows/TitleLogo.cpp
@@ -61,7 +61,7 @@ namespace OpenLoco::Ui::Windows::TitleLogo
     }
 
     // 0x004392AD
-    static void onMouseUp(Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex)
     {
         switch (widgetIndex)
         {

--- a/src/OpenLoco/src/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Windows/TitleMenu.cpp
@@ -357,7 +357,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     }
 
     // 0x004390DD
-    static void onDropdown(Ui::Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void onDropdown([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         sub_46E328();
         switch (widgetIndex)
@@ -369,7 +369,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     }
 
     // 0x004390ED
-    static void onTextInput(Window& window, WidgetIndex_t widgetIndex, const char* input)
+    static void onTextInput([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex, const char* input)
     {
         switch (widgetIndex)
         {
@@ -383,7 +383,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     }
 
     // 0x004390f8
-    static Ui::CursorId onCursor(Window& window, int16_t widgetIdx, int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId onCursor([[maybe_unused]] Window& window, [[maybe_unused]] int16_t widgetIdx, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
     {
         // Reset tooltip timeout to keep tooltips open.
         addr<0x0052338A, uint16_t>() = 2000;

--- a/src/OpenLoco/src/Windows/TitleOptions.cpp
+++ b/src/OpenLoco/src/Windows/TitleOptions.cpp
@@ -71,7 +71,7 @@ namespace OpenLoco::Ui::Windows::TitleOptions
         drawingCtx.drawStringCentredWrapped(*rt, origin, window.width, Colour::white, StringIds::outlined_wcolour2_stringid, (const char*)&StringIds::options);
     }
 
-    static void onMouseUp(Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex)
     {
         if (Intro::isActive())
         {

--- a/src/OpenLoco/src/Windows/ToolTip.cpp
+++ b/src/OpenLoco/src/Windows/ToolTip.cpp
@@ -61,7 +61,7 @@ namespace OpenLoco::Ui::Windows::ToolTip
             });
     }
 
-    static void common(const Window* window, int32_t widgetIndex, string_id stringId, int16_t cursorX, int16_t cursorY, FormatArguments& args)
+    static void common([[maybe_unused]] const Window* window, [[maybe_unused]] int32_t widgetIndex, string_id stringId, int16_t cursorX, int16_t cursorY, FormatArguments& args)
     {
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -194,14 +194,14 @@ namespace OpenLoco::Ui::Windows::ToolTip
     }
 
     // 0x004C94F7
-    static void onClose(Ui::Window& window)
+    static void onClose([[maybe_unused]] Ui::Window& window)
     {
         auto str337 = const_cast<char*>(StringManager::getString(StringIds::buffer_337));
         str337[0] = '\0';
     }
 
     // 0x004C94FF
-    static void update(Ui::Window& window)
+    static void update([[maybe_unused]] Ui::Window& window)
     {
         if (_52336E == false)
         {

--- a/src/OpenLoco/src/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Windows/ToolbarTop.cpp
@@ -218,7 +218,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     }
 
     // 0x0043B154
-    static void loadsaveMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void loadsaveMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         auto id = Dropdown::getSelectedItem<LoadSaveDropdownId>(itemIndex);
         if (!id)
@@ -287,7 +287,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     }
 
     // 0x0043B0B8
-    static void audioMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void audioMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -342,7 +342,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             Dropdown::setItemSelected(7);
     }
 
-    static void cheatsMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void cheatsMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = 0;
@@ -438,7 +438,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     }
 
     // 0x0043A39F
-    static void railroadMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void railroadMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -482,7 +482,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     }
 
     // 0x0043AA0A
-    static void portMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void portMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -548,7 +548,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     }
 
     // 0x0043ADC7
-    static void buildVehiclesMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void buildVehiclesMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -612,7 +612,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     }
 
     // 0x0043ACEF
-    static void vehiclesMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void vehiclesMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -646,7 +646,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     }
 
     // 0x0043A596
-    static void stationsMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void stationsMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();

--- a/src/OpenLoco/src/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Windows/ToolbarTopAlt.cpp
@@ -126,7 +126,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
     }
 
     // 0x0043D695
-    static void loadsaveMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void loadsaveMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -201,7 +201,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
     }
 
     // 0x0043D7C1
-    static void audioMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void audioMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -223,7 +223,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
     }
 
     // 0x004402DA
-    static void mapGenerationMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void mapGenerationMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();

--- a/src/OpenLoco/src/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/src/Windows/ToolbarTopCommon.cpp
@@ -251,7 +251,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     }
 
     // 0x0043A86D
-    void zoomMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    void zoomMenuDropdown(Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -278,7 +278,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     }
 
     // 0x0043A624
-    void rotateMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    void rotateMenuDropdown(Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -303,7 +303,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     }
 
     // 0x0043AF37
-    void viewMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    void viewMenuDropdown(Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -332,7 +332,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     }
 
     // 0x0043A4A8
-    void terraformMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    void terraformMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -362,7 +362,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     }
 
     // 0x0043A28C
-    void roadMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    void roadMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -375,7 +375,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     }
 
     // 0x0043A932
-    void townsMenuDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    void townsMenuDropdown([[maybe_unused]] Window* window, [[maybe_unused]] WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
         if (itemIndex == -1)
             itemIndex = Dropdown::getHighlightedItem();
@@ -453,7 +453,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
         }
     }
 
-    void onUpdate(Window& window)
+    void onUpdate([[maybe_unused]] Window& window)
     {
         _zoomTicks++;
     }

--- a/src/OpenLoco/src/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Windows/TownList.cpp
@@ -142,7 +142,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A0F8
-        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -265,7 +265,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A56D
-        static void onScrollMouseDown(Ui::Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+        static void onScrollMouseDown(Ui::Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             uint16_t currentRow = y / kRowHeight;
             if (currentRow > self.var_83C)
@@ -279,7 +279,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A532
-        static void onScrollMouseOver(Ui::Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+        static void onScrollMouseOver(Ui::Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             self.flags &= ~(WindowFlags::notScrollView);
 
@@ -457,13 +457,13 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A4FA
-        static void getScrollSize(Ui::Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
         {
             *scrollHeight = kRowHeight * self.var_83C;
         }
 
         // 0x00491841
-        static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_town_list);
@@ -471,7 +471,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x004919A4
-        static Ui::CursorId cursor(Window& self, int16_t widgetIdx, int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, int16_t widgetIdx, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
         {
             if (widgetIdx != widx::scrollview)
                 return fallback;
@@ -691,13 +691,13 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A7C1
-        static void onToolAbort(Window& self, const WidgetIndex_t widgetIndex)
+        static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex)
         {
             Ui::Windows::hideGridlines();
         }
 
         // 0x0049A710
-        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             Map::TileManager::mapInvalidateSelectionRect();
             Input::resetMapSelectionFlag(Input::MapSelectionFlags::enable);
@@ -713,7 +713,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A75E
-        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             auto mapPos = Ui::ViewportInteraction::getSurfaceOrWaterLocFromUi({ x, y });
             if (mapPos)
@@ -730,7 +730,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A69E
-        static void populateTownSizeSelect(Window* self, Widget* widget)
+        static void populateTownSizeSelect(Window* self, [[maybe_unused]] Widget* widget)
         {
             auto& currentSizeWidget = self->widgets[widx::current_size];
 
@@ -993,7 +993,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AD46
-        static void onToolAbort(Window& self, const WidgetIndex_t widgetIndex)
+        static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex)
         {
             removeBuildingGhost();
             Ui::Windows::hideGridlines();
@@ -1065,7 +1065,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049ABF0
-        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             Map::TileManager::mapInvalidateSelectionRect();
             Input::resetMapSelectionFlag(Input::MapSelectionFlags::enable);
@@ -1101,7 +1101,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049ACBD
-        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             removeBuildingGhost();
             auto placementArgs = getBuildingPlacementArgsFromCursor(x, y);
@@ -1170,7 +1170,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AE83
-        static void getScrollSize(Ui::Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
         {
             *scrollHeight = (4 + self.var_83C) / 5;
             if (*scrollHeight == 0)
@@ -1179,7 +1179,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049ABBB
-        static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_building_list);
@@ -1187,7 +1187,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AA1C
-        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+        static void drawScroll(Ui::Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -1256,7 +1256,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AEFD
-        static void onScrollMouseDown(Ui::Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+        static void onScrollMouseDown(Ui::Window& self, int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             int16_t xPos = (x / 112);
             int16_t yPos = (y / 112) * 5;
@@ -1291,7 +1291,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AEBA
-        static void onScrollMouseOver(Ui::Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+        static void onScrollMouseOver(Ui::Window& self, int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             auto index = getRowIndex(x, y);
             uint16_t rowInfo = y;

--- a/src/OpenLoco/src/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Windows/Vehicle.cpp
@@ -1230,13 +1230,13 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x4B38FA
-        static void getScrollSize(Ui::Window& self, const uint32_t scrollIndex, uint16_t* const width, uint16_t* const height)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint16_t* const width, uint16_t* const height)
         {
             *height = static_cast<uint16_t>(Common::getNumCars(&self) * self.rowHeight);
         }
 
         // 0x004B3B54
-        static void scrollMouseDown(Window& self, const int16_t x, const int16_t y, const uint8_t scrollIndex)
+        static void scrollMouseDown(Window& self, [[maybe_unused]] const int16_t x, const int16_t y, [[maybe_unused]] const uint8_t scrollIndex)
         {
             auto head = Common::getVehicle(&self);
             if (head == nullptr)
@@ -1266,7 +1266,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B399E
-        static void scrollMouseOver(Window& self, const int16_t x, const int16_t y, const uint8_t scrollIndex)
+        static void scrollMouseOver(Window& self, [[maybe_unused]] const int16_t x, const int16_t y, [[maybe_unused]] const uint8_t scrollIndex)
         {
             Input::setTooltipTimeout(2000);
             self.flags &= ~WindowFlags::notScrollView;
@@ -1382,7 +1382,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B3B18
-        static Ui::CursorId cursor(Window& self, const int16_t widgetIdx, const int16_t x, const int16_t y, const Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, const int16_t widgetIdx, [[maybe_unused]] const int16_t x, const int16_t y, const Ui::CursorId fallback)
         {
             if (widgetIdx != widx::carList)
             {
@@ -1569,7 +1569,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B36A3
-        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t i)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t i)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -1881,7 +1881,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 004B3F62
-        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t i)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t i)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -2055,7 +2055,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4360
-        static void getScrollSize(Ui::Window& self, const uint32_t scrollIndex, uint16_t* const width, uint16_t* const height)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint16_t* const width, uint16_t* const height)
         {
             *height = static_cast<uint16_t>(Common::getNumCars(&self) * self.rowHeight);
         }
@@ -2100,7 +2100,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4404
-        static void scrollMouseOver(Window& self, const int16_t x, const int16_t y, const uint8_t scrollIndex)
+        static void scrollMouseOver(Window& self, [[maybe_unused]] const int16_t x, const int16_t y, [[maybe_unused]] const uint8_t scrollIndex)
         {
             Input::setTooltipTimeout(2000);
             self.flags &= ~WindowFlags::notScrollView;
@@ -2739,14 +2739,14 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B5088
-        static void toolCancel(Window& self, const WidgetIndex_t widgetIdx)
+        static void toolCancel(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIdx)
         {
             self.invalidate();
             Input::resetMapSelectionFlag(Input::MapSelectionFlags::unk_04);
             Gfx::invalidateScreen();
         }
 
-        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
         {
             auto [type, args] = sub_4B5A1A(self, x, y);
             switch (type)
@@ -2840,7 +2840,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4D9B
-        static void getScrollSize(Ui::Window& self, const uint32_t scrollIndex, uint16_t* const width, uint16_t* const height)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint16_t* const width, uint16_t* const height)
         {
             auto head = Common::getVehicle(&self);
             if (head == nullptr)
@@ -2854,7 +2854,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             *height += lineHeight;
         }
 
-        static void scrollMouseDown(Window& self, const int16_t x, const int16_t y, const uint8_t scrollIndex)
+        static void scrollMouseDown(Window& self, const int16_t x, const int16_t y, [[maybe_unused]] const uint8_t scrollIndex)
         {
             auto head = Common::getVehicle(&self);
             if (head == nullptr)
@@ -2950,7 +2950,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B530C
-        static void scrollMouseOver(Window& self, const int16_t x, const int16_t y, const uint8_t scrollIndex)
+        static void scrollMouseOver(Window& self, [[maybe_unused]] const int16_t x, const int16_t y, [[maybe_unused]] const uint8_t scrollIndex)
         {
             self.flags &= ~WindowFlags::notScrollView;
             auto item = y / lineHeight;
@@ -2962,7 +2962,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B5339
-        static Ui::CursorId cursor(Window& self, const int16_t widgetIdx, const int16_t x, const int16_t y, const Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, const int16_t widgetIdx, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y, const Ui::CursorId fallback)
         {
             if (widgetIdx != widx::routeList)
             {
@@ -3193,7 +3193,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B48BA
-        static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t i)
+        static void drawScroll(Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t i)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 

--- a/src/OpenLoco/src/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Windows/VehicleList.cpp
@@ -706,7 +706,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C21CD
-    static void drawScroll(Window& self, Gfx::RenderTarget& rt, const uint32_t scrollIndex)
+    static void drawScroll(Window& self, Gfx::RenderTarget& rt, [[maybe_unused]] const uint32_t scrollIndex)
     {
         auto shade = Colours::getShade(self.getColour(WindowColour::secondary).c(), 1);
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
@@ -974,7 +974,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C24CA
-    static std::optional<FormatArguments> tooltip(Window& self, WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_vehicle_list);
@@ -1013,13 +1013,13 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C265B
-    static void getScrollSize(Window& self, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
     {
         *scrollHeight = self.var_83C * self.rowHeight;
     }
 
     // 0x004C266D
-    static CursorId cursor(Window& self, int16_t widgetIdx, int16_t xPos, int16_t yPos, CursorId fallback)
+    static CursorId cursor(Window& self, int16_t widgetIdx, [[maybe_unused]] int16_t xPos, int16_t yPos, CursorId fallback)
     {
         if (widgetIdx != Widx::scrollview)
             return fallback;
@@ -1032,7 +1032,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C26A4
-    static void onScrollMouseOver(Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+    static void onScrollMouseOver(Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         Input::setTooltipTimeout(2000);
 
@@ -1096,7 +1096,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C27C0
-    static void onScrollMouseDown(Window& self, int16_t x, int16_t y, uint8_t scroll_index)
+    static void onScrollMouseDown(Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         uint16_t currentRow = y / self.rowHeight;
         if (currentRow >= self.var_83C)

--- a/src/Platform/src/Crash.cpp
+++ b/src/Platform/src/Crash.cpp
@@ -93,7 +93,7 @@ CExceptionHandler crashInit()
 #endif // USE_BREAKPAD
 }
 
-void crashClose(CExceptionHandler exHandler)
+void crashClose([[maybe_unused]] CExceptionHandler exHandler)
 {
 #if defined(USE_BREAKPAD)
     delete exHandler;

--- a/src/Platform/src/Platform.Posix.cpp
+++ b/src/Platform/src/Platform.Posix.cpp
@@ -98,7 +98,7 @@ namespace OpenLoco::Platform
         return exePath;
     }
 
-    fs::path promptDirectory(const std::string& Title, [[maybe_unused]] void* hwnd)
+    fs::path promptDirectory([[maybe_unused]] const std::string& Title, [[maybe_unused]] void* hwnd)
     {
         std::string input;
         std::cout << "Type your Locomotion path: ";

--- a/src/Utility/include/OpenLoco/Utility/Stream.hpp
+++ b/src/Utility/include/OpenLoco/Utility/Stream.hpp
@@ -83,9 +83,9 @@ namespace OpenLoco
         virtual ~Stream() {}
         virtual uint64_t getLength() const { throwInvalidOperation(); }
         virtual uint64_t getPosition() const { throwInvalidOperation(); }
-        virtual void setPosition(uint64_t position) { throwInvalidOperation(); }
-        virtual void read(void* buffer, size_t len) { throwInvalidOperation(); }
-        virtual void write(const void* buffer, size_t len) { throwInvalidOperation(); }
+        virtual void setPosition(uint64_t) { throwInvalidOperation(); }
+        virtual void read(void*, size_t) { throwInvalidOperation(); }
+        virtual void write(const void*, size_t) { throwInvalidOperation(); }
 
         void seek(int64_t pos)
         {
@@ -93,7 +93,7 @@ namespace OpenLoco
         }
 
     private:
-        [[noreturn]] static void throwInvalidOperation() { throw std::runtime_error("Invalid operation"); }
+        [[noreturn]] static void throwInvalidOperation(...) { throw std::runtime_error("Invalid operation"); }
     };
 
     class BinaryStream final : public Stream

--- a/src/Utility/src/String.cpp
+++ b/src/Utility/src/String.cpp
@@ -101,7 +101,7 @@ namespace OpenLoco::Utility
 #endif
     }
 
-    std::wstring toUtf16(const std::string_view& src)
+    std::wstring toUtf16([[maybe_unused]] const std::string_view& src)
     {
 #ifdef _WIN32
         int srcLen = src.size();


### PR DESCRIPTION
Based on #1854 so I'll have to rebase if thats in. This removes a couple disabled warnings and added `[[maybe_unused]]` for the time being, ordinarily unused parameters should be nameless according to https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f9-unused-parameters-should-be-unnamed but the signatures of the functions or use may change so I sticked to `[[maybe_unused]]` for most of it, once Interop is gone we can adjust the function signatures to improve this.