### PR TITLE
Fix #1475: Slow view panning with uncaps FPS disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 23.01+ (???)
 ------------------------------------------------------------------------
 - Feature: [#1837]: Add search/filter functionality to object selection window.
+- Fix: [#1475] Slow view panning with uncaps FPS disabled.
 - Fix: [#1763] Title music does not stop when unchecked in options window.
 - Fix: [#1772] Toggling edge scrolling option does not work.
 - Fix: [#1798] Memory leak when resizing the window.

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -1024,14 +1024,15 @@ namespace OpenLoco
 
         if (_accumulator < UpdateTime)
         {
-            auto timeMissing = static_cast<uint32_t>((UpdateTime - _accumulator) * 1000);
-            std::this_thread::sleep_for(std::chrono::milliseconds(timeMissing));
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
+        else
+        {
+            tick();
+            _accumulator -= UpdateTime;
 
-        tick();
-        _accumulator -= UpdateTime;
-
-        Ui::render();
+            Ui::render();
+        }
     }
 
     static void update()


### PR DESCRIPTION
Actually my bad, sleeping for the remaining time until the next tick halted the entire game loop for that time of course.

Closes #1475