### PR TITLE
Fix #1870: 'Exit game' button glitches

### DIFF
--- a/src/OpenLoco/src/Windows/TitleExit.cpp
+++ b/src/OpenLoco/src/Windows/TitleExit.cpp
@@ -62,8 +62,11 @@ namespace OpenLoco::Ui::Windows::TitleExit
     static void prepareDraw(Ui::Window& self)
     {
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
+
         auto exitString = StringManager::getString(StringIds::title_exit_game);
+        drawingCtx.setCurrentFontSpriteBase(Font::medium_bold);
         self.width = drawingCtx.getStringWidthNewLined(exitString) + 10;
+
         self.x = Ui::width() - self.width;
         self.widgets[Widx::exit_button].right = self.width;
     }


### PR DESCRIPTION

The 'Exit game' button at the bottom-right of the title screen uses `getStringWidthNewLined` to determine the width of the button. This is expected to return a width of 40px for English, but other languages may use a wider button (e.g. German, Spanish).

The width does not seem to be consistent, however, due to the tooltip window overriding the font used. Due to the string rendering functions still using globals, this triggers a race condition, which this PR addresses.