### PR TITLE
Refactor Console logging and introduce fmtlib

### DIFF
--- a/src/Console/CMakeLists.txt
+++ b/src/Console/CMakeLists.txt
@@ -12,3 +12,8 @@ loco_add_library(Console STATIC
     PRIVATE_FILES
         ${private_files}
 )
+
+target_link_libraries(Console 
+    PUBLIC
+        Core
+)

--- a/src/Console/include/OpenLoco/Console/Console.h
+++ b/src/Console/include/OpenLoco/Console/Console.h
@@ -41,10 +41,12 @@ namespace OpenLoco::Console
     }
 
     template<typename... TArgs>
-    void verbose(const char* fmt, TArgs&&... args)
+    void verbose([[maybe_unused]] const char* fmt, [[maybe_unused]] TArgs&&... args)
     {
+#ifdef VERBOSE
         auto msg = fmt::format(fmt, std::forward<TArgs>(args)...);
         Detail::print(Level::verbose, msg);
+#endif
     }
 
     // Use the functions above, those should be phased out.

--- a/src/Console/include/OpenLoco/Console/Console.h
+++ b/src/Console/include/OpenLoco/Console/Console.h
@@ -4,6 +4,50 @@
 
 namespace OpenLoco::Console
 {
+    enum class Level
+    {
+        info,
+        warning,
+        error,
+        verbose,
+    };
+
+    namespace Detail
+    {
+        void print(Level level, std::string_view message);
+    }
+
+    void initialize();
+
+    template<typename... TArgs>
+    void info(const char* fmt, TArgs&&... args)
+    {
+        auto msg = fmt::format(fmt, std::forward<TArgs>(args)...);
+        Detail::print(Level::info, msg);
+    }
+
+    template<typename... TArgs>
+    void warn(const char* fmt, TArgs&&... args)
+    {
+        auto msg = fmt::format(fmt, std::forward<TArgs>(args)...);
+        Detail::print(Level::warning, msg);
+    }
+
+    template<typename... TArgs>
+    void error(const char* fmt, TArgs&&... args)
+    {
+        auto msg = fmt::format(fmt, std::forward<TArgs>(args)...);
+        Detail::print(Level::error, msg);
+    }
+
+    template<typename... TArgs>
+    void verbose(const char* fmt, TArgs&&... args)
+    {
+        auto msg = fmt::format(fmt, std::forward<TArgs>(args)...);
+        Detail::print(Level::verbose, msg);
+    }
+
+    // Use the functions above, those should be phased out.
     void logDeprecated(const char* format, ...);
     void logVerboseDeprecated(const char* format, ...);
     void errorDeprecated(const char* format, ...);

--- a/src/Console/include/OpenLoco/Console/Console.h
+++ b/src/Console/include/OpenLoco/Console/Console.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <fmt/format.h>
+#include <string_view>
 
 namespace OpenLoco::Console
 {

--- a/src/Console/include/OpenLoco/Console/Console.h
+++ b/src/Console/include/OpenLoco/Console/Console.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <fmt/format.h>
+
 namespace OpenLoco::Console
 {
-    void log(const char* format, ...);
-    void logVerbose(const char* format, ...);
-    void error(const char* format, ...);
+    void logDeprecated(const char* format, ...);
+    void logVerboseDeprecated(const char* format, ...);
+    void errorDeprecated(const char* format, ...);
 
-    void group(const char* format, ...);
-    void groupEnd();
+    void groupDeprecated(const char* format, ...);
+    void groupEndDeprecated();
 }

--- a/src/Console/src/Console.cpp
+++ b/src/Console/src/Console.cpp
@@ -15,10 +15,11 @@ namespace OpenLoco::Console
 {
     namespace Detail
     {
-        static const auto colourInfo = fmt::fg(fmt::color::white_smoke);
+        static const auto colourInfo = fmt::fg(fmt::color::light_gray);
         static const auto colourWarning = fmt::fg(fmt::color::yellow);
         static const auto colourError = fmt::fg(fmt::color::red);
-        static const auto colourVerbose = fmt::fg(fmt::color::light_gray);
+        static const auto colourVerbose = fmt::fg(fmt::color::gray);
+
 
         void Detail::print(Level level, std::string_view message)
         {

--- a/src/Console/src/Console.cpp
+++ b/src/Console/src/Console.cpp
@@ -20,7 +20,7 @@ namespace OpenLoco::Console
         static const auto colourError = fmt::fg(fmt::color::red);
         static const auto colourVerbose = fmt::fg(fmt::color::gray);
 
-        void Detail::print(Level level, std::string_view message)
+        void print(Level level, std::string_view message)
         {
             // TODO: Move this into the Terminal sink.
             switch (level)

--- a/src/Console/src/Console.cpp
+++ b/src/Console/src/Console.cpp
@@ -20,7 +20,6 @@ namespace OpenLoco::Console
         static const auto colourError = fmt::fg(fmt::color::red);
         static const auto colourVerbose = fmt::fg(fmt::color::gray);
 
-
         void Detail::print(Level level, std::string_view message)
         {
             // TODO: Move this into the Terminal sink.

--- a/src/Console/src/Console.cpp
+++ b/src/Console/src/Console.cpp
@@ -17,7 +17,7 @@ namespace OpenLoco::Console
         fprintf(buffer, "\n");
     }
 
-    void log(const char* format, ...)
+    void logDeprecated(const char* format, ...)
     {
         va_list args;
         va_start(args, format);
@@ -25,7 +25,7 @@ namespace OpenLoco::Console
         va_end(args);
     }
 
-    void logVerbose([[maybe_unused]] const char* format, ...)
+    void logVerboseDeprecated([[maybe_unused]] const char* format, ...)
     {
 #ifdef VERBOSE
         va_list args;
@@ -35,7 +35,7 @@ namespace OpenLoco::Console
 #endif
     }
 
-    void error(const char* format, ...)
+    void errorDeprecated(const char* format, ...)
     {
         va_list args;
         va_start(args, format);
@@ -43,7 +43,7 @@ namespace OpenLoco::Console
         va_end(args);
     }
 
-    void group(const char* format, ...)
+    void groupDeprecated(const char* format, ...)
     {
         for (int i = 0; i < _group; i++)
         {
@@ -60,7 +60,7 @@ namespace OpenLoco::Console
         _group++;
     }
 
-    void groupEnd()
+    void groupEndDeprecated()
     {
         _group--;
     }

--- a/src/Console/src/Console.cpp
+++ b/src/Console/src/Console.cpp
@@ -15,10 +15,10 @@ namespace OpenLoco::Console
 {
     namespace Detail
     {
-        static const auto colourInfo = fmt::fg(fmt::color::light_gray);
-        static const auto colourWarning = fmt::fg(fmt::color::yellow);
-        static const auto colourError = fmt::fg(fmt::color::red);
-        static const auto colourVerbose = fmt::fg(fmt::color::gray);
+        static const auto kColourInfo = fmt::fg(fmt::color::light_gray);
+        static const auto kColourWarning = fmt::fg(fmt::color::yellow);
+        static const auto kColourError = fmt::fg(fmt::color::red);
+        static const auto kColourVerbose = fmt::fg(fmt::color::gray);
 
         void print(Level level, std::string_view message)
         {
@@ -26,16 +26,16 @@ namespace OpenLoco::Console
             switch (level)
             {
                 case Level::info:
-                    fmt::print(stdout, colourInfo, "{}\n", message);
+                    fmt::print(stdout, kColourInfo, "{}\n", message);
                     return;
                 case Level::warning:
-                    fmt::print(stdout, colourWarning, "{}\n", message);
+                    fmt::print(stdout, kColourWarning, "{}\n", message);
                     return;
                 case Level::error:
-                    fmt::print(stderr, colourError, "{}\n", message);
+                    fmt::print(stderr, kColourError, "{}\n", message);
                     return;
                 case Level::verbose:
-                    fmt::print(stdout, colourVerbose, "{}\n", message);
+                    fmt::print(stdout, kColourVerbose, "{}\n", message);
                     return;
                 default:
                     break;

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -29,6 +29,7 @@ loco_add_library(Core STATIC
 target_link_libraries(Core
     PUBLIC
         nonstd::span-lite
+        fmt::fmt
     PRIVATE
         Utility)
 

--- a/src/Interop/src/Interop.cpp
+++ b/src/Interop/src/Interop.cpp
@@ -95,7 +95,7 @@ namespace OpenLoco::Interop
     static int32_t DISABLE_OPT callByRef(int32_t address, int32_t* _eax, int32_t* _ebx, int32_t* _ecx, int32_t* _edx, int32_t* _esi, int32_t* _edi, int32_t* _ebp)
     {
 #ifdef _LOG_INTEROP_CALLS_
-        OpenLoco::Console::group("0x%x", address);
+        OpenLoco::Console::groupDeprecated("0x%x", address);
 #endif
         int32_t result = 0;
         _originalAddress = address;
@@ -252,7 +252,7 @@ namespace OpenLoco::Interop
         _originalAddress = 0;
 
 #ifdef _LOG_INTEROP_CALLS_
-        OpenLoco::Console::groupEnd();
+        OpenLoco::Console::groupEndDeprecated();
 #endif
         // lahf only modifies ah, zero out the rest
         return (result >> 8) & 0xFF;

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -127,7 +127,7 @@ namespace OpenLoco::Audio
 
     static std::vector<uint32_t> loadSoundsFromCSS(const fs::path& path)
     {
-        Console::logVerbose("loadSoundsFromCSS(%s)", path.string().c_str());
+        Console::logVerboseDeprecated("loadSoundsFromCSS(%s)", path.string().c_str());
         std::vector<uint32_t> results;
         std::ifstream fs(path, std::ios::in | std::ios::binary);
 
@@ -473,7 +473,7 @@ namespace OpenLoco::Audio
     {
         if (v->var_4A & 1)
         {
-            Console::logVerbose("playSound(vehicle #%d)", v->id);
+            Console::logVerboseDeprecated("playSound(vehicle #%d)", v->id);
             auto vc = getFreeVehicleChannel();
             if (vc != nullptr)
             {
@@ -576,7 +576,7 @@ namespace OpenLoco::Audio
 
     static void mixSound(SoundId id, bool loop, int32_t volume, int32_t pan, int32_t freq)
     {
-        Console::logVerbose("mixSound(%d, %s, %d, %d, %d)", (int32_t)id, loop ? "true" : "false", volume, pan, freq);
+        Console::logVerboseDeprecated("mixSound(%d, %s, %d, %d, %d)", (int32_t)id, loop ? "true" : "false", volume, pan, freq);
         auto sample = getSoundSample(id);
         if (sample)
         {
@@ -655,7 +655,7 @@ namespace OpenLoco::Audio
     // 0x00401A05
     static void stopChannel(ChannelId id)
     {
-        Console::logVerbose("stopChannel(%d)", id);
+        Console::logVerboseDeprecated("stopChannel(%d)", id);
 
         auto channel = getChannel(id);
         if (channel != nullptr)

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -127,7 +127,7 @@ namespace OpenLoco::Audio
 
     static std::vector<uint32_t> loadSoundsFromCSS(const fs::path& path)
     {
-        Console::logVerboseDeprecated("loadSoundsFromCSS(%s)", path.string().c_str());
+        Console::verbose("loadSoundsFromCSS({})", path.string());
         std::vector<uint32_t> results;
         std::ifstream fs(path, std::ios::in | std::ios::binary);
 
@@ -473,7 +473,7 @@ namespace OpenLoco::Audio
     {
         if (v->var_4A & 1)
         {
-            Console::logVerboseDeprecated("playSound(vehicle #%d)", v->id);
+            Console::verbose("playSound(vehicle #{})", enumValue(v->id));
             auto vc = getFreeVehicleChannel();
             if (vc != nullptr)
             {
@@ -576,7 +576,7 @@ namespace OpenLoco::Audio
 
     static void mixSound(SoundId id, bool loop, int32_t volume, int32_t pan, int32_t freq)
     {
-        Console::logVerboseDeprecated("mixSound(%d, %s, %d, %d, %d)", (int32_t)id, loop ? "true" : "false", volume, pan, freq);
+        Console::verbose("mixSound({}, {}, {}, {}, {})", enumValue(id), loop ? "true" : "false", volume, pan, freq);
         auto sample = getSoundSample(id);
         if (sample)
         {
@@ -655,7 +655,7 @@ namespace OpenLoco::Audio
     // 0x00401A05
     static void stopChannel(ChannelId id)
     {
-        Console::logVerboseDeprecated("stopChannel(%d)", id);
+        Console::logVerboseDeprecated("stopChannel({})", id);
 
         auto channel = getChannel(id);
         if (channel != nullptr)

--- a/src/OpenLoco/src/Drawing/SoftwareDrawingEngine.cpp
+++ b/src/OpenLoco/src/Drawing/SoftwareDrawingEngine.cpp
@@ -313,7 +313,7 @@ namespace OpenLoco::Drawing
         {
             if (SDL_BlitSurface(_screenSurface, nullptr, SDL_GetWindowSurface(_window), nullptr))
             {
-                Console::error("SDL_BlitSurface %s", SDL_GetError());
+                Console::errorDeprecated("SDL_BlitSurface %s", SDL_GetError());
                 exit(1);
             }
         }
@@ -322,14 +322,14 @@ namespace OpenLoco::Drawing
             // first blit to rgba surface to change the pixel format
             if (SDL_BlitSurface(_screenSurface, nullptr, _screenRGBASurface, nullptr))
             {
-                Console::error("SDL_BlitSurface %s", SDL_GetError());
+                Console::errorDeprecated("SDL_BlitSurface %s", SDL_GetError());
                 exit(1);
             }
             // then scale to window size. Without changing to RGBA first, SDL complains
             // about blit configurations being incompatible.
             if (SDL_BlitScaled(_screenRGBASurface, nullptr, SDL_GetWindowSurface(_window), nullptr))
             {
-                Console::error("SDL_BlitScaled %s", SDL_GetError());
+                Console::errorDeprecated("SDL_BlitScaled %s", SDL_GetError());
                 exit(1);
             }
         }

--- a/src/OpenLoco/src/Drawing/SoftwareDrawingEngine.cpp
+++ b/src/OpenLoco/src/Drawing/SoftwareDrawingEngine.cpp
@@ -313,7 +313,7 @@ namespace OpenLoco::Drawing
         {
             if (SDL_BlitSurface(_screenSurface, nullptr, SDL_GetWindowSurface(_window), nullptr))
             {
-                Console::errorDeprecated("SDL_BlitSurface %s", SDL_GetError());
+                Console::error("SDL_BlitSurface {}", SDL_GetError());
                 exit(1);
             }
         }
@@ -322,14 +322,14 @@ namespace OpenLoco::Drawing
             // first blit to rgba surface to change the pixel format
             if (SDL_BlitSurface(_screenSurface, nullptr, _screenRGBASurface, nullptr))
             {
-                Console::errorDeprecated("SDL_BlitSurface %s", SDL_GetError());
+                Console::error("SDL_BlitSurface {}", SDL_GetError());
                 exit(1);
             }
             // then scale to window size. Without changing to RGBA first, SDL complains
             // about blit configurations being incompatible.
             if (SDL_BlitScaled(_screenRGBASurface, nullptr, SDL_GetWindowSurface(_window), nullptr))
             {
-                Console::errorDeprecated("SDL_BlitScaled %s", SDL_GetError());
+                Console::error("SDL_BlitScaled {}", SDL_GetError());
                 exit(1);
             }
         }

--- a/src/OpenLoco/src/Entities/EntityManager.cpp
+++ b/src/OpenLoco/src/Entities/EntityManager.cpp
@@ -199,7 +199,7 @@ namespace OpenLoco::EntityManager
         {
             if (!removeFromSpatialIndex(entity, oldIndex))
             {
-                Console::logDeprecated("Invalid quadrant ids... Reseting spatial index.");
+                Console::info("Invalid quadrant ids... Reseting spatial index.");
                 resetSpatialIndex();
                 moveSpatialEntry(entity, loc);
                 return;
@@ -214,7 +214,7 @@ namespace OpenLoco::EntityManager
         auto* newEntity = get<EntityBase>(id);
         if (newEntity == nullptr)
         {
-            Console::errorDeprecated("Tried to create invalid entity!");
+            Console::error("Tried to create invalid entity! id: {}, list: {}", enumValue(id), enumValue(list));
             return nullptr;
         }
         moveEntityToList(newEntity, list);
@@ -284,7 +284,7 @@ namespace OpenLoco::EntityManager
 
         if (!removeFromSpatialIndex(*entity))
         {
-            Console::logDeprecated("Invalid quadrant ids... Reseting spatial index.");
+            Console::info("Invalid quadrant ids... Reseting spatial index.");
             resetSpatialIndex();
         }
     }
@@ -312,7 +312,7 @@ namespace OpenLoco::EntityManager
             auto* previousEntity = get<EntityBase>(previousId);
             if (previousEntity == nullptr)
             {
-                Console::errorDeprecated("Invalid previous entity id. Entity linked list corrupted?");
+                Console::error("Invalid previous entity id. Entity linked list corrupted? Id: {}", enumValue(previousId));
             }
             else
             {
@@ -325,7 +325,7 @@ namespace OpenLoco::EntityManager
             auto* nextEntity = get<EntityBase>(nextId);
             if (nextEntity == nullptr)
             {
-                Console::errorDeprecated("Invalid next entity id. Entity linked list corrupted?");
+                Console::error("Invalid next entity id. Entity linked list corrupted? Id: {}", enumValue(nextId));
             }
             else
             {
@@ -343,7 +343,7 @@ namespace OpenLoco::EntityManager
             auto* nextEntity = get<EntityBase>(entity->nextThingId);
             if (nextEntity == nullptr)
             {
-                Console::errorDeprecated("Invalid next entity id. Entity linked list corrupted?");
+                Console::error("Invalid next entity id. Entity linked list corrupted? Id: {}", enumValue(entity->nextThingId));
             }
             else
             {

--- a/src/OpenLoco/src/Entities/EntityManager.cpp
+++ b/src/OpenLoco/src/Entities/EntityManager.cpp
@@ -199,7 +199,7 @@ namespace OpenLoco::EntityManager
         {
             if (!removeFromSpatialIndex(entity, oldIndex))
             {
-                Console::log("Invalid quadrant ids... Reseting spatial index.");
+                Console::logDeprecated("Invalid quadrant ids... Reseting spatial index.");
                 resetSpatialIndex();
                 moveSpatialEntry(entity, loc);
                 return;
@@ -214,7 +214,7 @@ namespace OpenLoco::EntityManager
         auto* newEntity = get<EntityBase>(id);
         if (newEntity == nullptr)
         {
-            Console::error("Tried to create invalid entity!");
+            Console::errorDeprecated("Tried to create invalid entity!");
             return nullptr;
         }
         moveEntityToList(newEntity, list);
@@ -284,7 +284,7 @@ namespace OpenLoco::EntityManager
 
         if (!removeFromSpatialIndex(*entity))
         {
-            Console::log("Invalid quadrant ids... Reseting spatial index.");
+            Console::logDeprecated("Invalid quadrant ids... Reseting spatial index.");
             resetSpatialIndex();
         }
     }
@@ -312,7 +312,7 @@ namespace OpenLoco::EntityManager
             auto* previousEntity = get<EntityBase>(previousId);
             if (previousEntity == nullptr)
             {
-                Console::error("Invalid previous entity id. Entity linked list corrupted?");
+                Console::errorDeprecated("Invalid previous entity id. Entity linked list corrupted?");
             }
             else
             {
@@ -325,7 +325,7 @@ namespace OpenLoco::EntityManager
             auto* nextEntity = get<EntityBase>(nextId);
             if (nextEntity == nullptr)
             {
-                Console::error("Invalid next entity id. Entity linked list corrupted?");
+                Console::errorDeprecated("Invalid next entity id. Entity linked list corrupted?");
             }
             else
             {
@@ -343,7 +343,7 @@ namespace OpenLoco::EntityManager
             auto* nextEntity = get<EntityBase>(entity->nextThingId);
             if (nextEntity == nullptr)
             {
-                Console::error("Invalid next entity id. Entity linked list corrupted?");
+                Console::errorDeprecated("Invalid next entity id. Entity linked list corrupted?");
             }
             else
             {

--- a/src/OpenLoco/src/GameCommands/Cheat.cpp
+++ b/src/OpenLoco/src/GameCommands/Cheat.cpp
@@ -192,7 +192,7 @@ namespace OpenLoco::GameCommands
         static uint32_t modifyDateCheat(int32_t year, int32_t month, int32_t day)
         {
             OpenLoco::Scenario::initialiseDate(static_cast<uint16_t>(year), static_cast<MonthId>(month), static_cast<uint8_t>(day));
-            Console::log("Date set to: Day=%u Month=%u Year=%u", day, month, year);
+            Console::logDeprecated("Date set to: Day=%u Month=%u Year=%u", day, month, year);
             return 0;
         }
     }

--- a/src/OpenLoco/src/GameCommands/Cheat.cpp
+++ b/src/OpenLoco/src/GameCommands/Cheat.cpp
@@ -192,7 +192,7 @@ namespace OpenLoco::GameCommands
         static uint32_t modifyDateCheat(int32_t year, int32_t month, int32_t day)
         {
             OpenLoco::Scenario::initialiseDate(static_cast<uint16_t>(year), static_cast<MonthId>(month), static_cast<uint8_t>(day));
-            Console::logDeprecated("Date set to: Day=%u Month=%u Year=%u", day, month, year);
+            Console::info("Date set to: Day={} Month={} Year={}", day, month, year);
             return 0;
         }
     }

--- a/src/OpenLoco/src/Graphics/Gfx.cpp
+++ b/src/OpenLoco/src/Graphics/Gfx.cpp
@@ -79,11 +79,10 @@ namespace OpenLoco::Gfx
 
         if (header.numEntries != G1ExpectedCount::kDisc)
         {
-            std::cout << "G1 element count doesn't match expected value: ";
-            std::cout << "Expected " << G1ExpectedCount::kDisc << "; Got " << header.numEntries << std::endl;
+            Console::warn("G1 element count doesn't match expected value:\nExpected {}; Got {}", G1ExpectedCount::kDisc, header.numEntries);
             if (header.numEntries == G1ExpectedCount::kSteam)
             {
-                std::cout << "Got Steam G1.DAT variant, will fix elements automatically." << std::endl;
+                Console::info("Got Steam G1.DAT variant, will fix elements automatically.");
             }
         }
 

--- a/src/OpenLoco/src/Interop/Hooks.cpp
+++ b/src/OpenLoco/src/Interop/Hooks.cpp
@@ -47,7 +47,7 @@
 
 using namespace OpenLoco;
 
-#define STUB() Console::logVerbose(__FUNCTION__)
+#define STUB() Console::logVerboseDeprecated(__FUNCTION__)
 
 #ifdef _MSC_VER
 #define STDCALL __stdcall
@@ -146,26 +146,26 @@ static void STDCALL fn_407b26()
 FORCE_ALIGN_ARG_POINTER
 static void CDECL fn_4080bb(char*, uint32_t)
 {
-    Console::log("Create progress bar");
+    Console::logDeprecated("Create progress bar");
 }
 
 FORCE_ALIGN_ARG_POINTER
 static void CDECL fn_408163()
 {
-    Console::log("Destroy progress bar");
+    Console::logDeprecated("Destroy progress bar");
 }
 
 FORCE_ALIGN_ARG_POINTER
 static void CDECL fn_40817b(uint16_t arg0)
 {
-    Console::log("SendMessage(PBM_SETRANGE, %d)", arg0);
-    Console::log("SendMessage(PBM_SETSTEP, %d)", 1);
+    Console::logDeprecated("SendMessage(PBM_SETRANGE, %d)", arg0);
+    Console::logDeprecated("SendMessage(PBM_SETSTEP, %d)", 1);
 }
 
 FORCE_ALIGN_ARG_POINTER
 static void CDECL fn_4081ad(int32_t wParam)
 {
-    Console::log("SendMessage(PBM_SETPOS, %d)", wParam);
+    Console::logDeprecated("SendMessage(PBM_SETPOS, %d)", wParam);
 }
 
 /// endregion
@@ -173,7 +173,7 @@ static void CDECL fn_4081ad(int32_t wParam)
 FORCE_ALIGN_ARG_POINTER
 static uint32_t CDECL fn_FileSeekSet(FILE* a0, int32_t distance)
 {
-    Console::logVerbose("seek %d bytes from start", distance);
+    Console::logVerboseDeprecated("seek %d bytes from start", distance);
     fseek(a0, distance, SEEK_SET);
     return ftell(a0);
 }
@@ -181,7 +181,7 @@ static uint32_t CDECL fn_FileSeekSet(FILE* a0, int32_t distance)
 FORCE_ALIGN_ARG_POINTER
 static uint32_t CDECL fn_FileSeekFromCurrent(FILE* a0, int32_t distance)
 {
-    Console::logVerbose("seek %d bytes from current", distance);
+    Console::logVerboseDeprecated("seek %d bytes from current", distance);
     fseek(a0, distance, SEEK_CUR);
     return ftell(a0);
 }
@@ -189,7 +189,7 @@ static uint32_t CDECL fn_FileSeekFromCurrent(FILE* a0, int32_t distance)
 FORCE_ALIGN_ARG_POINTER
 static uint32_t CDECL fn_FileSeekFromEnd(FILE* a0, int32_t distance)
 {
-    Console::logVerbose("seek %d bytes from end", distance);
+    Console::logVerboseDeprecated("seek %d bytes from end", distance);
     fseek(a0, distance, SEEK_END);
     return ftell(a0);
 }
@@ -197,7 +197,7 @@ static uint32_t CDECL fn_FileSeekFromEnd(FILE* a0, int32_t distance)
 FORCE_ALIGN_ARG_POINTER
 static int32_t CDECL fn_FileRead(FILE* a0, char* buffer, int32_t size)
 {
-    Console::logVerbose("read %d bytes (%d)", size, fileno(a0));
+    Console::logVerboseDeprecated("read %d bytes (%d)", size, fileno(a0));
     size = fread(buffer, 1, size, a0);
 
     return size;
@@ -228,7 +228,7 @@ public:
 FORCE_ALIGN_ARG_POINTER
 static Session* CDECL fn_FindFirstFile(char* lpFileName, FindFileData* out)
 {
-    Console::logVerbose("%s (%s)", __FUNCTION__, lpFileName);
+    Console::logVerboseDeprecated("%s (%s)", __FUNCTION__, lpFileName);
 
     Session* data = new Session;
 
@@ -349,7 +349,7 @@ static void CDECL fn_free(void* block)
 FORCE_ALIGN_ARG_POINTER
 static void STDCALL fn_dump(uint32_t address)
 {
-    Console::log("Missing hook: 0x%x", address);
+    Console::logDeprecated("Missing hook: 0x%x", address);
 }
 
 enum
@@ -361,7 +361,7 @@ enum
 FORCE_ALIGN_ARG_POINTER
 static uint32_t STDCALL lib_DirectSoundCreate(void* lpGuid, void* ppDS, void* pUnkOuter)
 {
-    Console::log("lib_DirectSoundCreate(%lx, %lx, %lx)", (uintptr_t)lpGuid, (uintptr_t)ppDS, (uintptr_t)pUnkOuter);
+    Console::logDeprecated("lib_DirectSoundCreate(%lx, %lx, %lx)", (uintptr_t)lpGuid, (uintptr_t)ppDS, (uintptr_t)pUnkOuter);
 
     return DSERR_NODRIVER;
 }
@@ -369,21 +369,21 @@ static uint32_t STDCALL lib_DirectSoundCreate(void* lpGuid, void* ppDS, void* pU
 FORCE_ALIGN_ARG_POINTER
 static uint32_t STDCALL lib_CreateRectRgn(int x1, int y1, int x2, int y2)
 {
-    Console::log("CreateRectRgn(%d, %d, %d, %d)", x1, y1, x2, y2);
+    Console::logDeprecated("CreateRectRgn(%d, %d, %d, %d)", x1, y1, x2, y2);
     return 0;
 }
 
 FORCE_ALIGN_ARG_POINTER
 static uint32_t STDCALL lib_GetUpdateRgn(uintptr_t hWnd, uintptr_t hRgn, bool bErase)
 {
-    Console::log("GetUpdateRgn(%lx, %lx, %d)", hWnd, hRgn, bErase);
+    Console::logDeprecated("GetUpdateRgn(%lx, %lx, %d)", hWnd, hRgn, bErase);
     return 0;
 }
 
 FORCE_ALIGN_ARG_POINTER
 static void* STDCALL lib_OpenMutexA(uint32_t dwDesiredAccess, bool bInheritHandle, char* lpName)
 {
-    Console::log("OpenMutexA(0x%x, %d, %s)", dwDesiredAccess, bInheritHandle, lpName);
+    Console::logDeprecated("OpenMutexA(0x%x, %d, %s)", dwDesiredAccess, bInheritHandle, lpName);
 
     return nullptr;
 }
@@ -391,7 +391,7 @@ static void* STDCALL lib_OpenMutexA(uint32_t dwDesiredAccess, bool bInheritHandl
 FORCE_ALIGN_ARG_POINTER
 static uint32_t STDCALL lib_DeleteFileA(char* lpFileName)
 {
-    Console::log("DeleteFileA(%s)", lpFileName);
+    Console::logDeprecated("DeleteFileA(%s)", lpFileName);
 
     return 0;
 }
@@ -405,7 +405,7 @@ static uint32_t STDCALL lib_WriteFile(
     uintptr_t)
 {
     *lpNumberOfBytesWritten = fwrite(buffer, 1, nNumberOfBytesToWrite, hFile);
-    Console::logVerbose("WriteFile(%s)", buffer);
+    Console::logVerboseDeprecated("WriteFile(%s)", buffer);
 
     return 1;
 }
@@ -429,7 +429,7 @@ static int32_t STDCALL lib_CreateFileA(
     uint32_t,
     uintptr_t)
 {
-    Console::logVerbose("CreateFile(%s, 0x%x, 0x%x)", lpFileName, dwDesiredAccess, dwCreationDisposition);
+    Console::logVerboseDeprecated("CreateFile(%s, 0x%x, 0x%x)", lpFileName, dwDesiredAccess, dwCreationDisposition);
 
     FILE* pFILE = nullptr;
     if (dwDesiredAccess == GENERIC_READ && dwCreationDisposition == OPEN_EXISTING)
@@ -458,7 +458,7 @@ static uint32_t STDCALL lib_SetFileAttributesA(char* lpFileName, uint32_t dwFile
 {
     // FILE_ATTRIBUTE_NORMAL = 0x80
     assert(dwFileAttributes == 0x80);
-    Console::log("SetFileAttributes(%s, %x)", lpFileName, dwFileAttributes);
+    Console::logDeprecated("SetFileAttributes(%s, %x)", lpFileName, dwFileAttributes);
 
     std::error_code ec;
     auto path = fs::path(lpFileName);
@@ -474,7 +474,7 @@ static uint32_t STDCALL lib_SetFileAttributesA(char* lpFileName, uint32_t dwFile
 FORCE_ALIGN_ARG_POINTER
 static void* STDCALL lib_CreateMutexA(uintptr_t lmMutexAttributes, bool bInitialOwner, char* lpName)
 {
-    Console::log("CreateMutexA(0x%lx, %d, %s)", lmMutexAttributes, bInitialOwner, lpName);
+    Console::logDeprecated("CreateMutexA(0x%lx, %d, %s)", lmMutexAttributes, bInitialOwner, lpName);
 
     return nullptr;
 }
@@ -490,7 +490,7 @@ static uint32_t STDCALL lib_CloseHandle(void* hObject)
 FORCE_ALIGN_ARG_POINTER
 static void STDCALL lib_PostQuitMessage(int32_t exitCode)
 {
-    Console::log("lib_PostQuitMessage(%d)", exitCode);
+    Console::logDeprecated("lib_PostQuitMessage(%d)", exitCode);
     exit(exitCode);
 }
 #endif // _NO_LOCO_WIN32_

--- a/src/OpenLoco/src/Localisation/StringManager.cpp
+++ b/src/OpenLoco/src/Localisation/StringManager.cpp
@@ -681,7 +681,7 @@ namespace OpenLoco::StringManager
             if (sourceStr == nullptr)
             {
                 sprintf(buffer, "(missing string id: %d)", id);
-                Console::log("formatString: nullptr for string id: %d", id);
+                Console::logDeprecated("formatString: nullptr for string id: %d", id);
                 buffer += strlen(buffer);
                 return buffer;
             }
@@ -720,7 +720,7 @@ namespace OpenLoco::StringManager
         else
         {
             sprintf(buffer, "(invalid string id: %d)", id);
-            Console::log("formatString: invalid string id: %d", id);
+            Console::logDeprecated("formatString: invalid string id: %d", id);
             buffer += strlen(buffer);
             return buffer;
         }

--- a/src/OpenLoco/src/Network/Network.cpp
+++ b/src/OpenLoco/src/Network/Network.cpp
@@ -117,7 +117,7 @@ namespace OpenLoco::Network
     void receiveChatMessage(client_id_t client, std::string_view message)
     {
         std::string szMessage(message);
-        Console::log("Player #%d: %s", static_cast<int>(client), szMessage.c_str());
+        Console::logDeprecated("Player #%d: %s", static_cast<int>(client), szMessage.c_str());
     }
 
     void queueGameCommand(CompanyId company, const OpenLoco::Interop::registers& regs)

--- a/src/OpenLoco/src/Network/NetworkClient.cpp
+++ b/src/OpenLoco/src/Network/NetworkClient.cpp
@@ -37,7 +37,7 @@ void NetworkClient::connect(std::string_view host, port_t port)
     _serverConnection = std::make_unique<NetworkConnection>(socket.get(), _serverEndpoint->clone());
 
     auto szHostIpAddress = _serverEndpoint->getIpAddress();
-    Console::log("Resolved endpoint for %s:%d", szHostIpAddress.c_str(), port);
+    Console::logDeprecated("Resolved endpoint for %s:%d", szHostIpAddress.c_str(), port);
 
     beginReceivePacketLoop();
 
@@ -56,7 +56,7 @@ void NetworkClient::onClose()
     {
         _status = NetworkClientStatus::closed;
         clearScreenFlag(ScreenFlags::networked);
-        Console::log("Disconnected from server");
+        Console::logDeprecated("Disconnected from server");
     }
     else if (_status == NetworkClientStatus::connecting)
     {
@@ -73,7 +73,7 @@ void NetworkClient::onUpdate()
         if (Platform::getTime() >= _timeout)
         {
             close();
-            Console::log("Failed to connect to server");
+            Console::logDeprecated("Failed to connect to server");
             endStatus("Failed to connect to server");
         }
     }
@@ -81,7 +81,7 @@ void NetworkClient::onUpdate()
     {
         if (hasTimedOut())
         {
-            Console::log("Connection with server timed out");
+            Console::logDeprecated("Connection with server timed out");
             close();
         }
         else
@@ -143,7 +143,7 @@ void NetworkClient::onCancel()
     switch (_status)
     {
         case NetworkClientStatus::connecting:
-            Console::log("Connecting to server cancelled");
+            Console::logDeprecated("Connecting to server cancelled");
             close();
             break;
         default:

--- a/src/OpenLoco/src/Network/NetworkConnection.cpp
+++ b/src/OpenLoco/src/Network/NetworkConnection.cpp
@@ -191,23 +191,23 @@ void NetworkConnection::logPacket([[maybe_unused]] const Packet& packet, [[maybe
     if (packet.header.kind == PacketKind::ack || packet.header.kind == PacketKind::ping || resend)
     {
 #ifdef LOG_ACK_PACKETS
-        Console::log("[%s] #%4d | ACK", szDirection, seq);
+        Console::logDeprecated("[%s] #%4d | ACK", szDirection, seq);
 #endif
     }
     else if (resend)
     {
-        Console::log("[%s] #%4d | RESEND", szDirection, seq);
+        Console::logDeprecated("[%s] #%4d | RESEND", szDirection, seq);
     }
     else if (packet.header.kind == PacketKind::gameCommand)
     {
         auto kind = getPacketKindString(packet.header.kind);
         const auto& gc = packet.Cast<GameCommandPacket>();
-        Console::log("[%s] #%4d | %s (Index = %d Tick = %d Command = %d)", szDirection, seq, kind, gc->index, gc->tick, gc->regs.esi);
+        Console::logDeprecated("[%s] #%4d | %s (Index = %d Tick = %d Command = %d)", szDirection, seq, kind, gc->index, gc->tick, gc->regs.esi);
     }
     else
     {
         auto kind = getPacketKindString(packet.header.kind);
-        Console::log("[%s] #%4d | %s (%d bytes)", szDirection, seq, kind, bytes);
+        Console::logDeprecated("[%s] #%4d | %s (%d bytes)", szDirection, seq, kind, bytes);
     }
 #endif
 #endif

--- a/src/OpenLoco/src/Network/NetworkServer.cpp
+++ b/src/OpenLoco/src/Network/NetworkServer.cpp
@@ -55,7 +55,7 @@ void NetworkServer::listen(const std::string& bind, port_t port)
     setScreenFlag(ScreenFlags::networked);
     setScreenFlag(ScreenFlags::networkHost);
 
-    Console::log("Server opened");
+    Console::logDeprecated("Server opened");
     for (const auto& socket : _sockets)
     {
         auto ipAddress = socket->getIpAddress();
@@ -63,7 +63,7 @@ void NetworkServer::listen(const std::string& bind, port_t port)
         {
             ipAddress = '[' + ipAddress + ']';
         }
-        Console::log("Listening for incoming connections on %s:%d...", ipAddress.c_str(), port);
+        Console::logDeprecated("Listening for incoming connections on %s:%d...", ipAddress.c_str(), port);
     }
 }
 
@@ -71,7 +71,7 @@ void NetworkServer::onClose()
 {
     clearScreenFlag(ScreenFlags::networked);
     clearScreenFlag(ScreenFlags::networkHost);
-    Console::log("Server closed");
+    Console::logDeprecated("Server closed");
 }
 
 Client* NetworkServer::findClient(const INetworkEndpoint& endpoint)
@@ -100,7 +100,7 @@ void NetworkServer::createNewClient(std::unique_ptr<NetworkConnection> conn, con
     response.result = ConnectionResult::success;
     newClientPtr.connection->sendPacket(response);
 
-    Console::log("Accepted new client: %s", newClientPtr.name.c_str());
+    Console::logDeprecated("Accepted new client: %s", newClientPtr.name.c_str());
 }
 
 void NetworkServer::onReceivePacket(IUdpSocket& socket, std::unique_ptr<INetworkEndpoint> endpoint, const Packet& packet)
@@ -199,7 +199,7 @@ void NetworkServer::removedTimedOutClients()
         auto& client = *it;
         if (client->connection->hasTimedOut())
         {
-            Console::log("Client timed out: %s", client->name.c_str());
+            Console::logDeprecated("Client timed out: %s", client->name.c_str());
             it = _clients.erase(it);
         }
         else

--- a/src/OpenLoco/src/Network/Socket.cpp
+++ b/src/OpenLoco/src/Network/Socket.cpp
@@ -79,11 +79,11 @@ namespace OpenLoco::Network
         {
             if (!_isInitialised)
             {
-                Console::logVerbose("WSAStartup()");
+                Console::logVerboseDeprecated("WSAStartup()");
                 WSADATA wsaData;
                 if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0)
                 {
-                    Console::error("Unable to initialise winsock.");
+                    Console::errorDeprecated("Unable to initialise winsock.");
                     return false;
                 }
                 _isInitialised = true;
@@ -95,7 +95,7 @@ namespace OpenLoco::Network
         {
             if (_isInitialised)
             {
-                Console::logVerbose("WSACleanup()");
+                Console::logVerboseDeprecated("WSACleanup()");
                 WSACleanup();
                 _isInitialised = false;
             }
@@ -570,7 +570,7 @@ namespace OpenLoco::Network
                 // Incomming IPv4 addresses will be mapped to IPv6 addresses
                 if (!setOption(sock, IPPROTO_IPV6, IPV6_V6ONLY, false))
                 {
-                    Console::logVerbose("setsockopt(socket, IPV6_V6ONLY) failed: %d", LAST_SOCKET_ERROR());
+                    Console::logVerboseDeprecated("setsockopt(socket, IPV6_V6ONLY) failed: %d", LAST_SOCKET_ERROR());
                 }
             }
             else if (protocol == Protocol::ipv6)
@@ -578,13 +578,13 @@ namespace OpenLoco::Network
                 // Turn on IPV6_V6ONLY so we only accept both v6 connections
                 if (!setOption(sock, IPPROTO_IPV6, IPV6_V6ONLY, true))
                 {
-                    Console::logVerbose("setsockopt(socket, IPV6_V6ONLY) failed: %d", LAST_SOCKET_ERROR());
+                    Console::logVerboseDeprecated("setsockopt(socket, IPV6_V6ONLY) failed: %d", LAST_SOCKET_ERROR());
                 }
             }
 
             if (!setOption(sock, SOL_SOCKET, SO_REUSEADDR, true))
             {
-                Console::logVerbose("setsockopt(socket, SO_REUSEADDR) failed: %d", LAST_SOCKET_ERROR());
+                Console::logVerboseDeprecated("setsockopt(socket, SO_REUSEADDR) failed: %d", LAST_SOCKET_ERROR());
             }
 
             if (!setNonBlocking(sock, true))

--- a/src/OpenLoco/src/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/src/Objects/ObjectManager.cpp
@@ -392,7 +392,7 @@ namespace OpenLoco::ObjectManager
         {
             // Something wrong has happened and installed object does not match index
             // Vanilla continued to search for subsequent matching installed headers.
-            Console::error("Missmatch between installed object header and object file header!");
+            Console::errorDeprecated("Missmatch between installed object header and object file header!");
             return std::nullopt;
         }
 
@@ -402,7 +402,7 @@ namespace OpenLoco::ObjectManager
         if (!computeObjectChecksum(preLoadObj.header, data))
         {
             // Something wrong has happened and installed object checksum is broken
-            Console::error("Missmatch between installed object header checksum and object file checksum!");
+            Console::errorDeprecated("Missmatch between installed object header checksum and object file checksum!");
             return std::nullopt;
         }
 
@@ -421,7 +421,7 @@ namespace OpenLoco::ObjectManager
             free(preLoadObj.object);
             // Object failed validation
             std::string str(header.getName());
-            Console::error("Object %s in index failed validation! (This should not be possible)", str.c_str());
+            Console::errorDeprecated("Object %s in index failed validation! (This should not be possible)", str.c_str());
             return std::nullopt;
         }
 
@@ -584,7 +584,7 @@ namespace OpenLoco::ObjectManager
                 result.success = false;
                 result.problemObject = header;
                 std::string str(header.getName());
-                Console::error("Failed to load: %s", str.c_str());
+                Console::errorDeprecated("Failed to load: %s", str.c_str());
                 // Could break early here but we want to list all of the failed objects
             }
             index++;

--- a/src/OpenLoco/src/Objects/VehicleObject.cpp
+++ b/src/OpenLoco/src/Objects/VehicleObject.cpp
@@ -592,7 +592,7 @@ namespace OpenLoco
             // There are some official objects that suffer from this so can't assert on this.
             const auto& header = ObjectManager::getHeader(handle);
             std::string objName(header.getName());
-            Console::logVerbose("Incorrect number of images for object: %s", objName.c_str());
+            Console::logVerboseDeprecated("Incorrect number of images for object: %s", objName.c_str());
         }
     }
 

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -491,7 +491,7 @@ namespace OpenLoco
     static void tickInterrupted()
     {
         EntityTweener::get().reset();
-        Console::log("Tick interrupted");
+        Console::logDeprecated("Tick interrupted");
     }
 
     // 0x0046A794
@@ -1122,17 +1122,17 @@ namespace OpenLoco
         }
         catch (const std::exception& e)
         {
-            Console::error("Unable to simulate park: %s", e.what());
+            Console::errorDeprecated("Unable to simulate park: %s", e.what());
         }
         catch (const GameException i)
         {
             if (i != GameException::Interrupt)
             {
-                Console::error("Unable to simulate park!");
+                Console::errorDeprecated("Unable to simulate park!");
             }
             else
             {
-                Console::log("File loaded. Starting simulation.");
+                Console::logDeprecated("File loaded. Starting simulation.");
             }
         }
         tickLogic(ticks);
@@ -1155,7 +1155,7 @@ namespace OpenLoco
         }
         else
         {
-            Console::log("Detected wine, not installing crash handler as it doesn't provide useful data. Consider using native builds of OpenLoco instead.\n");
+            Console::logDeprecated("Detected wine, not installing crash handler as it doesn't provide useful data. Consider using native builds of OpenLoco instead.\n");
         }
 
         auto versionInfo = OpenLoco::getVersionInfo();

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -1141,6 +1141,8 @@ namespace OpenLoco
     // 0x00406D13
     static int main(const CommandLineOptions& options)
     {
+        Console::initialize();
+
         auto ret = runCommandLineOnlyCommand(options);
         if (ret)
         {

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -491,7 +491,7 @@ namespace OpenLoco
     static void tickInterrupted()
     {
         EntityTweener::get().reset();
-        Console::logDeprecated("Tick interrupted");
+        Console::info("Tick interrupted");
     }
 
     // 0x0046A794
@@ -1122,17 +1122,17 @@ namespace OpenLoco
         }
         catch (const std::exception& e)
         {
-            Console::errorDeprecated("Unable to simulate park: %s", e.what());
+            Console::error("Unable to simulate park: {}", e.what());
         }
         catch (const GameException i)
         {
             if (i != GameException::Interrupt)
             {
-                Console::errorDeprecated("Unable to simulate park!");
+                Console::error("Unable to simulate park!");
             }
             else
             {
-                Console::logDeprecated("File loaded. Starting simulation.");
+                Console::info("File loaded. Starting simulation.");
             }
         }
         tickLogic(ticks);
@@ -1142,6 +1142,9 @@ namespace OpenLoco
     static int main(const CommandLineOptions& options)
     {
         Console::initialize();
+
+        // Always print the product name and version first.
+        Console::info("{}", OpenLoco::getVersionInfo());
 
         auto ret = runCommandLineOnlyCommand(options);
         if (ret)
@@ -1157,11 +1160,9 @@ namespace OpenLoco
         }
         else
         {
-            Console::logDeprecated("Detected wine, not installing crash handler as it doesn't provide useful data. Consider using native builds of OpenLoco instead.\n");
+            Console::warn("Detected wine, not installing crash handler as it doesn't provide useful data. Consider using native builds of OpenLoco instead.\n");
         }
 
-        auto versionInfo = OpenLoco::getVersionInfo();
-        std::cout << versionInfo << std::endl;
         try
         {
             const auto& cfg = Config::read();
@@ -1177,16 +1178,12 @@ namespace OpenLoco
             Audio::initialiseDSound();
             run();
             exitCleanly();
-
-            // TODO extra clean up code
-            return 0;
         }
         catch (const std::exception& e)
         {
-            std::cerr << e.what() << std::endl;
+            Console::error("Exception: {}", e.what());
             Ui::showMessageBox("Exception", e.what());
             exitCleanly();
-            return 2;
         }
     }
 

--- a/src/OpenLoco/src/Ui.cpp
+++ b/src/OpenLoco/src/Ui.cpp
@@ -639,7 +639,7 @@ namespace OpenLoco::Ui
         // Set the window fullscreen mode.
         if (SDL_SetWindowFullscreen(window, flags) != 0)
         {
-            Console::error("SDL_SetWindowFullscreen failed: %s", SDL_GetError());
+            Console::errorDeprecated("SDL_SetWindowFullscreen failed: %s", SDL_GetError());
             return false;
         }
 

--- a/src/OpenLoco/src/Ui/Dropdown.cpp
+++ b/src/OpenLoco/src/Ui/Dropdown.cpp
@@ -97,7 +97,7 @@ namespace OpenLoco::Ui::Dropdown
                 }
 
                 default:
-                    Console::error("Unknown format: %d", arg.type);
+                    Console::errorDeprecated("Unknown format: %d", arg.type);
                     break;
             }
         }

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -719,7 +719,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             }
             catch (const fs::filesystem_error& err)
             {
-                Console::error("Invalid directory or file: %s", err.what());
+                Console::errorDeprecated("Invalid directory or file: %s", err.what());
             }
         }
 

--- a/src/OpenLoco/src/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioSelect.cpp
@@ -202,7 +202,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
                 ObjectManager::unload(ObjectManager::getHeader({ ObjectType::currency, 0 }));
                 if (!ObjectManager::load(scenarioInfo->currency))
                 {
-                    Console::error("Currency object failed to load! Game will likely crash.");
+                    Console::errorDeprecated("Currency object failed to load! Game will likely crash.");
                 }
                 ObjectManager::reloadAll();
                 Gfx::loadCurrency();
@@ -211,7 +211,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             {
                 if (!_warnOnce)
                 {
-                    Console::error("Currency object could not be found. Scenario may be corrupt.");
+                    Console::errorDeprecated("Currency object could not be found. Scenario may be corrupt.");
                     _warnOnce = true;
                 }
             }

--- a/src/Platform/src/Platform.Posix.cpp
+++ b/src/Platform/src/Platform.Posix.cpp
@@ -79,14 +79,14 @@ namespace OpenLoco::Platform
         auto bytesRead = readlink("/proc/self/exe", exePath, sizeof(exePath));
         if (bytesRead == -1)
         {
-            Console::error("failed to read /proc/self/exe");
+            Console::errorDeprecated("failed to read /proc/self/exe");
         }
 #elif defined(__FreeBSD__)
         const int32_t mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
         auto exeLen = sizeof(exePath);
         if (sysctl(mib, 4, exePath, &exeLen, nullptr, 0) == -1)
         {
-            Console::error("failed to get process path");
+            Console::errorDeprecated("failed to get process path");
         }
 #elif defined(__OpenBSD__)
         // There is no way to get the path name of a running executable.

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,7 +1,5 @@
 # TODO: look into using FetchContent's FIND_PACKAGE_ARGS when next increasing CMake version
 find_package(yaml-cpp QUIET)
-find_package(span-lite QUIET)
-
 if ( NOT yaml-cpp_FOUND )
     ## yaml-cpp
     # Get rid of yaml uninstall target
@@ -25,6 +23,7 @@ if ( NOT yaml-cpp_FOUND )
     set_target_properties(yaml-cpp PROPERTIES FOLDER "ThirdParty")
 endif()
 
+find_package(span-lite QUIET)
 if ( NOT span-lite_FOUND )
     ## span-lite
     FetchContent_Declare(

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -70,3 +70,18 @@ if (MSVC)
     find_package(unofficial-breakpad CONFIG REQUIRED)
     set(BREAKPAD_LIBRARIES unofficial::breakpad::libbreakpad unofficial::breakpad::libbreakpad_client)
 endif()
+
+find_package(fmt QUIET)
+if ( NOT fmt_FOUND )
+    ## fmt
+    FetchContent_Declare(
+        fmt
+        GIT_REPOSITORY      https://github.com/fmtlib/fmt
+        GIT_TAG             9.1.0
+        GIT_SHALLOW         ON
+    )
+    FetchContent_MakeAvailable(fmt)
+
+    # Group all the ThirdParty items under a ThirdParty folder in IDEs
+    set_target_properties(fmt PROPERTIES FOLDER "ThirdParty")
+endif()

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -81,7 +81,9 @@ if ( NOT fmt_FOUND )
         GIT_SHALLOW         ON
     )
     FetchContent_MakeAvailable(fmt)
-
+    
+    loco_thirdparty_target_compile_link_flags(fmt)
+    
     # Group all the ThirdParty items under a ThirdParty folder in IDEs
     set_target_properties(fmt PROPERTIES FOLDER "ThirdParty")
 endif()


### PR DESCRIPTION
As the title suggests, its about time we ditch the old way of formatting strings. I also started to refactor the Console library a little, I think we should rename this to Logging/Diagnostics at some point. Another benefit of libfmt is its dynamic_args_store which works a little like the CS way, one can push arguments to that object and format the string later with it, might be useful to have localisation actually type safe. I haven't refactored all uses of the old logging, its quite a few and i just renamed them to deprecated, can gradually replace them. The output is also now colorized on the console for each logging level. I think this can be merged as is besides potential review comments, all of this should be a bit prettier.