### PR TITLE
Fix hang when crashing uncleanly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix: [#1021] Excessive CPU usage when the Load/Save window is open.
 - Fix: [#1783] Crash when drawing track tunnels under certain situations.
 - Fix: [#1875] Tooltips weren't line-wrapping properly.
+- Fix: [#1882] Process hang when the game trys to crash uncleanly.
 
 23.02 (2023-02-19)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Audio/OpenAL.cpp
+++ b/src/OpenLoco/src/Audio/OpenAL.cpp
@@ -40,7 +40,8 @@ namespace OpenAL
 
     Device::~Device()
     {
-        close();
+        // Although we should close on destruction this is causing a hang if destruction happens during process exit. Revisit when standalone
+        // close();
     }
 
     std::vector<std::string> Device::getAvailableDeviceNames() const
@@ -79,7 +80,8 @@ namespace OpenAL
 
     Context::~Context()
     {
-        close();
+        // Although we should close on destruction this is causing a hang if destruction happens during process exit. Revisit when standalone
+        // close();
     }
 
     void Source::play()

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -1188,6 +1188,11 @@ namespace OpenLoco
             Ui::showMessageBox("Exception", e.what());
             exitCleanly();
         }
+        catch (...)
+        {
+            Ui::showMessageBox("Exception", "Unsure what threw the exception!");
+            exitCleanly();
+        }
     }
 
     int main(int argc, const char** argv)


### PR DESCRIPTION
If we crash uncleanly i.e. not through an exception then the audio will get stuck waiting on a lock that is never free'd. This address's the issue by removing the destructor. If we exit uncleanly the audio will not be shutdown correctly but at least we wont hang. Also added an additional catch all exception handler as its possible we might have thrown an exception that isn't derived from std::exception

Fixes #1882