### PR TITLE
Make ObjectHeader trvially constructable

### DIFF
--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -27,6 +27,8 @@ namespace OpenLoco::Config
         return _newConfig;
     }
 
+    constexpr ObjectHeader kDefaultPreferredCurrency = { 0x00000082u, { 'C', 'U', 'R', 'R', 'D', 'O', 'L', 'L' }, 0u };
+
     constexpr LocoConfig kDefaultConfig = {
         /*flags*/ Flags::exportObjectsWithSaves,
         /*resolutionWidth*/ -1,
@@ -88,7 +90,7 @@ namespace OpenLoco::Config
         /*musicPlaylist*/ MusicPlaylistType::currentEra,
         /*heightMarkerOffset*/ 0x100,
         /*newsSettings*/ { NewsType::newsWindow, NewsType::newsWindow, NewsType::ticker, NewsType::newsWindow, NewsType::newsWindow },
-        /*preferredCurrency*/ { 0xFF },
+        /*preferredCurrency*/ kDefaultPreferredCurrency,
         /*enabledMusic*/ { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
         /*pad_A9*/ { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
         /*volume*/ -1100,
@@ -99,10 +101,9 @@ namespace OpenLoco::Config
         /*preferredName*/ { 0 },
     };
 
-    constexpr uint8_t _defaultMaxVehicleSounds[3] = { 4, 8, 16 };
-    constexpr uint8_t _defaultMaxSoundInstances[3] = { 6, 8, 10 };
-    constexpr ObjectHeader _defaultPreferredCurrency = { 0x00000082u, { 'C', 'U', 'R', 'R', 'D', 'O', 'L', 'L' }, 0u };
-    constexpr uint32_t _legacyConfigMagicNumber = 0x62272;
+    constexpr uint8_t kDefaultMaxVehicleSounds[3] = { 4, 8, 16 };
+    constexpr uint8_t kDefaultMaxSoundInstances[3] = { 6, 8, 10 };
+    constexpr uint32_t kLegacyConfigMagicNumber = 0x62272;
 
     static void writeNewConfig();
 
@@ -124,9 +125,8 @@ namespace OpenLoco::Config
             getLegacy().soundQuality = 2;
             getLegacy().vehiclesMinScale = 2;
         }
-        getLegacy().maxVehicleSounds = _defaultMaxVehicleSounds[getLegacy().soundQuality];
-        getLegacy().maxSoundInstances = _defaultMaxSoundInstances[getLegacy().soundQuality];
-        getLegacy().preferredCurrency = _defaultPreferredCurrency;
+        getLegacy().maxVehicleSounds = kDefaultMaxVehicleSounds[getLegacy().soundQuality];
+        getLegacy().maxSoundInstances = kDefaultMaxSoundInstances[getLegacy().soundQuality];
     }
 
     // 0x00441A6C
@@ -144,7 +144,7 @@ namespace OpenLoco::Config
             {
                 uint32_t magicNumber{};
                 stream.read(reinterpret_cast<char*>(&magicNumber), sizeof(magicNumber));
-                if (magicNumber == _legacyConfigMagicNumber)
+                if (magicNumber == kLegacyConfigMagicNumber)
                 {
                     stream.read(reinterpret_cast<char*>(&getLegacy()), sizeof(LocoConfig));
                     return getLegacy();
@@ -166,7 +166,7 @@ namespace OpenLoco::Config
         stream.open(Environment::getPathNoWarning(Environment::PathId::gamecfg), std::ios::out | std::ios::binary);
         if (stream.is_open())
         {
-            uint32_t magicNumber = _legacyConfigMagicNumber;
+            uint32_t magicNumber = kLegacyConfigMagicNumber;
             stream.write(reinterpret_cast<char*>(&magicNumber), sizeof(magicNumber));
             stream.write(reinterpret_cast<char*>(&getLegacy()), sizeof(LocoConfig));
         }

--- a/src/OpenLoco/src/Objects/Object.h
+++ b/src/OpenLoco/src/Objects/Object.h
@@ -49,13 +49,12 @@ namespace OpenLoco
     struct ObjectHeader
     {
     private:
-        static constexpr char cFF = static_cast<char>(0xFF);
         static constexpr uint32_t kFuzzyFlagsMask = 0xFFFE0000;
 
     public:
-        uint32_t flags = 0xFFFFFFFF;
-        char name[8] = { cFF, cFF, cFF, cFF, cFF, cFF, cFF, cFF };
-        uint32_t checksum = 0xFFFFFFFF;
+        uint32_t flags;
+        char name[8];
+        uint32_t checksum;
 
         std::string_view getName() const
         {
@@ -82,13 +81,9 @@ namespace OpenLoco
             return getSourceGame() == 0;
         }
 
-        bool isEmpty() const
-        {
-            auto ab = reinterpret_cast<const int64_t*>(this);
-            return ab[0] == -1 && ab[1] == -1;
-        }
+        constexpr bool isEmpty() const;
 
-        bool operator==(const ObjectHeader& rhs) const
+        constexpr bool operator==(const ObjectHeader& rhs) const
         {
             // Some vanilla objects reference other vanilla objects using a
             // ObjectHeader that is set as custom. To handle those we need
@@ -104,13 +99,19 @@ namespace OpenLoco
             }
         }
 
-        bool operator!=(const ObjectHeader& rhs) const
+        constexpr bool operator!=(const ObjectHeader& rhs) const
         {
             return !(*this == rhs);
         }
     };
     static_assert(sizeof(ObjectHeader) == 0x10);
 #pragma pack(pop)
+    constexpr ObjectHeader kEmptyObjectHeader = ObjectHeader{ 0xFFFFFFFFU, { '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF' }, 0xFFFFFFFFU };
+
+    constexpr bool ObjectHeader::isEmpty() const
+    {
+        return *this == kEmptyObjectHeader;
+    }
 
     /**
      * Represents an index / ID of a specific object type.

--- a/src/OpenLoco/src/Objects/Object.h
+++ b/src/OpenLoco/src/Objects/Object.h
@@ -81,9 +81,9 @@ namespace OpenLoco
             return getSourceGame() == 0;
         }
 
-        constexpr bool isEmpty() const;
+        bool isEmpty() const;
 
-        constexpr bool operator==(const ObjectHeader& rhs) const
+        bool operator==(const ObjectHeader& rhs) const
         {
             // Some vanilla objects reference other vanilla objects using a
             // ObjectHeader that is set as custom. To handle those we need
@@ -99,7 +99,7 @@ namespace OpenLoco
             }
         }
 
-        constexpr bool operator!=(const ObjectHeader& rhs) const
+        bool operator!=(const ObjectHeader& rhs) const
         {
             return !(*this == rhs);
         }
@@ -108,9 +108,9 @@ namespace OpenLoco
 #pragma pack(pop)
     constexpr ObjectHeader kEmptyObjectHeader = ObjectHeader{ 0xFFFFFFFFU, { '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF' }, 0xFFFFFFFFU };
 
-    constexpr bool ObjectHeader::isEmpty() const
+    inline bool ObjectHeader::isEmpty() const
     {
-        return *this == kEmptyObjectHeader;
+        return std::memcmp(this, &kEmptyObjectHeader, sizeof(ObjectHeader)) == 0;
     }
 
     /**

--- a/src/OpenLoco/src/Objects/Object.h
+++ b/src/OpenLoco/src/Objects/Object.h
@@ -81,7 +81,7 @@ namespace OpenLoco
             return getSourceGame() == 0;
         }
 
-        bool isEmpty() const;
+        constexpr bool isEmpty() const;
 
         bool operator==(const ObjectHeader& rhs) const
         {
@@ -108,9 +108,10 @@ namespace OpenLoco
 #pragma pack(pop)
     constexpr ObjectHeader kEmptyObjectHeader = ObjectHeader{ 0xFFFFFFFFU, { '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF' }, 0xFFFFFFFFU };
 
-    inline bool ObjectHeader::isEmpty() const
+    constexpr bool ObjectHeader::isEmpty() const
     {
-        return std::memcmp(this, &kEmptyObjectHeader, sizeof(ObjectHeader)) == 0;
+        // No point checking the name as its already invalid if flags is all 0xFFFFFFFFU
+        return this->flags == kEmptyObjectHeader.flags && this->checksum == kEmptyObjectHeader.checksum;
     }
 
     /**

--- a/src/OpenLoco/src/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/src/Objects/ObjectManager.cpp
@@ -48,6 +48,7 @@
 #include "WallObject.h"
 #include "WaterObject.h"
 #include <OpenLoco/Core/FileSystem.hpp>
+#include <OpenLoco/Core/Traits.hpp>
 #include <OpenLoco/Interop/Interop.hpp>
 #include <OpenLoco/Utility/Numeric.hpp>
 #include <OpenLoco/Utility/Stream.hpp>
@@ -79,7 +80,7 @@ namespace OpenLoco::ObjectManager
     assert_struct_size(ObjectRepositoryItem, 8);
 #pragma pack(pop)
 
-    static_assert(std::is_trivial_v<ObjectHeader>, "Object Header must be trivial for I/O purposes");
+    static_assert(Traits::IsPOD<ObjectHeader>::value, "Object Header must be trivial for I/O purposes");
 
     loco_global<ObjectRepositoryItem[maxObjectTypes], 0x4FE0B8> _objectRepository;
 

--- a/src/OpenLoco/src/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/src/Objects/ObjectManager.cpp
@@ -79,6 +79,8 @@ namespace OpenLoco::ObjectManager
     assert_struct_size(ObjectRepositoryItem, 8);
 #pragma pack(pop)
 
+    static_assert(std::is_trivial_v<ObjectHeader>, "Object Header must be trivial for I/O purposes");
+
     loco_global<ObjectRepositoryItem[maxObjectTypes], 0x4FE0B8> _objectRepository;
 
     static loco_global<std::byte*, 0x0050D158> _dependentObjectsVector;


### PR DESCRIPTION
This is for #1902.

Nothing at present was expecting the object header to be default constructed to an empty header (at least i don't think there is I tried deleting the constructor and seeing where all the constructor sites were)