### PR TITLE
Use fmt-header-only target for static linkage

### DIFF
--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -29,7 +29,7 @@ loco_add_library(Core STATIC
 target_link_libraries(Core
     PUBLIC
         nonstd::span-lite
-        fmt::fmt
+        fmt::fmt-header-only
     PRIVATE
         Utility)
 


### PR DESCRIPTION
Not sure how it ever worked without a dll, perhaps solves the problem that @AaronVanGeffen has. Either way we should have fmt linked statically in Core, that is the recommended way anyway.