### PR TITLE
Improve logging library to handle cases where VT100 is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 23.03+ (???)
 ------------------------------------------------------------------------
 - Fix: [#1907] Hooks fail to install on ARM macOS with wine.
+- Change: [#1908] Detects if terminal is VT100 capable and uses colors for the output, can be disabled using [NO_COLOR](https://no-color.org/).
 
 23.03 (2023-03-16)
 ------------------------------------------------------------------------

--- a/src/Diagnostics/CMakeLists.txt
+++ b/src/Diagnostics/CMakeLists.txt
@@ -29,4 +29,5 @@ loco_add_library(Diagnostics STATIC
 target_link_libraries(Diagnostics 
     PUBLIC
         Core
+        Platform
 )

--- a/src/Diagnostics/include/OpenLoco/Diagnostics/LogLevel.h
+++ b/src/Diagnostics/include/OpenLoco/Diagnostics/LogLevel.h
@@ -46,4 +46,22 @@ namespace OpenLoco::Diagnostics::Logging
             return 0;
     }
 
+    constexpr std::string_view getLevelPrefix(Level level)
+    {
+        switch (level)
+        {
+            case Level::info:
+                return "[INF] ";
+            case Level::warning:
+                return "[WRN] ";
+            case Level::error:
+                return "[ERR] ";
+            case Level::verbose:
+                return "[VER] ";
+            default:
+                break;
+        }
+        return "[INVALID] ";
+    }
+
 }

--- a/src/Diagnostics/include/OpenLoco/Diagnostics/LogTerminal.h
+++ b/src/Diagnostics/include/OpenLoco/Diagnostics/LogTerminal.h
@@ -6,6 +6,8 @@ namespace OpenLoco::Diagnostics::Logging
 {
     class LogTerminal final : public LogSink
     {
+        bool _vt100Enabled{};
+
     public:
         LogTerminal();
 

--- a/src/Diagnostics/src/LogFile.cpp
+++ b/src/Diagnostics/src/LogFile.cpp
@@ -32,23 +32,8 @@ namespace OpenLoco::Diagnostics::Logging
         }
 
         const int intendSize = getIntendSize();
-        switch (level)
-        {
-            case Level::info:
-                fmt::print(_file, "{}[INF] {:<{}}\n", timestamp, message, intendSize);
-                break;
-            case Level::warning:
-                fmt::print(_file, "{}[WRN] {:<{}}\n", timestamp, message, intendSize);
-                break;
-            case Level::error:
-                fmt::print(_file, "{}[ERR] {:<{}}\n", timestamp, message, intendSize);
-                break;
-            case Level::verbose:
-                fmt::print(_file, "{}[VER] {:<{}}\n", timestamp, message, intendSize);
-                break;
-            default:
-                break;
-        }
+
+        fmt::print(_file, "{}{}{:<{}}\n", timestamp, getLevelPrefix(level), message, intendSize);
 
         // Ensure we are not loosing anything because of buffering in case of a crash.
         _file.flush();

--- a/src/Diagnostics/src/LogTerminal.cpp
+++ b/src/Diagnostics/src/LogTerminal.cpp
@@ -13,7 +13,7 @@ namespace OpenLoco::Diagnostics::Logging
 
     LogTerminal::LogTerminal()
     {
-        _vt100Enabled = false; // Platform::enableVT100TerminalMode();
+        _vt100Enabled = Platform::enableVT100TerminalMode();
     }
 
     static FILE* getOutputStream(Level level)
@@ -71,9 +71,13 @@ namespace OpenLoco::Diagnostics::Logging
         const int intendSize = getIntendSize();
 
         if (_vt100Enabled)
+        {
             fmt::print(getOutputStream(level), getTextStyle(level), "{}{:>{}}\n", timestamp, message, intendSize);
+        }
         else
-            fmt::print(getOutputStream(level), "{}{:>{}}\n", timestamp, message, intendSize);
+        {
+            fmt::print(getOutputStream(level), "{}{}{:<{}}\n", timestamp, getLevelPrefix(level), message, intendSize);
+        }
     }
 
 }

--- a/src/Platform/CMakeLists.txt
+++ b/src/Platform/CMakeLists.txt
@@ -24,6 +24,5 @@ loco_add_library(Platform STATIC
 
 target_link_libraries(Platform PUBLIC
     Core
-    Diagnostics
     Utility
 )

--- a/src/Platform/include/OpenLoco/Platform/Platform.h
+++ b/src/Platform/include/OpenLoco/Platform/Platform.h
@@ -16,4 +16,7 @@ namespace OpenLoco::Platform
 #if defined(__APPLE__) && defined(__MACH__)
     fs::path GetBundlePath();
 #endif
+    bool isStdOutRedirected();
+    bool hasTerminalVT100Support();
+    bool enableVT100TerminalMode();
 }

--- a/src/Platform/include/OpenLoco/Platform/Platform.h
+++ b/src/Platform/include/OpenLoco/Platform/Platform.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include <OpenLoco/Core/FileSystem.hpp>
@@ -12,6 +13,7 @@ namespace OpenLoco::Platform
     fs::path promptDirectory(const std::string& title, void* hwnd);
     fs::path getCurrentExecutablePath();
     std::vector<fs::path> getDrives();
+    std::string getEnvironmentVariable(const std::string& name);
     bool isRunningInWine();
 #if defined(__APPLE__) && defined(__MACH__)
     fs::path GetBundlePath();

--- a/src/Platform/src/Platform.Macos.mm
+++ b/src/Platform/src/Platform.Macos.mm
@@ -69,6 +69,35 @@ namespace OpenLoco::Platform
             return fs::path();
         }
     }
+    
+    bool isStdOutRedirected()
+    {
+        // TODO: Implement me
+        return false;
+    }
+
+    static bool hasTerminalVT100SupportImpl()
+    {
+        // TODO: Implement me.
+        return false;
+    }
+
+    bool hasTerminalVT100Support()
+    {
+        static bool hasVT100Support = hasTerminalVT100SupportImpl();
+        return hasVT100Support;
+    }
+    
+    bool enableVT100TerminalMode()
+    {
+        if (!isStdOutRedirected())
+            return false;
+
+        if (!hasTerminalVT100Support())
+            return false;
+
+        return true;
+    }
 }
 
 #endif

--- a/src/Platform/src/Platform.Macos.mm
+++ b/src/Platform/src/Platform.Macos.mm
@@ -1,6 +1,7 @@
 #if defined(__APPLE__) && defined(__MACH__)
 
 #include "Platform.h"
+#include <cstdlib>
 #include <limits.h>
 #include <mach-o/dyld.h>
 
@@ -69,7 +70,13 @@ namespace OpenLoco::Platform
             return fs::path();
         }
     }
-    
+
+    std::string getEnvironmentVariable(const std::string& name)
+    {
+        auto result = std::getenv(name.c_str());
+        return result == nullptr ? std::string() : result;
+    }
+
     bool isStdOutRedirected()
     {
         // TODO: Implement me

--- a/src/Platform/src/Platform.Posix.cpp
+++ b/src/Platform/src/Platform.Posix.cpp
@@ -19,8 +19,6 @@
 #include <unistd.h>
 #endif
 
-using namespace OpenLoco::Diagnostics;
-
 namespace OpenLoco::Platform
 {
     uint32_t getTime()

--- a/src/Platform/src/Platform.Posix.cpp
+++ b/src/Platform/src/Platform.Posix.cpp
@@ -33,13 +33,13 @@ namespace OpenLoco::Platform
         return {};
     }
 
-#if !(defined(__APPLE__) && defined(__MACH__))
-    static std::string getEnvironmentVariable(const std::string& name)
+    std::string getEnvironmentVariable(const std::string& name)
     {
         auto result = getenv(name.c_str());
         return result == nullptr ? std::string() : result;
     }
 
+#if !(defined(__APPLE__) && defined(__MACH__))
     static fs::path getHomeDirectory()
     {
         auto pw = getpwuid(getuid());
@@ -121,15 +121,22 @@ namespace OpenLoco::Platform
 
     static bool hasTerminalVT100SupportImpl()
     {
-        char* term = std::getenv("TERM");
-        if (term == nullptr)
+        // See https://no-color.org/ for reference.
+        const auto noColorEnvVar = getEnvironmentVariable("NO_COLOR");
+        if (!noColorEnvVar.empty())
         {
             return false;
         }
 
-        return std::strcmp(term, "xterm") == 0
-            || std::strcmp(term, "xterm-256color") == 0
-            || std::strcmp(term, "rxvt-unicode-256color") == 0;
+        const auto termEnvVar = getEnvironmentVariable("TERM");
+        if (termEnvVar.empty())
+        {
+            return false;
+        }
+
+        return termEnvVar.compare("xterm") == 0
+            || termEnvVar.compare("xterm-256color") == 0
+            || termEnvVar.compare("rxvt-unicode-256color") == 0;
     }
 
     bool hasTerminalVT100Support()

--- a/src/Platform/src/Platform.Posix.cpp
+++ b/src/Platform/src/Platform.Posix.cpp
@@ -2,6 +2,7 @@
 
 #include "Platform.h"
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <pwd.h>
 #include <time.h>

--- a/src/Platform/src/Platform.Windows.cpp
+++ b/src/Platform/src/Platform.Windows.cpp
@@ -1,17 +1,19 @@
 #ifdef _WIN32
 
+#include "Platform.h"
+#include <io.h>
 #include <iostream>
 
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-// We can't use lean and mean if we want timeGetTime
-// #define WIN32_LEAN_AND_MEAN
-#include <io.h>
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <shlobj.h>
+#include <timeapi.h>
 #include <windows.h>
 
-#include "Platform.h"
 #include <OpenLoco/Utility/String.hpp>
 
 namespace OpenLoco::Platform
@@ -151,7 +153,7 @@ namespace OpenLoco::Platform
         if (ntdllHandle == nullptr)
             return false;
 
-        using RtlGetVersionFn = NTSTATUS(WINAPI*)(PRTL_OSVERSIONINFOW);
+        using RtlGetVersionFn = LONG(WINAPI*)(PRTL_OSVERSIONINFOW);
 
         const auto RtlGetVersionFp = reinterpret_cast<RtlGetVersionFn>(GetProcAddress(ntdllHandle, "RtlGetVersion"));
         if (RtlGetVersionFp == nullptr)

--- a/src/Platform/src/Platform.Windows.cpp
+++ b/src/Platform/src/Platform.Windows.cpp
@@ -10,9 +10,12 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+// clang-format off
+// Windows headers are quite sensitive to the include order.
 #include <shlobj.h>
-#include <timeapi.h>
 #include <windows.h>
+#include <mmsystem.h>
+// clang-format on
 
 #include <OpenLoco/Utility/String.hpp>
 

--- a/src/Platform/src/Platform.Windows.cpp
+++ b/src/Platform/src/Platform.Windows.cpp
@@ -1,6 +1,10 @@
 #ifdef _WIN32
 
+#undef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS 1
+
 #include "Platform.h"
+#include <cstdlib>
 #include <io.h>
 #include <iostream>
 
@@ -133,6 +137,12 @@ namespace OpenLoco::Platform
         return drives;
     }
 
+    std::string getEnvironmentVariable(const std::string& name)
+    {
+        auto result = std::getenv(name.c_str());
+        return result == nullptr ? std::string() : result;
+    }
+
     bool isRunningInWine()
     {
         HMODULE ntdllMod = GetModuleHandleW(L"ntdll.dll");
@@ -152,6 +162,13 @@ namespace OpenLoco::Platform
 
     static bool hasTerminalVT100SupportImpl()
     {
+        // See https://no-color.org/ for reference.
+        const auto noColorEnvVar = getEnvironmentVariable("NO_COLOR");
+        if (!noColorEnvVar.empty())
+        {
+            return false;
+        }
+
         const auto ntdllHandle = GetModuleHandleW(L"ntdll.dll");
         if (ntdllHandle == nullptr)
             return false;

--- a/src/Platform/src/Platform.Windows.cpp
+++ b/src/Platform/src/Platform.Windows.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <io.h>
 #include <iostream>
+#include <tuple>
 
 #ifndef NOMINMAX
 #define NOMINMAX
@@ -175,7 +176,14 @@ namespace OpenLoco::Platform
 
         using RtlGetVersionFn = LONG(WINAPI*)(PRTL_OSVERSIONINFOW);
 
-        const auto RtlGetVersionFp = reinterpret_cast<RtlGetVersionFn>(GetProcAddress(ntdllHandle, "RtlGetVersion"));
+#if defined(__MINGW32__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
+        auto RtlGetVersionFp = reinterpret_cast<RtlGetVersionFn>(GetProcAddress(ntdllHandle, "RtlGetVersion"));
+#if defined(__MINGW32__)
+#pragma GCC diagnostic pop
+#endif
         if (RtlGetVersionFp == nullptr)
             return false;
 
@@ -186,7 +194,7 @@ namespace OpenLoco::Platform
             return false;
 
         // VT100 support was first introduced in 10.0.10586
-        if (info.dwMajorVersion >= 10 && info.dwMinorVersion >= 0 && info.dwBuildNumber >= 10586)
+        if (std::tie(info.dwMajorVersion, info.dwMinorVersion, info.dwBuildNumber) >= std::make_tuple(10U, 0U, 10586U))
             return true;
 
         return false;


### PR DESCRIPTION
I refactored out the platform specific code to the Platform library, I had to remove Diagnostics as the dependency as Platform should be one of the core libraries that doesn't really depend on anything. It will also now disable printing escape sequences in case stdout is redirected to a pipe/file and instead prints the level. VT100 detection is done on posix via reading the env variable TERM and check for common terminals there might be some that I missed, on Windows we have to check for the version, this is done by dynamically locating RtlGetVersion and calling it to get the window version.