### PR TITLE
Fix #1525: Compile warning gcc 12

### DIFF
--- a/src/OpenLoco/src/Graphics/Gfx.h
+++ b/src/OpenLoco/src/Graphics/Gfx.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Graphics/PaletteMap.h"
 #include "ImageId.h"
 #include "Types.hpp"
 #include <OpenLoco/Core/EnumFlags.hpp>


### PR DESCRIPTION
Could someone with gcc 12 check this. Also i noticed one potential issue the way vanilla handles children with attachements is slightly different to what we are doing. We should investigate that further as potentially we aren't displaying things quite correct with attachments. Possibly missing ones which are on the last child. But thats a bit odd design so i think we are fine.