### PR TITLE
Implement vehicle reverse game command

### DIFF
--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -93,6 +93,7 @@ set(OLOCO_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/TogglePause.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/UpdateOwnerStatus.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/VehiclePickup.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/VehicleReverse.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameState.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Graphics/Colour.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Graphics/Gfx.cpp"

--- a/src/OpenLoco/src/GameCommands/GameCommands.cpp
+++ b/src/OpenLoco/src/GameCommands/GameCommands.cpp
@@ -53,7 +53,7 @@ namespace OpenLoco::GameCommands
         { GameCommand::vehicleRearrange,             nullptr,                   0x004AF1DF, true  },
         { GameCommand::vehiclePlace,                 nullptr,                   0x004B01B6, true  },
         { GameCommand::vehiclePickup,                vehiclePickup,             0x004B0826, true  },
-        { GameCommand::vehicleReverse,               nullptr,                   0x004ADAA8, true  },
+        { GameCommand::vehicleReverse,               vehicleReverse,            0x004ADAA8, true  },
         { GameCommand::vehiclePassSignal,            nullptr,                   0x004B0B50, true  },
         { GameCommand::vehicleCreate,                Vehicles::create,          0x004AE5E4, true  },
         { GameCommand::vehicleSell,                  Vehicles::sell,            0x004AED34, true  },

--- a/src/OpenLoco/src/GameCommands/GameCommands.h
+++ b/src/OpenLoco/src/GameCommands/GameCommands.h
@@ -1892,6 +1892,9 @@ namespace OpenLoco::GameCommands
     // Defined in GameCommands/VehiclePickup.cpp
     void vehiclePickup(registers& regs);
 
+    // Defined in GameCommands/VehicleReverse.cpp
+    void vehicleReverse(registers& regs);
+
     // Defined in GameCommands/UpdateOwnerStatus.cpp
     void updateOwnerStatus(registers& regs);
 

--- a/src/OpenLoco/src/GameCommands/GameCommands.h
+++ b/src/OpenLoco/src/GameCommands/GameCommands.h
@@ -226,19 +226,15 @@ namespace OpenLoco::GameCommands
         VehicleReverseArgs() = default;
         explicit VehicleReverseArgs(const registers& regs)
             : head(static_cast<EntityId>(regs.dx))
-            , headPtr(nullptr)
         {
         }
 
         EntityId head;
-        // Bug in GameCommand::vehicleReverse requires setting edi to a vehicle prior to calling
-        Vehicles::VehicleHead* headPtr;
 
         explicit operator registers() const
         {
             registers regs;
             regs.dx = enumValue(head);
-            regs.edi = X86Pointer(headPtr);
             return regs;
         }
     };

--- a/src/OpenLoco/src/GameCommands/VehicleReverse.cpp
+++ b/src/OpenLoco/src/GameCommands/VehicleReverse.cpp
@@ -20,15 +20,6 @@ namespace OpenLoco::GameCommands
             return FAILURE;
         }
 
-        if (flags & Flags::apply)
-        {
-            uint8_t var_52_backup = head->var_52;
-            head->var_52 = 1;
-            head->sub_4ADB47(0);
-            head->var_52 = var_52_backup;
-            return 0;
-        }
-
         if (!sub_431E6A(head->owner))
         {
             return FAILURE;
@@ -46,7 +37,17 @@ namespace OpenLoco::GameCommands
             return FAILURE;
         }
 
+        if (!(flags & Flags::apply))
+        {
+            return 0;
+        }
+
+        uint8_t var_52_backup = head->var_52;
+        head->var_52 = 1;
+        head->sub_4ADB47(0);
+        head->var_52 = var_52_backup;
         setPosition(head->position);
+
         return 0;
     }
 

--- a/src/OpenLoco/src/GameCommands/VehicleReverse.cpp
+++ b/src/OpenLoco/src/GameCommands/VehicleReverse.cpp
@@ -1,0 +1,57 @@
+#include "Economy/Expenditures.h"
+#include "Entities/EntityManager.h"
+#include "GameCommands.h"
+#include "Types.hpp"
+#include "Vehicles/Vehicle.h"
+#include <OpenLoco/Interop/Interop.hpp>
+
+using namespace OpenLoco::Interop;
+
+namespace OpenLoco::GameCommands
+{
+    // 0x004ADAA8
+    static uint32_t vehicleReverse(EntityId headId, const uint8_t flags)
+    {
+        setExpenditureType(ExpenditureType::TrainRunningCosts);
+
+        auto* head = EntityManager::get<Vehicles::VehicleHead>(headId);
+        if (head == nullptr)
+        {
+            return FAILURE;
+        }
+
+        if (flags & Flags::apply)
+        {
+            uint8_t var_52_backup = head->var_52;
+            head->var_52 = 1;
+            head->sub_4ADB47(0);
+            head->var_52 = var_52_backup;
+            return 0;
+        }
+
+        if (!sub_431E6A(head->owner))
+        {
+            return FAILURE;
+        }
+
+        auto* head2 = EntityManager::get<Vehicles::VehicleHead>(head->head);
+        if (!head2->canBeModified())
+        {
+            return FAILURE;
+        }
+
+        if (static_cast<uint16_t>(head2->tileX) == 0xFFFF)
+        {
+            setErrorText(StringIds::empty);
+            return FAILURE;
+        }
+
+        setPosition(head->position);
+        return 0;
+    }
+
+    void vehicleReverse(registers& regs)
+    {
+        regs.ebx = vehicleReverse(EntityId(regs.dx), regs.bl);
+    }
+}

--- a/src/OpenLoco/src/GameCommands/VehicleReverse.cpp
+++ b/src/OpenLoco/src/GameCommands/VehicleReverse.cpp
@@ -25,6 +25,11 @@ namespace OpenLoco::GameCommands
             return FAILURE;
         }
 
+        if (!head->canBeModified())
+        {
+            return FAILURE;
+        }
+
         if (head->tileX == -1)
         {
             setErrorText(StringIds::empty);

--- a/src/OpenLoco/src/GameCommands/VehicleReverse.cpp
+++ b/src/OpenLoco/src/GameCommands/VehicleReverse.cpp
@@ -31,7 +31,7 @@ namespace OpenLoco::GameCommands
             return FAILURE;
         }
 
-        if (static_cast<uint16_t>(head2->tileX) == 0xFFFF)
+        if (head2->tileX == -1)
         {
             setErrorText(StringIds::empty);
             return FAILURE;

--- a/src/OpenLoco/src/GameCommands/VehicleReverse.cpp
+++ b/src/OpenLoco/src/GameCommands/VehicleReverse.cpp
@@ -25,13 +25,7 @@ namespace OpenLoco::GameCommands
             return FAILURE;
         }
 
-        auto* head2 = EntityManager::get<Vehicles::VehicleHead>(head->head);
-        if (!head2->canBeModified())
-        {
-            return FAILURE;
-        }
-
-        if (head2->tileX == -1)
+        if (head->tileX == -1)
         {
             setErrorText(StringIds::empty);
             return FAILURE;

--- a/src/OpenLoco/src/GameCommands/VehicleReverse.cpp
+++ b/src/OpenLoco/src/GameCommands/VehicleReverse.cpp
@@ -53,6 +53,7 @@ namespace OpenLoco::GameCommands
 
     void vehicleReverse(registers& regs)
     {
-        regs.ebx = vehicleReverse(EntityId(regs.dx), regs.bl);
+        VehicleReverseArgs args(regs);
+        regs.ebx = vehicleReverse(args.head, regs.bl);
     }
 }

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -351,6 +351,7 @@ namespace OpenLoco::Vehicles
         void sub_4B7CC3();
         currency32_t calculateRunningCost() const;
         void sub_4AD93A();
+        void sub_4ADB47(bool unk);
         uint32_t getCarCount() const;
         void applyBreakdownToTrain();
         void sub_4AF7A4();
@@ -418,7 +419,6 @@ namespace OpenLoco::Vehicles
         StationId manualFindTrainStationAtLocation();
         bool sub_4BADE4();
         bool isOnExpectedRoadOrTrack();
-        void sub_4ADB47(bool unk);
         VehicleStatus getStatusTravelling() const;
         void getSecondStatus(VehicleStatus& vehStatus) const;
         void updateLastIncomeStats(uint8_t cargoType, uint16_t cargoQty, uint16_t cargoDist, uint8_t cargoAge, currency32_t profit);

--- a/src/OpenLoco/src/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Windows/Vehicle.cpp
@@ -444,7 +444,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
             GameCommands::setErrorTitle(StringIds::cant_reverse_train);
             GameCommands::VehicleReverseArgs args{};
             args.head = static_cast<EntityId>(self->number);
-            args.headPtr = head;
             GameCommands::doCommand(args, GameCommands::Flags::apply);
         }
 

--- a/src/OpenLoco/src/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Windows/Vehicle.cpp
@@ -436,11 +436,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 _pickupDirection = _pickupDirection ^ 1;
                 return;
             }
-            auto head = Common::getVehicle(self);
-            if (head == nullptr)
-            {
-                return;
-            }
             GameCommands::setErrorTitle(StringIds::cant_reverse_train);
             GameCommands::VehicleReverseArgs args{};
             args.head = static_cast<EntityId>(self->number);


### PR DESCRIPTION
This implements the vehicle reverse game command. I was surprised to see the 'query' sanity checks weren't being executed when the 'apply' play is set. I've taken the liberty to change that -- better safe than sorry.

Regardless, this implementation probably means the workaround below isn't needed any more, right? Should I remove it?

https://github.com/OpenLoco/OpenLoco/blob/9e5cdcc2edac8f6c4c6761feffff7851b9438df9/src/OpenLoco/src/GameCommands/GameCommands.h#L233-L243