### PR TITLE
Use a utf8 command line on windows

### DIFF
--- a/src/OpenLoco/src/CommandLine.cpp
+++ b/src/OpenLoco/src/CommandLine.cpp
@@ -140,10 +140,10 @@ namespace OpenLoco
         }
 
     public:
-        CommandLineParser(int argc, const char** argv)
+        CommandLineParser(const std::vector<std::string>& argv)
         {
-            _args.resize(argc - 1);
-            for (int i = 1; i < argc; i++)
+            _args.resize(argv.size() - 1);
+            for (size_t i = 1; i < argv.size(); i++)
             {
                 _args[i - 1] = argv[i];
             }
@@ -283,9 +283,9 @@ namespace OpenLoco
         }
     };
 
-    std::optional<CommandLineOptions> parseCommandLine(int argc, const char** argv)
+    std::optional<CommandLineOptions> parseCommandLine(std::vector<std::string>&& argv)
     {
-        auto parser = CommandLineParser(argc, argv)
+        auto parser = CommandLineParser(argv)
                           .registerOption("--bind", 1)
                           .registerOption("--port", "-p", 1)
                           .registerOption("-o", 1)

--- a/src/OpenLoco/src/CommandLine.cpp
+++ b/src/OpenLoco/src/CommandLine.cpp
@@ -25,41 +25,6 @@ namespace OpenLoco
         _cmdlineOptions = options;
     }
 
-    static std::vector<std::string> splitArgs(const char* args)
-    {
-        std::vector<std::string> arguments;
-        arguments.push_back("");
-        auto ch = args;
-        auto arg = ch;
-        auto inQuotes = false;
-        while (*ch != '\0')
-        {
-            if (*ch == ' ' && !inQuotes)
-            {
-                if (ch != arg)
-                {
-                    arguments.emplace_back(arg, ch - arg);
-                }
-                arg = ch + 1;
-            }
-            else if (*ch == '"' && ch == arg)
-            {
-                inQuotes = true;
-                arg = ch + 1;
-            }
-            else if (*ch == '"' && (*(ch + 1) == ' ' || *(ch + 1) == '\0'))
-            {
-                arguments.emplace_back(arg, ch - arg);
-                arg = ch + 1;
-                inQuotes = false;
-            }
-            ch++;
-        }
-        if (*arg != '\0')
-            arguments.emplace_back(arg);
-        return arguments;
-    }
-
     class CommandLineParser
     {
     private:
@@ -390,17 +355,6 @@ namespace OpenLoco
             options.logLevels = "info, warning, error";
 
         return options;
-    }
-
-    std::optional<CommandLineOptions> parseCommandLine(const char* args)
-    {
-        auto argsV = splitArgs(args);
-        std::vector<const char*> argsC;
-        for (const auto& s : argsV)
-        {
-            argsC.push_back(s.c_str());
-        }
-        return parseCommandLine(argsC.size(), argsC.data());
     }
 
     void printVersion()

--- a/src/OpenLoco/src/CommandLine.h
+++ b/src/OpenLoco/src/CommandLine.h
@@ -31,7 +31,6 @@ namespace OpenLoco
     };
 
     std::optional<CommandLineOptions> parseCommandLine(int argc, const char** argv);
-    std::optional<CommandLineOptions> parseCommandLine(const char* args);
     std::optional<int> runCommandLineOnlyCommand(const CommandLineOptions& options);
     const CommandLineOptions& getCommandLineOptions();
     void setCommandLineOptions(const CommandLineOptions& options);

--- a/src/OpenLoco/src/CommandLine.h
+++ b/src/OpenLoco/src/CommandLine.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace OpenLoco
 {
@@ -30,7 +31,7 @@ namespace OpenLoco
         std::string logLevels;
     };
 
-    std::optional<CommandLineOptions> parseCommandLine(int argc, const char** argv);
+    std::optional<CommandLineOptions> parseCommandLine(std::vector<std::string>&& argv);
     std::optional<int> runCommandLineOnlyCommand(const CommandLineOptions& options);
     const CommandLineOptions& getCommandLineOptions();
     void setCommandLineOptions(const CommandLineOptions& options);

--- a/src/OpenLoco/src/Main.cpp
+++ b/src/OpenLoco/src/Main.cpp
@@ -31,14 +31,11 @@ extern "C" __declspec(dllexport) int StartOpenLoco([[maybe_unused]] HINSTANCE hI
 
     for (auto i = 0; i < argc; ++i)
     {
-        const auto srcLen = wcslen(argw[i]);
-
-        int length = WideCharToMultiByte(CP_UTF8, 0, argw[i], srcLen, 0, 0, NULL, NULL);
-        argvStrs[i].resize(length + 1);
+        int length = WideCharToMultiByte(CP_UTF8, 0, argw[i], -1, 0, 0, NULL, NULL);
+        argvStrs[i].resize(length);
         argv.get()[i] = argvStrs[i].data();
 
-        WideCharToMultiByte(CP_UTF8, 0, argw[i], srcLen, argvStrs[i].data(), length, NULL, NULL);
-        argvStrs[i].data()[length] = '\0';
+        WideCharToMultiByte(CP_UTF8, 0, argw[i], -1, argvStrs[i].data(), length, NULL, NULL);
     }
     LocalFree(reinterpret_cast<HLOCAL>(argw));
     const auto res = OpenLoco::main(argc, const_cast<const char**>(argv.get()));

--- a/src/OpenLoco/src/Main.cpp
+++ b/src/OpenLoco/src/Main.cpp
@@ -1,15 +1,11 @@
 #include "OpenLoco.h"
+#include <OpenLoco/Platform/Platform.h>
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#include <OpenLoco/Diagnostics/Logging.h>
 #include <windows.h>
-
-#include <shellapi.h>
-
-using namespace OpenLoco::Diagnostics;
 
 /**
  * The function that is called directly from the host application (loco.exe)'s WinMain. This will be removed when OpenLoco can
@@ -19,41 +15,7 @@ using namespace OpenLoco::Diagnostics;
 extern "C" __declspec(dllexport) int StartOpenLoco(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow);
 extern "C" __declspec(dllexport) int StartOpenLoco([[maybe_unused]] HINSTANCE hInstance, [[maybe_unused]] HINSTANCE hPrevInstance, [[maybe_unused]] LPSTR lpCmdLine, [[maybe_unused]] int nCmdShow)
 {
-    // We need to get the Wide command line and convert it to utf8 command line parameters
-    const auto cmdline = GetCommandLineW();
-
-    int argc{};
-    auto* argw = CommandLineToArgvW(cmdline, &argc);
-    if (argw == nullptr)
-    {
-        Logging::error("CommandLineToArgvW failed to convert commandline");
-        // We will continue but just ignore the command line args.
-        argc = 0;
-    }
-
-    // This will hold a utf8 string of the command line
-    std::vector<std::string> argvStrs;
-    argvStrs.resize(argc);
-
-    for (auto i = 0; i < argc; ++i)
-    {
-        int length = WideCharToMultiByte(CP_UTF8, 0, argw[i], -1, 0, 0, NULL, NULL);
-
-        if (length == 0)
-        {
-            // Sadly can't print what the argument is that is causing the issue as it needs to be in utf8...
-            Logging::error("Failed to get cmdline argument utf8 length.");
-            continue;
-        }
-        argvStrs[i].resize(length);
-
-        if (WideCharToMultiByte(CP_UTF8, 0, argw[i], -1, argvStrs[i].data(), length, NULL, NULL) == 0)
-        {
-            Logging::error("Failed to convert cmdline argument to utf8.");
-        }
-    }
-    LocalFree(reinterpret_cast<HLOCAL>(argw));
-    const auto res = OpenLoco::main(std::move(argvStrs));
+    const auto res = OpenLoco::main(OpenLoco::Platform::getCmdLineVector(0, nullptr));
 
     return res;
 }
@@ -63,12 +25,6 @@ extern "C" __declspec(dllexport) int StartOpenLoco([[maybe_unused]] HINSTANCE hI
 int main(int argc, const char** argv)
 {
     OpenLoco::Interop::loadSections();
-    std::vector<std::string> argvStrs;
-    argvStrs.resize(argc);
-    for (auto i = 0; i < argc; ++i)
-    {
-        argvStrs[i] = argv[i];
-    }
-    return OpenLoco::main(std::move(argvStrs));
+    return OpenLoco::main(OpenLoco::Platform::getCmdLineVector(argc, argv));
 }
 #endif

--- a/src/OpenLoco/src/Main.cpp
+++ b/src/OpenLoco/src/Main.cpp
@@ -5,15 +5,45 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
+
+#include <shellapi.h>
 /**
  * The function that is called directly from the host application (loco.exe)'s WinMain. This will be removed when OpenLoco can
  * be built as a stand alone application.
  */
 // Hack to trick mingw into thinking we forward-declared this function.
 extern "C" __declspec(dllexport) int StartOpenLoco(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow);
-extern "C" __declspec(dllexport) int StartOpenLoco([[maybe_unused]] HINSTANCE hInstance, [[maybe_unused]] HINSTANCE hPrevInstance, LPSTR lpCmdLine, [[maybe_unused]] int nCmdShow)
+extern "C" __declspec(dllexport) int StartOpenLoco([[maybe_unused]] HINSTANCE hInstance, [[maybe_unused]] HINSTANCE hPrevInstance, [[maybe_unused]] LPSTR lpCmdLine, [[maybe_unused]] int nCmdShow)
 {
-    return OpenLoco::main(lpCmdLine);
+    // We need to get the Wide command line and convert it to utf8 command line parameters
+    const auto cmdline = GetCommandLineW();
+
+    int argc{};
+    auto* argw = CommandLineToArgvW(cmdline, &argc);
+
+    // This will hold a utf8 string of the command line
+    // we are doing this convoluted method so that memory is
+    // cleaned up automatically
+    std::vector<std::string> argvStrs;
+    argvStrs.resize(argc);
+    // This will hold a utf8 c string of the command line
+    auto argv = std::make_unique<char*[]>(argc);
+
+    for (auto i = 0; i < argc; ++i)
+    {
+        const auto srcLen = wcslen(argw[i]);
+
+        int length = WideCharToMultiByte(CP_UTF8, 0, argw[i], srcLen, 0, 0, NULL, NULL);
+        argvStrs[i].resize(length + 1);
+        argv.get()[i] = argvStrs[i].data();
+
+        WideCharToMultiByte(CP_UTF8, 0, argw[i], srcLen, argvStrs[i].data(), length, NULL, NULL);
+        argvStrs[i].data()[length] = '\0';
+    }
+    LocalFree(reinterpret_cast<HLOCAL>(argw));
+    const auto res = OpenLoco::main(argc, const_cast<const char**>(argv.get()));
+
+    return res;
 }
 #else
 #include "Interop/Hooks.h"

--- a/src/OpenLoco/src/Main.cpp
+++ b/src/OpenLoco/src/Main.cpp
@@ -4,9 +4,13 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+#include <OpenLoco/Diagnostics/Logging.h>
 #include <windows.h>
 
 #include <shellapi.h>
+
+using namespace OpenLoco::Diagnostics;
+
 /**
  * The function that is called directly from the host application (loco.exe)'s WinMain. This will be removed when OpenLoco can
  * be built as a stand alone application.
@@ -20,6 +24,12 @@ extern "C" __declspec(dllexport) int StartOpenLoco([[maybe_unused]] HINSTANCE hI
 
     int argc{};
     auto* argw = CommandLineToArgvW(cmdline, &argc);
+    if (argw == nullptr)
+    {
+        Logging::error("CommandLineToArgvW failed to convert commandline");
+        // We will continue but just ignore the command line args.
+        argc = 0;
+    }
 
     // This will hold a utf8 string of the command line
     std::vector<std::string> argvStrs;
@@ -28,9 +38,19 @@ extern "C" __declspec(dllexport) int StartOpenLoco([[maybe_unused]] HINSTANCE hI
     for (auto i = 0; i < argc; ++i)
     {
         int length = WideCharToMultiByte(CP_UTF8, 0, argw[i], -1, 0, 0, NULL, NULL);
+
+        if (length == 0)
+        {
+            // Sadly can't print what the argument is that is causing the issue as it needs to be in utf8...
+            Logging::error("Failed to get cmdline argument utf8 length.");
+            continue;
+        }
         argvStrs[i].resize(length);
 
-        WideCharToMultiByte(CP_UTF8, 0, argw[i], -1, argvStrs[i].data(), length, NULL, NULL);
+        if (WideCharToMultiByte(CP_UTF8, 0, argw[i], -1, argvStrs[i].data(), length, NULL, NULL) == 0)
+        {
+            Logging::error("Failed to convert cmdline argument to utf8.");
+        }
     }
     LocalFree(reinterpret_cast<HLOCAL>(argw));
     const auto res = OpenLoco::main(std::move(argvStrs));

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -1211,17 +1211,4 @@ namespace OpenLoco
             return 1;
         }
     }
-
-    int main(const char* args)
-    {
-        auto options = parseCommandLine(args);
-        if (options)
-        {
-            return main(*options);
-        }
-        else
-        {
-            return 1;
-        }
-    }
 }

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -1199,9 +1199,9 @@ namespace OpenLoco
         }
     }
 
-    int main(int argc, const char** argv)
+    int main(std::vector<std::string>&& argv)
     {
-        auto options = parseCommandLine(argc, argv);
+        auto options = parseCommandLine(std::move(argv));
         if (options)
         {
             return main(*options);

--- a/src/OpenLoco/src/OpenLoco.h
+++ b/src/OpenLoco/src/OpenLoco.h
@@ -25,7 +25,7 @@ namespace OpenLoco
     void simulateGame(const fs::path& path, int32_t ticks);
 
     void sub_431695(uint16_t var_F253A0);
-    int main(int argc, const char** argv);
+    int main(std::vector<std::string>&& argv);
     void promptTickLoop(std::function<bool()> tickAction);
     [[noreturn]] void exitCleanly();
     [[noreturn]] void exitWithError(OpenLoco::string_id message, uint32_t errorCode);

--- a/src/OpenLoco/src/OpenLoco.h
+++ b/src/OpenLoco/src/OpenLoco.h
@@ -26,7 +26,6 @@ namespace OpenLoco
 
     void sub_431695(uint16_t var_F253A0);
     int main(int argc, const char** argv);
-    int main(const char* args);
     void promptTickLoop(std::function<bool()> tickAction);
     [[noreturn]] void exitCleanly();
     [[noreturn]] void exitWithError(OpenLoco::string_id message, uint32_t errorCode);

--- a/src/Platform/include/OpenLoco/Platform/Platform.h
+++ b/src/Platform/include/OpenLoco/Platform/Platform.h
@@ -21,4 +21,5 @@ namespace OpenLoco::Platform
     bool isStdOutRedirected();
     bool hasTerminalVT100Support();
     bool enableVT100TerminalMode();
+    std::vector<std::string> getCmdLineVector(int argc, const char** argv);
 }

--- a/src/Platform/src/Platform.Posix.cpp
+++ b/src/Platform/src/Platform.Posix.cpp
@@ -155,6 +155,17 @@ namespace OpenLoco::Platform
 
         return true;
     }
+
+    std::vector<std::string> getCmdLineVector(int argc, const char** argv)
+    {
+        std::vector<std::string> argvStrs;
+        argvStrs.resize(argc);
+        for (auto i = 0; i < argc; ++i)
+        {
+            argvStrs[i] = argv[i];
+        }
+        return argvStrs;
+    }
 }
 
 #endif


### PR DESCRIPTION
Slightly convoluted as i wanted all the memory allocated cleaned up automatically so i've got a std::unique_ptr of char* and a std::vector of strings.