### PR TITLE
Fix #1953: Cloning a vehicle doesn't copy cargo retrofit selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix: [#1281] The construction window won't open under some circumstances.
 - Fix: [#1942] Crash when attempting to clear a building with the clear construction tool.
 - Fix: [#1946] Crash when loading openloco.yml config that has no shortcuts defined.
+- Fix: [#1953] Cloning a vehicle doesn't copy cargo retrofit selection.
 - Technical: [#1934] The performance of scrollable lists has been improved.
 
 23.04.1 (2023-04-27)

--- a/src/OpenLoco/src/GameCommands/GameCommands.h
+++ b/src/OpenLoco/src/GameCommands/GameCommands.h
@@ -1713,15 +1713,28 @@ namespace OpenLoco::GameCommands
         return doCommand(GameCommand::vehiclePickupWater, regs) != FAILURE;
     }
 
-    // Refit vehicle
-    inline void do_64(EntityId vehicleHead, uint16_t option)
+    struct VehicleRefitArgs
     {
-        registers regs;
-        regs.bl = Flags::apply;
-        regs.di = enumValue(vehicleHead);
-        regs.dx = option;
-        doCommand(GameCommand::vehicleRefit, regs);
-    }
+        static constexpr auto command = GameCommand::vehicleRefit;
+
+        VehicleRefitArgs() = default;
+        explicit VehicleRefitArgs(const registers& regs)
+            : head(static_cast<EntityId>(regs.di))
+            , cargoType(regs.dx)
+        {
+        }
+
+        EntityId head;
+        uint16_t cargoType;
+
+        explicit operator registers() const
+        {
+            registers regs;
+            regs.di = enumValue(head);
+            regs.dx = cargoType;
+            return regs;
+        }
+    };
 
     // Change company face
     inline bool do_65(const ObjectHeader& object, CompanyId company)

--- a/src/OpenLoco/src/Vehicles/CloneVehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/CloneVehicle.cpp
@@ -44,6 +44,7 @@ namespace OpenLoco::Vehicles
             return totalCost;
         }
 
+        uint16_t cargoType = 0;
         uint32_t totalCost = 0;
         for (auto& car : existingTrain.cars)
         {
@@ -55,6 +56,7 @@ namespace OpenLoco::Vehicles
                 args.vehicleType = car.front->objectId;
 
                 cost = GameCommands::doCommand(args, GameCommands::Flags::apply);
+                cargoType = car.body->primaryCargo.type;
 
                 auto* newVeh = EntityManager::get<Vehicles::VehicleBase>(_113642A);
                 if (newVeh == nullptr)
@@ -105,6 +107,16 @@ namespace OpenLoco::Vehicles
         {
             GameCommands::do12(newHead->id, 2);
         }
+
+        // Copy cargo refit status (only applies to boats and airplanes)
+        if (newHead->vehicleType == VehicleType::ship || newHead->vehicleType == VehicleType::aircraft)
+        {
+            GameCommands::VehicleRefitArgs args{};
+            args.head = newHead->head;
+            args.cargoType = cargoType;
+            GameCommands::doCommand(args, GameCommands::Flags::apply);
+        }
+
         return totalCost;
     }
 

--- a/src/OpenLoco/src/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Windows/Vehicle.cpp
@@ -1990,12 +1990,18 @@ namespace OpenLoco::Ui::Windows::Vehicle
             switch (i)
             {
                 case widx::refit:
+                {
                     if (dropdownIndex == -1)
                         break;
 
+                    GameCommands::VehicleRefitArgs args{};
+                    args.head = static_cast<EntityId>(self.number);
+                    args.cargoType = Dropdown::getItemArgument(dropdownIndex, 3);
+
                     GameCommands::setErrorTitle(StringIds::cant_refit_vehicle);
-                    GameCommands::do_64(EntityId(self.number), Dropdown::getItemArgument(dropdownIndex, 3));
+                    GameCommands::doCommand(args, GameCommands::Flags::apply);
                     break;
+                }
             }
         }
 


### PR DESCRIPTION
Based on work in #1954. Split off so the bugfix may be reviewed separately. 