### PR TITLE
Correct data type for clear land offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#376] Allow fractional UI scaling in addition to integer scaling.
 - Feature: [#418] Use hardware-backed SDL canvas when available for better performance.
+- Fix: [#1966] Unable to select terrain type for terrain painting.
 
 23.05 (2023-05-27)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/GameCommands/ClearLand.cpp
+++ b/src/OpenLoco/src/GameCommands/ClearLand.cpp
@@ -18,8 +18,8 @@ namespace OpenLoco::GameCommands
     static loco_global<uint16_t, 0x00F00144> _F00144;
     static loco_global<uint8_t*, 0x00F0016C> _F0016C; // stack offset to -eventually- flags
     static loco_global<uint16_t, 0x00F00170> _F00170;
-    static loco_global<uint32_t, 0x00F003CE> _F003CE; // tile x?
-    static loco_global<uint32_t, 0x00F003D0> _F003D0; // tile y?
+    static loco_global<coord_t, 0x00F003CE> _F003CE; // tile x?
+    static loco_global<coord_t, 0x00F003D0> _F003D0; // tile y?
     static loco_global<uint32_t, 0x00F25308> _sub469E07Cost;
 
     // 0x004690FC

--- a/src/OpenLoco/src/GameCommands/ClearLand.cpp
+++ b/src/OpenLoco/src/GameCommands/ClearLand.cpp
@@ -18,8 +18,8 @@ namespace OpenLoco::GameCommands
     static loco_global<uint16_t, 0x00F00144> _F00144;
     static loco_global<uint8_t*, 0x00F0016C> _F0016C; // stack offset to -eventually- flags
     static loco_global<uint16_t, 0x00F00170> _F00170;
-    static loco_global<coord_t, 0x00F003CE> _F003CE; // tile x?
-    static loco_global<coord_t, 0x00F003D0> _F003D0; // tile y?
+    static loco_global<tile_coord_t, 0x00F003CE> _F003CE; // tile x?
+    static loco_global<tile_coord_t, 0x00F003D0> _F003D0; // tile y?
     static loco_global<uint32_t, 0x00F25308> _sub469E07Cost;
 
     // 0x004690FC


### PR DESCRIPTION
Fixes #1966

In #1942 the offsets for some loco_globals were corrected to the right memory address but not the right data type. This resulted in an overflow bug, overwriting the last selected land type from the paint tool.