### PR TITLE
Use tile_coord_t for TilePos2 and functions

### DIFF
--- a/src/Engine/include/OpenLoco/Engine/World.hpp
+++ b/src/Engine/include/OpenLoco/Engine/World.hpp
@@ -25,7 +25,7 @@ namespace OpenLoco::World
 
     using Pos2 = Math::Vector::TVector2<coord_t, 1>;
     using Pos3 = Math::Vector::TVector3<coord_t, 1>;
-    using TilePos2 = Math::Vector::TVector2<coord_t, kTileSize>;
+    using TilePos2 = Math::Vector::TVector2<tile_coord_t, kTileSize>;
 
     // Until interop is removed this is a requirement.
     static_assert(sizeof(Pos2) == 4);
@@ -37,7 +37,7 @@ namespace OpenLoco::World
         return (coord >= 0) && (coord < kMapWidth);
     }
 
-    constexpr bool validTileCoord(const coord_t coord)
+    constexpr bool validTileCoord(const tile_coord_t coord)
     {
         return (coord >= 0) && (coord < kMapColumns);
     }


### PR DESCRIPTION
Something I noticed in another PR, we should be using the right types and not confuse tile coordinates over map coordinates. Unfortunately we can't really make them real strong types but ideally we won't be storing plain integers and rather have vectors everywhere.