### PR TITLE
Use std::byte instead of uint8_t for raw memory

### DIFF
--- a/src/OpenLoco/src/Objects/ObjectManager.h
+++ b/src/OpenLoco/src/Objects/ObjectManager.h
@@ -174,7 +174,7 @@ namespace OpenLoco::ObjectManager
     void unload(const ObjectHeader& header);
     bool load(const ObjectHeader& header);
 
-    bool tryInstallObject(const ObjectHeader& object, stdx::span<const uint8_t> data);
+    bool tryInstallObject(const ObjectHeader& object, stdx::span<const std::byte> data);
 
     size_t getByteLength(const LoadedObjectHandle& handle);
 

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -435,7 +435,7 @@ namespace OpenLoco::S5
                 ObjectHeader object;
                 fs.read(&object, sizeof(ObjectHeader));
                 auto unownedObjectData = fs.readChunk();
-                std::vector<uint8_t> objectData;
+                std::vector<std::byte> objectData;
                 objectData.resize(unownedObjectData.size());
                 std::copy(std::begin(unownedObjectData), std::end(unownedObjectData), std::begin(objectData));
                 file->packedObjects.push_back(std::make_pair(object, std::move(objectData)));

--- a/src/OpenLoco/src/S5/S5.h
+++ b/src/OpenLoco/src/S5/S5.h
@@ -421,7 +421,7 @@ namespace OpenLoco::S5
         ObjectHeader requiredObjects[859];
         GameState gameState;
         std::vector<TileElement> tileElements;
-        std::vector<std::pair<ObjectHeader, std::vector<uint8_t>>> packedObjects;
+        std::vector<std::pair<ObjectHeader, std::vector<std::byte>>> packedObjects;
     };
 
     enum class LoadFlags : uint32_t

--- a/src/OpenLoco/src/S5/SawyerStream.h
+++ b/src/OpenLoco/src/S5/SawyerStream.h
@@ -27,26 +27,26 @@ namespace OpenLoco
     class FastBuffer
     {
     private:
-        uint8_t* _data{};
+        std::byte* _data{};
         size_t _len{};
         size_t _capacity{};
 
-        static uint8_t* alloc(size_t len);
-        static uint8_t* realloc(uint8_t* ptr, size_t len);
-        static void free(uint8_t* ptr);
+        static std::byte* alloc(size_t len);
+        static std::byte* realloc(std::byte* ptr, size_t len);
+        static void free(std::byte* ptr);
 
     public:
         ~FastBuffer();
 
-        uint8_t* data();
+        std::byte* data();
         size_t size() const;
         void resize(size_t len);
         void reserve(size_t len);
         void clear();
-        void push_back(uint8_t value);
-        void push_back(uint8_t value, size_t len);
-        void push_back(const uint8_t* src, size_t len);
-        stdx::span<uint8_t const> getSpan() const;
+        void push_back(std::byte value);
+        void push_back(std::byte value, size_t len);
+        void push_back(const std::byte* src, size_t len);
+        stdx::span<const std::byte> getSpan() const;
     };
 
     class SawyerStreamReader
@@ -57,16 +57,16 @@ namespace OpenLoco
         FastBuffer _decodeBuffer;
         FastBuffer _decodeBuffer2;
 
-        stdx::span<uint8_t const> decode(SawyerEncoding encoding, stdx::span<uint8_t const> data);
-        static void decodeRunLengthSingle(FastBuffer& buffer, stdx::span<uint8_t const> data);
-        static void decodeRunLengthMulti(FastBuffer& buffer, stdx::span<uint8_t const> data);
-        static void decodeRotate(FastBuffer& buffer, stdx::span<uint8_t const> data);
+        stdx::span<const std::byte> decode(SawyerEncoding encoding, stdx::span<const std::byte> data);
+        static void decodeRunLengthSingle(FastBuffer& buffer, stdx::span<const std::byte> data);
+        static void decodeRunLengthMulti(FastBuffer& buffer, stdx::span<const std::byte> data);
+        static void decodeRotate(FastBuffer& buffer, stdx::span<const std::byte> data);
 
     public:
         SawyerStreamReader(Stream& stream);
         SawyerStreamReader(const fs::path& path);
 
-        stdx::span<uint8_t const> readChunk();
+        stdx::span<const std::byte> readChunk();
         size_t readChunk(void* data, size_t maxDataLen);
         void read(void* data, size_t dataLen);
         bool validateChecksum();
@@ -83,10 +83,10 @@ namespace OpenLoco
         FastBuffer _encodeBuffer2;
 
         void writeStream(const void* data, size_t dataLen);
-        stdx::span<uint8_t const> encode(SawyerEncoding encoding, stdx::span<uint8_t const> data);
-        static void encodeRunLengthSingle(FastBuffer& buffer, stdx::span<uint8_t const> data);
-        static void encodeRunLengthMulti(FastBuffer& buffer, stdx::span<uint8_t const> data);
-        static void encodeRotate(FastBuffer& buffer, stdx::span<uint8_t const> data);
+        stdx::span<const std::byte> encode(SawyerEncoding encoding, stdx::span<const std::byte> data);
+        static void encodeRunLengthSingle(FastBuffer& buffer, stdx::span<const std::byte> data);
+        static void encodeRunLengthMulti(FastBuffer& buffer, stdx::span<const std::byte> data);
+        static void encodeRotate(FastBuffer& buffer, stdx::span<const std::byte> data);
 
     public:
         SawyerStreamWriter(Stream& stream);

--- a/src/Utility/include/OpenLoco/Utility/Numeric.hpp
+++ b/src/Utility/include/OpenLoco/Utility/Numeric.hpp
@@ -11,34 +11,52 @@ namespace OpenLoco::Utility
 
     int32_t bitScanReverse(uint32_t source);
 
+    namespace Detail
+    {
+        // TODO: Move this into Core/Traits.hpp, however Core depends on Utility so we can't do that yet.
+        template<typename T, typename = void>
+        struct UnderlyingType
+        {
+            using type = T;
+        };
+
+        template<typename T>
+        struct UnderlyingType<T, std::enable_if_t<std::is_enum_v<T>>>
+        {
+            using type = typename std::underlying_type<T>::type;
+        };
+    }
+
     template<typename _UIntType>
     static constexpr _UIntType rol(_UIntType x, size_t shift)
     {
         // C++20 replace with std::rotl
-        static_assert(std::is_unsigned<_UIntType>::value, "result_type must be an unsigned integral type");
-        using limits = typename std::numeric_limits<_UIntType>;
+        using T = typename Detail::UnderlyingType<_UIntType>::type;
+        static_assert(std::is_unsigned_v<T>, "result_type must be an unsigned integral type");
+        using limits = typename std::numeric_limits<T>;
         const auto amount = shift & (limits::digits - 1);
         const auto upperShift = limits::digits - amount;
         if (amount == 0)
         {
             return x;
         }
-        return ((static_cast<_UIntType>(x) << amount) | (static_cast<_UIntType>(x) >> upperShift));
+        return static_cast<_UIntType>(((static_cast<T>(x) << amount) | (static_cast<T>(x) >> upperShift)));
     }
 
     template<typename _UIntType>
     static constexpr _UIntType ror(_UIntType x, size_t shift)
     {
         // C++20 replace with std::rotr
-        static_assert(std::is_unsigned<_UIntType>::value, "result_type must be an unsigned integral type");
-        using limits = std::numeric_limits<_UIntType>;
+        using T = typename Detail::UnderlyingType<_UIntType>::type;
+        static_assert(std::is_unsigned_v<T>, "result_type must be an unsigned integral type");
+        using limits = std::numeric_limits<T>;
         const auto amount = shift & (limits::digits - 1);
         const auto upperShift = limits::digits - amount;
         if (amount == 0)
         {
             return x;
         }
-        return ((static_cast<_UIntType>(x) >> amount) | (static_cast<_UIntType>(x) << upperShift));
+        return static_cast<_UIntType>(((static_cast<_UIntType>(x) >> amount) | (static_cast<_UIntType>(x) << upperShift)));
     }
 
     template<typename T>


### PR DESCRIPTION
This is for #1982, we should generally use std::byte for all raw memory data.