### PR TITLE
Remove window event interop

### DIFF
--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -2019,7 +2019,7 @@ namespace OpenLoco::Input
                             if (wnd)
                             {
                                 bool out = false;
-                                cursorId = wnd->call_15(x, y, cursorId, &out);
+                                cursorId = wnd->callToolCursor(x, y, cursorId, &out);
                                 if (out)
                                 {
                                     skipItem = true;

--- a/src/OpenLoco/src/Window.cpp
+++ b/src/OpenLoco/src/Window.cpp
@@ -1052,7 +1052,7 @@ namespace OpenLoco::Ui
     Ui::CursorId Window::call_15(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out)
     {
         if (eventHandlers->event_15 == nullptr)
-            return CursorId::pointer;
+            return fallback;
 
         assert(!isInteropEvent(eventHandlers->event_15));
 

--- a/src/OpenLoco/src/Window.cpp
+++ b/src/OpenLoco/src/Window.cpp
@@ -1049,14 +1049,14 @@ namespace OpenLoco::Ui
         eventHandlers->onToolAbort(*this, widgetIndex);
     }
 
-    Ui::CursorId Window::call_15(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out)
+    Ui::CursorId Window::callToolCursor(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out)
     {
-        if (eventHandlers->event_15 == nullptr)
+        if (eventHandlers->toolCursor == nullptr)
             return fallback;
 
-        assert(!isInteropEvent(eventHandlers->event_15));
+        assert(!isInteropEvent(eventHandlers->toolCursor));
 
-        return eventHandlers->event_15(*this, xPos, yPos, fallback, *out);
+        return eventHandlers->toolCursor(*this, xPos, yPos, fallback, *out);
     }
 
     Ui::CursorId Window::callCursor(int16_t widgetIdx, int16_t xPos, int16_t yPos, Ui::CursorId fallback)

--- a/src/OpenLoco/src/Window.cpp
+++ b/src/OpenLoco/src/Window.cpp
@@ -25,6 +25,12 @@ using namespace OpenLoco::World;
 
 namespace OpenLoco::Ui
 {
+    template<typename T>
+    static bool isInteropEvent(T e)
+    {
+        return (uint32_t)e < 0x004D7000;
+    }
+
     Window::Window(Ui::Point position, Ui::Size size)
         : x(position.x)
         , y(position.y)
@@ -948,6 +954,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->onClose == nullptr)
             return;
 
+        assert(!isInteropEvent(eventHandlers->onClose));
+
         eventHandlers->onClose(*this);
     }
 
@@ -955,6 +963,8 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onPeriodicUpdate == nullptr)
             return;
+
+        assert(!isInteropEvent(eventHandlers->onPeriodicUpdate));
 
         eventHandlers->onPeriodicUpdate(*this);
     }
@@ -964,6 +974,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->onUpdate == nullptr)
             return;
 
+        assert(!isInteropEvent(eventHandlers->onUpdate));
+
         eventHandlers->onUpdate(*this);
     }
 
@@ -971,6 +983,8 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->event_08 == nullptr)
             return;
+
+        assert(!isInteropEvent(eventHandlers->event_08));
 
         eventHandlers->event_08(*this);
     }
@@ -980,6 +994,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->event_09 == nullptr)
             return;
 
+        assert(!isInteropEvent(eventHandlers->event_09));
+
         eventHandlers->event_09(*this);
     }
 
@@ -987,6 +1003,8 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onToolUpdate == nullptr)
             return;
+
+        assert(!isInteropEvent(eventHandlers->onToolUpdate));
 
         eventHandlers->onToolUpdate(*this, widgetIndex, xPos, yPos);
     }
@@ -996,6 +1014,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->onToolDown == nullptr)
             return;
 
+        assert(!isInteropEvent(eventHandlers->onToolDown));
+
         eventHandlers->onToolDown(*this, widgetIndex, xPos, yPos);
     }
 
@@ -1003,6 +1023,8 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->toolDragContinue == nullptr)
             return;
+
+        assert(!isInteropEvent(eventHandlers->toolDragContinue));
 
         eventHandlers->toolDragContinue(*this, widgetIndex, xPos, yPos);
     }
@@ -1012,6 +1034,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->toolDragEnd == nullptr)
             return;
 
+        assert(!isInteropEvent(eventHandlers->toolDragEnd));
+
         eventHandlers->toolDragEnd(*this, widgetIndex);
     }
 
@@ -1019,6 +1043,8 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onToolAbort == nullptr)
             return;
+
+        assert(!isInteropEvent(eventHandlers->onToolAbort));
 
         eventHandlers->onToolAbort(*this, widgetIndex);
     }
@@ -1028,6 +1054,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->event_15 == nullptr)
             return CursorId::pointer;
 
+        assert(!isInteropEvent(eventHandlers->event_15));
+
         return eventHandlers->event_15(*this, xPos, yPos, fallback, *out);
     }
 
@@ -1035,6 +1063,8 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->cursor == nullptr)
             return fallback;
+
+        assert(!isInteropEvent(eventHandlers->cursor));
 
         return eventHandlers->cursor(*this, widgetIdx, xPos, yPos, fallback);
     }
@@ -1044,6 +1074,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->onMouseUp == nullptr)
             return;
 
+        assert(!isInteropEvent(&eventHandlers->onMouseUp));
+
         eventHandlers->onMouseUp(*this, widgetIndex);
     }
 
@@ -1051,6 +1083,8 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onResize == nullptr)
             return this;
+
+        assert(!isInteropEvent(eventHandlers->onResize));
 
         eventHandlers->onResize(*this);
         return this;
@@ -1061,6 +1095,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->event_03 == nullptr)
             return;
 
+        assert(!isInteropEvent(eventHandlers->event_03));
+
         eventHandlers->event_03(*this, widgetIndex);
     }
 
@@ -1068,6 +1104,8 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onMouseDown == nullptr)
             return;
+
+        assert(!isInteropEvent(eventHandlers->onMouseDown));
 
         eventHandlers->onMouseDown(*this, widgetIndex);
     }
@@ -1077,6 +1115,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->onDropdown == nullptr)
             return;
 
+        assert(!isInteropEvent(eventHandlers->onDropdown));
+
         eventHandlers->onDropdown(*this, widgetIndex, itemIndex);
     }
 
@@ -1084,6 +1124,8 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->getScrollSize == nullptr)
             return;
+
+        assert(!isInteropEvent(eventHandlers->getScrollSize));
 
         eventHandlers->getScrollSize(*this, scrollIndex, scrollWidth, scrollHeight);
     }
@@ -1093,6 +1135,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->scrollMouseDown == nullptr)
             return;
 
+        assert(!isInteropEvent(eventHandlers->scrollMouseDown));
+
         this->eventHandlers->scrollMouseDown(*this, xPos, yPos, scrollIndex);
     }
 
@@ -1100,6 +1144,8 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->scrollMouseDrag == nullptr)
             return;
+
+        assert(!isInteropEvent(eventHandlers->scrollMouseDrag));
 
         this->eventHandlers->scrollMouseDrag(*this, xPos, yPos, scrollIndex);
     }
@@ -1109,6 +1155,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->scrollMouseOver == nullptr)
             return;
 
+        assert(!isInteropEvent(eventHandlers->scrollMouseOver));
+
         this->eventHandlers->scrollMouseOver(*this, xPos, yPos, scrollIndex);
     }
 
@@ -1117,6 +1165,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->textInput == nullptr)
             return;
 
+        assert(!isInteropEvent(eventHandlers->textInput));
+
         this->eventHandlers->textInput(*this, caller, buffer);
     }
 
@@ -1124,6 +1174,8 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->viewportRotate == nullptr)
             return;
+
+        assert(!isInteropEvent(eventHandlers->viewportRotate));
 
         this->eventHandlers->viewportRotate(*this);
     }
@@ -1134,6 +1186,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->tooltip == nullptr)
             return FormatArguments();
 
+        assert(!isInteropEvent(eventHandlers->tooltip));
+
         return eventHandlers->tooltip(*this, widgetIndex);
     }
 
@@ -1141,6 +1195,8 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onMove == nullptr)
             return;
+
+        assert(!isInteropEvent(eventHandlers->onMove));
 
         this->eventHandlers->onMove(*this, xPos, yPos);
     }
@@ -1150,6 +1206,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->prepareDraw == nullptr)
             return;
 
+        assert(!isInteropEvent(eventHandlers->prepareDraw));
+
         eventHandlers->prepareDraw(*this);
     }
 
@@ -1158,6 +1216,8 @@ namespace OpenLoco::Ui
         if (eventHandlers->draw == nullptr)
             return;
 
+        assert(!isInteropEvent(this->eventHandlers->draw));
+
         eventHandlers->draw(*this, rt);
     }
 
@@ -1165,6 +1225,8 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->drawScroll == nullptr)
             return;
+
+        assert(!isInteropEvent(this->eventHandlers->drawScroll));
 
         eventHandlers->drawScroll(*this, *rt, scrollIndex);
     }

--- a/src/OpenLoco/src/Window.cpp
+++ b/src/OpenLoco/src/Window.cpp
@@ -25,12 +25,6 @@ using namespace OpenLoco::World;
 
 namespace OpenLoco::Ui
 {
-    template<typename T>
-    static bool isInteropEvent(T e)
-    {
-        return (uint32_t)e < 0x004D7000;
-    }
-
     Window::Window(Ui::Point position, Ui::Size size)
         : x(position.x)
         , y(position.y)
@@ -954,8 +948,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->onClose == nullptr)
             return;
 
-        assert(!isInteropEvent(eventHandlers->onClose));
-
         eventHandlers->onClose(*this);
     }
 
@@ -963,8 +955,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onPeriodicUpdate == nullptr)
             return;
-
-        assert(!isInteropEvent(eventHandlers->onPeriodicUpdate));
 
         eventHandlers->onPeriodicUpdate(*this);
     }
@@ -974,8 +964,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->onUpdate == nullptr)
             return;
 
-        assert(!isInteropEvent(eventHandlers->onUpdate));
-
         eventHandlers->onUpdate(*this);
     }
 
@@ -983,8 +971,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->event_08 == nullptr)
             return;
-
-        assert(!isInteropEvent(eventHandlers->event_08));
 
         eventHandlers->event_08(*this);
     }
@@ -994,8 +980,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->event_09 == nullptr)
             return;
 
-        assert(!isInteropEvent(eventHandlers->event_09));
-
         eventHandlers->event_09(*this);
     }
 
@@ -1003,8 +987,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onToolUpdate == nullptr)
             return;
-
-        assert(!isInteropEvent(eventHandlers->onToolUpdate));
 
         eventHandlers->onToolUpdate(*this, widgetIndex, xPos, yPos);
     }
@@ -1014,8 +996,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->onToolDown == nullptr)
             return;
 
-        assert(!isInteropEvent(eventHandlers->onToolDown));
-
         eventHandlers->onToolDown(*this, widgetIndex, xPos, yPos);
     }
 
@@ -1023,8 +1003,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->toolDragContinue == nullptr)
             return;
-
-        assert(!isInteropEvent(eventHandlers->toolDragContinue));
 
         eventHandlers->toolDragContinue(*this, widgetIndex, xPos, yPos);
     }
@@ -1034,8 +1012,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->toolDragEnd == nullptr)
             return;
 
-        assert(!isInteropEvent(eventHandlers->toolDragEnd));
-
         eventHandlers->toolDragEnd(*this, widgetIndex);
     }
 
@@ -1043,8 +1019,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onToolAbort == nullptr)
             return;
-
-        assert(!isInteropEvent(eventHandlers->onToolAbort));
 
         eventHandlers->onToolAbort(*this, widgetIndex);
     }
@@ -1054,8 +1028,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->toolCursor == nullptr)
             return fallback;
 
-        assert(!isInteropEvent(eventHandlers->toolCursor));
-
         return eventHandlers->toolCursor(*this, xPos, yPos, fallback, *out);
     }
 
@@ -1063,8 +1035,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->cursor == nullptr)
             return fallback;
-
-        assert(!isInteropEvent(eventHandlers->cursor));
 
         return eventHandlers->cursor(*this, widgetIdx, xPos, yPos, fallback);
     }
@@ -1074,8 +1044,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->onMouseUp == nullptr)
             return;
 
-        assert(!isInteropEvent(&eventHandlers->onMouseUp));
-
         eventHandlers->onMouseUp(*this, widgetIndex);
     }
 
@@ -1083,8 +1051,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onResize == nullptr)
             return this;
-
-        assert(!isInteropEvent(eventHandlers->onResize));
 
         eventHandlers->onResize(*this);
         return this;
@@ -1095,8 +1061,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->event_03 == nullptr)
             return;
 
-        assert(!isInteropEvent(eventHandlers->event_03));
-
         eventHandlers->event_03(*this, widgetIndex);
     }
 
@@ -1104,8 +1068,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onMouseDown == nullptr)
             return;
-
-        assert(!isInteropEvent(eventHandlers->onMouseDown));
 
         eventHandlers->onMouseDown(*this, widgetIndex);
     }
@@ -1115,8 +1077,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->onDropdown == nullptr)
             return;
 
-        assert(!isInteropEvent(eventHandlers->onDropdown));
-
         eventHandlers->onDropdown(*this, widgetIndex, itemIndex);
     }
 
@@ -1124,8 +1084,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->getScrollSize == nullptr)
             return;
-
-        assert(!isInteropEvent(eventHandlers->getScrollSize));
 
         eventHandlers->getScrollSize(*this, scrollIndex, scrollWidth, scrollHeight);
     }
@@ -1135,8 +1093,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->scrollMouseDown == nullptr)
             return;
 
-        assert(!isInteropEvent(eventHandlers->scrollMouseDown));
-
         this->eventHandlers->scrollMouseDown(*this, xPos, yPos, scrollIndex);
     }
 
@@ -1144,8 +1100,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->scrollMouseDrag == nullptr)
             return;
-
-        assert(!isInteropEvent(eventHandlers->scrollMouseDrag));
 
         this->eventHandlers->scrollMouseDrag(*this, xPos, yPos, scrollIndex);
     }
@@ -1155,8 +1109,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->scrollMouseOver == nullptr)
             return;
 
-        assert(!isInteropEvent(eventHandlers->scrollMouseOver));
-
         this->eventHandlers->scrollMouseOver(*this, xPos, yPos, scrollIndex);
     }
 
@@ -1165,8 +1117,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->textInput == nullptr)
             return;
 
-        assert(!isInteropEvent(eventHandlers->textInput));
-
         this->eventHandlers->textInput(*this, caller, buffer);
     }
 
@@ -1174,8 +1124,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->viewportRotate == nullptr)
             return;
-
-        assert(!isInteropEvent(eventHandlers->viewportRotate));
 
         this->eventHandlers->viewportRotate(*this);
     }
@@ -1186,8 +1134,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->tooltip == nullptr)
             return FormatArguments();
 
-        assert(!isInteropEvent(eventHandlers->tooltip));
-
         return eventHandlers->tooltip(*this, widgetIndex);
     }
 
@@ -1195,8 +1141,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onMove == nullptr)
             return;
-
-        assert(!isInteropEvent(eventHandlers->onMove));
 
         this->eventHandlers->onMove(*this, xPos, yPos);
     }
@@ -1206,8 +1150,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->prepareDraw == nullptr)
             return;
 
-        assert(!isInteropEvent(eventHandlers->prepareDraw));
-
         eventHandlers->prepareDraw(*this);
     }
 
@@ -1216,8 +1158,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->draw == nullptr)
             return;
 
-        assert(!isInteropEvent(this->eventHandlers->draw));
-
         eventHandlers->draw(*this, rt);
     }
 
@@ -1225,8 +1165,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->drawScroll == nullptr)
             return;
-
-        assert(!isInteropEvent(this->eventHandlers->drawScroll));
 
         eventHandlers->drawScroll(*this, *rt, scrollIndex);
     }

--- a/src/OpenLoco/src/Window.cpp
+++ b/src/OpenLoco/src/Window.cpp
@@ -25,12 +25,6 @@ using namespace OpenLoco::World;
 
 namespace OpenLoco::Ui
 {
-    template<typename T>
-    static bool isInteropEvent(T e)
-    {
-        return (uint32_t)e < 0x004D7000;
-    }
-
     Window::Window(Ui::Point position, Ui::Size size)
         : x(position.x)
         , y(position.y)
@@ -954,14 +948,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->onClose == nullptr)
             return;
 
-        if (isInteropEvent(eventHandlers->onClose))
-        {
-            registers regs;
-            regs.esi = X86Pointer(this);
-            call((uint32_t)this->eventHandlers->onClose, regs);
-            return;
-        }
-
         eventHandlers->onClose(*this);
     }
 
@@ -969,14 +955,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onPeriodicUpdate == nullptr)
             return;
-
-        if (isInteropEvent(eventHandlers->onPeriodicUpdate))
-        {
-            registers regs;
-            regs.esi = X86Pointer(this);
-            call((uint32_t)this->eventHandlers->onPeriodicUpdate, regs);
-            return;
-        }
 
         eventHandlers->onPeriodicUpdate(*this);
     }
@@ -986,14 +964,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->onUpdate == nullptr)
             return;
 
-        if (isInteropEvent(eventHandlers->onUpdate))
-        {
-            registers regs;
-            regs.esi = X86Pointer(this);
-            call((uintptr_t)this->eventHandlers->onUpdate, regs);
-            return;
-        }
-
         eventHandlers->onUpdate(*this);
     }
 
@@ -1001,14 +971,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->event_08 == nullptr)
             return;
-
-        if (isInteropEvent(eventHandlers->event_08))
-        {
-            registers regs;
-            regs.esi = X86Pointer(this);
-            call((uintptr_t)this->eventHandlers->event_08, regs);
-            return;
-        }
 
         eventHandlers->event_08(*this);
     }
@@ -1018,14 +980,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->event_09 == nullptr)
             return;
 
-        if (isInteropEvent(eventHandlers->event_09))
-        {
-            registers regs;
-            regs.esi = X86Pointer(this);
-            call((uintptr_t)this->eventHandlers->event_09, regs);
-            return;
-        }
-
         eventHandlers->event_09(*this);
     }
 
@@ -1033,17 +987,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onToolUpdate == nullptr)
             return;
-
-        if (isInteropEvent(eventHandlers->onToolUpdate))
-        {
-            registers regs;
-            regs.esi = X86Pointer(this);
-            regs.dx = widgetIndex;
-            regs.ax = xPos;
-            regs.bx = yPos;
-            call((uintptr_t)this->eventHandlers->onToolUpdate, regs);
-            return;
-        }
 
         eventHandlers->onToolUpdate(*this, widgetIndex, xPos, yPos);
     }
@@ -1053,17 +996,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->onToolDown == nullptr)
             return;
 
-        if (isInteropEvent(eventHandlers->onToolDown))
-        {
-            registers regs;
-            regs.ax = xPos;
-            regs.bx = yPos;
-            regs.dx = widgetIndex;
-            regs.esi = X86Pointer(this);
-            call((uint32_t)this->eventHandlers->onToolDown, regs);
-            return;
-        }
-
         eventHandlers->onToolDown(*this, widgetIndex, xPos, yPos);
     }
 
@@ -1071,17 +1003,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->toolDragContinue == nullptr)
             return;
-
-        if (isInteropEvent(eventHandlers->toolDragContinue))
-        {
-            registers regs;
-            regs.ax = xPos;
-            regs.bx = yPos;
-            regs.dx = widgetIndex;
-            regs.esi = X86Pointer(this);
-            call((uint32_t)this->eventHandlers->toolDragContinue, regs);
-            return;
-        }
 
         eventHandlers->toolDragContinue(*this, widgetIndex, xPos, yPos);
     }
@@ -1091,15 +1012,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->toolDragEnd == nullptr)
             return;
 
-        if (isInteropEvent(eventHandlers->toolDragEnd))
-        {
-            registers regs;
-            regs.dx = widgetIndex;
-            regs.esi = X86Pointer(this);
-            call((uint32_t)this->eventHandlers->toolDragEnd, regs);
-            return;
-        }
-
         eventHandlers->toolDragEnd(*this, widgetIndex);
     }
 
@@ -1108,15 +1020,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->onToolAbort == nullptr)
             return;
 
-        if (isInteropEvent(eventHandlers->onToolAbort))
-        {
-            registers regs;
-            regs.dx = widgetIndex;
-            regs.esi = X86Pointer(this);
-            call((uint32_t)this->eventHandlers->onToolAbort, regs);
-            return;
-        }
-
         eventHandlers->onToolAbort(*this, widgetIndex);
     }
 
@@ -1124,20 +1027,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->event_15 == nullptr)
             return CursorId::pointer;
-        if (isInteropEvent(eventHandlers->event_15))
-        {
-            registers regs;
-            regs.ax = xPos;
-            regs.bl = *out;
-            regs.cx = yPos;
-            regs.edi = (int32_t)fallback;
-            regs.esi = X86Pointer(this);
-            call(reinterpret_cast<uint32_t>(this->eventHandlers->event_15), regs);
-
-            *out = regs.bl;
-
-            return (CursorId)regs.edi;
-        }
 
         return eventHandlers->event_15(*this, xPos, yPos, fallback, *out);
     }
@@ -1147,25 +1036,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->cursor == nullptr)
             return fallback;
 
-        if (isInteropEvent(eventHandlers->cursor))
-        {
-            registers regs;
-            regs.cx = xPos;
-            regs.dx = yPos;
-            regs.ax = widgetIdx;
-            regs.ebx = -1;
-            regs.edi = X86Pointer(&this->widgets[widgetIdx]);
-            regs.esi = X86Pointer(this);
-            call((uintptr_t)this->eventHandlers->cursor, regs);
-
-            if (regs.ebx == -1)
-            {
-                return fallback;
-            }
-
-            return (CursorId)regs.ebx;
-        }
-
         return eventHandlers->cursor(*this, widgetIdx, xPos, yPos, fallback);
     }
 
@@ -1174,19 +1044,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->onMouseUp == nullptr)
             return;
 
-        if (isInteropEvent(&eventHandlers->onMouseUp))
-        {
-            registers regs;
-            regs.edx = widgetIndex;
-            regs.esi = X86Pointer(this);
-
-            // Not sure if this is used
-            regs.edi = X86Pointer(&this->widgets[widgetIndex]);
-
-            call((uintptr_t)this->eventHandlers->onMouseUp, regs);
-            return;
-        }
-
         eventHandlers->onMouseUp(*this, widgetIndex);
     }
 
@@ -1194,14 +1051,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onResize == nullptr)
             return this;
-
-        if (isInteropEvent(eventHandlers->onResize))
-        {
-            registers regs;
-            regs.esi = X86Pointer(this);
-            call((uint32_t)eventHandlers->onResize, regs);
-            return (Window*)regs.esi;
-        }
 
         eventHandlers->onResize(*this);
         return this;
@@ -1212,16 +1061,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->event_03 == nullptr)
             return;
 
-        if (isInteropEvent(eventHandlers->event_03))
-        {
-            registers regs;
-            regs.edx = widgetIndex;
-            regs.esi = X86Pointer(this);
-            regs.edi = X86Pointer(&this->widgets[widgetIndex]);
-            call((uint32_t)this->eventHandlers->event_03, regs);
-            return;
-        }
-
         eventHandlers->event_03(*this, widgetIndex);
     }
 
@@ -1229,16 +1068,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->onMouseDown == nullptr)
             return;
-
-        if (isInteropEvent(eventHandlers->onMouseDown))
-        {
-            registers regs;
-            regs.edx = widgetIndex;
-            regs.esi = X86Pointer(this);
-            regs.edi = X86Pointer(&this->widgets[widgetIndex]);
-            call((uint32_t)this->eventHandlers->onMouseDown, regs);
-            return;
-        }
 
         eventHandlers->onMouseDown(*this, widgetIndex);
     }
@@ -1248,16 +1077,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->onDropdown == nullptr)
             return;
 
-        if (isInteropEvent(eventHandlers->onDropdown))
-        {
-            registers regs;
-            regs.ax = itemIndex;
-            regs.edx = widgetIndex;
-            regs.esi = X86Pointer(this);
-            call((uint32_t)this->eventHandlers->onDropdown, regs);
-            return;
-        }
-
         eventHandlers->onDropdown(*this, widgetIndex, itemIndex);
     }
 
@@ -1265,17 +1084,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->getScrollSize == nullptr)
             return;
-
-        if (isInteropEvent(eventHandlers->getScrollSize))
-        {
-            registers regs;
-            regs.eax = scrollIndex;
-            regs.esi = X86Pointer(this);
-            call((uint32_t)this->eventHandlers->getScrollSize, regs);
-            *scrollWidth = regs.cx;
-            *scrollHeight = regs.dx;
-            return;
-        }
 
         eventHandlers->getScrollSize(*this, scrollIndex, scrollWidth, scrollHeight);
     }
@@ -1285,17 +1093,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->scrollMouseDown == nullptr)
             return;
 
-        if (isInteropEvent(eventHandlers->scrollMouseDown))
-        {
-            registers regs;
-            regs.ax = scrollIndex;
-            regs.esi = X86Pointer(this);
-            regs.cx = xPos;
-            regs.dx = yPos;
-            call((uint32_t)this->eventHandlers->scrollMouseDown, regs);
-            return;
-        }
-
         this->eventHandlers->scrollMouseDown(*this, xPos, yPos, scrollIndex);
     }
 
@@ -1303,17 +1100,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->scrollMouseDrag == nullptr)
             return;
-
-        if (isInteropEvent(eventHandlers->scrollMouseDrag))
-        {
-            registers regs;
-            regs.ax = scrollIndex;
-            regs.esi = X86Pointer(this);
-            regs.cx = xPos;
-            regs.dx = yPos;
-            call((uint32_t)this->eventHandlers->scrollMouseDrag, regs);
-            return;
-        }
 
         this->eventHandlers->scrollMouseDrag(*this, xPos, yPos, scrollIndex);
     }
@@ -1323,17 +1109,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->scrollMouseOver == nullptr)
             return;
 
-        if (isInteropEvent(eventHandlers->scrollMouseOver))
-        {
-            registers regs;
-            regs.ax = scrollIndex;
-            regs.esi = X86Pointer(this);
-            regs.cx = xPos;
-            regs.dx = yPos;
-            call((uint32_t)this->eventHandlers->scrollMouseOver, regs);
-            return;
-        }
-
         this->eventHandlers->scrollMouseOver(*this, xPos, yPos, scrollIndex);
     }
 
@@ -1342,17 +1117,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->textInput == nullptr)
             return;
 
-        if (isInteropEvent(eventHandlers->textInput))
-        {
-            registers regs;
-            regs.dx = caller;
-            regs.esi = X86Pointer(this);
-            regs.cl = 1;
-            regs.edi = X86Pointer(buffer);
-            call((uintptr_t)this->eventHandlers->textInput, regs);
-            return;
-        }
-
         this->eventHandlers->textInput(*this, caller, buffer);
     }
 
@@ -1360,14 +1124,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->viewportRotate == nullptr)
             return;
-
-        if (isInteropEvent(eventHandlers->viewportRotate))
-        {
-            registers regs;
-            regs.esi = X86Pointer(this);
-            call((uintptr_t)this->eventHandlers->viewportRotate, regs);
-            return;
-        }
 
         this->eventHandlers->viewportRotate(*this);
     }
@@ -1378,18 +1134,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->tooltip == nullptr)
             return FormatArguments();
 
-        if (isInteropEvent(eventHandlers->tooltip))
-        {
-            registers regs;
-            regs.ax = widgetIndex;
-            regs.esi = X86Pointer(this);
-            call((int32_t)this->eventHandlers->tooltip, regs);
-            auto args = FormatArguments();
-            if (regs.ax == (int16_t)StringIds::null)
-                return {};
-            return args;
-        }
-
         return eventHandlers->tooltip(*this, widgetIndex);
     }
 
@@ -1398,14 +1142,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->onMove == nullptr)
             return;
 
-        if (isInteropEvent(eventHandlers->onMove))
-        {
-            registers regs;
-            regs.cx = xPos;
-            regs.dx = yPos;
-            regs.esi = X86Pointer(this);
-            call(reinterpret_cast<int32_t>(this->eventHandlers->onMove), regs);
-        }
         this->eventHandlers->onMove(*this, xPos, yPos);
     }
 
@@ -1413,14 +1149,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->prepareDraw == nullptr)
             return;
-
-        if (isInteropEvent(eventHandlers->prepareDraw))
-        {
-            registers regs;
-            regs.esi = X86Pointer(this);
-            call((int32_t)this->eventHandlers->prepareDraw, regs);
-            return;
-        }
 
         eventHandlers->prepareDraw(*this);
     }
@@ -1430,15 +1158,6 @@ namespace OpenLoco::Ui
         if (eventHandlers->draw == nullptr)
             return;
 
-        if (isInteropEvent(this->eventHandlers->draw))
-        {
-            registers regs;
-            regs.esi = X86Pointer(this);
-            regs.edi = X86Pointer(rt);
-            call((int32_t)this->eventHandlers->draw, regs);
-            return;
-        }
-
         eventHandlers->draw(*this, rt);
     }
 
@@ -1446,16 +1165,6 @@ namespace OpenLoco::Ui
     {
         if (eventHandlers->drawScroll == nullptr)
             return;
-
-        if (isInteropEvent(this->eventHandlers->drawScroll))
-        {
-            registers regs;
-            regs.ax = scrollIndex;
-            regs.esi = X86Pointer(this);
-            regs.edi = X86Pointer(rt);
-            call((int32_t)eventHandlers->drawScroll, regs);
-            return;
-        }
 
         eventHandlers->drawScroll(*this, *rt, scrollIndex);
     }

--- a/src/OpenLoco/src/Window.h
+++ b/src/OpenLoco/src/Window.h
@@ -116,7 +116,7 @@ namespace OpenLoco::Ui
         void (*toolDragContinue)(Window&, const WidgetIndex_t, const int16_t, const int16_t) = nullptr;
         void (*toolDragEnd)(Window&, const WidgetIndex_t) = nullptr;
         void (*onToolAbort)(Window&, const WidgetIndex_t) = nullptr;
-        Ui::CursorId (*event_15)(Window&, const int16_t x, const int16_t y, const Ui::CursorId, bool&) = nullptr;
+        Ui::CursorId (*toolCursor)(Window&, const int16_t x, const int16_t y, const Ui::CursorId, bool&) = nullptr;
         void (*getScrollSize)(Window&, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight) = nullptr;
         void (*scrollMouseDown)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
         void (*scrollMouseDrag)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
@@ -400,7 +400,7 @@ namespace OpenLoco::Ui
         void callToolDragContinue(const int16_t widgetIndex, const int16_t xPos, const int16_t yPos);  // 12
         void callToolDragEnd(const int16_t widgetIndex);                                               // 13
         void callToolAbort(int16_t widgetIndex);                                                       // 14
-        Ui::CursorId call_15(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out);            // 15
+        Ui::CursorId callToolCursor(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out);     // 15
         void callGetScrollSize(uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);   // 16
         void callScrollMouseDown(int16_t x, int16_t y, uint8_t scrollIndex);                           // 17
         void callScrollMouseDrag(int16_t x, int16_t y, uint8_t scrollIndex);                           // 18

--- a/src/OpenLoco/src/Window.h
+++ b/src/OpenLoco/src/Window.h
@@ -101,48 +101,35 @@ namespace OpenLoco::Ui
 
     struct WindowEventList
     {
-        union
-        {
-            void* events[29];
-            struct
-            {
-                void (*onClose)(Window&);
-                void (*onMouseUp)(Window&, WidgetIndex_t);
-                void (*onResize)(Window&);
-                void (*event_03)(Window&, WidgetIndex_t); // mouse_over?
-                void (*onMouseDown)(Window&, WidgetIndex_t);
-                void (*onDropdown)(Window&, WidgetIndex_t, int16_t);
-                void (*onPeriodicUpdate)(Window&);
-                void (*onUpdate)(Window&);
-                void (*event_08)(Window&);
-                void (*event_09)(Window&);
-                void (*onToolUpdate)(Window&, const WidgetIndex_t, const int16_t, const int16_t);
-                void (*onToolDown)(Window&, const WidgetIndex_t, const int16_t, const int16_t);
-                void (*toolDragContinue)(Window&, const WidgetIndex_t, const int16_t, const int16_t);
-                void (*toolDragEnd)(Window&, const WidgetIndex_t);
-                void (*onToolAbort)(Window&, const WidgetIndex_t);
-                Ui::CursorId (*event_15)(Window&, const int16_t x, const int16_t y, const Ui::CursorId, bool&);
-                void (*getScrollSize)(Window&, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);
-                void (*scrollMouseDown)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex);
-                void (*scrollMouseDrag)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex);
-                void (*scrollMouseOver)(Ui::Window& window, int16_t x, int16_t y, uint8_t scrollIndex);
-                void (*textInput)(Window&, WidgetIndex_t, const char*);
-                void (*viewportRotate)(Window&);
-                uint32_t event_22;
-                std::optional<FormatArguments> (*tooltip)(Window&, WidgetIndex_t);
-                Ui::CursorId (*cursor)(Window&, int16_t, int16_t, int16_t, Ui::CursorId);
-                void (*onMove)(Window&, const int16_t x, const int16_t y);
-                void (*prepareDraw)(Window&);
-                void (*draw)(Window&, Gfx::RenderTarget*);
-                void (*drawScroll)(Window&, Gfx::RenderTarget&, const uint32_t scrollIndex);
-            };
-        };
-
-        WindowEventList()
-        {
-            // Set all events to a `ret` instruction
-            std::fill_n(events, 29, (void*)0x0042A034);
-        }
+        void (*onClose)(Window&) = nullptr;
+        void (*onMouseUp)(Window&, WidgetIndex_t) = nullptr;
+        void (*onResize)(Window&) = nullptr;
+        void (*event_03)(Window&, WidgetIndex_t) = nullptr; // mouse_over?
+        void (*onMouseDown)(Window&, WidgetIndex_t) = nullptr;
+        void (*onDropdown)(Window&, WidgetIndex_t, int16_t) = nullptr;
+        void (*onPeriodicUpdate)(Window&) = nullptr;
+        void (*onUpdate)(Window&) = nullptr;
+        void (*event_08)(Window&) = nullptr;
+        void (*event_09)(Window&) = nullptr;
+        void (*onToolUpdate)(Window&, const WidgetIndex_t, const int16_t, const int16_t) = nullptr;
+        void (*onToolDown)(Window&, const WidgetIndex_t, const int16_t, const int16_t) = nullptr;
+        void (*toolDragContinue)(Window&, const WidgetIndex_t, const int16_t, const int16_t) = nullptr;
+        void (*toolDragEnd)(Window&, const WidgetIndex_t) = nullptr;
+        void (*onToolAbort)(Window&, const WidgetIndex_t) = nullptr;
+        Ui::CursorId (*event_15)(Window&, const int16_t x, const int16_t y, const Ui::CursorId, bool&) = nullptr;
+        void (*getScrollSize)(Window&, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight) = nullptr;
+        void (*scrollMouseDown)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
+        void (*scrollMouseDrag)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
+        void (*scrollMouseOver)(Ui::Window& window, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
+        void (*textInput)(Window&, WidgetIndex_t, const char*) = nullptr;
+        void (*viewportRotate)(Window&) = nullptr;
+        uint32_t event_22;
+        std::optional<FormatArguments> (*tooltip)(Window&, WidgetIndex_t) = nullptr;
+        Ui::CursorId (*cursor)(Window&, int16_t, int16_t, int16_t, Ui::CursorId) = nullptr;
+        void (*onMove)(Window&, const int16_t x, const int16_t y) = nullptr;
+        void (*prepareDraw)(Window&) = nullptr;
+        void (*draw)(Window&, Gfx::RenderTarget*) = nullptr;
+        void (*drawScroll)(Window&, Gfx::RenderTarget&, const uint32_t scrollIndex) = nullptr;
     };
 
     struct SavedViewSimple

--- a/src/OpenLoco/src/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Windows/Vehicle.cpp
@@ -2904,7 +2904,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B50CE
-        static Ui::CursorId event15(Window& self, const int16_t x, const int16_t y, const Ui::CursorId fallback, bool& out)
+        static Ui::CursorId toolCursor(Window& self, const int16_t x, const int16_t y, const Ui::CursorId fallback, bool& out)
         {
             auto typeP = sub_4B5A1A(self, x, y);
             out = typeP.first != Ui::ViewportInteraction::InteractionItem::noInteraction;
@@ -3376,7 +3376,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             events.event_09 = Common::event9;
             events.onToolDown = onToolDown;
             events.onToolAbort = toolCancel;
-            events.event_15 = event15;
+            events.toolCursor = toolCursor;
             events.getScrollSize = getScrollSize;
             events.scrollMouseDown = scrollMouseDown;
             events.scrollMouseOver = scrollMouseOver;


### PR DESCRIPTION
All windows have been reimplemented for a while — save for the multiplayer one, which we're going to tackle in a different way. This means that we can now remove interop support for window events.

In doing so, I have found one bug hiding in the call for `event_15`. All events defaulted to an interop event, which meant the fallback/default cursor for `event_15` was never used in the C++ side of things. This meant e.g. terraform tool cursors wouldn't be set. Easy fix, fortunately. I'm renaming this event `toolCursor` in this PR as well, to reflect its usage.

I've currently left `isInteropEvent` in for assertion purposes. In my testing, it hasn't triggered, and I indeed haven't found any place where they should trigger. Before merging, I'd like the assertions to be removed, but I'd like others to test as well.

After this PR is merged, I'd like us to start using a vector as the container for windows, to finally increase the window limit. (Currently, we're limited to 12 windows max due us to staying in vanilla memory space.)