### PR TITLE
Introduce getClampedRange and getWorldRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 23.06.1+ (???)
 ------------------------------------------------------------------------
+- Feature: [#2013] Add headers for base/clearance height, direction, and ghost flag to the tile inspector.
 - Feature: [#7627] Allow mouse scrolling on +/- stepper widgets to change their values.
 - Fix: [#1999] Potential crash at startup due to the screen buffer being too small.
+- Fix: [#2011] Crash when using terraform tools using a range that exceeds the map edge.
 - Fix: [#2027] Crash when loading scenarios with a non-ASCII locomotion installtion path.
 - Fix: [#2028] Incorrect industry building clearing heights causing graphical glitches.
 - Fix: [#2039] Crash/hang when clicking on news items of new vehicle available.

--- a/src/Engine/include/OpenLoco/Engine/World.hpp
+++ b/src/Engine/include/OpenLoco/Engine/World.hpp
@@ -2,6 +2,7 @@
 
 #include "Types.hpp"
 #include <OpenLoco/Math/Vector.hpp>
+#include <algorithm>
 
 namespace OpenLoco::World
 {
@@ -97,5 +98,15 @@ namespace OpenLoco::World
     constexpr Pos2 toWorldSpace(const TilePos2& coords)
     {
         return Pos2{ static_cast<coord_t>(coords.x * kTileSize), static_cast<coord_t>(coords.y * kTileSize) };
+    }
+
+    constexpr coord_t clampCoord(coord_t coord)
+    {
+        return std::clamp<coord_t>(coord, 1, kMapWidth);
+    }
+
+    constexpr coord_t clampTileCoord(coord_t coord)
+    {
+        return std::clamp<coord_t>(coord, 1, kMapColumns);
     }
 }

--- a/src/Engine/include/OpenLoco/Engine/World.hpp
+++ b/src/Engine/include/OpenLoco/Engine/World.hpp
@@ -67,12 +67,12 @@ namespace OpenLoco::World
     // drawing coordinates validation differs from general valid coordinate validation
     constexpr bool drawableCoord(const coord_t coord)
     {
-        return (coord >= World::kTileSize) && (coord < (World::kMapWidth - World::kTileSize));
+        return (coord >= World::kTileSize) && (coord < (World::kMapWidth - World::kTileSize - 1));
     }
 
     constexpr bool drawableTileCoord(const tile_coord_t coord)
     {
-        return (coord >= 1) && (coord < (kMapRows - 1));
+        return (coord >= 1) && (coord < (kMapColumns - 2));
     }
 
     constexpr bool drawableCoords(const Pos2& coords)
@@ -102,11 +102,11 @@ namespace OpenLoco::World
 
     constexpr coord_t clampCoord(coord_t coord)
     {
-        return std::clamp<coord_t>(coord, 1, kMapWidth - 1);
+        return std::clamp<coord_t>(coord, 0, kMapWidth - 1);
     }
 
     constexpr coord_t clampTileCoord(coord_t coord)
     {
-        return std::clamp<coord_t>(coord, 1, kMapColumns - 1);
+        return std::clamp<coord_t>(coord, 0, kMapColumns - 1);
     }
 }

--- a/src/Engine/include/OpenLoco/Engine/World.hpp
+++ b/src/Engine/include/OpenLoco/Engine/World.hpp
@@ -102,11 +102,11 @@ namespace OpenLoco::World
 
     constexpr coord_t clampCoord(coord_t coord)
     {
-        return std::clamp<coord_t>(coord, 1, kMapWidth);
+        return std::clamp<coord_t>(coord, 1, kMapWidth - 1);
     }
 
     constexpr coord_t clampTileCoord(coord_t coord)
     {
-        return std::clamp<coord_t>(coord, 1, kMapColumns);
+        return std::clamp<coord_t>(coord, 1, kMapColumns - 1);
     }
 }

--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -149,6 +149,7 @@ set(OLOCO_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/SurfaceElement.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/Tile.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/TileClearance.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/TileLoop.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/TileManager.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/Track/SubpositionData.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/Track/Track.cpp"

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -844,8 +844,8 @@ namespace OpenLoco::Audio
             const auto centre = mainViewport->getCentreMapPosition();
             const auto topLeft = World::toTileSpace(centre) - World::TilePos2{ 5, 5 };
             const auto bottomRight = topLeft + World::TilePos2{ 11, 11 };
+            const auto searchRange = World::getClampedRange(topLeft, bottomRight);
 
-            auto searchRange = World::getClampedRange(topLeft, bottomRight);
             size_t waterCount = 0;      // bl
             size_t wildernessCount = 0; // bh
             size_t treeCount = 0;       // cx

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -844,16 +844,13 @@ namespace OpenLoco::Audio
             const auto centre = mainViewport->getCentreMapPosition();
             const auto topLeft = World::toTileSpace(centre) - World::TilePos2{ 5, 5 };
             const auto bottomRight = topLeft + World::TilePos2{ 11, 11 };
-            World::TilePosRangeView searchRange(topLeft, bottomRight);
+
+            auto searchRange = World::getClampedRange(topLeft, bottomRight);
             size_t waterCount = 0;      // bl
             size_t wildernessCount = 0; // bh
             size_t treeCount = 0;       // cx
             for (auto& tilePos : searchRange)
             {
-                if (!World::validCoords(tilePos))
-                {
-                    continue;
-                }
                 const auto tile = World::TileManager::get(tilePos);
                 bool passedSurface = false;
                 for (const auto& el : tile)

--- a/src/OpenLoco/src/GameCommands/ChangeLandMaterial.cpp
+++ b/src/OpenLoco/src/GameCommands/ChangeLandMaterial.cpp
@@ -27,6 +27,9 @@ namespace OpenLoco::GameCommands
         World::TilePosRangeView tileLoop{ World::toTileSpace(pointA), World::toTileSpace(pointB) };
         for (const auto& tilePos : tileLoop)
         {
+            if (!World::validCoords(tilePos))
+                continue;
+
             auto surface = World::TileManager::get(tilePos).surface();
             if (surface == nullptr)
                 continue;

--- a/src/OpenLoco/src/GameCommands/ChangeLandMaterial.cpp
+++ b/src/OpenLoco/src/GameCommands/ChangeLandMaterial.cpp
@@ -24,12 +24,9 @@ namespace OpenLoco::GameCommands
             return 0;
         }
 
-        World::TilePosRangeView tileLoop{ World::toTileSpace(pointA), World::toTileSpace(pointB) };
+        auto tileLoop = World::getClampedRange(pointA, pointB);
         for (const auto& tilePos : tileLoop)
         {
-            if (!World::validCoords(tilePos))
-                continue;
-
             auto surface = World::TileManager::get(tilePos).surface();
             if (surface == nullptr)
                 continue;

--- a/src/OpenLoco/src/GameCommands/ChangeLandMaterial.cpp
+++ b/src/OpenLoco/src/GameCommands/ChangeLandMaterial.cpp
@@ -24,7 +24,7 @@ namespace OpenLoco::GameCommands
             return 0;
         }
 
-        auto tileLoop = World::getClampedRange(pointA, pointB);
+        const auto tileLoop = World::getClampedRange(pointA, pointB);
         for (const auto& tilePos : tileLoop)
         {
             auto surface = World::TileManager::get(tilePos).surface();

--- a/src/OpenLoco/src/GameCommands/ClearLand.cpp
+++ b/src/OpenLoco/src/GameCommands/ClearLand.cpp
@@ -60,7 +60,7 @@ namespace OpenLoco::GameCommands
     // 0x00469CCB
     static uint32_t clearLand(const ClearLandArgs& args, const uint8_t flags)
     {
-        auto tileLoop = World::getClampedRange(args.pointA, args.pointB);
+        const auto tileLoop = World::getClampedRange(args.pointA, args.pointB);
         uint32_t totalCost = 0;
 
         // We keep track of removed buildings for each tile visited

--- a/src/OpenLoco/src/GameCommands/ClearLand.cpp
+++ b/src/OpenLoco/src/GameCommands/ClearLand.cpp
@@ -60,7 +60,7 @@ namespace OpenLoco::GameCommands
     // 0x00469CCB
     static uint32_t clearLand(const ClearLandArgs& args, const uint8_t flags)
     {
-        World::TilePosRangeView tileLoop{ World::toTileSpace(args.pointA), World::toTileSpace(args.pointB) };
+        auto tileLoop = World::getClampedRange(args.pointA, args.pointB);
         uint32_t totalCost = 0;
 
         // We keep track of removed buildings for each tile visited

--- a/src/OpenLoco/src/GameCommands/LowerLand.cpp
+++ b/src/OpenLoco/src/GameCommands/LowerLand.cpp
@@ -33,15 +33,12 @@ namespace OpenLoco::GameCommands
             }
         }
 
-        World::TilePosRangeView tileLoop{ toTileSpace(args.pointA), toTileSpace(args.pointB) };
+        auto tileLoop = World::getClampedRange(args.pointA, args.pointB);
 
         // Find out what the highest baseZ in the selected range is
         auto highestBaseZ = 0;
         for (const auto& tilePos : tileLoop)
         {
-            if (!validCoords(tilePos))
-                continue;
-
             auto tile = TileManager::get(tilePos);
             auto* surface = tile.surface();
 
@@ -53,9 +50,6 @@ namespace OpenLoco::GameCommands
         auto totalCost = 0;
         for (const auto& tilePos : tileLoop)
         {
-            if (!validCoords(tilePos))
-                continue;
-
             auto tile = TileManager::get(tilePos);
             auto* surface = tile.surface();
 

--- a/src/OpenLoco/src/GameCommands/LowerLand.cpp
+++ b/src/OpenLoco/src/GameCommands/LowerLand.cpp
@@ -33,7 +33,7 @@ namespace OpenLoco::GameCommands
             }
         }
 
-        auto tileLoop = World::getClampedRange(args.pointA, args.pointB);
+        const auto tileLoop = World::getClampedRange(args.pointA, args.pointB);
 
         // Find out what the highest baseZ in the selected range is
         auto highestBaseZ = 0;

--- a/src/OpenLoco/src/GameCommands/LowerLand.cpp
+++ b/src/OpenLoco/src/GameCommands/LowerLand.cpp
@@ -39,6 +39,9 @@ namespace OpenLoco::GameCommands
         auto highestBaseZ = 0;
         for (const auto& tilePos : tileLoop)
         {
+            if (!validCoords(tilePos))
+                continue;
+
             auto tile = TileManager::get(tilePos);
             auto* surface = tile.surface();
 
@@ -50,6 +53,9 @@ namespace OpenLoco::GameCommands
         auto totalCost = 0;
         for (const auto& tilePos : tileLoop)
         {
+            if (!validCoords(tilePos))
+                continue;
+
             auto tile = TileManager::get(tilePos);
             auto* surface = tile.surface();
 

--- a/src/OpenLoco/src/GameCommands/LowerWater.cpp
+++ b/src/OpenLoco/src/GameCommands/LowerWater.cpp
@@ -28,15 +28,12 @@ namespace OpenLoco::GameCommands
             S5::getOptions().madeAnyChanges = 1;
         }
 
-        World::TilePosRangeView tileLoop{ toTileSpace(args.pointA), toTileSpace(args.pointB) };
+        auto tileLoop = getClampedRange(args.pointA, args.pointB);
 
         // Find out what the highest water height in the selected range is
         auto highestWaterHeight = 0;
         for (const auto& tilePos : tileLoop)
         {
-            if (!validCoords(tilePos))
-                continue;
-
             auto tile = World::TileManager::get(tilePos);
             auto* surface = tile.surface();
             if (surface->water())
@@ -51,9 +48,6 @@ namespace OpenLoco::GameCommands
             // Now modify only the elements matching this highest water height
             for (const auto& tilePos : tileLoop)
             {
-                if (!validCoords(tilePos))
-                    continue;
-
                 auto tile = World::TileManager::get(tilePos);
                 auto* surface = tile.surface();
                 auto waterHeight = surface->water() * kMicroToSmallZStep;

--- a/src/OpenLoco/src/GameCommands/LowerWater.cpp
+++ b/src/OpenLoco/src/GameCommands/LowerWater.cpp
@@ -28,7 +28,7 @@ namespace OpenLoco::GameCommands
             S5::getOptions().madeAnyChanges = 1;
         }
 
-        auto tileLoop = getClampedRange(args.pointA, args.pointB);
+        const auto tileLoop = getClampedRange(args.pointA, args.pointB);
 
         // Find out what the highest water height in the selected range is
         auto highestWaterHeight = 0;

--- a/src/OpenLoco/src/GameCommands/LowerWater.cpp
+++ b/src/OpenLoco/src/GameCommands/LowerWater.cpp
@@ -34,6 +34,9 @@ namespace OpenLoco::GameCommands
         auto highestWaterHeight = 0;
         for (const auto& tilePos : tileLoop)
         {
+            if (!validCoords(tilePos))
+                continue;
+
             auto tile = World::TileManager::get(tilePos);
             auto* surface = tile.surface();
             if (surface->water())
@@ -48,6 +51,9 @@ namespace OpenLoco::GameCommands
             // Now modify only the elements matching this highest water height
             for (const auto& tilePos : tileLoop)
             {
+                if (!validCoords(tilePos))
+                    continue;
+
                 auto tile = World::TileManager::get(tilePos);
                 auto* surface = tile.surface();
                 auto waterHeight = surface->water() * kMicroToSmallZStep;

--- a/src/OpenLoco/src/GameCommands/RaiseLand.cpp
+++ b/src/OpenLoco/src/GameCommands/RaiseLand.cpp
@@ -33,15 +33,12 @@ namespace OpenLoco::GameCommands
             }
         }
 
-        World::TilePosRangeView tileLoop{ toTileSpace(args.pointA), toTileSpace(args.pointB) };
+        auto tileLoop = getClampedRange(args.pointA, args.pointB);
 
         // Find out what the lowest baseZ in the selected range is
         auto lowestBaseZ = 255;
         for (const auto& tilePos : tileLoop)
         {
-            if (!validCoords(tilePos))
-                continue;
-
             auto tile = World::TileManager::get(tilePos);
             auto* surface = tile.surface();
             lowestBaseZ = std::min<SmallZ>(lowestBaseZ, surface->baseZ());
@@ -51,9 +48,6 @@ namespace OpenLoco::GameCommands
         auto totalCost = 0;
         for (const auto& tilePos : tileLoop)
         {
-            if (!validCoords(tilePos))
-                continue;
-
             auto tile = World::TileManager::get(tilePos);
             auto* surface = tile.surface();
             if (surface->baseZ() > lowestBaseZ)

--- a/src/OpenLoco/src/GameCommands/RaiseLand.cpp
+++ b/src/OpenLoco/src/GameCommands/RaiseLand.cpp
@@ -33,7 +33,7 @@ namespace OpenLoco::GameCommands
             }
         }
 
-        auto tileLoop = getClampedRange(args.pointA, args.pointB);
+        const auto tileLoop = getClampedRange(args.pointA, args.pointB);
 
         // Find out what the lowest baseZ in the selected range is
         auto lowestBaseZ = 255;

--- a/src/OpenLoco/src/GameCommands/RaiseLand.cpp
+++ b/src/OpenLoco/src/GameCommands/RaiseLand.cpp
@@ -39,6 +39,9 @@ namespace OpenLoco::GameCommands
         auto lowestBaseZ = 255;
         for (const auto& tilePos : tileLoop)
         {
+            if (!validCoords(tilePos))
+                continue;
+
             auto tile = World::TileManager::get(tilePos);
             auto* surface = tile.surface();
             lowestBaseZ = std::min<SmallZ>(lowestBaseZ, surface->baseZ());
@@ -48,6 +51,9 @@ namespace OpenLoco::GameCommands
         auto totalCost = 0;
         for (const auto& tilePos : tileLoop)
         {
+            if (!validCoords(tilePos))
+                continue;
+
             auto tile = World::TileManager::get(tilePos);
             auto* surface = tile.surface();
             if (surface->baseZ() > lowestBaseZ)

--- a/src/OpenLoco/src/GameCommands/RaiseWater.cpp
+++ b/src/OpenLoco/src/GameCommands/RaiseWater.cpp
@@ -28,7 +28,7 @@ namespace OpenLoco::GameCommands
             S5::getOptions().madeAnyChanges = 1;
         }
 
-        auto tileLoop = getClampedRange(args.pointA, args.pointB);
+        const auto tileLoop = getClampedRange(args.pointA, args.pointB);
 
         // Find out what the lowest baseZ in the selected range is
         auto lowestBaseZ = 255;

--- a/src/OpenLoco/src/GameCommands/RaiseWater.cpp
+++ b/src/OpenLoco/src/GameCommands/RaiseWater.cpp
@@ -28,15 +28,12 @@ namespace OpenLoco::GameCommands
             S5::getOptions().madeAnyChanges = 1;
         }
 
-        World::TilePosRangeView tileLoop{ toTileSpace(args.pointA), toTileSpace(args.pointB) };
+        auto tileLoop = getClampedRange(args.pointA, args.pointB);
 
         // Find out what the lowest baseZ in the selected range is
         auto lowestBaseZ = 255;
         for (const auto& tilePos : tileLoop)
         {
-            if (!validCoords(tilePos))
-                continue;
-
             auto tile = World::TileManager::get(tilePos);
             auto* surface = tile.surface();
 
@@ -52,9 +49,6 @@ namespace OpenLoco::GameCommands
         // Now modify only the elements matching this lowest baseZ
         for (const auto& tilePos : tileLoop)
         {
-            if (!validCoords(tilePos))
-                continue;
-
             auto tile = World::TileManager::get(tilePos);
             auto* surface = tile.surface();
             if (surface->baseZ() > lowestBaseZ)

--- a/src/OpenLoco/src/GameCommands/RaiseWater.cpp
+++ b/src/OpenLoco/src/GameCommands/RaiseWater.cpp
@@ -34,6 +34,9 @@ namespace OpenLoco::GameCommands
         auto lowestBaseZ = 255;
         for (const auto& tilePos : tileLoop)
         {
+            if (!validCoords(tilePos))
+                continue;
+
             auto tile = World::TileManager::get(tilePos);
             auto* surface = tile.surface();
 
@@ -49,6 +52,9 @@ namespace OpenLoco::GameCommands
         // Now modify only the elements matching this lowest baseZ
         for (const auto& tilePos : tileLoop)
         {
+            if (!validCoords(tilePos))
+                continue;
+
             auto tile = World::TileManager::get(tilePos);
             auto* surface = tile.surface();
             if (surface->baseZ() > lowestBaseZ)

--- a/src/OpenLoco/src/GameCommands/RemoveIndustry.cpp
+++ b/src/OpenLoco/src/GameCommands/RemoveIndustry.cpp
@@ -93,7 +93,7 @@ namespace OpenLoco::GameCommands
     // 0x00455A5C
     static void revokeAllSurfaceClaims(const IndustryId id)
     {
-        for (auto& pos : World::TilePosRangeView({ 1, 1 }, { World::kMapRows - 1, World::kMapColumns - 1 }))
+        for (auto& pos : World::getWorldRange())
         {
             auto tile = World::TileManager::get(pos);
             auto* surface = tile.surface();

--- a/src/OpenLoco/src/GameCommands/RemoveTown.cpp
+++ b/src/OpenLoco/src/GameCommands/RemoveTown.cpp
@@ -44,9 +44,7 @@ namespace OpenLoco::GameCommands
 
         // Iterate over the entire map to find town tiles
         // TODO: can't we do better than vanilla for this? e.g. a radius around the town centre?
-        TilePosRangeView tileLoop{ { 1, 1 }, { kMapColumns - 1, kMapRows - 1 } };
-
-        for (auto& tilePos : tileLoop)
+        for (auto& tilePos : getWorldRange())
         {
             auto tile = TileManager::get(tilePos);
 

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -217,14 +217,9 @@ namespace OpenLoco::World
             constexpr coord_t kLowerRange = 4;
 
             // Find all stations in range of industry building
-            const auto tileStart = World::toTileSpace(loc);
-            for (auto& tilePos : TilePosRangeView(tileStart - World::TilePos2{ kLowerRange, kLowerRange }, tileStart + World::TilePos2{ upperRange, upperRange }))
+            const auto tileStart = toTileSpace(loc);
+            for (auto& tilePos : getClampedRange(tileStart - TilePos2{ kLowerRange, kLowerRange }, tileStart + TilePos2{ upperRange, upperRange }))
             {
-                if (!validCoords(tilePos))
-                {
-                    continue;
-                }
-
                 auto tile = TileManager::get(tilePos);
                 for (auto& el : tile)
                 {

--- a/src/OpenLoco/src/Map/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator.cpp
@@ -583,7 +583,7 @@ namespace OpenLoco::World::MapGenerator
             return;
         }
 
-        TilePosRangeView tileLoop = getWorldRange();
+        const TilePosRangeView tileLoop = getWorldRange();
         for (const auto& tilePos : tileLoop)
         {
             auto* surface = World::TileManager::get(tilePos).surface();

--- a/src/OpenLoco/src/Map/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator.cpp
@@ -583,7 +583,7 @@ namespace OpenLoco::World::MapGenerator
             return;
         }
 
-        const TilePosRangeView tileLoop = getWorldRange();
+        const TilePosRangeView tileLoop = getDrawableTileRange();
         for (const auto& tilePos : tileLoop)
         {
             auto* surface = World::TileManager::get(tilePos).surface();

--- a/src/OpenLoco/src/Map/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator.cpp
@@ -583,7 +583,7 @@ namespace OpenLoco::World::MapGenerator
             return;
         }
 
-        TilePosRangeView tileLoop{ { 1, 1 }, { kMapColumns - 1, kMapRows - 1 } };
+        TilePosRangeView tileLoop = getWorldRange();
         for (const auto& tilePos : tileLoop)
         {
             auto* surface = World::TileManager::get(tilePos).surface();
@@ -658,7 +658,7 @@ namespace OpenLoco::World::MapGenerator
         uint32_t randMask = gPrng1().randNext();
         uint32_t i = 0;
         std::vector<TileElement*> toBeRemoved;
-        for (auto& loc : TilePosRangeView({}, { kMapRows - 1, kMapColumns - 1 }))
+        for (auto& loc : getWorldRange())
         {
             auto tile = TileManager::get(loc);
             for (auto& el : tile)

--- a/src/OpenLoco/src/Map/TileLoop.cpp
+++ b/src/OpenLoco/src/Map/TileLoop.cpp
@@ -18,11 +18,11 @@ namespace OpenLoco::World
 
     TilePosRangeView getDrawableTileRange()
     {
-        return TilePosRangeView({ 1, 1 }, { kMapColumns - 1, kMapRows - 1 });
+        return TilePosRangeView({ 1, 1 }, { kMapColumns - 2, kMapRows - 2 });
     }
 
     TilePosRangeView getWorldRange()
     {
-        return TilePosRangeView({ 0, 0 }, { kMapColumns, kMapRows });
+        return TilePosRangeView({ 0, 0 }, { kMapColumns - 1, kMapRows - 1 });
     }
 }

--- a/src/OpenLoco/src/Map/TileLoop.cpp
+++ b/src/OpenLoco/src/Map/TileLoop.cpp
@@ -1,0 +1,23 @@
+#include "TileLoop.hpp"
+
+namespace OpenLoco::World
+{
+    TilePosRangeView getClampedRange(const TilePos2& posA, const TilePos2& posB)
+    {
+        auto clampedA = TilePos2(clampTileCoord(posA.x), clampTileCoord(posA.y));
+        auto clampedB = TilePos2(clampTileCoord(posB.x), clampTileCoord(posB.y));
+        return TilePosRangeView(clampedA, clampedB);
+    }
+
+    TilePosRangeView getClampedRange(const Pos2& posA, const Pos2& posB)
+    {
+        auto clampedA = Pos2(clampCoord(posA.x), clampCoord(posA.y));
+        auto clampedB = Pos2(clampCoord(posB.x), clampCoord(posB.y));
+        return TilePosRangeView(toTileSpace(clampedA), toTileSpace(clampedB));
+    }
+
+    TilePosRangeView getWorldRange()
+    {
+        return TilePosRangeView({ 1, 1 }, { kMapColumns - 1, kMapRows - 1 });
+    }
+}

--- a/src/OpenLoco/src/Map/TileLoop.cpp
+++ b/src/OpenLoco/src/Map/TileLoop.cpp
@@ -16,8 +16,13 @@ namespace OpenLoco::World
         return TilePosRangeView(toTileSpace(clampedA), toTileSpace(clampedB));
     }
 
-    TilePosRangeView getWorldRange()
+    TilePosRangeView getDrawableTileRange()
     {
         return TilePosRangeView({ 1, 1 }, { kMapColumns - 1, kMapRows - 1 });
+    }
+
+    TilePosRangeView getWorldRange()
+    {
+        return TilePosRangeView({ 0, 0 }, { kMapColumns, kMapRows });
     }
 }

--- a/src/OpenLoco/src/Map/TileLoop.hpp
+++ b/src/OpenLoco/src/Map/TileLoop.hpp
@@ -111,5 +111,6 @@ namespace OpenLoco::World
 
     TilePosRangeView getClampedRange(const TilePos2& posA, const TilePos2& posB);
     TilePosRangeView getClampedRange(const Pos2& posA, const Pos2& posB);
+    TilePosRangeView getDrawableTileRange();
     TilePosRangeView getWorldRange();
 }

--- a/src/OpenLoco/src/Map/TileLoop.hpp
+++ b/src/OpenLoco/src/Map/TileLoop.hpp
@@ -108,4 +108,8 @@ namespace OpenLoco::World
             return Iterator(TilePos2(_bottomLeft.x, _topRight.y + 1), _topRight);
         }
     };
+
+    TilePosRangeView getClampedRange(const TilePos2& posA, const TilePos2& posB);
+    TilePosRangeView getClampedRange(const Pos2& posA, const Pos2& posB);
+    TilePosRangeView getWorldRange();
 }

--- a/src/OpenLoco/src/Map/TileManager.cpp
+++ b/src/OpenLoco/src/Map/TileManager.cpp
@@ -746,10 +746,8 @@ namespace OpenLoco::World::TileManager
         // (Its just the heighest point - the lowest point)
         int16_t lowest = std::numeric_limits<int16_t>::max();
         int16_t highest = 0;
-        const auto initialTilePos = World::toTileSpace(loc);
-        World::TilePosRangeView range{
-            initialTilePos - World::TilePos2{ 5, 5 }, initialTilePos + World::TilePos2{ 5, 5 }
-        };
+        const auto initialTilePos = toTileSpace(loc);
+        auto range = getClampedRange(initialTilePos - TilePos2{ 5, 5 }, initialTilePos + TilePos2{ 5, 5 });
         for (auto& tilePos : range)
         {
             if (!World::validCoords(tilePos))
@@ -804,15 +802,12 @@ namespace OpenLoco::World::TileManager
     {
         // Search a 10x10 area centred at pos.
         // Initial tile position is the top left of the area.
-        auto initialTilePos = World::toTileSpace(pos) - World::TilePos2(5, 5);
+        auto initialTilePos = toTileSpace(pos) - TilePos2(5, 5);
 
         uint16_t surroundingDesertTiles = 0;
 
-        for (const auto& tilePos : TilePosRangeView(initialTilePos, initialTilePos + World::TilePos2{ 10, 10 }))
+        for (const auto& tilePos : getClampedRange(initialTilePos, initialTilePos + TilePos2{ 10, 10 }))
         {
-            if (!World::validCoords(tilePos))
-                continue;
-
             auto tile = get(tilePos);
             auto* surface = tile.surface();
             // Desert tiles can't have water! Oasis aren't deserts.

--- a/src/OpenLoco/src/Map/TileManager.cpp
+++ b/src/OpenLoco/src/Map/TileManager.cpp
@@ -750,10 +750,6 @@ namespace OpenLoco::World::TileManager
         auto range = getClampedRange(initialTilePos - TilePos2{ 5, 5 }, initialTilePos + TilePos2{ 5, 5 });
         for (auto& tilePos : range)
         {
-            if (!World::validCoords(tilePos))
-            {
-                continue;
-            }
             auto tile = World::TileManager::get(tilePos);
             auto* surface = tile.surface();
             auto height = surface->baseHeight();

--- a/src/OpenLoco/src/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/StationTab.cpp
@@ -264,7 +264,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         _constructionArrowDirection = args->rotation;
         _constructionArrowPos = args->pos;
 
-        setMapSelectedTilesFromRange(World::TilePosRangeView(World::toTileSpace(*_1135F7C), World::toTileSpace(*_1135F90)));
+        setMapSelectedTilesFromRange(World::getClampedRange(*_1135F7C, *_1135F90));
 
         if ((_ghostVisibilityFlags & GhostVisibilityFlags::station) != GhostVisibilityFlags::none)
         {
@@ -327,7 +327,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         _constructionArrowDirection = args->rotation;
         _constructionArrowPos = args->pos;
 
-        setMapSelectedTilesFromRange(World::TilePosRangeView(World::toTileSpace(*_1135F7C), World::toTileSpace(*_1135F90)));
+        setMapSelectedTilesFromRange(World::getClampedRange(*_1135F7C, *_1135F90));
 
         if ((_ghostVisibilityFlags & GhostVisibilityFlags::station) != GhostVisibilityFlags::none)
         {

--- a/src/OpenLoco/src/World/Industry.cpp
+++ b/src/OpenLoco/src/World/Industry.cpp
@@ -568,12 +568,8 @@ namespace OpenLoco
         }
 
         std::size_t i = 0;
-        for (const auto& tilePos : TilePosRangeView{ topRight, bottomLeft })
+        for (const auto& tilePos : getClampedRange(topRight, bottomLeft))
         {
-            if (!World::validCoords(tilePos))
-            {
-                continue;
-            }
             if (is23prng.has_value())
             {
                 const auto randVal = is23prng->randNext();

--- a/src/OpenLoco/src/World/Industry.cpp
+++ b/src/OpenLoco/src/World/Industry.cpp
@@ -530,15 +530,12 @@ namespace OpenLoco
     {
         std::size_t numBorders = 0;
         // Search a 5x5 area centred on Pos
-        const auto initialTilePos = World::toTileSpace(pos);
+        const auto initialTilePos = toTileSpace(pos);
         const auto topRight = initialTilePos - TilePos2{ 2, 2 };
         const auto bottomLeft = initialTilePos + TilePos2{ 2, 2 };
-        for (const auto& tilePos : TilePosRangeView{ topRight, bottomLeft })
+
+        for (const auto& tilePos : getClampedRange(topRight, bottomLeft))
         {
-            if (!World::validCoords(tilePos))
-            {
-                continue;
-            }
             if (isSurfaceClaimed(tilePos))
             {
                 numBorders++;

--- a/src/OpenLoco/src/World/Industry.cpp
+++ b/src/OpenLoco/src/World/Industry.cpp
@@ -535,6 +535,10 @@ namespace OpenLoco
         const auto bottomLeft = initialTilePos + TilePos2{ 2, 2 };
         for (const auto& tilePos : TilePosRangeView{ topRight, bottomLeft })
         {
+            if (!World::validCoords(tilePos))
+            {
+                continue;
+            }
             if (isSurfaceClaimed(tilePos))
             {
                 numBorders++;
@@ -569,6 +573,10 @@ namespace OpenLoco
         std::size_t i = 0;
         for (const auto& tilePos : TilePosRangeView{ topRight, bottomLeft })
         {
+            if (!World::validCoords(tilePos))
+            {
+                continue;
+            }
             if (is23prng.has_value())
             {
                 const auto randVal = is23prng->randNext();

--- a/src/OpenLoco/src/World/TownManager.cpp
+++ b/src/OpenLoco/src/World/TownManager.cpp
@@ -80,8 +80,7 @@ namespace OpenLoco::TownManager
             std::fill(std::begin(town.var_150), std::end(town.var_150), 0);
         }
 
-        World::TilePosRangeView tileLoop{ { 1, 1 }, { World::kMapColumns - 1, World::kMapRows - 1 } };
-        for (const auto& tilePos : tileLoop)
+        for (const auto& tilePos : World::getWorldRange())
         {
             auto tile = World::TileManager::get(tilePos);
             for (auto& element : tile)


### PR DESCRIPTION
The assumption that lead to this bug was that TilePosRangeView would not produce invalid TilePos2 coordinates. For various reasons, it can and should. In short, we have to check that coords are valid before using them.

This PR introduces two new methods, `getClampedRange` and `getWorldRange`, as a means of obtaining a constrained `TilePosRangeView`.

Fixes #2011, a crash when using terraform tools exceeding the map edge