### PR TITLE
Fix breakpad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 23.06.1+ (???)
 ------------------------------------------------------------------------
 - Fix: [#1999] Potential crash at startup due to the screen buffer being too small.
+- Technical: [#2004] Crash reports are no longer being generated (Windows only).
 
 23.06.1 (2023-06-17)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -565,7 +565,6 @@ target_link_libraries(OpenLoco
     ${OPENAL_LIBRARIES})
 
 if (WIN32)
-    target_link_libraries(OpenLoco ${BREAKPAD_LIBRARIES})
     target_link_libraries(OpenLoco winmm ws2_32 Resources)
 endif ()
 
@@ -590,8 +589,7 @@ elseif (MSVC)
             _CRT_NONSTDC_NO_DEPRECATE
             _USE_MATH_DEFINES
             SDL_MAIN_HANDLED
-            _WINSOCK_DEPRECATED_NO_WARNINGS
-            USE_BREAKPAD)
+            _WINSOCK_DEPRECATED_NO_WARNINGS)
 else ()
     target_compile_definitions(OpenLoco
         PRIVATE

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -93,7 +93,7 @@ namespace OpenLoco
 
     static double _accumulator = 0.0;
     static Timepoint _lastUpdate = Clock::now();
-    static CExceptionHandler _exHandler = nullptr;
+    static CrashHandler::Handle _exHandler = nullptr;
 
     loco_global<char[256], 0x005060D0> _gCDKey;
 
@@ -224,7 +224,7 @@ namespace OpenLoco
             Logging::info("Removing temp file '{}'", path8.c_str());
             fs::remove(tempFilePath);
         }
-        crashClose(_exHandler);
+        CrashHandler::shutdown(_exHandler);
 
         // Logging should be the last before terminating.
         Logging::shutdown();
@@ -1161,7 +1161,11 @@ namespace OpenLoco
 
         if (!OpenLoco::Platform::isRunningInWine())
         {
-            _exHandler = crashInit();
+            CrashHandler::AppInfo appInfo;
+            appInfo.name = "OpenLoco";
+            appInfo.version = getVersionInfo();
+
+            _exHandler = CrashHandler::init(appInfo);
         }
         else
         {

--- a/src/Platform/CMakeLists.txt
+++ b/src/Platform/CMakeLists.txt
@@ -22,7 +22,17 @@ loco_add_library(Platform STATIC
         ${private_files}
 )
 
+if (MSVC)
+    target_compile_definitions(Platform
+        PRIVATE
+            USE_BREAKPAD)
+endif()
+
 target_link_libraries(Platform PUBLIC
     Core
     Utility
 )
+
+if (MSVC)
+    target_link_libraries(Platform PUBLIC ${BREAKPAD_LIBRARIES})
+endif ()

--- a/src/Platform/include/OpenLoco/Platform/Crash.h
+++ b/src/Platform/include/OpenLoco/Platform/Crash.h
@@ -1,9 +1,18 @@
 #pragma once
-namespace google_breakpad
-{
-    class ExceptionHandler;
-}
 
-using CExceptionHandler = google_breakpad::ExceptionHandler*;
-CExceptionHandler crashInit();
-void crashClose(CExceptionHandler);
+#include <string>
+
+namespace OpenLoco::CrashHandler
+{
+    using Handle = void*;
+
+    struct AppInfo
+    {
+        std::string name;
+        std::string version;
+    };
+
+    Handle init(const AppInfo& appInfo);
+    void shutdown(Handle handler);
+
+}

--- a/src/Platform/src/Crash.cpp
+++ b/src/Platform/src/Crash.cpp
@@ -1,101 +1,119 @@
 #include "Crash.h"
+
 #if defined(USE_BREAKPAD)
-#include "OpenLoco.h"
 #include "Platform.h"
 #include <OpenLoco/Utility/String.hpp>
 #include <ShlObj.h>
 #include <client/windows/handler/exception_handler.h>
+#endif
 
-[[maybe_unused]] static bool onCrash(
-    const wchar_t* dumpPath, const wchar_t* miniDumpId, void* context, EXCEPTION_POINTERS* exinfo,
-    MDRawAssertionInfo* assertion, bool succeeded)
-{
-    if (!succeeded)
-    {
-        constexpr const char* dumpFailedMessage = "Failed to create the dump. Please file an issue with OpenLoco on GitHub and "
-                                                  "provide latest save, and provide "
-                                                  "information about what you did before the crash occurred.";
-        printf("%s\n", dumpFailedMessage);
-        MessageBoxA(nullptr, dumpFailedMessage, "OpenLoco", MB_OK | MB_ICONERROR);
-        return succeeded;
-    }
-    wchar_t dumpFilePath[MAX_PATH];
-    swprintf_s(dumpFilePath, std::size(dumpFilePath), L"%s\\%s.dmp", dumpPath, miniDumpId);
-
-    std::wstring version = OpenLoco::Utility::toUtf16(OpenLoco::getVersionInfo());
-
-    wchar_t dumpFilePathNew[MAX_PATH];
-    swprintf_s(
-        dumpFilePathNew, std::size(dumpFilePathNew), L"%s\\%s(%s).dmp", dumpPath, miniDumpId, version.c_str());
-
-    // Try to rename the files
-    if (_wrename(dumpFilePath, dumpFilePathNew) == 0)
-    {
-        std::wcscpy(dumpFilePath, dumpFilePathNew);
-    }
-
-    // Log information to output
-    wprintf(L"Dump Path: %s\n", dumpPath);
-    wprintf(L"Dump File Path: %s\n", dumpFilePath);
-    wprintf(L"Dump Id: %s\n", miniDumpId);
-    wprintf(L"Version: %s\n", version.c_str());
-
-    constexpr const wchar_t* MessageFormat = L"A crash has occurred and a dump was created at\n%s.\n\nPlease file an issue "
-                                             L"with OpenLoco on GitHub and provide "
-                                             L"the dump and most recently saved game there.\n\n\nVersion: %s\n\n";
-    wchar_t message[MAX_PATH * 2];
-    swprintf_s(message, MessageFormat, dumpFilePath, version.c_str());
-    MessageBoxW(nullptr, message, L"OpenLoco", MB_OK | MB_ICONERROR);
-
-    HRESULT coInitializeResult = CoInitialize(nullptr);
-    if (SUCCEEDED(coInitializeResult))
-    {
-        LPITEMIDLIST pidl = ILCreateFromPathW(dumpPath);
-        LPITEMIDLIST files[6];
-        uint32_t numFiles = 0;
-
-        files[numFiles++] = ILCreateFromPathW(dumpFilePath);
-        if (pidl != nullptr)
-        {
-            SHOpenFolderAndSelectItems(pidl, numFiles, (LPCITEMIDLIST*)files, 0);
-            ILFree(pidl);
-            for (uint32_t i = 0; i < numFiles; i++)
-            {
-                ILFree(files[i]);
-            }
-        }
-        CoUninitialize();
-    }
-    return succeeded;
-}
-
-[[maybe_unused]] static std::wstring getDumpDirectory()
-{
-    auto userDir = OpenLoco::Platform::getUserDirectory();
-    auto result = OpenLoco::Utility::toUtf16(userDir.string());
-    return result;
-}
-
-// Using non-null pipe name here lets breakpad try setting OOP crash handling
-constexpr const wchar_t* PipeName = L"openloco-bpad";
-
-#endif // USE_BREAKPAD
-
-CExceptionHandler crashInit()
-{
-#if defined(USE_BREAKPAD) && !defined(DEBUG)
-    // Path must exist and be RW!
-    auto exHandler = new google_breakpad::ExceptionHandler(
-        getDumpDirectory(), 0, onCrash, 0, google_breakpad::ExceptionHandler::HANDLER_ALL, MiniDumpWithDataSegs, PipeName, 0);
-    return exHandler;
-#else  // USE_BREAKPAD
-    return nullptr;
-#endif // USE_BREAKPAD
-}
-
-void crashClose([[maybe_unused]] CExceptionHandler exHandler)
+namespace OpenLoco::CrashHandler
 {
 #if defined(USE_BREAKPAD)
-    delete exHandler;
+    static AppInfo _appInfo;
+
+    [[maybe_unused]] static bool onCrash(
+        const wchar_t* dumpPath, const wchar_t* miniDumpId,
+        [[maybe_unused]] void* context,
+        [[maybe_unused]] EXCEPTION_POINTERS* exinfo,
+        [[maybe_unused]] MDRawAssertionInfo* assertion,
+        bool succeeded)
+    {
+        if (!succeeded)
+        {
+            constexpr const char* dumpFailedMessage = "Failed to create the dump. Please file an issue with OpenLoco on GitHub and "
+                                                      "provide latest save, and provide "
+                                                      "information about what you did before the crash occurred.";
+            printf("%s\n", dumpFailedMessage);
+            MessageBoxA(nullptr, dumpFailedMessage, "OpenLoco", MB_OK | MB_ICONERROR);
+            return succeeded;
+        }
+        wchar_t dumpFilePath[MAX_PATH];
+        swprintf_s(dumpFilePath, std::size(dumpFilePath), L"%s\\%s.dmp", dumpPath, miniDumpId);
+
+        std::wstring version = Utility::toUtf16(_appInfo.version);
+
+        wchar_t dumpFilePathNew[MAX_PATH];
+        swprintf_s(
+            dumpFilePathNew, std::size(dumpFilePathNew), L"%s\\%s(%s).dmp", dumpPath, miniDumpId, version.c_str());
+
+        // Try to rename the files
+        if (_wrename(dumpFilePath, dumpFilePathNew) == 0)
+        {
+            wcscpy_s(dumpFilePath, dumpFilePathNew);
+        }
+
+        // Log information to output
+        wprintf(L"Dump Path: %s\n", dumpPath);
+        wprintf(L"Dump File Path: %s\n", dumpFilePath);
+        wprintf(L"Dump Id: %s\n", miniDumpId);
+        wprintf(L"Version: %s\n", version.c_str());
+
+        constexpr const wchar_t* MessageFormat = L"A crash has occurred and a dump was created at\n%s.\n\nPlease file an issue "
+                                                 L"with %S on GitHub and provide "
+                                                 L"the dump and most recently saved game there.\n\n\nVersion: %s\n\n";
+        wchar_t message[MAX_PATH * 2];
+        swprintf_s(message, MessageFormat, dumpFilePath, _appInfo.name.c_str(), version.c_str());
+        MessageBoxW(nullptr, message, L"OpenLoco", MB_OK | MB_ICONERROR);
+
+        HRESULT coInitializeResult = CoInitialize(nullptr);
+        if (SUCCEEDED(coInitializeResult))
+        {
+            LPITEMIDLIST pidl = ILCreateFromPathW(dumpPath);
+            LPITEMIDLIST files[6];
+            uint32_t numFiles = 0;
+
+            files[numFiles++] = ILCreateFromPathW(dumpFilePath);
+            if (pidl != nullptr)
+            {
+                SHOpenFolderAndSelectItems(pidl, numFiles, (LPCITEMIDLIST*)files, 0);
+                ILFree(pidl);
+                for (uint32_t i = 0; i < numFiles; i++)
+                {
+                    ILFree(files[i]);
+                }
+            }
+            CoUninitialize();
+        }
+        return succeeded;
+    }
+
+    [[maybe_unused]] static std::wstring getDumpDirectory()
+    {
+        auto crashDir = Platform::getUserDirectory() / "crashes";
+        if (!fs::exists(crashDir))
+        {
+            fs::create_directories(crashDir);
+        }
+        auto result = Utility::toUtf16(crashDir.string());
+        return result;
+    }
+
 #endif // USE_BREAKPAD
+
+    Handle init([[maybe_unused]] const AppInfo& appInfo)
+    {
+#if !defined(DEBUG) && defined(USE_BREAKPAD)
+        _appInfo = appInfo;
+
+        const auto pipeName = Utility::toUtf16(appInfo.name + "_breakpad");
+
+        // Path must exist and be RW!
+        auto exHandler = new google_breakpad::ExceptionHandler(
+            getDumpDirectory(), 0, onCrash, 0, google_breakpad::ExceptionHandler::HANDLER_ALL, MiniDumpWithDataSegs, pipeName.c_str(), 0);
+        return exHandler;
+#else
+        return nullptr;
+#endif
+    }
+
+    void shutdown([[maybe_unused]] Handle exHandler)
+    {
+#if !defined(DEBUG) && defined(USE_BREAKPAD)
+        if (exHandler == nullptr)
+            return;
+
+        delete static_cast<google_breakpad::ExceptionHandler*>(exHandler);
+#endif
+    }
 }

--- a/src/Platform/src/Crash.cpp
+++ b/src/Platform/src/Crash.cpp
@@ -85,8 +85,7 @@ namespace OpenLoco::CrashHandler
         {
             fs::create_directories(crashDir);
         }
-        auto result = Utility::toUtf16(crashDir.string());
-        return result;
+        return crashDir.wstring();
     }
 
 #endif // USE_BREAKPAD


### PR DESCRIPTION
I also took the liberty to clean it up a bit, I also had to refactor it a bit to be independent as Platform can't have a dependency to OpenLoco so instead it passes AppInfo to the initialization. Also wrapped it in a namespace to match the current code style a bit better. Also removed the forward declaration and instead use void* as the handle, we shouldn't be forward declaring thirdparty library types.