### PR TITLE
Group vehicles by type in object selection window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 23.07+ (???)
 ------------------------------------------------------------------------
+- Feature: [#2036] Vehicle object selection is now split into tabs by vehicle subtype.
 - Change: [#61] Placing headquarters now respects the building rotation shortcut.
 - Change: [#2078] Building construction ghosts now show finished buildings instead of scaffolding.
 - Fix: [#56] Orphaned arrow bug when closing construction window with shortcut (original bug).

--- a/src/OpenLoco/src/Objects/ObjectIndex.cpp
+++ b/src/OpenLoco/src/Objects/ObjectIndex.cpp
@@ -28,6 +28,8 @@ namespace OpenLoco::ObjectManager
     static loco_global<bool, 0x0050AEAD> _isFirstTime;
     static loco_global<bool, 0x0050D161> _isPartialLoaded;
 
+    static constexpr uint8_t kCurrentIndexVersion = 3;
+
 #pragma pack(push, 1)
     struct ObjectFolderState
     {
@@ -75,8 +77,10 @@ namespace OpenLoco::ObjectManager
             currentState.dateHash = Numerics::ror(currentState.dateHash, 5);
             currentState.totalFileSize += file.file_size();
         }
-        // NB: flag 24 is original; flag 25 was introduced by OpenLoco for vehicle subtype purposes
-        currentState.numObjects |= (1U << 24) | (1U << 25);
+
+        // NB: vanilla used to set just flag 24 to 1; we use it as a version byte.
+        currentState.numObjects |= kCurrentIndexVersion << 24;
+
         return currentState;
     }
 

--- a/src/OpenLoco/src/Objects/ObjectIndex.cpp
+++ b/src/OpenLoco/src/Objects/ObjectIndex.cpp
@@ -75,7 +75,8 @@ namespace OpenLoco::ObjectManager
             currentState.dateHash = Numerics::ror(currentState.dateHash, 5);
             currentState.totalFileSize += file.file_size();
         }
-        currentState.numObjects |= (1 << 24);
+        // NB: flag 24 is original; flag 25 was introduced by OpenLoco for vehicle subtype purposes
+        currentState.numObjects |= (1U << 24) | (1U << 25);
         return currentState;
     }
 

--- a/src/OpenLoco/src/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/src/Objects/ObjectManager.cpp
@@ -455,12 +455,15 @@ namespace OpenLoco::ObjectManager
 
         const uint32_t oldNumImages = getTotalNumImages();
         setTotalNumImages(Gfx::G1ExpectedCount::kDisc);
+
         _temporaryObject = preLoadObj->object;
         _isPartialLoaded = true;
         _isTemporaryObject = 0xFF;
+
         auto* depObjs = Interop::addr<0x0050D158, uint8_t*>();
         DependentObjects dependencies;
         callObjectLoad({ preLoadObj->header.getType(), 0 }, *preLoadObj->object, preLoadObj->objectData, depObjs != reinterpret_cast<uint8_t*>(0xFFFFFFFF) ? &dependencies : nullptr);
+
         if (depObjs != reinterpret_cast<uint8_t*>(0xFFFFFFFF))
         {
             *depObjs++ = static_cast<uint8_t>(dependencies.required.size());
@@ -475,14 +478,17 @@ namespace OpenLoco::ObjectManager
                 std::copy(dependencies.willLoad.begin(), dependencies.willLoad.end(), reinterpret_cast<ObjectHeader*>(depObjs));
             }
         }
+
         _isTemporaryObject = 0;
         _isPartialLoaded = false;
 
         _numImages = getTotalNumImages() - Gfx::G1ExpectedCount::kDisc;
         setTotalNumImages(oldNumImages);
+
         TempLoadMetaData result{};
         result.fileSizeHeader.decodedFileSize = preLoadObj->objectData.size();
         result.displayData.numImages = _numImages;
+
         if (header.getType() == ObjectType::competitor)
         {
             auto* competitor = reinterpret_cast<CompetitorObject*>(preLoadObj->object);
@@ -490,6 +496,14 @@ namespace OpenLoco::ObjectManager
             result.displayData.competitiveness = competitor->competitiveness;
             result.displayData.intelligence = competitor->intelligence;
         }
+        else if (header.getType() == ObjectType::vehicle)
+        {
+            auto* vehicle = reinterpret_cast<VehicleObject*>(preLoadObj->object);
+            result.displayData.vehicleSubType = enumValue(vehicle->type);
+
+            Logging::info("Index: vehicle {} is of type {}", header.getName(), enumValue(vehicle->type));
+        }
+
         return result;
     }
 

--- a/src/OpenLoco/src/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/src/Objects/ObjectManager.cpp
@@ -500,8 +500,6 @@ namespace OpenLoco::ObjectManager
         {
             auto* vehicle = reinterpret_cast<VehicleObject*>(preLoadObj->object);
             result.displayData.vehicleSubType = enumValue(vehicle->type);
-
-            Logging::info("Index: vehicle {} is of type {}", header.getName(), enumValue(vehicle->type));
         }
 
         return result;

--- a/src/OpenLoco/src/Objects/ObjectManager.h
+++ b/src/OpenLoco/src/Objects/ObjectManager.h
@@ -134,7 +134,8 @@ namespace OpenLoco::ObjectManager
         uint8_t intelligence;    // 0x4 competitor stats
         uint8_t aggressiveness;  // 0x5
         uint8_t competitiveness; // 0x6
-        uint8_t pad_07[0x5];
+        uint8_t vehicleSubType;  // 0x7
+        uint8_t pad_08[0x4];
     };
 
 #pragma pack(pop)

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -134,6 +134,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         ObjectManager::ObjectIndexId index;
         ObjectManager::ObjectIndexEntry object;
         Visibility display;
+        std::optional<VehicleType> vehicleType;
     };
 
     static loco_global<char[2], 0x005045F8> _strCheckmark;
@@ -327,8 +328,12 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         {
             if (_filterByVehicleType)
             {
-                auto type = getVehicleTypeFromObject(entry);
-                if (type != _currentVehicleType)
+                if (!entry.vehicleType.has_value())
+                {
+                    entry.vehicleType = getVehicleTypeFromObject(entry);
+                }
+
+                if (entry.vehicleType != _currentVehicleType)
                 {
                     entry.display = Visibility::hidden;
                     continue;
@@ -363,7 +368,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         _tabObjectList.reserve(objects.size());
         for (auto [index, object] : objects)
         {
-            auto entry = TabObjectEntry{ index, object, Visibility::shown };
+            auto entry = TabObjectEntry{ index, object, Visibility::shown, std::nullopt };
             _tabObjectList.emplace_back(std::move(entry));
         }
 

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -136,7 +136,6 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         ObjectManager::ObjectIndexId index;
         ObjectManager::ObjectIndexEntry object;
         Visibility display;
-        std::optional<VehicleType> vehicleType;
     };
 
     static loco_global<char[2], 0x005045F8> _strCheckmark;
@@ -333,11 +332,6 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         {
             if (_filterByVehicleType)
             {
-                // if (!entry.vehicleType.has_value())
-                // {
-                //     entry.vehicleType = getVehicleTypeFromObject(entry);
-                // }
-
                 auto vehicleType = getVehicleTypeFromObject(entry);
                 if (vehicleType != _currentVehicleType)
                 {
@@ -374,7 +368,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         _tabObjectList.reserve(objects.size());
         for (auto [index, object] : objects)
         {
-            auto entry = TabObjectEntry{ index, object, Visibility::shown, std::nullopt };
+            auto entry = TabObjectEntry{ index, object, Visibility::shown };
             _tabObjectList.emplace_back(std::move(entry));
         }
 

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -47,9 +47,11 @@
 #include "Window.h"
 #include "World/CompanyManager.h"
 #include <OpenLoco/Core/EnumFlags.hpp>
+#include <OpenLoco/Diagnostics/Logging.h>
 #include <OpenLoco/Interop/Interop.hpp>
 #include <array>
 
+using namespace OpenLoco::Diagnostics;
 using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
@@ -311,12 +313,18 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             != a.end();
     }
 
-    static VehicleType getVehicleTypeFromObject(TabObjectEntry& entry)
+    static std::optional<VehicleType> getVehicleTypeFromObject(TabObjectEntry& entry)
     {
         ObjectManager::freeTemporaryObject();
         ObjectManager::loadTemporaryObject(*entry.object._header);
 
         auto vehicleObj = reinterpret_cast<VehicleObject*>(ObjectManager::getTemporaryObject());
+        if (vehicleObj == nullptr)
+        {
+            Logging::info("Could not load determine vehicle type for object '{}', skipping", entry.object._header->getName());
+            return std::nullopt;
+        }
+
         return vehicleObj->type;
     }
 

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -322,8 +322,6 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             return std::nullopt;
         }
 
-        Logging::info("Vehicle {} is of type {}", entry.object._header->getName(), displayData->vehicleSubType);
-
         return static_cast<VehicleType>(displayData->vehicleSubType);
     }
 

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -315,17 +315,16 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     static std::optional<VehicleType> getVehicleTypeFromObject(TabObjectEntry& entry)
     {
-        ObjectManager::freeTemporaryObject();
-        ObjectManager::loadTemporaryObject(*entry.object._header);
-
-        auto vehicleObj = reinterpret_cast<VehicleObject*>(ObjectManager::getTemporaryObject());
-        if (vehicleObj == nullptr)
+        auto* displayData = entry.object._displayData;
+        if (displayData == nullptr || displayData->vehicleSubType == 0xFF)
         {
             Logging::info("Could not load determine vehicle type for object '{}', skipping", entry.object._header->getName());
             return std::nullopt;
         }
 
-        return vehicleObj->type;
+        Logging::info("Vehicle {} is of type {}", entry.object._header->getName(), displayData->vehicleSubType);
+
+        return static_cast<VehicleType>(displayData->vehicleSubType);
     }
 
     static void applyFilterToObjectList()
@@ -336,12 +335,13 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         {
             if (_filterByVehicleType)
             {
-                if (!entry.vehicleType.has_value())
-                {
-                    entry.vehicleType = getVehicleTypeFromObject(entry);
-                }
+                // if (!entry.vehicleType.has_value())
+                // {
+                //     entry.vehicleType = getVehicleTypeFromObject(entry);
+                // }
 
-                if (entry.vehicleType != _currentVehicleType)
+                auto vehicleType = getVehicleTypeFromObject(entry);
+                if (vehicleType != _currentVehicleType)
                 {
                     entry.display = Visibility::hidden;
                     continue;

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -175,6 +175,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         vehicleTypeTram,
         vehicleTypeAircraft,
         vehicleTypeShip,
+        scrollviewFrame,
         scrollview,
         objectImage,
     };
@@ -202,6 +203,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         makeRemapWidget({ 158, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_ships),
 
         // Scroll and preview areas
+        makeWidget({ 3, 83 }, { 290, 303 }, WidgetType::panel, WindowColour::secondary),
         makeWidget({ 4, 85 }, { 288, 300 }, WidgetType::scrollview, WindowColour::secondary, Scrollbars::vertical),
         makeWidget({ 391, 68 }, { 114, 114 }, WidgetType::buttonWithImage, WindowColour::secondary),
         widgetEnd(),
@@ -485,6 +487,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             self.enabledWidgets |= (1ULL << widx::vehicleTypeTrain) | (1ULL << widx::vehicleTypeBus) | (1ULL << widx::vehicleTypeTruck) | (1ULL << widx::vehicleTypeTram) | (1ULL << widx::vehicleTypeAircraft) | (1ULL << widx::vehicleTypeShip);
 
             self.widgets[widx::scrollview].top = 85 + 28;
+            self.widgets[widx::scrollviewFrame].type = WidgetType::panel;
+            self.widgets[widx::scrollviewFrame].top = self.widgets[widx::scrollview].top - 2;
             self.widgets[widx::objectImage].top = 68 + 28;
         }
         else
@@ -492,6 +496,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             self.enabledWidgets &= ~((1ULL << widx::vehicleTypeTrain) | (1ULL << widx::vehicleTypeBus) | (1ULL << widx::vehicleTypeTruck) | (1ULL << widx::vehicleTypeTram) | (1ULL << widx::vehicleTypeAircraft) | (1ULL << widx::vehicleTypeShip));
 
             self.widgets[widx::scrollview].top = 85;
+            self.widgets[widx::scrollviewFrame].type = WidgetType::none;
             self.widgets[widx::objectImage].top = 68;
         }
     }

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -478,18 +478,18 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             self.widgets[i].type = showSecondaryTabs ? WidgetType::tab : WidgetType::none;
         }
 
-        self.activatedWidgets &= ~((1U << widx::vehicleTypeTrain) | (1U << widx::vehicleTypeBus) | (1U << widx::vehicleTypeTruck) | (1U << widx::vehicleTypeTram) | (1U << widx::vehicleTypeAircraft) | (1U << widx::vehicleTypeShip));
+        self.activatedWidgets &= ~((1ULL << widx::vehicleTypeTrain) | (1ULL << widx::vehicleTypeBus) | (1ULL << widx::vehicleTypeTruck) | (1ULL << widx::vehicleTypeTram) | (1ULL << widx::vehicleTypeAircraft) | (1ULL << widx::vehicleTypeShip));
         if (showSecondaryTabs)
         {
-            self.activatedWidgets |= 1U << (widx::vehicleTypeTrain + self.currentSecondaryTab);
-            self.enabledWidgets |= (1U << widx::vehicleTypeTrain) | (1U << widx::vehicleTypeBus) | (1U << widx::vehicleTypeTruck) | (1U << widx::vehicleTypeTram) | (1U << widx::vehicleTypeAircraft) | (1U << widx::vehicleTypeShip);
+            self.activatedWidgets |= 1ULL << (widx::vehicleTypeTrain + self.currentSecondaryTab);
+            self.enabledWidgets |= (1ULL << widx::vehicleTypeTrain) | (1ULL << widx::vehicleTypeBus) | (1ULL << widx::vehicleTypeTruck) | (1ULL << widx::vehicleTypeTram) | (1ULL << widx::vehicleTypeAircraft) | (1ULL << widx::vehicleTypeShip);
 
             self.widgets[widx::scrollview].top = 85 + 28;
             self.widgets[widx::objectImage].top = 68 + 28;
         }
         else
         {
-            self.enabledWidgets &= ~((1U << widx::vehicleTypeTrain) | (1U << widx::vehicleTypeBus) | (1U << widx::vehicleTypeTruck) | (1U << widx::vehicleTypeTram) | (1U << widx::vehicleTypeAircraft) | (1U << widx::vehicleTypeShip));
+            self.enabledWidgets &= ~((1ULL << widx::vehicleTypeTrain) | (1ULL << widx::vehicleTypeBus) | (1ULL << widx::vehicleTypeTruck) | (1ULL << widx::vehicleTypeTram) | (1ULL << widx::vehicleTypeAircraft) | (1ULL << widx::vehicleTypeShip));
 
             self.widgets[widx::scrollview].top = 85;
             self.widgets[widx::objectImage].top = 68;

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -1131,6 +1131,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 self.currentSecondaryTab = w - widx::vehicleTypeTrain;
                 _currentVehicleType = static_cast<VehicleType>(self.currentSecondaryTab);
                 applyFilterToObjectList();
+                self.initScrollWidgets();
                 self.invalidate();
             }
         }


### PR DESCRIPTION
This PR introduces secondary tabs to the object selection window, grouping vehicles by type if the vehicle objects tab is active. These new secondary tabs are not shown in any of the other tabs.

NB: merge after #2085.

Before:
![254879082-f5c2381a-d7ab-46af-9c35-f4d2bcb44af3](https://github.com/OpenLoco/OpenLoco/assets/604665/e6f3ab22-8d09-4913-89d1-d53e2d93c286)

After:
![Unnamed](https://github.com/OpenLoco/OpenLoco/assets/604665/c317dc36-9835-4a08-9339-b41bbd5f5210)
![Unnamed (1)](https://github.com/OpenLoco/OpenLoco/assets/604665/229fc0b0-1823-482d-ac41-0ee1948a4d86)
