### PR TITLE
Fix crash when loading objects from non ascii paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 23.06.1+ (???)
 ------------------------------------------------------------------------
 - Fix: [#1999] Potential crash at startup due to the screen buffer being too small.
+- Fix: [#2027] Crash when loading scenarios with a non-ASCII locomotion installtion path.
 - Fix: [#2028] Incorrect industry building clearing heights causing graphical glitches.
 - Technical: [#2004] Crash reports are no longer being generated (Windows only).
 

--- a/src/OpenLoco/src/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/src/Objects/ObjectManager.cpp
@@ -961,5 +961,17 @@ namespace OpenLoco::ObjectManager
                 regs.eax = res.imageOffset;
                 return 0;
             });
+
+        registerHook(
+            0x00471BCE,
+            [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
+
+                ObjectHeader* header = X86Pointer<ObjectHeader>(regs.ebp);
+                auto res = load(*header);
+                regs = backup;
+
+                return res ? 0 : X86_FLAG_CARRY;
+            });
     }
 }


### PR DESCRIPTION
Crash would happen when loading a scenario and you had your objects in a folder with a non ascii path. This is due to it failing to load a competitor object. Normal object loading happened fine just the competitor object as that happens through a different mechanism that we haven't implemented just yet. Fix was to just hook our utf8 loader. 