### PR TITLE
Fix crash when DEP enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: [#2027] Crash when loading scenarios with a non-ASCII locomotion installtion path.
 - Fix: [#2028] Incorrect industry building clearing heights causing graphical glitches.
 - Fix: [#2039] Crash/hang when clicking on news items of new vehicle available.
+- Fix: [#2042] Crash when Data Execution Prevention (DEP) is enabled on all executables on Windows.
 - Technical: [#2004] Crash reports are no longer being generated (Windows only).
 
 23.06.1 (2023-06-17)

--- a/src/Interop/src/Hook.cpp
+++ b/src/Interop/src/Hook.cpp
@@ -175,7 +175,7 @@ namespace OpenLoco::Interop
         if (!_hookTableAddress)
         {
 #ifdef _WIN32
-            _hookTableAddress = VirtualAllocEx(GetCurrentProcess(), NULL, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+            _hookTableAddress = VirtualAllocEx(GetCurrentProcess(), NULL, size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE);
             if (_hookTableAddress == nullptr)
             {
                 const auto errCode = static_cast<uint32_t>(GetLastError());


### PR DESCRIPTION
Our hook table is executable code but was marked as read/write code.

~~https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setprocessdeppolicy~~

~~On Win11 DEP is enabled by default so could see this as being an issue for a lot of folks.~~