### PR TITLE
Change two log messages to verbose log level

### DIFF
--- a/src/Interop/src/Hook.cpp
+++ b/src/Interop/src/Hook.cpp
@@ -212,7 +212,7 @@ namespace OpenLoco::Interop
             if (page0Address != page1Address)
             {
                 uint8_t nopCount = 4096 - (address & 0xFFF);
-                Logging::info("Address {:#08x} straddles page boundary (page0 = {:#08x}, page1 = {:#08x}), injecting {} nops", address, page0Address, page1Address, nopCount);
+                Logging::verbose("Address {:#08x} straddles page boundary (page0 = {:#08x}, page1 = {:#08x}), injecting {} nops", address, page0Address, page1Address, nopCount);
                 for (; nopCount > 0; nopCount--)
                 {
                     data[i++] = 0x90; // nop

--- a/src/OpenLoco/src/Graphics/Gfx.cpp
+++ b/src/OpenLoco/src/Graphics/Gfx.cpp
@@ -83,11 +83,11 @@ namespace OpenLoco::Gfx
         {
             if (header.numEntries == G1ExpectedCount::kSteam)
             {
-                Logging::info("Got Steam G1.DAT variant, will fix elements automatically.");
+                Logging::verbose("Got Steam G1.DAT variant, will fix elements automatically.");
             }
             else
             {
-                Logging::verbose("G1 element count doesn't match expected value:\nExpected {}; Got {}", G1ExpectedCount::kDisc, header.numEntries);
+                Logging::warn("G1 element count doesn't match expected value:\nExpected {}; Got {}", G1ExpectedCount::kDisc, header.numEntries);
             }
         }
 

--- a/src/OpenLoco/src/Graphics/Gfx.cpp
+++ b/src/OpenLoco/src/Graphics/Gfx.cpp
@@ -81,10 +81,13 @@ namespace OpenLoco::Gfx
 
         if (header.numEntries != G1ExpectedCount::kDisc)
         {
-            Logging::warn("G1 element count doesn't match expected value:\nExpected {}; Got {}", G1ExpectedCount::kDisc, header.numEntries);
             if (header.numEntries == G1ExpectedCount::kSteam)
             {
                 Logging::info("Got Steam G1.DAT variant, will fix elements automatically.");
+            }
+            else
+            {
+                Logging::verbose("G1 element count doesn't match expected value:\nExpected {}; Got {}", G1ExpectedCount::kDisc, header.numEntries);
             }
         }
 


### PR DESCRIPTION
This PR change the log level for two log messages, as they often confused players.

* The warning for G1 element count not matching is now only shown if it _isn't_ the Steam version.
* Warnings about a hook straddling the page boundary are now shown in verbose mode only.