### PR TITLE
Implement TileManager::allocateMapElements

### DIFF
--- a/src/OpenLoco/src/Map/TileManager.cpp
+++ b/src/OpenLoco/src/Map/TileManager.cpp
@@ -70,6 +70,19 @@ namespace OpenLoco::World::TileManager
         }
     }
 
+    // 0x004BF476
+    void allocateMapElements()
+    {
+        TileElement* elements = reinterpret_cast<TileElement*>(malloc(0x360000));
+        if (elements == nullptr)
+        {
+            exitWithError(StringIds::game_init_failure, StringIds::unable_to_allocate_enough_memory);
+            return;
+        }
+
+        _elements = elements;
+    }
+
     // 0x00461179
     void initialise()
     {

--- a/src/OpenLoco/src/Map/TileManager.h
+++ b/src/OpenLoco/src/Map/TileManager.h
@@ -32,6 +32,7 @@ namespace OpenLoco::World::TileManager
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(ElementPositionFlags);
 
+    void allocateMapElements();
     void initialise();
     stdx::span<TileElement> getElements();
     TileElement* getElementsEnd();

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -281,7 +281,7 @@ namespace OpenLoco
         std::srand(std::time(0));
         addr<0x0050C18C, int32_t>() = addr<0x00525348, int32_t>();
         call(0x004078BE); // getSystemTime unused dead code?
-        call(0x004BF476); // Map::TileManager::initaliseElements
+        World::TileManager::allocateMapElements();
         Environment::resolvePaths();
         Localisation::enumerateLanguages();
         Localisation::loadLanguageFile();


### PR DESCRIPTION
This implements TileManager::allocateMapElements using a simple malloc, like the original function, answering questions about tile element capacity.

I think we might want to switch to a std container for allocation, but the original game expects 0x005230C8 to contain a ptr instead. Should we just allocate the internal tile element pool separately (statically?), then set 0x005230C8 to point to the start of that internal tile element buffer?