### PR TITLE
Add names for some of the routing flags

### DIFF
--- a/src/OpenLoco/src/Map/Track/Track.cpp
+++ b/src/OpenLoco/src/Map/Track/Track.cpp
@@ -88,12 +88,12 @@ namespace OpenLoco::World::Track
                         if (elRoad->hasBridge())
                         {
                             trackAndDirection2 |= elRoad->bridge() << 9;
-                            trackAndDirection2 |= (1 << 12);
+                            trackAndDirection2 |= AdditionalTaDFlags::hasBridge;
                         }
 
                         if (_113601A[1] != elRoad->mods())
                         {
-                            trackAndDirection2 |= (1 << 13);
+                            trackAndDirection2 |= AdditionalTaDFlags::hasMods;
                         }
 
                         if (elRoad->hasStationElement())
@@ -135,12 +135,12 @@ namespace OpenLoco::World::Track
             if (elRoad->hasBridge())
             {
                 trackAndDirection2 |= elRoad->bridge() << 9;
-                trackAndDirection2 |= (1 << 12);
+                trackAndDirection2 |= AdditionalTaDFlags::hasBridge;
             }
 
             if (_113601A[1] != elRoad->mods())
             {
-                trackAndDirection2 |= (1 << 13);
+                trackAndDirection2 |= AdditionalTaDFlags::hasMods;
             }
 
             if (elRoad->hasStationElement())
@@ -218,12 +218,12 @@ namespace OpenLoco::World::Track
                         if (elTrack->hasBridge())
                         {
                             trackAndDirection2 |= elTrack->bridge() << 9;
-                            trackAndDirection2 |= (1 << 12);
+                            trackAndDirection2 |= AdditionalTaDFlags::hasBridge;
                         }
 
                         if (_113601A[1] != elTrack->mods())
                         {
-                            trackAndDirection2 |= (1 << 13);
+                            trackAndDirection2 |= AdditionalTaDFlags::hasMods;
                         }
 
                         if (elTrack->hasStationElement())
@@ -283,12 +283,12 @@ namespace OpenLoco::World::Track
             if (elTrack->hasBridge())
             {
                 trackAndDirection2 |= elTrack->bridge() << 9;
-                trackAndDirection2 |= (1 << 12);
+                trackAndDirection2 |= AdditionalTaDFlags::hasBridge;
             }
 
             if (_113601A[1] != elTrack->mods())
             {
-                trackAndDirection2 |= (1 << 13);
+                trackAndDirection2 |= AdditionalTaDFlags::hasMods;
             }
 
             if (elTrack->hasStationElement())

--- a/src/OpenLoco/src/Map/Track/Track.h
+++ b/src/OpenLoco/src/Map/Track/Track.h
@@ -18,6 +18,16 @@ namespace OpenLoco::World::Track
     };
     static_assert(sizeof(TrackConnections) == 0x24);
 
+    namespace AdditionalTaDFlags
+    {
+        constexpr uint16_t basicTaDMask = 0b0000'0001'1111'1111;
+        constexpr uint16_t bridgeMask = 0b0000'1110'0000'0000;
+        constexpr uint16_t hasBridge = (1U << 12);
+        constexpr uint16_t hasMods = (1U << 13);
+        constexpr uint16_t hasSignal = (1U << 15); // Track only (not roads)
+        constexpr uint16_t basicTaDWithSignalMask = basicTaDMask | hasSignal;
+    }
+
     enum class TrackId : uint8_t
     {
         straight,

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3214,7 +3214,7 @@ namespace OpenLoco::Vehicles
         {
             return false;
         }
-        TrackAndDirection::_TrackAndDirection tad((connections.data[0] & 0x1FF) >> 3, connections.data[0] & 0x7);
+        TrackAndDirection::_TrackAndDirection tad((connections.data[0] & World::Track::AdditionalTaDFlags::basicTaDMask) >> 3, connections.data[0] & 0x7);
         return sub_4A2A58(nextPos, tad, owner, trackType) & (1 << 1);
     }
 

--- a/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
@@ -360,7 +360,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             return;
         }
 
-        const auto trackAndDirection2 = (_113609C->data[_113609C->size - 1] & 0x1FF) ^ (1 << 2);
+        const auto trackAndDirection2 = (_113609C->data[_113609C->size - 1] & World::Track::AdditionalTaDFlags::basicTaDMask) ^ (1 << 2);
         World::Pos3 loc2(_x, _y, _constructionZ);
         loc2 -= TrackData::getUnkTrack(trackAndDirection2).pos;
         if (trackAndDirection2 & (1 << 2))
@@ -440,7 +440,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         uint16_t trackAndDirection2 = 0;
         while (_113609C->size != 0)
         {
-            trackAndDirection2 = (_113609C->pop_back() & 0x1FF) ^ (1 << 2);
+            trackAndDirection2 = (_113609C->pop_back() & World::Track::AdditionalTaDFlags::basicTaDMask) ^ (1 << 2);
             World::Pos3 loc2(_x, _y, _constructionZ);
             loc2 -= TrackData::getUnkRoad(trackAndDirection2).pos;
             if (trackAndDirection2 & (1 << 2))


### PR DESCRIPTION
I'm still trying to work out how I can add some helper classes for the TaD mess. We basically have a variety of different things that can get shoved into a uint16_t and some can be used by other functions. The road/track split is really quite annoying for this.