### PR TITLE
Fix #2047: Game not properly closing when the load/save prompt is open

### DIFF
--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -983,20 +983,24 @@ namespace OpenLoco
         } while (Platform::getTime() - _last_tick_time < Engine::UpdateRateInMs);
     }
 
-    void promptTickLoop(std::function<bool()> tickAction)
+    bool promptTickLoop(std::function<bool()> tickAction)
     {
         while (true)
         {
             _last_tick_time = Platform::getTime();
             _time_since_last_tick = 31;
-            if (!Ui::processMessages() || !tickAction())
+            if (!Ui::processMessages())
+            {
+                return false;
+            }
+            if (!tickAction())
             {
                 break;
             }
             Ui::render();
-
             tickWait();
         }
+        return true;
     }
 
     constexpr auto MaxUpdateTime = static_cast<double>(Engine::MaxTimeDeltaMs) / 1000.0;

--- a/src/OpenLoco/src/OpenLoco.h
+++ b/src/OpenLoco/src/OpenLoco.h
@@ -26,7 +26,7 @@ namespace OpenLoco
 
     void sub_431695(uint16_t var_F253A0);
     int main(std::vector<std::string>&& argv);
-    void promptTickLoop(std::function<bool()> tickAction);
+    bool promptTickLoop(std::function<bool()> tickAction);
     [[noreturn]] void exitCleanly();
     [[noreturn]] void exitWithError(OpenLoco::string_id message, uint32_t errorCode);
     [[noreturn]] void exitWithError(string_id eax, string_id ebx);

--- a/src/OpenLoco/src/Ui.cpp
+++ b/src/OpenLoco/src/Ui.cpp
@@ -79,6 +79,7 @@ namespace OpenLoco::Ui
 
     static SDL_Window* window;
     static std::map<CursorId, SDL_Cursor*> _cursors;
+    static bool _exitRequested = false;
 
     static void setWindowIcon();
     static void resize(int32_t width, int32_t height);
@@ -464,12 +465,20 @@ namespace OpenLoco::Ui
     {
         using namespace Input;
 
+        // The game has more than one loop for processing messages, if the secondary loop receives
+        // SDL_QUIT then the message would be lost for the primary loop so we have to keep track of it.
+        if (_exitRequested)
+        {
+            return false;
+        }
+
         SDL_Event e;
         while (SDL_PollEvent(&e))
         {
             switch (e.type)
             {
                 case SDL_QUIT:
+                    _exitRequested = true;
                     return false;
                 case SDL_WINDOWEVENT:
                     switch (e.window.event)

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -148,7 +148,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             window->setColour(WindowColour::secondary, Colour::mutedSeaGreen);
 
             WindowManager::setCurrentModalType(WindowType::fileBrowserPrompt);
-            promptTickLoop(
+            const bool success = promptTickLoop(
                 []() {
                     Input::handleKeyboard();
                     Audio::updateSounds();
@@ -162,7 +162,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             WindowManager::setCurrentModalType(WindowType::undefined);
 
             // TODO: return std::optional instead
-            return _savePath[0] != '\0';
+            return success && _savePath[0] != '\0';
         }
         return false;
     }


### PR DESCRIPTION
This one is a bit tricky as the load/save prompt runs on an alternate loop rather than the primary one, so when the loop received SDL_Quit it would just bail out of it but had no indication for the callee that it wants to terminate. This is a bit of a work-around until we get rid of all the alternate game loops.