### PR TITLE
Fix issues with HQ placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 23.07+ (???)
 ------------------------------------------------------------------------
 - Fix: [#2047] Error message when closing the game while load/save prompt window is open.
+- Fix: [#2053] Placing a headquarter preview ghost immediately removes any existing HQ.
 
 23.07 (2023-07-25)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/GameCommands/BuildCompanyHeadquarters.cpp
+++ b/src/OpenLoco/src/GameCommands/BuildCompanyHeadquarters.cpp
@@ -16,7 +16,7 @@ namespace OpenLoco::GameCommands
         auto targetCompanyId = getUpdatingCompanyId();
         auto* company = CompanyManager::get(targetCompanyId);
 
-        if (company->headquartersX != -1)
+        if (company->headquartersX != -1 && !(flags & Flags::ghost))
         {
             HeadquarterRemovalArgs rmArgs{};
             rmArgs.pos = World::Pos3(company->headquartersX, company->headquartersY, company->headquartersZ * World::kSmallZStep);

--- a/src/OpenLoco/src/GameCommands/RemoveCompanyHeadquarters.cpp
+++ b/src/OpenLoco/src/GameCommands/RemoveCompanyHeadquarters.cpp
@@ -39,7 +39,7 @@ namespace OpenLoco::GameCommands
 
         BuildingRemovalArgs args{};
         args.pos = pos;
-        if (auto cost = GameCommands::doCommand(args, flags) != FAILURE)
+        if (auto cost = GameCommands::doCommand(args, flags); cost != FAILURE)
         {
             totalCost += cost;
         }


### PR DESCRIPTION
- [x] HQ ghost placement immediately removes any existing HQ
- [x] Removal prices look odd?? (-$2, -$12 for removal)
- [x] ~Placement prices are zero sometimes, but not always??~ Costs are only incurred for landscaping. Building is supposed to be free, somehow.
- [x] User reported not being able to place anything, but that was solved by fixing the ghost placement issue