### PR TITLE
Fix #2056 and #2005

### DIFF
--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -815,6 +815,16 @@ namespace OpenLoco::Input
                         auto offsetX = dragOffset.x << (vp->zoom + 1);
                         auto offsetY = dragOffset.y << (vp->zoom + 1);
 
+                        // Fix #2056 / #2005: Somehow, when the scaling factor (Config.scalingFactor) is set to >1.0,
+                        //                    offsetX and/or offsetY sometimes become exactly -2 for unknown reasons.
+                        //                    This leads to unintended map scrolling even when the user does not move the mouse.
+                        //                    The early exit here prevents this issue from occurring.
+                        // TODO: find out where this -2 is comming from
+                        if (std::abs(offsetX) <= 2 || std::abs(offsetY) <= 2)
+                        {
+                            return;
+                        }
+
                         window->viewportConfigurations[0].savedViewX += offsetX * invert;
                         window->viewportConfigurations[0].savedViewY += offsetY * invert;
                     }


### PR DESCRIPTION
Fixed unintended map scrolling when the scaling factor is set to a value greater than 1.0.

In OpenLoco, we use a scaling factor (Config.scalingFactor) to adjust the scaling on the screen.
This is often done to accommodate different display resolutions or to offer users the ability to scale the interface.
However, a bug was occurring when the scaling factor was set to a value greater than 1.0.

The issue was that under certain conditions, the variables "offsetX" and/or "offsetY" were unexpectedly becoming -2.
This behavior was difficult to pinpoint, and further investigation is required to identify the cause.

The consequence of these unexpected negative offsets was that it led to the map scrolling automatically, even when the user did not move the mouse.
Essentially, the user experienced an automatic scrolling effect, which was unintended and disruptive to the user experience.

For more information, please refer to issues #2056 and #2005.
