### PR TITLE
Better exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_policy(VERSION 3.22)
 
 set (PROJECT openloco)
 
+# Store the top level source directory in a variable to be passed down to targets.
+set(OPENLOCO_PROJECT_PATH ${CMAKE_SOURCE_DIR})
+
 # Note: Searching for CCache must be before project() so project() can use CCache too
 # if it is available
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/cmake/OpenLocoUtility.cmake
+++ b/cmake/OpenLocoUtility.cmake
@@ -233,6 +233,9 @@ function(_loco_add_target TARGET TYPE)
         set_target_properties(${TARGET} ${TEST_TARGET} PROPERTIES FOLDER ${TARGET})
         # Group files nicely in IDEs
         source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/tests" PREFIX "tests" FILES ${_TEST_FILES})
+        
+        # Tell each target about the project directory.
+        target_compile_definitions(${TEST_TARGET} PRIVATE OPENLOCO_PROJECT_PATH="${OPENLOCO_PROJECT_PATH}")
     endif()
     
     # Tell each target about the project directory.

--- a/cmake/OpenLocoUtility.cmake
+++ b/cmake/OpenLocoUtility.cmake
@@ -234,6 +234,9 @@ function(_loco_add_target TARGET TYPE)
         # Group files nicely in IDEs
         source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/tests" PREFIX "tests" FILES ${_TEST_FILES})
     endif()
+    
+    # Tell each target about the project directory.
+    target_compile_definitions(${TARGET} PRIVATE OPENLOCO_PROJECT_PATH="${OPENLOCO_PROJECT_PATH}")
 endfunction()
 
 function(loco_add_library TARGET TYPE)

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -2,6 +2,7 @@ set(public_files
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/BinaryStream.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/BitSet.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/EnumFlags.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/Exception.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/FileStream.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/FileSystem.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Core/LocoFixedVector.hpp"

--- a/src/Core/include/OpenLoco/Core/Exception.hpp
+++ b/src/Core/include/OpenLoco/Core/Exception.hpp
@@ -3,9 +3,25 @@
 #include <exception>
 #include <fmt/format.h>
 #include <string>
+#include <string_view>
 
 namespace OpenLoco::Exception
 {
+    namespace Detail
+    {
+        // TODO: Make this consteval for C++20
+        constexpr std::string_view sanitizePath(std::string_view path)
+        {
+#if defined(OPENLOCO_PROJECT_PATH)
+            constexpr std::string_view projectPath = OPENLOCO_PROJECT_PATH;
+            // Removes also the first slash.
+            return path.substr(projectPath.size() + 1);
+#else
+            return path;
+#endif
+        }
+    }
+
     // Something like std::source_location except this works prior to C++20.
     class SourceLocation
     {
@@ -14,7 +30,7 @@ namespace OpenLoco::Exception
         int _line;
 
     public:
-        explicit SourceLocation(const char* func = __builtin_FUNCTION(), const char* file = __builtin_FILE(), int line = __builtin_LINE())
+        explicit SourceLocation(std::string_view func = __builtin_FUNCTION(), std::string_view file = Detail::sanitizePath(__builtin_FILE()), int line = __builtin_LINE())
             : _function(func)
             , _file(file)
             , _line(line)

--- a/src/Core/include/OpenLoco/Core/Exception.hpp
+++ b/src/Core/include/OpenLoco/Core/Exception.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <exception>
+#include <fmt/format.h>
+#include <string>
+
+namespace OpenLoco::Exception
+{
+    // Something like std::source_location except this works prior to C++20.
+    class SourceLocation
+    {
+        std::string _function;
+        std::string _file;
+        int _line;
+
+    public:
+        explicit SourceLocation(const char* func = __builtin_FUNCTION(), const char* file = __builtin_FILE(), int line = __builtin_LINE())
+            : _function(func)
+            , _file(file)
+            , _line(line)
+        {
+        }
+        const std::string& file() const noexcept
+        {
+            return _file;
+        }
+        const std::string& function() const noexcept
+        {
+            return _function;
+        }
+        int line() const noexcept
+        {
+            return _line;
+        }
+    };
+
+    namespace Detail
+    {
+        template<typename TExceptionTag>
+        class ExceptionBase : public std::exception
+        {
+        private:
+            SourceLocation _location;
+            std::string _message;
+
+        public:
+            explicit ExceptionBase(const SourceLocation& location = SourceLocation{})
+                : _location{ location }
+            {
+                _message = fmt::format("Exception thrown at '{}' - {}:{}", _location.function(), _location.file(), _location.line());
+            }
+            explicit ExceptionBase(const std::string& message, const SourceLocation& location = SourceLocation{})
+                : _location{ location }
+            {
+                _message = fmt::format("Exception '{}', thrown at '{}' - {}:{}", message, _location.function(), _location.file(), _location.line());
+            }
+            const char* what() const noexcept override
+            {
+                return _message.c_str();
+            }
+        };
+    }
+
+    using RuntimeError = Detail::ExceptionBase<struct RuntimeErrorTag>;
+    using InvalidArgument = Detail::ExceptionBase<struct InvalidArgumentTag>;
+    using NotImplemented = Detail::ExceptionBase<struct NotImplementedTag>;
+    using InvalidOperation = Detail::ExceptionBase<struct InvalidOperationTag>;
+    using BadAlloc = Detail::ExceptionBase<struct BadAllocTag>;
+
+}

--- a/src/Core/src/BinaryStream.cpp
+++ b/src/Core/src/BinaryStream.cpp
@@ -1,6 +1,6 @@
 #include "BinaryStream.h"
+#include "Exception.hpp"
 #include <cstring>
-#include <stdexcept>
 
 namespace OpenLoco
 {
@@ -29,13 +29,13 @@ namespace OpenLoco
     {
         auto maxReadLen = _len - _index;
         if (len > maxReadLen)
-            throw std::runtime_error("Failed to read data");
+            throw Exception::RuntimeError("Failed to read data");
         std::memcpy(buffer, reinterpret_cast<const void*>(reinterpret_cast<size_t>(_data) + _index), len);
         _index += len;
     }
 
     void BinaryStream::write([[maybe_unused]] const void* buffer, [[maybe_unused]] size_t len)
     {
-        throw std::runtime_error("Invalid operation");
+        throw Exception::InvalidOperation("Can not write");
     }
 }

--- a/src/Core/src/FileStream.cpp
+++ b/src/Core/src/FileStream.cpp
@@ -1,6 +1,6 @@
 #include "FileStream.h"
+#include "Exception.hpp"
 #include <algorithm>
-#include <stdexcept>
 #include <stdio.h>
 
 namespace OpenLoco
@@ -9,7 +9,7 @@ namespace OpenLoco
     {
         if (mode == StreamMode::none)
         {
-            throw std::invalid_argument("Invalid mode argument");
+            throw Exception::InvalidArgument("Invalid mode argument");
         }
 #ifdef _WIN32
         FILE* fs;
@@ -79,7 +79,7 @@ namespace OpenLoco
         if (!open(path, mode))
         {
             // TODO: Make this work like fstream which is not throwing for failing to open the file.
-            throw std::runtime_error("Failed to open '" + path.u8string() + "' for writing");
+            throw Exception::RuntimeError("Failed to open '" + path.u8string() + "' for writing");
         }
     }
 
@@ -150,7 +150,7 @@ namespace OpenLoco
     {
         if (_mode == StreamMode::none)
         {
-            throw std::runtime_error("Invalid operation");
+            throw Exception::InvalidOperation("Invalid mode");
         }
         position = std::min(_length, static_cast<size_t>(position));
         fileSeek(_file, position, SEEK_SET);
@@ -161,13 +161,13 @@ namespace OpenLoco
     {
         if (_mode != StreamMode::read)
         {
-            throw std::runtime_error("Invalid operation");
+            throw Exception::InvalidOperation("Can not read");
         }
 
         const auto bytesRead = readFile(buffer, len, _file);
         if (bytesRead != len)
         {
-            throw std::runtime_error("Failed to read data");
+            throw Exception::RuntimeError("Failed to read data");
         }
 
         _offset += bytesRead;
@@ -177,7 +177,7 @@ namespace OpenLoco
     {
         if (_mode != StreamMode::write)
         {
-            throw std::runtime_error("Invalid operation");
+            throw Exception::InvalidOperation("Can not write");
         }
         if (len == 0)
         {
@@ -187,7 +187,7 @@ namespace OpenLoco
         const auto bytesWriten = writeFile(buffer, len, _file);
         if (bytesWriten != len)
         {
-            throw std::runtime_error("Failed to write data");
+            throw Exception::RuntimeError("Failed to write data");
         }
 
         _offset += bytesWriten;

--- a/src/Core/src/MemoryStream.cpp
+++ b/src/Core/src/MemoryStream.cpp
@@ -1,7 +1,7 @@
 #include "MemoryStream.h"
+#include "Exception.hpp"
 #include <algorithm>
 #include <cstring>
-#include <stdexcept>
 
 namespace OpenLoco
 {
@@ -23,7 +23,7 @@ namespace OpenLoco
         auto* newData = static_cast<std::byte*>(std::realloc(_data, len));
         if (newData == nullptr)
         {
-            throw std::bad_alloc();
+            throw Exception::BadAlloc();
         }
 
         _data = newData;
@@ -94,7 +94,7 @@ namespace OpenLoco
         const auto maxReadLength = std::min(len, _length - _offset);
         if (len > maxReadLength)
         {
-            throw std::runtime_error("Failed to read data");
+            throw Exception::RuntimeError("Failed to read data");
         }
 
         std::memcpy(buffer, _data + _offset, len);
@@ -128,7 +128,7 @@ namespace OpenLoco
             auto* newData = static_cast<std::byte*>(std::realloc(_data, finalCapacity));
             if (newData == nullptr)
             {
-                throw std::bad_alloc();
+                throw Exception::BadAlloc();
             }
 
             _data = newData;

--- a/src/Core/tests/FileStreamTests.cpp
+++ b/src/Core/tests/FileStreamTests.cpp
@@ -1,3 +1,4 @@
+#include <OpenLoco/Core/Exception.hpp>
 #include <OpenLoco/Core/FileStream.h>
 #include <array>
 #include <cstdio>
@@ -82,7 +83,7 @@ TEST(FileStreamTest, testBadRead)
     ASSERT_EQ(streamIn.getPosition(), 2);
 
     std::array<uint8_t, 4> readBuffer{};
-    EXPECT_THROW(streamIn.read(readBuffer.data(), readBuffer.size()), std::runtime_error);
+    EXPECT_THROW(streamIn.read(readBuffer.data(), readBuffer.size()), Exception::RuntimeError);
 
     streamIn.close();
     std::filesystem::remove(filePath);
@@ -133,7 +134,7 @@ TEST(FileStreamTest, testModeWriteRead)
     ASSERT_EQ(streamOut.getPosition(), 0);
 
     DataBuffer readBuffer(testDataSize);
-    EXPECT_THROW(streamOut.read(readBuffer.data(), readBuffer.size()), std::runtime_error);
+    EXPECT_THROW(streamOut.read(readBuffer.data(), readBuffer.size()), Exception::InvalidOperation);
 
     streamOut.close();
     std::filesystem::remove(filePath);
@@ -151,7 +152,7 @@ TEST(FileStreamTest, testModeReadWrite)
     ASSERT_EQ(streamIn.getLength(), testData.size());
     ASSERT_EQ(streamIn.getPosition(), 0);
 
-    EXPECT_THROW(streamIn.write(testData.data(), testData.size()), std::runtime_error);
+    EXPECT_THROW(streamIn.write(testData.data(), testData.size()), Exception::InvalidOperation);
 
     streamIn.close();
     std::filesystem::remove(filePath);

--- a/src/Core/tests/MemoryStreamTests.cpp
+++ b/src/Core/tests/MemoryStreamTests.cpp
@@ -1,3 +1,4 @@
+#include <OpenLoco/Core/Exception.hpp>
 #include <OpenLoco/Core/MemoryStream.h>
 #include <array>
 #include <gtest/gtest.h>
@@ -82,7 +83,7 @@ TEST(MemoryStreamTest, testBadRead)
     ASSERT_EQ(ms.getPosition(), 2);
 
     std::array<uint8_t, 4> readBuffer{};
-    EXPECT_THROW(ms.read(readBuffer.data(), readBuffer.size()), std::runtime_error);
+    EXPECT_THROW(ms.read(readBuffer.data(), readBuffer.size()), Exception::RuntimeError);
 }
 
 TEST(MemoryStreamTest, testWrite100MiB)


### PR DESCRIPTION
Instead of not knowing where exceptions come from this approach includes always the source location, most compilers already implement the functions to obtain the information only std::source_location is C++20 but we don't need it, if we ever go to C++20 we can ditch the custom thing.

This is what it looks like now:
![image](https://github.com/OpenLoco/OpenLoco/assets/5415177/6e3edcd3-771c-48c0-8529-c5e0db3540c7)
