### PR TITLE
Construction related bugfixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 23.07+ (???)
 ------------------------------------------------------------------------
+- Change: [#61] Placing headquarters now respects the building rotation shortcut.
+- Change: [#2078] Building construction ghosts now show finished buildings instead of scaffolding.
+- Fix: [#56] Orphaned arrow bug when closing construction window with shortcut (original bug).
 - Fix: [#2005] Right-clicking when display scaling is set to a fractional percent causes random scrolling of view.
 - Fix: [#2047] Error message when closing the game while load/save prompt window is open.
 - Fix: [#2053] Placing a headquarter preview ghost immediately removes any existing HQ.
+- Fix: [#2078] Remove any leftover headquarter ghost when the company window is closed with a shortcut.
 - Fix: [#2080] The map generator is not setting water levels correctly at map edges.
 
 23.07 (2023-07-25)

--- a/src/OpenLoco/src/GameCommands/Company/BuildCompanyHeadquarters.cpp
+++ b/src/OpenLoco/src/GameCommands/Company/BuildCompanyHeadquarters.cpp
@@ -40,6 +40,7 @@ namespace OpenLoco::GameCommands
         buildArgs.type = args.type;
         buildArgs.variation = company->getHeadquarterPerformanceVariation();
         buildArgs.colour = CompanyManager::getCompanyColour(targetCompanyId);
+        buildArgs.buildImmediately = args.buildImmediately;
 
         auto buildCost = doCommand(buildArgs, flags);
         if (buildCost != FAILURE)

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -113,6 +113,13 @@ namespace OpenLoco::Input::Shortcuts
             if (Ui::Windows::TownList::rotate(window))
                 return;
         }
+
+        window = WindowManager::find(WindowType::company);
+        if (window != nullptr)
+        {
+            if (Ui::Windows::CompanyWindow::rotate(*window))
+                return;
+        }
     }
 
     // 0x004BF18A

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -155,6 +155,7 @@ namespace OpenLoco::Ui::Windows
         Window* openAndSetName();
         Window* openChallenge(CompanyId companyId);
         Window* openFinances(CompanyId companyId);
+        bool rotate(Window& self);
     }
 
     namespace Construction

--- a/src/OpenLoco/src/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Windows/CompanyWindow.cpp
@@ -1067,6 +1067,12 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             Ui::Windows::hideGridlines();
         }
 
+        static void onClose(Window& self)
+        {
+            if (Input::isToolActive(self.type, self.number))
+                Input::toolCancel();
+        }
+
         // 0x0432D85
         static void onUpdate(Window& self)
         {
@@ -1168,6 +1174,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             events.onToolUpdate = onToolUpdate;
             events.onToolDown = onToolDown;
             events.onToolAbort = onToolAbort;
+            events.onClose = onClose;
             events.onUpdate = onUpdate;
             events.onResize = onResize;
             events.viewportRotate = viewportRotate;

--- a/src/OpenLoco/src/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Windows/CompanyWindow.cpp
@@ -1013,6 +1013,9 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 return;
             }
 
+            // Always show buildings, not scaffolding, for ghost placements.
+            placementArgs->buildImmediately = true;
+
             Input::setMapSelectionFlags(Input::MapSelectionFlags::enable);
             World::TileManager::setMapSelectionCorner(4);
 

--- a/src/OpenLoco/src/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Windows/Construction/Common.cpp
@@ -985,6 +985,7 @@ namespace OpenLoco::Ui::Windows::Construction
             WindowManager::viewportSetVisibility(WindowManager::ViewportVisibility::reset);
             TileManager::mapInvalidateMapSelectionTiles();
             Input::resetMapSelectionFlag(Input::MapSelectionFlags::enableConstruct);
+            Input::resetMapSelectionFlag(Input::MapSelectionFlags::enableConstructionArrow);
             hideDirectionArrows();
             hideGridlines();
         }

--- a/src/OpenLoco/src/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Windows/IndustryList.cpp
@@ -1046,6 +1046,9 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 return;
             }
 
+            // Always show buildings, not scaffolding, for ghost placements.
+            placementArgs->buildImmediately = true;
+
             Input::setMapSelectionFlags(Input::MapSelectionFlags::enable);
             World::TileManager::setMapSelectionCorner(4);
             World::TileManager::setMapSelectionArea(placementArgs->pos, placementArgs->pos);

--- a/src/OpenLoco/src/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Windows/TownList.cpp
@@ -1092,6 +1092,9 @@ namespace OpenLoco::Ui::Windows::TownList
                 return;
             }
 
+            // Always show buildings, not scaffolding, for ghost placements.
+            placementArgs->buildImmediately = true;
+
             Input::setMapSelectionFlags(Input::MapSelectionFlags::enable);
             World::TileManager::setMapSelectionCorner(4);
             auto* building = ObjectManager::get<BuildingObject>(placementArgs->type);


### PR DESCRIPTION
* Allow modifying HQ rotation using keyboard shortcut (default Z; #61)
* Fix: HQ placement now correctly passes buildImmediately flag onto building placement command (our bug)
* Change: construction ghosts now show finished buildings instead of scaffolding
* Fix: remove HQ ghost when company window is closed with shortcut
* Fix: Orphaned arrow bug when closing construction window with shortcut (original bug; #56)