### PR TITLE
Fix #891: Non-ASCII characters do not show up correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Change: [#61] Placing headquarters now respects the building rotation shortcut.
 - Change: [#2078] Building construction ghosts now show finished buildings instead of scaffolding.
 - Fix: [#56] Orphaned arrow bug when closing construction window with shortcut (original bug).
+- Fix: [#891] Non-ASCII characters do not show up correctly in directory listings.
 - Fix: [#2005] Right-clicking when display scaling is set to a fractional percent causes random scrolling of view.
 - Fix: [#2047] Error message when closing the game while load/save prompt window is open.
 - Fix: [#2053] Placing a headquarter preview ghost immediately removes any existing HQ.

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -5,6 +5,7 @@
 #include "Graphics/Colour.h"
 #include "Graphics/ImageIds.h"
 #include "Input.h"
+#include "Localisation/Conversion.h"
 #include "Localisation/FormatArguments.hpp"
 #include "Localisation/Formatting.h"
 #include "Localisation/StringIds.h"
@@ -341,7 +342,8 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
 
         // We'll ensure the folder width does not reach the parent button.
         const uint16_t maxWidth = self.widgets[widx::parent_button].left - folderLabelWidth - 10;
-        const std::string nameBuffer = _currentDirectory.u8string();
+        auto nameBuffer = _currentDirectory.u8string();
+        nameBuffer = Localisation::convertUnicodeToLoco(nameBuffer);
         strncpy(&_displayFolderBuffer[0], nameBuffer.c_str(), 512);
         uint16_t folderWidth = drawingCtx.getStringWidth(_displayFolderBuffer);
 
@@ -401,7 +403,9 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                 auto x = window.x + widget.right + 3;
                 auto y = window.y + 45;
 
-                const std::string nameBuffer = selectedFile.stem().u8string();
+                auto nameBuffer = selectedFile.stem().u8string();
+                nameBuffer = Localisation::convertUnicodeToLoco(nameBuffer);
+
                 auto args = getStringPtrFormatArgs(nameBuffer.c_str());
                 drawingCtx.drawStringCentredClipped(
                     *rt,
@@ -616,7 +620,8 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             }
 
             // Copy name to our work buffer (if drive letter use the full path)
-            const std::string nameBuffer = isRootPath(entry) ? entry.u8string() : entry.stem().u8string();
+            auto nameBuffer = isRootPath(entry) ? entry.u8string() : entry.stem().u8string();
+            nameBuffer = Localisation::convertUnicodeToLoco(nameBuffer);
 
             // Draw the name
             auto args = getStringPtrFormatArgs(nameBuffer.c_str());


### PR DESCRIPTION
Ideally, we'd move the drawing routines to use Unicode, but in the mean time, this is such an improvement.

Before:
![Screenshot (2)](https://github.com/OpenLoco/OpenLoco/assets/604665/d2216801-0f5f-49c7-9376-3be9ea6333c0)

After:
![Screenshot (1)](https://github.com/OpenLoco/OpenLoco/assets/604665/d19409f5-df22-44a4-8704-5e14bb7c41a8)