### PR TITLE
Add 'expert mode' to object selection window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 23.08.1+ (???)
 ------------------------------------------------------------------------
+- Feature: [#2116] Allow hiding vanilla and/or custom objects in object selection window.
 - Change: [#2018] Scroll bar thumbs now have a minimum size, making it easier to scroll long lists.
 
 23.08.1 (2023-08-30)

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2345,3 +2345,8 @@ strings:
   2290: "{SMALLFONT}{COLOUR BLACK}Clear height of the tile element"
   2291: "{SMALLFONT}{COLOUR BLACK}Direction of the tile element"
   2292: "{SMALLFONT}{COLOUR BLACK}Ghost status of the tile element"
+  2293: "Beginner"
+  2294: "Advanced"
+  2295: "Expert"
+  2296: "Vanilla"
+  2297: "Custom"

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1693,6 +1693,7 @@ namespace OpenLoco::StringIds
     constexpr string_id export_plugin_objects = 2089;
     constexpr string_id export_plugin_objects_tip = 2090;
 
+    // Two unused strings below
     constexpr string_id object_selection_advanced = 2093;
     constexpr string_id object_selection_advanced_tooltip = 2094;
     constexpr string_id object_currency_big_font = 2095;
@@ -1882,6 +1883,11 @@ namespace OpenLoco::StringIds
     constexpr string_id tileInspectorHeaderClearHeightTip = 2290;
     constexpr string_id tileInspectorHeaderDirectionTip = 2291;
     constexpr string_id tileInspectorHeaderGhostTip = 2292;
+    constexpr string_id objSelectionFilterBeginner = 2293;
+    constexpr string_id objSelectionFilterAdvanced = 2294;
+    constexpr string_id objSelectionFilterExpert = 2295;
+    constexpr string_id objSelectionFilterVanilla = 2296;
+    constexpr string_id objSelectionFilterCustom = 2297;
 
     constexpr string_id temporary_object_load_str_0 = 8192;
     constexpr string_id temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -288,8 +288,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         if ((tabFlags & ObjectTabFlags::showEvenIfSingular) == ObjectTabFlags::none && _tabObjectCounts[objectType] == 1)
             return false;
 
-        // Hide advanced object types as needed
-        if (filterLevel < FilterLevel::advanced && (tabFlags & ObjectTabFlags::advanced) != ObjectTabFlags::none)
+        // Hide advanced object types in beginner mode
+        if (filterLevel == FilterLevel::beginner && (tabFlags & ObjectTabFlags::advanced) != ObjectTabFlags::none)
             return false;
 
         if (isEditorMode() && (tabFlags & ObjectTabFlags::hideInEditor) != ObjectTabFlags::none)

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -893,9 +893,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         {
             static constexpr std::array<string_id, 3> levelStringIds = {
-                StringIds::scenario_group_beginner,
-                StringIds::object_selection_advanced,
-                StringIds::scenario_group_expert,
+                StringIds::objSelectionFilterBeginner,
+                StringIds::objSelectionFilterAdvanced,
+                StringIds::objSelectionFilterExpert,
             };
 
             FormatArguments args{};
@@ -1179,12 +1179,12 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             auto& dropdown = self.widgets[widx::filterLabel];
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 6, 0x80);
 
-            Dropdown::add(0, StringIds::dropdown_stringid, StringIds::scenario_group_beginner);
-            Dropdown::add(1, StringIds::dropdown_stringid, StringIds::object_selection_advanced);
-            Dropdown::add(2, StringIds::dropdown_stringid, StringIds::scenario_group_expert);
+            Dropdown::add(0, StringIds::dropdown_stringid, StringIds::objSelectionFilterBeginner);
+            Dropdown::add(1, StringIds::dropdown_stringid, StringIds::objSelectionFilterAdvanced);
+            Dropdown::add(2, StringIds::dropdown_stringid, StringIds::objSelectionFilterExpert);
             Dropdown::add(3, 0);
-            Dropdown::add(4, StringIds::dropdown_without_checkmark, StringIds::flat_land);
-            Dropdown::add(5, StringIds::dropdown_without_checkmark, StringIds::small_hills);
+            Dropdown::add(4, StringIds::dropdown_without_checkmark, StringIds::objSelectionFilterVanilla);
+            Dropdown::add(5, StringIds::dropdown_without_checkmark, StringIds::objSelectionFilterCustom);
 
             // Mark current level
             Dropdown::setItemSelected(self.var_856);


### PR DESCRIPTION
- [x] Add extra 'expert mode' level that shows all tabs at all times
- [x] Add dropdown selection for beginner/advanced/expert
- [x] Default to toggling advanced mode to mimic vanilla behaviour
- [x] Add options to toggle showing vanilla and/or custom objects
- [x] Use new strings rather than reusing scenario difficulty strings

<img width="1512" alt="Screenshot 2023-09-19 at 20 00 43" src="https://github.com/OpenLoco/OpenLoco/assets/604665/578838a8-44a5-401d-bca7-e4b38ba73804">
