### PR TITLE
Allow 0-town landscape generation as per vanilla behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 23.08.1+ (???)
 ------------------------------------------------------------------------
 - Change: [#2018] Scroll bar thumbs now have a minimum size, making it easier to scroll long lists.
+- Change: [#2117] Scenario editor can generate maps with no towns, matching vanilla behaviour.
 
 23.08.1 (2023-08-30)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -103,7 +103,7 @@ namespace OpenLoco::EditorController
             return true;
         }
 
-        if (!TownManager::towns().empty())
+        if (TownManager::towns().size() >= Limits::kMinTowns)
         {
             return true;
         }

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -1068,6 +1068,10 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
                 case widx::number_of_towns_down:
                 {
+                    // Vanilla behaviour: Zero-town map generation is allowed in the scenario editor and
+                    // is checked on the editor stage progression for non-zero. It is required to be non-zero
+                    // for gameplay since industries must have at least one associated town. The user must
+                    // manually place at least one town if they generate a landscape with zero towns.
                     if (options.numberOfTowns > 0)
                     {
                         uint16_t newNumTowns = std::max<uint16_t>(Limits::kMinTowns - 1, options.numberOfTowns - 1);

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -1068,8 +1068,11 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
                 case widx::number_of_towns_down:
                 {
-                    uint16_t newNumTowns = std::max<uint16_t>(Limits::kMinTowns, options.numberOfTowns - 1);
-                    options.numberOfTowns = newNumTowns;
+                    if (options.numberOfTowns > 0)
+                    {
+                        uint16_t newNumTowns = std::max<uint16_t>(Limits::kMinTowns - 1, options.numberOfTowns - 1);
+                        options.numberOfTowns = newNumTowns;
+                    }
                     window.invalidate();
                     break;
                 }


### PR DESCRIPTION
Vanilla scenario editor lets you select 0 towns and regenerate the map, and only checks you have a town when you try to advance the editor stage. OpenLoco currently doesn't allow you to step to 0, it caps it at 1. The reason to allow it to go to 0 is to produce a map with no towns and let the user place the towns themselves. They can currently generate a 1-town map and delete it, but that leaves a small terraforming mess that must be manually fixed.