### PR TITLE
Use uint8_t for ElementType enum class

### DIFF
--- a/src/OpenLoco/src/Map/TileElementBase.h
+++ b/src/OpenLoco/src/Map/TileElementBase.h
@@ -9,7 +9,7 @@ namespace OpenLoco::World
 {
     struct TileElement;
 
-    enum class ElementType
+    enum class ElementType : uint8_t
     {
         surface,  // 0x00
         track,    // 0x04

--- a/src/OpenLoco/src/Map/TileManager.h
+++ b/src/OpenLoco/src/Map/TileManager.h
@@ -12,7 +12,7 @@ namespace OpenLoco::World
     struct BuildingElement;
     struct TreeElement;
     struct SurfaceElement;
-    enum class ElementType;
+    enum class ElementType : uint8_t;
 }
 
 namespace OpenLoco::World::TileManager


### PR DESCRIPTION
Noticed this while toying around with messing around with tile element queries