### PR TITLE
Refactor TrackAndDirection

### DIFF
--- a/src/OpenLoco/src/GameCommands/Track/CreateSignal.cpp
+++ b/src/OpenLoco/src/GameCommands/Track/CreateSignal.cpp
@@ -298,7 +298,7 @@ namespace OpenLoco::GameCommands
                     World::Track::getTrackConnections(nextLoc, nextRotation, connections, getUpdatingCompanyId(), args.trackObjType);
                     if (connections.size != 0)
                     {
-                        Vehicles::TrackAndDirection::_TrackAndDirection tad2{ 0, 0 };
+                        Vehicles::TrackAndDirection tad2{ 0, 0 };
                         tad2._data = connections.data[0] & World::Track::AdditionalTaDFlags::basicTaDWithSignalMask;
                         Vehicles::sub_4A2AD7(nextLoc, tad2, getUpdatingCompanyId(), args.trackObjType);
                     }
@@ -316,7 +316,7 @@ namespace OpenLoco::GameCommands
                 World::Track::getTrackConnections(nextTrackStart, World::kReverseRotation[trackSize.rotationEnd], connections, getUpdatingCompanyId(), args.trackObjType);
                 if (connections.size != 0)
                 {
-                    Vehicles::TrackAndDirection::_TrackAndDirection tad2{ 0, 0 };
+                    Vehicles::TrackAndDirection tad2{ 0, 0 };
                     tad2._data = connections.data[0] & World::Track::AdditionalTaDFlags::basicTaDWithSignalMask;
                     Vehicles::sub_4A2AD7(nextTrackStart, tad2, getUpdatingCompanyId(), args.trackObjType);
                 }

--- a/src/OpenLoco/src/GameCommands/Track/CreateTrackMod.cpp
+++ b/src/OpenLoco/src/GameCommands/Track/CreateTrackMod.cpp
@@ -73,7 +73,7 @@ namespace OpenLoco::GameCommands
             piece.z
         };
         const auto firstTilePos = args.pos - offsetToFirstTile;
-        const auto tad = Vehicles::TrackAndDirection::_TrackAndDirection(elTrack->trackId(), elTrack->unkDirection());
+        const auto tad = Vehicles::TrackAndDirection(elTrack->trackId(), elTrack->unkDirection());
 
         auto result = Vehicles::applyTrackModsToTrackNetwork(firstTilePos, tad, elTrack->owner(), args.trackObjType, flags, args.modSection, args.type);
         if (result.allPlacementsFailed)

--- a/src/OpenLoco/src/GameCommands/Track/RemoveTrackMod.cpp
+++ b/src/OpenLoco/src/GameCommands/Track/RemoveTrackMod.cpp
@@ -73,7 +73,7 @@ namespace OpenLoco::GameCommands
             piece.z
         };
         const auto firstTilePos = args.pos - offsetToFirstTile;
-        const auto tad = Vehicles::TrackAndDirection::_TrackAndDirection(elTrack->trackId(), elTrack->unkDirection());
+        const auto tad = Vehicles::TrackAndDirection(elTrack->trackId(), elTrack->unkDirection());
 
         auto cost = Vehicles::removeTrackModsToTrackNetwork(firstTilePos, tad, elTrack->owner(), args.trackObjType, flags, args.modSection, args.type);
 

--- a/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
@@ -254,7 +254,7 @@ namespace OpenLoco::GameCommands
         newBody->tileY = 0;
         newBody->tileBaseZ = 0;
         newBody->subPosition = 0;
-        newBody->_trackAndDirection = TrackAndDirection::_TrackAndDirection(0, 0);
+        newBody->trad = 0;
         newBody->routingHandle = lastVeh->getRoutingHandle();
         newBody->var_38 = Flags38::unk_0; // different to create bogie
         newBody->objectId = vehicleTypeId;

--- a/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
@@ -135,7 +135,7 @@ namespace OpenLoco::GameCommands
         newBogie->tileY = 0;
         newBogie->tileBaseZ = 0;
         newBogie->subPosition = 0;
-        newBogie->trackAndDirection = TrackAndDirection(0, 0);
+        newBogie->trad = 0;
         newBogie->routingHandle = lastVeh->getRoutingHandle();
         newBogie->objectId = vehicleTypeId;
 
@@ -254,7 +254,7 @@ namespace OpenLoco::GameCommands
         newBody->tileY = 0;
         newBody->tileBaseZ = 0;
         newBody->subPosition = 0;
-        newBody->trackAndDirection = TrackAndDirection(0, 0);
+        newBody->_trackAndDirection = TrackAndDirection::_TrackAndDirection(0, 0);
         newBody->routingHandle = lastVeh->getRoutingHandle();
         newBody->var_38 = Flags38::unk_0; // different to create bogie
         newBody->objectId = vehicleTypeId;
@@ -478,7 +478,7 @@ namespace OpenLoco::GameCommands
         newVeh1->tileBaseZ = 0;
         newVeh1->remainingDistance = 0;
         newVeh1->subPosition = 0;
-        newVeh1->trackAndDirection = TrackAndDirection(0, 0);
+        newVeh1->trad = 0;
         newVeh1->routingHandle = lastVeh->getRoutingHandle();
         newVeh1->spriteWidth = 0;
         newVeh1->spriteHeightNegative = 0;
@@ -509,7 +509,7 @@ namespace OpenLoco::GameCommands
         newVeh2->tileBaseZ = 0;
         newVeh2->remainingDistance = 0;
         newVeh2->subPosition = 0;
-        newVeh2->trackAndDirection = TrackAndDirection(0, 0);
+        newVeh2->trad = 0;
         newVeh2->routingHandle = lastVeh->getRoutingHandle();
         newVeh2->spriteWidth = 0;
         newVeh2->spriteHeightNegative = 0;
@@ -545,7 +545,7 @@ namespace OpenLoco::GameCommands
         newTail->tileBaseZ = 0;
         newTail->remainingDistance = 0;
         newTail->subPosition = 0;
-        newTail->trackAndDirection = TrackAndDirection(0, 0);
+        newTail->trad = 0;
         newTail->routingHandle = lastVeh->getRoutingHandle();
         newTail->spriteWidth = 0;
         newTail->spriteHeightNegative = 0;

--- a/src/OpenLoco/src/Vehicles/Routing.cpp
+++ b/src/OpenLoco/src/Vehicles/Routing.cpp
@@ -44,9 +44,9 @@ namespace OpenLoco::Vehicles
             return (loc == rhs.loc) && (trackAndDirection == rhs.trackAndDirection) && (company == rhs.company) && (trackType == rhs.trackType);
         }
 
-        TrackAndDirection::_TrackAndDirection tad() const
+        TrackAndDirection tad() const
         {
-            return TrackAndDirection::_TrackAndDirection((trackAndDirection & 0x1F8) >> 3, trackAndDirection & 0x7);
+            return TrackAndDirection((trackAndDirection & 0x1F8) >> 3, trackAndDirection & 0x7);
         }
     };
 
@@ -181,7 +181,7 @@ namespace OpenLoco::Vehicles
     static loco_global<uint8_t, 0x01136085> _1136085;
     static loco_global<uint8_t[2], 0x0113601A> _113601A; // Track Connection mod global
 
-    static std::optional<std::pair<World::SignalElement*, World::TrackElement*>> findSignalOnTrack(const World::Pos3& signalLoc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint8_t trackType, const uint8_t index)
+    static std::optional<std::pair<World::SignalElement*, World::TrackElement*>> findSignalOnTrack(const World::Pos3& signalLoc, const TrackAndDirection trackAndDirection, const uint8_t trackType, const uint8_t index)
     {
         auto tile = World::TileManager::get(signalLoc);
         for (auto& el : tile)
@@ -227,7 +227,7 @@ namespace OpenLoco::Vehicles
     }
 
     // 0x0048963F but only when flags are 0xXXXX_XXXA
-    uint8_t getSignalState(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint8_t trackType, uint32_t flags)
+    uint8_t getSignalState(const World::Pos3& loc, const TrackAndDirection trackAndDirection, const uint8_t trackType, uint32_t flags)
     {
         auto trackStart = loc;
         if (trackAndDirection.isReversed())
@@ -294,7 +294,7 @@ namespace OpenLoco::Vehicles
     }
 
     // 0x0048963F
-    void setSignalState(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint8_t trackType, uint32_t flags)
+    void setSignalState(const World::Pos3& loc, const TrackAndDirection trackAndDirection, const uint8_t trackType, uint32_t flags)
     {
         const auto unk1 = flags & 0xFFFF;
         assert(unk1 != 10); // Only happens if wrong function was called call getSignalState
@@ -441,13 +441,13 @@ namespace OpenLoco::Vehicles
                     continue;
                 }
 
-                if (vehicle->getTrackLoc() == interest.loc && vehicle->getTrackAndDirection().track == tad)
+                if (vehicle->getTrackLoc() == interest.loc && vehicle->getTrackAndDirection() == tad)
                 {
                     routingTransformData = 1;
                     break;
                 }
 
-                if (vehicle->getTrackLoc() == nextLoc && vehicle->getTrackAndDirection().track == backwardTaD)
+                if (vehicle->getTrackLoc() == nextLoc && vehicle->getTrackAndDirection() == backwardTaD)
                 {
                     routingTransformData = 1;
                     break;
@@ -558,7 +558,7 @@ namespace OpenLoco::Vehicles
 
                 const auto startTargetPos2 = World::Pos2{ pieceLoc } - Math::Vector::rotate(World::Pos2{ targetPiece.x, targetPiece.y }, elTrack->unkDirection());
                 const auto startTargetPos = World::Pos3{ startTargetPos2, static_cast<int16_t>(elTrack->baseHeight() - targetPiece.z) };
-                TrackAndDirection::_TrackAndDirection tad2(elTrack->trackId(), elTrack->unkDirection());
+                TrackAndDirection tad2(elTrack->trackId(), elTrack->unkDirection());
                 LocationOfInterest newInterest{ startTargetPos, tad2._data, elTrack->owner(), elTrack->trackObjectId() };
 
                 if (hashMap.tryAdd(newInterest))
@@ -660,7 +660,7 @@ namespace OpenLoco::Vehicles
 
     // 0x004A2E46 & 0x004A2DE4
     template<typename FilterFunction, typename TransformFunction>
-    static void findAllTracksFilterTransform(LocationOfInterestHashMap& interestMap, TrackNetworkSearchFlags searchFlags, const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const CompanyId company, const uint8_t trackType, FilterFunction&& filterFunction, TransformFunction&& transformFunction)
+    static void findAllTracksFilterTransform(LocationOfInterestHashMap& interestMap, TrackNetworkSearchFlags searchFlags, const World::Pos3& loc, const TrackAndDirection trackAndDirection, const CompanyId company, const uint8_t trackType, FilterFunction&& filterFunction, TransformFunction&& transformFunction)
     {
         // _1135F06 = &interestMap;
         // _filterFunction = filterFunction;
@@ -682,7 +682,7 @@ namespace OpenLoco::Vehicles
     }
 
     // 0x004A2AD7
-    void sub_4A2AD7(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const CompanyId company, const uint8_t trackType)
+    void sub_4A2AD7(const World::Pos3& loc, const TrackAndDirection trackAndDirection, const CompanyId company, const uint8_t trackType)
     {
         // 0x001135F88
         uint16_t routingTransformData = 0;
@@ -702,7 +702,7 @@ namespace OpenLoco::Vehicles
             transformFunction);
     }
 
-    uint8_t sub_4A2A58(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const CompanyId company, const uint8_t trackType)
+    uint8_t sub_4A2A58(const World::Pos3& loc, const TrackAndDirection trackAndDirection, const CompanyId company, const uint8_t trackType)
     {
         // 0x001135F88
         uint16_t unk = 0;
@@ -1021,7 +1021,7 @@ namespace OpenLoco::Vehicles
         return false;
     }
 
-    ApplyTrackModsResult applyTrackModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection::_TrackAndDirection trackAndDirection, CompanyId company, uint8_t trackType, uint8_t flags, uint8_t modSelection, uint8_t trackModObjIds)
+    ApplyTrackModsResult applyTrackModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection trackAndDirection, CompanyId company, uint8_t trackType, uint8_t flags, uint8_t modSelection, uint8_t trackModObjIds)
     {
         ApplyTrackModsResult result{};
         result.cost = 0;
@@ -1045,7 +1045,7 @@ namespace OpenLoco::Vehicles
         return result;
     }
 
-    currency32_t removeTrackModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection::_TrackAndDirection trackAndDirection, CompanyId company, uint8_t trackType, uint8_t flags, uint8_t modSelection, uint8_t trackModObjIds)
+    currency32_t removeTrackModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection trackAndDirection, CompanyId company, uint8_t trackType, uint8_t flags, uint8_t modSelection, uint8_t trackModObjIds)
     {
         currency32_t cost = 0;
         if (modSelection == 0)

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -140,7 +140,7 @@ namespace OpenLoco::Vehicles
     // bp : trackAndDirection
     // ebp : bp | (setOccupied << 31)
     // returns dh : trackType
-    uint8_t VehicleBase::sub_47D959(const World::Pos3& loc, const TrackAndDirection::_RoadAndDirection trackAndDirection, const bool setOccupied)
+    uint8_t VehicleBase::sub_47D959(const World::Pos3& loc, const RoadAndDirection trackAndDirection, const bool setOccupied)
     {
         auto trackType = getTrackType();
         auto tile = World::TileManager::get(loc);

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -130,68 +130,56 @@ namespace OpenLoco::Vehicles
 #pragma pack(push, 1)
     struct TrackAndDirection
     {
-        struct _TrackAndDirection
-        {
-            uint16_t _data;
-            constexpr _TrackAndDirection(uint8_t id, uint8_t direction)
-                : _data((id << 3) | direction)
-            {
-            }
-            constexpr uint8_t id() const { return (_data >> 3) & 0x3F; }
-            constexpr uint8_t cardinalDirection() const { return _data & 0x3; }
-            constexpr bool isReversed() const { return _data & (1 << 2); }
-            constexpr void setReversed(bool state)
-            {
-                _data &= ~(1 << 2);
-                _data |= state ? (1 << 2) : 0;
-            }
-            constexpr bool operator==(const _TrackAndDirection other) const { return _data == other._data; }
-        };
-        struct _RoadAndDirection
-        {
-            uint16_t _data;
-            constexpr _RoadAndDirection(uint8_t id, uint8_t direction)
-                : _data((id << 3) | direction)
-            {
-            }
-            constexpr uint8_t id() const { return (_data >> 3) & 0xF; }
-            constexpr uint8_t cardinalDirection() const { return _data & 0x3; }
-            // Used by road and tram vehicles to indicate side
-            constexpr bool isReversed() const { return _data & (1 << 2); }
-            // Road vehicles are briefly back to front when reaching dead ends
-            // Trams can stay back to front
-            constexpr bool isBackToFront() const { return _data & (1 << 7); }
-            // Related to road vehicles turning around
-            constexpr bool isUnk8() const { return _data & (1 << 8); }
-            constexpr bool operator==(const _RoadAndDirection other) const { return _data == other._data; }
-        };
-
-        union
-        {
-            _TrackAndDirection track;
-            _RoadAndDirection road;
-        };
-
+        uint16_t _data;
         constexpr TrackAndDirection(uint8_t id, uint8_t direction)
-            : track(id, direction)
+            : _data((id << 3) | direction)
         {
         }
+        constexpr uint8_t id() const { return (_data >> 3) & 0x3F; }
+        constexpr uint8_t cardinalDirection() const { return _data & 0x3; }
+        constexpr bool isReversed() const { return _data & (1 << 2); }
+        constexpr void setReversed(bool state)
+        {
+            _data &= ~(1 << 2);
+            _data |= state ? (1 << 2) : 0;
+        }
+        constexpr bool operator==(const TrackAndDirection other) const { return _data == other._data; }
     };
     static_assert(sizeof(TrackAndDirection) == 2);
 
+    struct RoadAndDirection
+    {
+        uint16_t _data;
+        constexpr RoadAndDirection(uint8_t id, uint8_t direction)
+            : _data((id << 3) | direction)
+        {
+        }
+        constexpr uint8_t id() const { return (_data >> 3) & 0xF; }
+        constexpr uint8_t cardinalDirection() const { return _data & 0x3; }
+        // Used by road and tram vehicles to indicate side
+        constexpr bool isReversed() const { return _data & (1 << 2); }
+        // Road vehicles are briefly back to front when reaching dead ends
+        // Trams can stay back to front
+        constexpr bool isBackToFront() const { return _data & (1 << 7); }
+        // Related to road vehicles turning around
+        constexpr bool isUnk8() const { return _data & (1 << 8); }
+        constexpr bool operator==(const RoadAndDirection other) const { return _data == other._data; }
+    };
+    static_assert(sizeof(RoadAndDirection) == 2);
+
     // TODO move to a different header
-    void setSignalState(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint8_t trackType, uint32_t flags);
-    uint8_t getSignalState(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint8_t trackType, uint32_t flags);
-    void sub_4A2AD7(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const CompanyId company, const uint8_t trackType);
-    uint8_t sub_4A2A58(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const CompanyId company, const uint8_t trackType);
+    void setSignalState(const World::Pos3& loc, const TrackAndDirection trackAndDirection, const uint8_t trackType, uint32_t flags);
+    uint8_t getSignalState(const World::Pos3& loc, const TrackAndDirection trackAndDirection, const uint8_t trackType, uint32_t flags);
+    void sub_4A2AD7(const World::Pos3& loc, const TrackAndDirection trackAndDirection, const CompanyId company, const uint8_t trackType);
+    uint8_t sub_4A2A58(const World::Pos3& loc, const TrackAndDirection trackAndDirection, const CompanyId company, const uint8_t trackType);
     struct ApplyTrackModsResult
     {
         currency32_t cost;
         bool networkTooComplex;
         bool allPlacementsFailed;
     };
-    ApplyTrackModsResult applyTrackModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection::_TrackAndDirection trackAndDirection, CompanyId company, uint8_t trackType, uint8_t flags, uint8_t modSelection, uint8_t trackModObjIds);
-    currency32_t removeTrackModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection::_TrackAndDirection trackAndDirection, CompanyId company, uint8_t trackType, uint8_t flags, uint8_t modSelection, uint8_t trackModObjIds);
+    ApplyTrackModsResult applyTrackModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection trackAndDirection, CompanyId company, uint8_t trackType, uint8_t flags, uint8_t modSelection, uint8_t trackModObjIds);
+    currency32_t removeTrackModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection trackAndDirection, CompanyId company, uint8_t trackType, uint8_t flags, uint8_t modSelection, uint8_t trackModObjIds);
 
     void playPickupSound(Vehicles::Vehicle2* veh2);
 
@@ -270,7 +258,7 @@ namespace OpenLoco::Vehicles
         VehicleBase* nextVehicleComponent();
         bool updateComponent();
         void sub_4AA464();
-        uint8_t sub_47D959(const World::Pos3& loc, const TrackAndDirection::_RoadAndDirection trackAndDirection, const bool setOccupied);
+        uint8_t sub_47D959(const World::Pos3& loc, const RoadAndDirection trackAndDirection, const bool setOccupied);
         uint32_t sub_4B15FF(uint32_t unk1);
         void explodeComponent();
     };
@@ -464,8 +452,8 @@ namespace OpenLoco::Vehicles
         uint32_t remainingDistance; // 0x28
         union
         {
-            TrackAndDirection::_TrackAndDirection _trackAndDirection;
-            TrackAndDirection::_RoadAndDirection roadAndDirection;
+            TrackAndDirection _trackAndDirection;
+            RoadAndDirection roadAndDirection;
             uint16_t trad;
         };                           // 0x2C
         uint16_t subPosition;        // 0x2E
@@ -502,20 +490,20 @@ namespace OpenLoco::Vehicles
     {
         static constexpr auto kVehicleThingType = VehicleEntityType::vehicle_2;
         uint8_t pad_24[0x26 - 0x24];
-        EntityId head;                       // 0x26
-        uint32_t remainingDistance;          // 0x28
+        EntityId head;              // 0x26
+        uint32_t remainingDistance; // 0x28
         union
         {
-            TrackAndDirection::_TrackAndDirection _trackAndDirection;
-            TrackAndDirection::_RoadAndDirection roadAndDirection;
+            TrackAndDirection _trackAndDirection;
+            RoadAndDirection roadAndDirection;
             uint16_t trad;
-        };                                   // 0x2C
-        uint16_t subPosition;                // 0x2E
-        int16_t tileX;                       // 0x30
-        int16_t tileY;                       // 0x32
-        World::SmallZ tileBaseZ;             // 0x34
-        uint8_t trackType;                   // 0x35 field same in all vehicles
-        RoutingHandle routingHandle;         // 0x36 field same in all vehicles
+        };                           // 0x2C
+        uint16_t subPosition;        // 0x2E
+        int16_t tileX;               // 0x30
+        int16_t tileY;               // 0x32
+        World::SmallZ tileBaseZ;     // 0x34
+        uint8_t trackType;           // 0x35 field same in all vehicles
+        RoutingHandle routingHandle; // 0x36 field same in all vehicles
         Flags38 var_38;
         uint8_t pad_39;              // 0x39
         EntityId nextCarId;          // 0x3A
@@ -556,21 +544,21 @@ namespace OpenLoco::Vehicles
     struct VehicleBody : VehicleBase
     {
         static constexpr auto kVehicleThingType = VehicleEntityType::body_continued;
-        ColourScheme colourScheme;           // 0x24
-        EntityId head;                       // 0x26
-        uint32_t remainingDistance;          // 0x28
+        ColourScheme colourScheme;  // 0x24
+        EntityId head;              // 0x26
+        uint32_t remainingDistance; // 0x28
         union
         {
-            TrackAndDirection::_TrackAndDirection _trackAndDirection;
-            TrackAndDirection::_RoadAndDirection roadAndDirection;
+            TrackAndDirection _trackAndDirection;
+            RoadAndDirection roadAndDirection;
             uint16_t trad;
-        };                                   // 0x2C
-        uint16_t subPosition;                // 0x2E
-        int16_t tileX;                       // 0x30
-        int16_t tileY;                       // 0x32
-        World::SmallZ tileBaseZ;             // 0x34
-        uint8_t trackType;                   // 0x35 field same in all vehicles
-        RoutingHandle routingHandle;         // 0x36 field same in all vehicles
+        };                           // 0x2C
+        uint16_t subPosition;        // 0x2E
+        int16_t tileX;               // 0x30
+        int16_t tileY;               // 0x32
+        World::SmallZ tileBaseZ;     // 0x34
+        uint8_t trackType;           // 0x35 field same in all vehicles
+        RoutingHandle routingHandle; // 0x36 field same in all vehicles
         Flags38 var_38;
         uint8_t objectSpriteType; // 0x39
         EntityId nextCarId;       // 0x3A
@@ -620,21 +608,21 @@ namespace OpenLoco::Vehicles
     struct VehicleBogie : VehicleBase
     {
         static constexpr auto kVehicleThingType = VehicleEntityType::bogie;
-        ColourScheme colourScheme;           // 0x24
-        EntityId head;                       // 0x26
-        uint32_t remainingDistance;          // 0x28
+        ColourScheme colourScheme;  // 0x24
+        EntityId head;              // 0x26
+        uint32_t remainingDistance; // 0x28
         union
         {
-            TrackAndDirection::_TrackAndDirection _trackAndDirection;
-            TrackAndDirection::_RoadAndDirection roadAndDirection;
+            TrackAndDirection _trackAndDirection;
+            RoadAndDirection roadAndDirection;
             uint16_t trad;
-        };                                   // 0x2C
-        uint16_t subPosition;                // 0x2E
-        int16_t tileX;                       // 0x30
-        int16_t tileY;                       // 0x32
-        World::SmallZ tileBaseZ;             // 0x34
-        uint8_t trackType;                   // 0x35 field same in all vehicles
-        RoutingHandle routingHandle;         // 0x36 field same in all vehicles
+        };                           // 0x2C
+        uint16_t subPosition;        // 0x2E
+        int16_t tileX;               // 0x30
+        int16_t tileY;               // 0x32
+        World::SmallZ tileBaseZ;     // 0x34
+        uint8_t trackType;           // 0x35 field same in all vehicles
+        RoutingHandle routingHandle; // 0x36 field same in all vehicles
         Flags38 var_38;
         uint8_t objectSpriteType; // 0x39
         EntityId nextCarId;       // 0x3A
@@ -680,20 +668,20 @@ namespace OpenLoco::Vehicles
     {
         static constexpr auto kVehicleThingType = VehicleEntityType::tail;
         uint8_t pad_24[0x26 - 0x24];
-        EntityId head;                       // 0x26
-        uint32_t remainingDistance;          // 0x28
+        EntityId head;              // 0x26
+        uint32_t remainingDistance; // 0x28
         union
         {
-            TrackAndDirection::_TrackAndDirection _trackAndDirection;
-            TrackAndDirection::_RoadAndDirection roadAndDirection;
+            TrackAndDirection _trackAndDirection;
+            RoadAndDirection roadAndDirection;
             uint16_t trad;
-        };                                   // 0x2C
-        uint16_t subPosition;                // 0x2E
-        int16_t tileX;                       // 0x30
-        int16_t tileY;                       // 0x32
-        World::SmallZ tileBaseZ;             // 0x34
-        uint8_t trackType;                   // 0x35 field same in all vehicles
-        RoutingHandle routingHandle;         // 0x36 field same in all vehicles
+        };                           // 0x2C
+        uint16_t subPosition;        // 0x2E
+        int16_t tileX;               // 0x30
+        int16_t tileY;               // 0x32
+        World::SmallZ tileBaseZ;     // 0x34
+        uint8_t trackType;           // 0x35 field same in all vehicles
+        RoutingHandle routingHandle; // 0x36 field same in all vehicles
         Flags38 var_38;
         uint8_t pad_39;              // 0x39
         EntityId nextCarId;          // 0x3A

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -460,15 +460,20 @@ namespace OpenLoco::Vehicles
     {
         static constexpr auto kVehicleThingType = VehicleEntityType::vehicle_1;
         uint8_t pad_24[0x26 - 0x24];
-        EntityId head;                       // 0x26
-        uint32_t remainingDistance;          // 0x28
-        TrackAndDirection trackAndDirection; // 0x2C
-        uint16_t subPosition;                // 0x2E
-        int16_t tileX;                       // 0x30
-        int16_t tileY;                       // 0x32
-        World::SmallZ tileBaseZ;             // 0x34
-        uint8_t trackType;                   // 0x35 field same in all vehicles
-        RoutingHandle routingHandle;         // 0x36 field same in all vehicles
+        EntityId head;              // 0x26
+        uint32_t remainingDistance; // 0x28
+        union
+        {
+            TrackAndDirection::_TrackAndDirection _trackAndDirection;
+            TrackAndDirection::_RoadAndDirection roadAndDirection;
+            uint16_t trad;
+        };                           // 0x2C
+        uint16_t subPosition;        // 0x2E
+        int16_t tileX;               // 0x30
+        int16_t tileY;               // 0x32
+        World::SmallZ tileBaseZ;     // 0x34
+        uint8_t trackType;           // 0x35 field same in all vehicles
+        RoutingHandle routingHandle; // 0x36 field same in all vehicles
         Flags38 var_38;
         uint8_t pad_39;      // 0x39
         EntityId nextCarId;  // 0x3A
@@ -499,7 +504,12 @@ namespace OpenLoco::Vehicles
         uint8_t pad_24[0x26 - 0x24];
         EntityId head;                       // 0x26
         uint32_t remainingDistance;          // 0x28
-        TrackAndDirection trackAndDirection; // 0x2C
+        union
+        {
+            TrackAndDirection::_TrackAndDirection _trackAndDirection;
+            TrackAndDirection::_RoadAndDirection roadAndDirection;
+            uint16_t trad;
+        };                                   // 0x2C
         uint16_t subPosition;                // 0x2E
         int16_t tileX;                       // 0x30
         int16_t tileY;                       // 0x32
@@ -549,7 +559,12 @@ namespace OpenLoco::Vehicles
         ColourScheme colourScheme;           // 0x24
         EntityId head;                       // 0x26
         uint32_t remainingDistance;          // 0x28
-        TrackAndDirection trackAndDirection; // 0x2C
+        union
+        {
+            TrackAndDirection::_TrackAndDirection _trackAndDirection;
+            TrackAndDirection::_RoadAndDirection roadAndDirection;
+            uint16_t trad;
+        };                                   // 0x2C
         uint16_t subPosition;                // 0x2E
         int16_t tileX;                       // 0x30
         int16_t tileY;                       // 0x32
@@ -608,7 +623,12 @@ namespace OpenLoco::Vehicles
         ColourScheme colourScheme;           // 0x24
         EntityId head;                       // 0x26
         uint32_t remainingDistance;          // 0x28
-        TrackAndDirection trackAndDirection; // 0x2C
+        union
+        {
+            TrackAndDirection::_TrackAndDirection _trackAndDirection;
+            TrackAndDirection::_RoadAndDirection roadAndDirection;
+            uint16_t trad;
+        };                                   // 0x2C
         uint16_t subPosition;                // 0x2E
         int16_t tileX;                       // 0x30
         int16_t tileY;                       // 0x32
@@ -662,7 +682,12 @@ namespace OpenLoco::Vehicles
         uint8_t pad_24[0x26 - 0x24];
         EntityId head;                       // 0x26
         uint32_t remainingDistance;          // 0x28
-        TrackAndDirection trackAndDirection; // 0x2C
+        union
+        {
+            TrackAndDirection::_TrackAndDirection _trackAndDirection;
+            TrackAndDirection::_RoadAndDirection roadAndDirection;
+            uint16_t trad;
+        };                                   // 0x2C
         uint16_t subPosition;                // 0x2E
         int16_t tileX;                       // 0x30
         int16_t tileY;                       // 0x32

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -452,7 +452,7 @@ namespace OpenLoco::Vehicles
         uint32_t remainingDistance; // 0x28
         union
         {
-            TrackAndDirection _trackAndDirection;
+            TrackAndDirection trackAndDirection;
             RoadAndDirection roadAndDirection;
             uint16_t trad;
         };                           // 0x2C
@@ -494,7 +494,7 @@ namespace OpenLoco::Vehicles
         uint32_t remainingDistance; // 0x28
         union
         {
-            TrackAndDirection _trackAndDirection;
+            TrackAndDirection trackAndDirection;
             RoadAndDirection roadAndDirection;
             uint16_t trad;
         };                           // 0x2C
@@ -549,7 +549,7 @@ namespace OpenLoco::Vehicles
         uint32_t remainingDistance; // 0x28
         union
         {
-            TrackAndDirection _trackAndDirection;
+            TrackAndDirection trackAndDirection;
             RoadAndDirection roadAndDirection;
             uint16_t trad;
         };                           // 0x2C
@@ -613,7 +613,7 @@ namespace OpenLoco::Vehicles
         uint32_t remainingDistance; // 0x28
         union
         {
-            TrackAndDirection _trackAndDirection;
+            TrackAndDirection trackAndDirection;
             RoadAndDirection roadAndDirection;
             uint16_t trad;
         };                           // 0x2C
@@ -672,7 +672,7 @@ namespace OpenLoco::Vehicles
         uint32_t remainingDistance; // 0x28
         union
         {
-            TrackAndDirection _trackAndDirection;
+            TrackAndDirection trackAndDirection;
             RoadAndDirection roadAndDirection;
             uint16_t trad;
         };                           // 0x2C

--- a/src/OpenLoco/src/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBody.cpp
@@ -168,8 +168,8 @@ namespace OpenLoco::Vehicles
             }
             else
             {
-                ah = _vehicle_arr_4F865C[frontBogie->trackAndDirection.track._data >> 2];
-                if ((frontBogie->trackAndDirection.track.id() == 12) || (frontBogie->trackAndDirection.track.id() == 13))
+                ah = _vehicle_arr_4F865C[frontBogie->_trackAndDirection._data >> 2];
+                if ((frontBogie->_trackAndDirection.id() == 12) || (frontBogie->_trackAndDirection.id() == 13))
                 {
                     if (frontBogie->subPosition >= 48)
                     {
@@ -985,9 +985,9 @@ namespace OpenLoco::Vehicles
                     continue;
                 if (track->baseZ() != frontBogie->tileBaseZ)
                     continue;
-                if (track->trackId() != frontBogie->trackAndDirection.track.id())
+                if (track->trackId() != frontBogie->_trackAndDirection.id())
                     continue;
-                if (track->unkDirection() != frontBogie->trackAndDirection.track.cardinalDirection())
+                if (track->unkDirection() != frontBogie->_trackAndDirection.cardinalDirection())
                     continue;
                 if (!track->hasStationElement())
                     continue;
@@ -1228,12 +1228,12 @@ namespace OpenLoco::Vehicles
         auto yaw = (spriteYaw + 16) & 0x3F;
         auto firstBogie = has38Flags(Flags38::isReversed) ? backBogie : frontBogie;
         auto unkFactor = 5;
-        if (!_trackIdToSparkDirection[(firstBogie->trackAndDirection.road._data >> 3)])
+        if (!_trackIdToSparkDirection[(firstBogie->roadAndDirection._data >> 3)])
         {
             unkFactor = -5;
         }
 
-        if (firstBogie->trackAndDirection.road.isReversed())
+        if (firstBogie->roadAndDirection.isReversed())
         {
             unkFactor = -unkFactor;
         }

--- a/src/OpenLoco/src/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBody.cpp
@@ -168,8 +168,8 @@ namespace OpenLoco::Vehicles
             }
             else
             {
-                ah = _vehicle_arr_4F865C[frontBogie->_trackAndDirection._data >> 2];
-                if ((frontBogie->_trackAndDirection.id() == 12) || (frontBogie->_trackAndDirection.id() == 13))
+                ah = _vehicle_arr_4F865C[frontBogie->trackAndDirection._data >> 2];
+                if ((frontBogie->trackAndDirection.id() == 12) || (frontBogie->trackAndDirection.id() == 13))
                 {
                     if (frontBogie->subPosition >= 48)
                     {
@@ -985,9 +985,9 @@ namespace OpenLoco::Vehicles
                     continue;
                 if (track->baseZ() != frontBogie->tileBaseZ)
                     continue;
-                if (track->trackId() != frontBogie->_trackAndDirection.id())
+                if (track->trackId() != frontBogie->trackAndDirection.id())
                     continue;
-                if (track->unkDirection() != frontBogie->_trackAndDirection.cardinalDirection())
+                if (track->unkDirection() != frontBogie->trackAndDirection.cardinalDirection())
                     continue;
                 if (!track->hasStationElement())
                     continue;

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3211,13 +3211,13 @@ namespace OpenLoco::Vehicles
     {
         Track::TrackConnections connections{};
         connections.size = 0;
-        const auto [nextPos, rotation] = World::Track::getTrackConnectionEnd(getTrackLoc(), trackAndDirection.track._data);
+        const auto [nextPos, rotation] = World::Track::getTrackConnectionEnd(getTrackLoc(), trackAndDirection._data);
         World::Track::getTrackConnections(nextPos, rotation, connections, owner, trackType);
         if (connections.size != 1)
         {
             return false;
         }
-        TrackAndDirection::_TrackAndDirection tad((connections.data[0] & World::Track::AdditionalTaDFlags::basicTaDMask) >> 3, connections.data[0] & 0x7);
+        TrackAndDirection tad((connections.data[0] & World::Track::AdditionalTaDFlags::basicTaDMask) >> 3, connections.data[0] & 0x7);
         return sub_4A2A58(nextPos, tad, owner, trackType) & (1 << 1);
     }
 
@@ -3229,7 +3229,7 @@ namespace OpenLoco::Vehicles
 
         Track::TrackConnections connections{};
         connections.size = 0;
-        const auto [nextPos, rotation] = World::Track::getTrackConnectionEnd(getTrackLoc(), trackAndDirection.track._data);
+        const auto [nextPos, rotation] = World::Track::getTrackConnectionEnd(getTrackLoc(), trackAndDirection._data);
         World::Track::getTrackConnections(nextPos, rotation, connections, owner, trackType);
         if (connections.size != 1)
         {
@@ -3246,7 +3246,7 @@ namespace OpenLoco::Vehicles
 
         for (auto i = 0U; i < connections.size; ++i)
         {
-            TrackAndDirection::_TrackAndDirection tad{ 0, 0 };
+            TrackAndDirection tad{ 0, 0 };
             tad._data = connections.data[i] & Track::AdditionalTaDFlags::basicTaDMask;
             auto& trackSize = World::TrackData::getUnkTrack(tad._data);
             auto pos = nextNextPos + trackSize.pos;

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -2561,8 +2561,8 @@ namespace OpenLoco::Vehicles
             case TransportMode::rail:
             {
                 auto tile = World::TileManager::get(Pos2{ bogie->tileX, bogie->tileY });
-                auto direction = bogie->_trackAndDirection.cardinalDirection();
-                auto trackId = bogie->_trackAndDirection.id();
+                auto direction = bogie->trackAndDirection.cardinalDirection();
+                auto trackId = bogie->trackAndDirection.id();
                 auto loadingModifier = 12;
                 auto* elStation = tile.trackStation(trackId, direction, bogie->tileBaseZ);
                 if (elStation != nullptr)
@@ -3265,7 +3265,7 @@ namespace OpenLoco::Vehicles
                 if (veh2->tileX == pos.x
                     && veh2->tileY == pos.y
                     && veh2->tileBaseZ == pos.z / World::kSmallZStep
-                    && veh2->_trackAndDirection == reverseTad)
+                    && veh2->trackAndDirection == reverseTad)
                 {
                     return true;
                 }
@@ -3292,8 +3292,8 @@ namespace OpenLoco::Vehicles
 
     static StationId tryFindStationAt(VehicleBogie* bogie)
     {
-        auto direction = bogie->_trackAndDirection.cardinalDirection();
-        auto trackId = bogie->_trackAndDirection.id();
+        auto direction = bogie->trackAndDirection.cardinalDirection();
+        auto trackId = bogie->trackAndDirection.id();
 
         auto tile = TileManager::get(World::Pos2{ bogie->tileX, bogie->tileY });
         auto* elStation = tile.trackStation(trackId, direction, bogie->tileBaseZ);
@@ -3470,10 +3470,10 @@ namespace OpenLoco::Vehicles
                 if (elTrack->isGhost() || elTrack->isFlag5())
                     continue;
 
-                if (elTrack->unkDirection() != veh->_trackAndDirection.cardinalDirection())
+                if (elTrack->unkDirection() != veh->trackAndDirection.cardinalDirection())
                     continue;
 
-                if (elTrack->trackId() != veh->_trackAndDirection.id())
+                if (elTrack->trackId() != veh->trackAndDirection.id())
                     continue;
 
                 return true;

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -977,7 +977,7 @@ namespace OpenLoco::Vehicles
 
         if (trackType == 0xFF || ObjectManager::get<RoadObject>(trackType)->hasFlags(RoadObjectFlags::isRoad))
         {
-            if (train.veh1->trackAndDirection.road.isBackToFront())
+            if (train.veh1->roadAndDirection.isBackToFront())
             {
                 param1 = 128;
                 turnaroundAtSignalTimeout = 544;
@@ -987,7 +987,7 @@ namespace OpenLoco::Vehicles
         {
             // Tram
             turnaroundAtSignalTimeout = kTramSignalTimeout;
-            if (train.veh1->trackAndDirection.road.isBackToFront())
+            if (train.veh1->roadAndDirection.isBackToFront())
             {
                 param1 = 64;
                 turnaroundAtSignalTimeout = 128;
@@ -2561,8 +2561,8 @@ namespace OpenLoco::Vehicles
             case TransportMode::rail:
             {
                 auto tile = World::TileManager::get(Pos2{ bogie->tileX, bogie->tileY });
-                auto direction = bogie->trackAndDirection.track.cardinalDirection();
-                auto trackId = bogie->trackAndDirection.track.id();
+                auto direction = bogie->_trackAndDirection.cardinalDirection();
+                auto trackId = bogie->_trackAndDirection.id();
                 auto loadingModifier = 12;
                 auto* elStation = tile.trackStation(trackId, direction, bogie->tileBaseZ);
                 if (elStation != nullptr)
@@ -2580,8 +2580,8 @@ namespace OpenLoco::Vehicles
             case TransportMode::road:
             {
                 auto tile = World::TileManager::get(Pos2{ bogie->tileX, bogie->tileY });
-                auto direction = bogie->trackAndDirection.road.cardinalDirection();
-                auto roadId = bogie->trackAndDirection.road.id();
+                auto direction = bogie->roadAndDirection.cardinalDirection();
+                auto roadId = bogie->roadAndDirection.id();
                 auto loadingModifier = 2;
                 auto* elStation = tile.roadStation(roadId, direction, bogie->tileBaseZ);
                 if (elStation != nullptr)
@@ -3265,7 +3265,7 @@ namespace OpenLoco::Vehicles
                 if (veh2->tileX == pos.x
                     && veh2->tileY == pos.y
                     && veh2->tileBaseZ == pos.z / World::kSmallZStep
-                    && veh2->trackAndDirection.track == reverseTad)
+                    && veh2->_trackAndDirection == reverseTad)
                 {
                     return true;
                 }
@@ -3292,8 +3292,8 @@ namespace OpenLoco::Vehicles
 
     static StationId tryFindStationAt(VehicleBogie* bogie)
     {
-        auto direction = bogie->trackAndDirection.track.cardinalDirection();
-        auto trackId = bogie->trackAndDirection.track.id();
+        auto direction = bogie->_trackAndDirection.cardinalDirection();
+        auto trackId = bogie->_trackAndDirection.id();
 
         auto tile = TileManager::get(World::Pos2{ bogie->tileX, bogie->tileY });
         auto* elStation = tile.trackStation(trackId, direction, bogie->tileBaseZ);
@@ -3448,7 +3448,7 @@ namespace OpenLoco::Vehicles
                 if (elRoad->isGhost() || elRoad->isFlag5())
                     continue;
 
-                if (elRoad->roadId() != veh->trackAndDirection.road.id())
+                if (elRoad->roadId() != veh->roadAndDirection.id())
                     continue;
 
                 return true;
@@ -3470,10 +3470,10 @@ namespace OpenLoco::Vehicles
                 if (elTrack->isGhost() || elTrack->isFlag5())
                     continue;
 
-                if (elTrack->unkDirection() != veh->trackAndDirection.track.cardinalDirection())
+                if (elTrack->unkDirection() != veh->_trackAndDirection.cardinalDirection())
                     continue;
 
-                if (elTrack->trackId() != veh->trackAndDirection.track.id())
+                if (elTrack->trackId() != veh->_trackAndDirection.id())
                     continue;
 
                 return true;

--- a/src/OpenLoco/src/Vehicles/VehicleManager.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleManager.cpp
@@ -128,7 +128,7 @@ namespace OpenLoco::VehicleManager
         regs.cx = y;
         regs.bx = unk2;
         regs.dl = baseZ;
-        regs.ebp = unk1.track._data;
+        regs.ebp = unk1._data;
         call(0x004B05E4, regs);
     }
 

--- a/src/OpenLoco/src/Vehicles/VehicleTail.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleTail.cpp
@@ -18,7 +18,7 @@ namespace OpenLoco::Vehicles
     static loco_global<uint32_t, 0x01136114> _vehicleUpdate_var_1136114;
 
     // 0x004794BC
-    static void leaveLevelCrossing(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint16_t unk)
+    static void leaveLevelCrossing(const World::Pos3& loc, const TrackAndDirection trackAndDirection, const uint16_t unk)
     {
         auto levelCrossingLoc = loc;
         if (trackAndDirection.isReversed())
@@ -91,18 +91,19 @@ namespace OpenLoco::Vehicles
         }
 
         const auto ref = RoutingManager::getRouting(_oldRoutingHandle);
-        TrackAndDirection trackAndDir((ref & 0x1F8) >> 3, ref & 0x7);
         RoutingManager::freeRouting(_oldRoutingHandle);
 
         if (mode == TransportMode::road)
         {
-            sub_47D959(_oldTilePos, trackAndDir.road, false);
+            RoadAndDirection roadAndDir((ref & 0x1F8) >> 3, ref & 0x7);
+            sub_47D959(_oldTilePos, roadAndDir, false);
         }
         else
         {
+            TrackAndDirection trackAndDir((ref & 0x1F8) >> 3, ref & 0x7);
             if (ref & (1 << 15))
             {
-                setSignalState(_oldTilePos, trackAndDir.track, trackType, 0);
+                setSignalState(_oldTilePos, trackAndDir, trackType, 0);
             }
 
             const auto& trackSize = World::TrackData::getUnkTrack(ref & 0x1FF);
@@ -112,9 +113,9 @@ namespace OpenLoco::Vehicles
                 nextTile -= World::Pos3{ World::kRotationOffset[trackSize.rotationEnd], 0 };
             }
             auto trackAndDirection2 = trackAndDir;
-            trackAndDirection2.track.setReversed(!trackAndDirection2.track.isReversed());
-            sub_4A2AD7(nextTile, trackAndDirection2.track, owner, trackType);
-            leaveLevelCrossing(_oldTilePos, trackAndDir.track, 9);
+            trackAndDirection2.setReversed(!trackAndDirection2.isReversed());
+            sub_4A2AD7(nextTile, trackAndDirection2, owner, trackType);
+            leaveLevelCrossing(_oldTilePos, trackAndDir, 9);
         }
         return true;
     }


### PR DESCRIPTION
Having it stored directly in the union makes the code a bit more readable and definitely shorter, most if not all functions already expected the correct type, there should be no logic changes.