### PR TITLE
Fix issue with std algos and signed/unsigned types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#1685] Crash when removing a crashed vehicle.
 - Fix: [#2110] Very large signal placement cost when upgrading a signal.
+- Fix: [#2153] Hang on scenario load when enabling custom owner name feature.
 
 23.09 (2023-09-28)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/GameCommands/Company/RenameCompanyOwner.cpp
+++ b/src/OpenLoco/src/GameCommands/Company/RenameCompanyOwner.cpp
@@ -126,7 +126,7 @@ namespace OpenLoco::GameCommands
             // Copy the string as it needs some processing
             std::string objectName = object.second._name;
             // Not sure what ControlCodes::pop16 is doing in the object name but it is at the start of all the object names
-            objectName.erase(std::remove(std::begin(objectName), std::end(objectName), ControlCodes::pop16));
+            objectName.erase(std::remove(std::begin(objectName), std::end(objectName), static_cast<char>(ControlCodes::pop16)));
 
             auto strcmpSpecial = [](const char* lhs, const char* rhs) {
                 while (*lhs && *rhs)


### PR DESCRIPTION
pop16 is defined as unsigned. std::string is signed. std::remove first checks if the value is within the bounds of the type :(.