### PR TITLE
Split road connections function

### DIFF
--- a/src/OpenLoco/src/Map/Track/Track.cpp
+++ b/src/OpenLoco/src/Map/Track/Track.cpp
@@ -28,14 +28,21 @@ namespace OpenLoco::World::Track
     static loco_global<uint16_t, 0x01136087> _1136087;
     static loco_global<uint8_t, 0x0113607D> _113607D;
 
-    // 0x00478895
-    void getRoadConnections(const World::Pos3& pos, TrackConnections& data, const CompanyId company, const uint8_t roadObjectId, const uint16_t trackAndDirection)
+    // Part of 0x00478895
+    // For 0x00478895 call this followed by getRoadConnections
+    std::pair<World::Pos3, uint8_t> getRoadConnectionEnd(const World::Pos3& pos, const uint16_t trackAndDirection)
     {
-        const auto nextTrackPos = pos + TrackData::getUnkRoad(trackAndDirection).pos;
+        const auto& roadData = TrackData::getUnkRoad(trackAndDirection);
+
+        return std::make_pair(pos + roadData.pos, roadData.rotationEnd);
+    }
+
+    // 0x004788C8
+    void getRoadConnections(const World::Pos3& nextTrackPos, const uint8_t nextRotation, TrackConnections& data, const CompanyId company, const uint8_t roadObjectId)
+    {
         _1135FAE = StationId::null; // stationId
 
         uint8_t baseZ = nextTrackPos.z / 4;
-        uint8_t nextRotation = TrackData::getUnkRoad(trackAndDirection).rotationEnd;
         _112C2EE = nextRotation;
 
         const auto tile = World::TileManager::get(nextTrackPos);

--- a/src/OpenLoco/src/Map/Track/Track.h
+++ b/src/OpenLoco/src/Map/Track/Track.h
@@ -76,7 +76,8 @@ namespace OpenLoco::World::Track
         unkTurnaround,
     };
 
-    void getRoadConnections(const World::Pos3& pos, TrackConnections& data, const CompanyId company, const uint8_t roadObjectId, const uint16_t trackAndDirection);
+    void getRoadConnections(const World::Pos3& nextTrackPos, const uint8_t nextRotation, TrackConnections& data, const CompanyId company, const uint8_t roadObjectId);
+    std::pair<World::Pos3, uint8_t> getRoadConnectionEnd(const World::Pos3& pos, const uint16_t trackAndDirection);
     void getTrackConnections(const World::Pos3& nextTrackPos, const uint8_t nextRotation, TrackConnections& data, const CompanyId company, const uint8_t trackObjectId);
     std::pair<World::Pos3, uint8_t> getTrackConnectionEnd(const World::Pos3& pos, const uint16_t trackAndDirection);
 }

--- a/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
@@ -412,7 +412,8 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         _113601A[0] = 0;
         _113601A[1] = 0;
         _113609C->size = 0;
-        World::Track::getRoadConnections(loc, _113609C, CompanyManager::getControllingId(), _trackType & ~(1 << 7), trackAndDirection);
+        const auto roadEnd = World::Track::getRoadConnectionEnd(loc, trackAndDirection);
+        World::Track::getRoadConnections(roadEnd.first, roadEnd.second, _113609C, CompanyManager::getControllingId(), _trackType & ~(1 << 7));
 
         if (_113609C->size == 0)
         {


### PR DESCRIPTION
This is needed as some functions need the next road position.

When looking at a few road functions this was needed. Makes things match the track equivalent functions as well.