### PR TITLE
Add cstdint include to OpenAL.h

### DIFF
--- a/src/OpenLoco/src/Audio/OpenAL.h
+++ b/src/OpenLoco/src/Audio/OpenAL.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <AL/alc.h>
+#include <cstdint>
 #include <span>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Needed to successfully compile on g++ (GCC) 13.2.1