### PR TITLE
Cmake Mingw32 Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,13 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 set(DEBUG_LEVEL 0 CACHE STRING "Select debug level for compilation. Use value in range 0–3.")
 list(APPEND COMMON_COMPILE_OPTIONS -DDEBUG=${DEBUG_LEVEL})
 
+if (MINGW)
+    # MingW32 does not at present compile OpenLoco.exe
+    # so we must ensure the .dll file has the same
+    # prefix on Windows and MingW32 i.e. none
+    set(CMAKE_SHARED_LIBRARY_PREFIX "")
+endif()
+
 # Display source files nicely in IDEs
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 

--- a/cmake/mingw32_toolchain.cmake
+++ b/cmake/mingw32_toolchain.cmake
@@ -1,24 +1,26 @@
-SET(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_NAME Windows)
 
-SET(COMPILER_PREFIX i686-w64-mingw32-)
-SET(CMAKE_C_COMPILER ${COMPILER_PREFIX}gcc)
-SET(CMAKE_CXX_COMPILER ${COMPILER_PREFIX}c++)
-SET(CMAKE_RC_COMPILER ${COMPILER_PREFIX}windres)
-SET(CMAKE_PKGCONFIG_EXECUTABLE ${COMPILER_PREFIX}pkg-config)
-SET(PKG_CONFIG_EXECUTABLE ${COMPILER_PREFIX}pkg-config)
-SET(CMAKE_SYSTEM_PROCESSOR x86)
+set(COMPILER_PREFIX i686-w64-mingw32-)
+set(CMAKE_C_COMPILER ${COMPILER_PREFIX}gcc)
+set(CMAKE_CXX_COMPILER ${COMPILER_PREFIX}c++)
+set(CMAKE_RC_COMPILER ${COMPILER_PREFIX}windres)
+set(CMAKE_PKGCONFIG_EXECUTABLE ${COMPILER_PREFIX}pkg-config)
+set(PKG_CONFIG_EXECUTABLE ${COMPILER_PREFIX}pkg-config)
+set(CMAKE_SYSTEM_PROCESSOR x86)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
 
 if(APPLE)
-     SET(TARGET_ENVIRONMENT "/usr/local/mingw-w32-bin_i686-darwin/i686-w64-mingw32")
+     set(TARGET_ENVIRONMENT "/usr/local/mingw-w32-bin_i686-darwin/i686-w64-mingw32")
 else()
-     SET(TARGET_ENVIRONMENT "/usr/i686-w64-mingw32/sys-root/mingw/")
-endif(APPLE)
+     set(TARGET_ENVIRONMENT "/usr/i686-w64-mingw32/sys-root/mingw/")
+endif()
+
+set(CMAKE_SHARED_LIBRARY_PREFIX "")
 
 # here is the target environment located
-SET(CMAKE_FIND_ROOT_PATH ${TARGET_ENVIRONMENT})
+set(CMAKE_FIND_ROOT_PATH ${TARGET_ENVIRONMENT})
 
 # adjust the default behaviour of the FIND_XXX() commands:
 # search headers and libraries in the target environment, search

--- a/cmake/mingw32_toolchain.cmake
+++ b/cmake/mingw32_toolchain.cmake
@@ -17,8 +17,6 @@ else()
      set(TARGET_ENVIRONMENT "/usr/i686-w64-mingw32/sys-root/mingw/")
 endif()
 
-set(CMAKE_SHARED_LIBRARY_PREFIX "")
-
 # here is the target environment located
 set(CMAKE_FIND_ROOT_PATH ${TARGET_ENVIRONMENT})
 

--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -648,6 +648,8 @@ target_link_libraries(OpenLoco
 
 if (WIN32)
     target_link_libraries(OpenLoco winmm ws2_32 Resources)
+    # Loco.exe is looking for openloco.dll. Remove this when standalone.
+    set_target_properties(OpenLoco PROPERTIES OUTPUT_NAME "openloco")
 endif ()
 
 if (NOT WIN32)


### PR DESCRIPTION
Changing things so that the dll output is compatible with OpenLoco.exe i.e. no lib prefix and cased `openloco`.