### PR TITLE
Fix #2114: Company face in object selection window is wrong size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 23.10+ (???)
 ------------------------------------------------------------------------
+- Fix: [#2114] The company face preview in the object selection window is the wrong size.
 - Fix: [#2184] The game is stuck on a black screen for a long time on some double-density screen set-ups.
 
 23.10 (2023-10-25)

--- a/src/OpenLoco/src/Objects/CompetitorObject.cpp
+++ b/src/OpenLoco/src/Objects/CompetitorObject.cpp
@@ -25,7 +25,7 @@ namespace OpenLoco
 
         drawingCtx.drawRect(rt, 0, 0, kObjectPreviewSize.width, kObjectPreviewSize.height, Colours::getShade(Colour::mutedSeaGreen, 1), Drawing::RectFlags::none);
 
-        auto image = Gfx::recolour(images[0], Colour::mutedSeaGreen);
+        auto image = Gfx::recolour(images[0] + 1, Colour::mutedSeaGreen);
         drawingCtx.drawImage(&rt, x - 32, y - 32, image);
     }
 


### PR DESCRIPTION
Unified the preview image in `ObjectSelectionWindow` with what is used in `CompanyFaceSelection`.

Before:
![Screenshot (3)](https://github.com/OpenLoco/OpenLoco/assets/604665/56cadf7f-3d19-4795-a39f-e5e0a519a0bb)

After:
![Screenshot (2)](https://github.com/OpenLoco/OpenLoco/assets/604665/2bcb76bb-d820-4301-a5e4-4b405b75f325)

