### PR TITLE
Enable some extra optimization options for Release and RelWithDebInfo

### DIFF
--- a/cmake/OpenLocoUtility.cmake
+++ b/cmake/OpenLocoUtility.cmake
@@ -3,10 +3,12 @@ function(loco_thirdparty_target_compile_link_flags TARGET)
 
     # MSVC
     set(COMMON_COMPILE_OPTIONS_MSVC
-        /MP                      # Multithreaded compilation
-        $<$<CONFIG:Debug>:/ZI>   # Debug Edit and Continue (Hot reload)
-        $<$<CONFIG:Release>:/Zi> # Debug information in release
-        /Zc:char8_t-             # Enable char8_t<->char conversion :(
+        /MP                                 # Multithreaded compilation
+        $<$<CONFIG:Debug>:/ZI>              # Debug Edit and Continue (Hot reload)
+        $<$<CONFIG:Release>:/Zi>            # Debug information in release
+        $<$<CONFIG:Release>:/Oi>            # Intrinsics
+        $<$<CONFIG:RelWithDebInfo>:/Oi>     # Intrinsics
+        /Zc:char8_t-                        # Enable char8_t<->char conversion :(
     )
 
     # GNU/CLANG
@@ -24,9 +26,13 @@ function(loco_thirdparty_target_compile_link_flags TARGET)
 
     # MSVC
     set(COMMON_LINK_OPTIONS_MSVC
-        $<$<CONFIG:Release>:/DEBUG>         # Generate debug symbols even in release
-        $<$<CONFIG:Debug>:/INCREMENTAL>     # Incremental linking required for hot reload
-        $<$<CONFIG:Debug>:/SAFESEH:NO>    # No safeseh linking required for hot reload
+        $<$<CONFIG:Release>:/DEBUG>             # Generate debug symbols even in release
+        $<$<CONFIG:Debug>:/INCREMENTAL>         # Incremental linking required for hot reload
+        $<$<CONFIG:Debug>:/SAFESEH:NO>          # No safeseh linking required for hot reload
+        $<$<CONFIG:Release>:/OPT:ICF>           # COMDAT folding
+        $<$<CONFIG:Release>:/OPT:REF>           # Eliminate unreferenced code/data
+        $<$<CONFIG:RelWithDebInfo>:/OPT:ICF>    # COMDAT folding
+        $<$<CONFIG:RelWithDebInfo>:/OPT:REF>    # Eliminate unreferenced code/data
     )
 
     # GNU/CLANG


### PR DESCRIPTION
Not having intrinsics enabled means that it won't generate direct memory writes and uses memcpy calls. Also the linker didn't eliminate unreferenced data and code, COMDAT folding enables the linker to merge identical functions and data to one, this shrinks the binary by 300 KiB, decreased the amount of functions from 10195 down to 6899. Free code and size optimizations basically.