### PR TITLE
Fix divergences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#2203] Crash when clipping strings for display.
 - Fix: [#2209] Town size limits are not being taken account in the map generator.
+- Fix: [#2217] Road stations loading at incorrect rate under certain situations.
 
 23.11 (2023-11-26)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Map/Tile.cpp
+++ b/src/OpenLoco/src/Map/Tile.cpp
@@ -144,15 +144,26 @@ namespace OpenLoco::World
                 result = tile.as<StationElement>();
                 if (result != nullptr)
                 {
-                    break;
+                    return result;
                 }
             }
             auto* elRoad = tile.as<RoadElement>();
             if (elRoad == nullptr)
+            {
+                // We can have any amount of road elements between the station
+                // this is different to a track where the station is always the next
+                // element.
+                trackFound = false;
                 continue;
-            trackFound = false;
+            }
             if (elRoad->baseZ() != baseZ)
+            {
+                // We can have any amount of road elements between the station
+                // but if the base height is different then the station doesn't
+                // exist here! (Should never happen)
+                trackFound = false;
                 continue;
+            }
             if (elRoad->unkDirection() != direction)
                 continue;
             if (elRoad->roadId() != roadId)

--- a/src/OpenLoco/src/Map/Track/Track.cpp
+++ b/src/OpenLoco/src/Map/Track/Track.cpp
@@ -98,7 +98,7 @@ namespace OpenLoco::World::Track
                             trackAndDirection2 |= AdditionalTaDFlags::hasBridge;
                         }
 
-                        if (_113601A[1] != elRoad->mods())
+                        if ((_113601A[1] & elRoad->mods()) != 0)
                         {
                             trackAndDirection2 |= AdditionalTaDFlags::hasMods;
                         }
@@ -145,7 +145,7 @@ namespace OpenLoco::World::Track
                 trackAndDirection2 |= AdditionalTaDFlags::hasBridge;
             }
 
-            if (_113601A[1] != elRoad->mods())
+            if ((_113601A[1] & elRoad->mods()) != 0)
             {
                 trackAndDirection2 |= AdditionalTaDFlags::hasMods;
             }
@@ -228,7 +228,7 @@ namespace OpenLoco::World::Track
                             trackAndDirection2 |= AdditionalTaDFlags::hasBridge;
                         }
 
-                        if (_113601A[1] != elTrack->mods())
+                        if ((_113601A[1] & elTrack->mods()) != 0)
                         {
                             trackAndDirection2 |= AdditionalTaDFlags::hasMods;
                         }
@@ -293,7 +293,7 @@ namespace OpenLoco::World::Track
                 trackAndDirection2 |= AdditionalTaDFlags::hasBridge;
             }
 
-            if (_113601A[1] != elTrack->mods())
+            if ((_113601A[1] & elTrack->mods()) != 0)
             {
                 trackAndDirection2 |= AdditionalTaDFlags::hasMods;
             }

--- a/src/OpenLoco/src/Vehicles/Vehicle1.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle1.cpp
@@ -265,7 +265,9 @@ namespace OpenLoco::Vehicles
 
         if (!train.head->hasVehicleFlags(VehicleFlags::manualControl))
         {
-            newTargetSpeed = std::min(newTargetSpeed, toSpeed16(speedFromDistanceInATick(var_3C)) + 5_mph);
+            // TODO: Original CS Bug. Fix when we diverge on replays
+            // newTargetSpeed = std::min(newTargetSpeed, toSpeed16(speedFromDistanceInATick(var_3C)) + 5_mph);
+            newTargetSpeed = std::min(newTargetSpeed, Speed16(static_cast<uint32_t>(var_3C) >> 15) + 5_mph);
         }
 
         if ((train.head->hasVehicleFlags(VehicleFlags::manualControl) && train.head->manualPower <= -20)

--- a/src/OpenLoco/src/Vehicles/Vehicle1.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle1.cpp
@@ -109,7 +109,9 @@ namespace OpenLoco::Vehicles
             newTargetSpeed = std::min(newTargetSpeed, train.veh2->rackRailMaxSpeed);
         }
 
-        newTargetSpeed = std::min(newTargetSpeed, toSpeed16(speedFromDistanceInATick(var_3C)) + 5_mph);
+        // TODO: Original CS Bug. Fix when we diverge on replays
+        // newTargetSpeed = std::min(newTargetSpeed, toSpeed16(speedFromDistanceInATick(var_3C)) + 5_mph);
+        newTargetSpeed = std::min(newTargetSpeed, Speed16(static_cast<uint32_t>(var_3C) >> 15) + 5_mph);
 
         if ((train.head->hasVehicleFlags(VehicleFlags::manualControl) && train.head->manualPower <= -20)
             || train.head->hasVehicleFlags(VehicleFlags::commandStop))


### PR DESCRIPTION
There were two divergences from v23.10 that had been missed until I ran my ai test save. Annoyingly the Tile::roadStation mistake caused a mistake in a function that was implemented much older than before my ai test saves. So will need to rerecord replays and call this the base. The trackConnections is also a potentially big change this function is used in many many many places so a mistake in it might cause a lot of difference. Still need to apply the vehicle1::updateRoad CS bug reproduction as well.