### PR TITLE
Correct a small mistake

### DIFF
--- a/src/OpenLoco/src/Paint/Paint.h
+++ b/src/OpenLoco/src/Paint/Paint.h
@@ -351,12 +351,7 @@ namespace OpenLoco::Paint
         inline static Interop::loco_global<PaintStruct*, 0x00E400C8> _savedPSCur;  // Unused.
         inline static Interop::loco_global<PaintStruct*, 0x00E400CC> _savedPSCur2; // Unused.
         inline static Interop::loco_global<PaintStruct* [5], 0x00E400D0> _trackRoadPaintStructs;
-        inline static Interop::loco_global<int32_t, 0x00E400D4> _E400D4;
-        inline static Interop::loco_global<int32_t, 0x00E400D8> _E400D8;
-        inline static Interop::loco_global<int32_t, 0x00E400DC> _E400DC;
-        inline static Interop::loco_global<int32_t, 0x00E400E0> _E400E0;
         inline static Interop::loco_global<PaintStruct* [2], 0x00E400E4> _trackRoadAdditionsPaintStructs;
-        inline static Interop::loco_global<int32_t, 0x00E400E8> _E400E8;
         inline static Interop::loco_global<int32_t, 0x00E400EC> _E400EC;
         inline static Interop::loco_global<int16_t, 0x00E400F0> _E400F0;
         inline static Interop::loco_global<int16_t, 0x00E400F2> _E400F2;


### PR DESCRIPTION
Those fields were actually part of the array, in the disassembly they had references since CS just directly wrote to the address to zero them but it's better to treat this as a single array.