### PR TITLE
Reduce memory usage when reorganizing tiles

### DIFF
--- a/src/OpenLoco/src/Map/TileManager.cpp
+++ b/src/OpenLoco/src/Map/TileManager.cpp
@@ -515,7 +515,7 @@ namespace OpenLoco::World::TileManager
 
         try
         {
-            // Allocate a temporary buffer and tighly pack all the tile elements in the map
+            // Allocate a temporary buffer and tightly pack all the tile elements in the map
             std::vector<TileElement> tempBuffer;
             tempBuffer.resize(maxElements);
 

--- a/src/OpenLoco/src/Map/TileManager.cpp
+++ b/src/OpenLoco/src/Map/TileManager.cpp
@@ -517,7 +517,7 @@ namespace OpenLoco::World::TileManager
         {
             // Allocate a temporary buffer and tighly pack all the tile elements in the map
             std::vector<TileElement> tempBuffer;
-            tempBuffer.resize(maxElements * sizeof(TileElement));
+            tempBuffer.resize(maxElements);
 
             size_t numElements = 0;
             for (tile_coord_t y = 0; y < kMapRows; y++)


### PR DESCRIPTION
Resize of vector is not malloc so it did 8 times more than it should.