### PR TITLE
Terraform improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 23.12+ (???)
 ------------------------------------------------------------------------
+- Feature: [#1238]: Mountain tool is now a toggle, making it possible to specify the mountain table size.
+- Feature: [#2228]: Max terraform tool sizes have been increased from 10x10 to 64x64.
 - Fix: [#2231] Height mark shortcuts for land and tracks are swapped in some cases.
 - Change: [#1180] Separate track/road see-through toggles.
 - Change: [#2231] Separate trees/buildings/scenery see-through toggles.
+- Change: [#2228]: The landscape 'paint mode' button now uses a different paintbrush image.
+- Change: [#2228]: The landscape texture selection is now hidden until the 'paint' mode is activated.
 
 23.12 (2023-12-17)
 ------------------------------------------------------------------------

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2302,7 +2302,7 @@ strings:
   2247: "Allow building locked vehicles"
   2248: "{SMALLFONT}{COLOUR BLACK}When enabled, will allow building obsolete and proposed vehicles"
   2249: "Build Vehicles Window"
-  2250: "{SMALLFONT}{COLOUR BLACK}While dragging, paint landscape instead of changing elevation"
+  2250: "{SMALLFONT}{COLOUR BLACK}Enable to change terrain type instead of elevation"
   2251: "Invert right mouse dragging"
   2252: "{SMALLFONT}{COLOUR BLACK}When enabled, panning the main game view will have inverted movement"
   2253: "Show cash popups"
@@ -2375,3 +2375,4 @@ strings:
   2320: "See-through scenery toggle"
   2321: "See-through tracks toggle"
   2322: "See-through trees toggle"
+  2323: "{SMALLFONT}{COLOUR BLACK}Enable to smoothen the outer edges of land raised. Useful for creating mountains."

--- a/src/OpenLoco/src/Graphics/ImageIds.h
+++ b/src/OpenLoco/src/Graphics/ImageIds.h
@@ -999,7 +999,9 @@ namespace OpenLoco::ImageIds
     constexpr uint32_t rubbish_bin = 2363;
     constexpr uint32_t centre_viewport = 2364;
     constexpr uint32_t rotate_object = 2365;
-
+    constexpr uint32_t photo_camera = 2366;
+    constexpr uint32_t paintbrush = 2367;
+    constexpr uint32_t stopwatch = 2368;
     constexpr uint32_t red_flag = 2369;
     constexpr uint32_t green_flag = 2370;
     constexpr uint32_t yellow_flag = 2371;

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1933,6 +1933,7 @@ namespace OpenLoco::StringIds
     constexpr StringId shortcutSeeThroughScenery = 2320;
     constexpr StringId shortcutSeeThroughTracks = 2321;
     constexpr StringId shortcutSeeThroughTrees = 2322;
+    constexpr StringId mountainModeTooltip = 2323;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Widget.cpp
+++ b/src/OpenLoco/src/Widget.cpp
@@ -273,11 +273,9 @@ namespace OpenLoco::Ui
             return;
         }
 
-        // TODO: this is odd most likely this is another flag like Widget::kImageIdColourSet
-        if (imageId.hasSecondary())
+        if (!isColourSet && imageId.hasSecondary())
         {
-            // 0x4CAE5F
-            assert(false);
+            imageId = imageId.withSecondary(colour.c());
         }
 
         if (!isColourSet && imageId.hasPrimary())

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -1576,9 +1576,6 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             self.widgets[widx::tool_area].image = _adjustToolSize + ImageIds::tool_area;
 
-            self.widgets[widx::land_material].type = WidgetType::none;
-            self.widgets[widx::paint_mode].type = WidgetType::none;
-
             // CHANGE: Allows the player to select which material is used in the adjust land tool outside of editor mode.
             if (_adjustToolSize != 0)
             {
@@ -1588,8 +1585,19 @@ namespace OpenLoco::Ui::Windows::Terraform
                 self.widgets[widx::paint_mode].type = WidgetType::buttonWithImage;
                 self.widgets[widx::paint_mode].image = Gfx::recolour2(ImageIds::paintbrush, Colour::white, pixelColour);
 
-                self.widgets[widx::land_material].type = WidgetType::wt_6;
-                self.widgets[widx::land_material].image = landObj->mapPixelImage + OpenLoco::Land::ImageIds::landscape_generator_tile_icon;
+                if (isPaintMode)
+                {
+                    self.widgets[widx::land_material].type = WidgetType::wt_6;
+                    self.widgets[widx::land_material].image = landObj->mapPixelImage + OpenLoco::Land::ImageIds::landscape_generator_tile_icon;
+                }
+                else
+                {
+                    self.widgets[widx::land_material].type = WidgetType::none;
+                }
+            }
+            else
+            {
+                self.widgets[widx::paint_mode].type = WidgetType::none;
             }
 
             Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls);

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -967,8 +967,8 @@ namespace OpenLoco::Ui::Windows::Terraform
                 case widx::increase_area:
                 {
                     _adjustToolSize++;
-                    if (_adjustToolSize > 10)
-                        _adjustToolSize = 10;
+                    if (_adjustToolSize > 64)
+                        _adjustToolSize = 64;
                     _clearAreaToolSize = _adjustToolSize;
                     self.invalidate();
                     break;
@@ -1061,7 +1061,10 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             self.activatedWidgets |= (1ULL << widx::tool_area);
 
-            self.widgets[widx::tool_area].image = _adjustToolSize + ImageIds::tool_area;
+            if (_adjustToolSize <= 10)
+                self.widgets[widx::tool_area].image = _adjustToolSize + ImageIds::tool_area;
+            else
+                self.widgets[widx::tool_area].image = Widget::kContentNull;
 
             Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls);
         }
@@ -1074,16 +1077,28 @@ namespace OpenLoco::Ui::Windows::Terraform
             self.draw(rt);
             Common::drawTabs(&self, rt);
 
+            auto& toolArea = self.widgets[widx::tool_area];
+
+            // Draw as a number if we can't fit a sprite
+            if (_adjustToolSize > 10)
+            {
+
+                auto xPos = toolArea.midX() + self.x;
+                auto yPos = toolArea.midY() + self.y - 5;
+
+                auto args = FormatArguments();
+                args.push<uint16_t>(_adjustToolSize);
+                drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::tile_inspector_coord, &args);
+            }
+
             if (_raiseLandCost == 0x80000000)
                 return;
 
             if (_raiseLandCost == 0)
                 return;
 
-            auto xPos = self.widgets[widx::tool_area].left + self.widgets[widx::tool_area].right;
-            xPos /= 2;
-            xPos += self.x;
-            auto yPos = self.widgets[widx::tool_area].bottom + self.y + 5;
+            auto xPos = toolArea.midX() + self.x;
+            auto yPos = toolArea.bottom + self.y + 5;
 
             auto args = FormatArguments();
             args.push<uint32_t>(_raiseLandCost);

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -1248,11 +1248,18 @@ namespace OpenLoco::Ui::Windows::Terraform
                     self.invalidate();
                     break;
                 }
+            }
+        }
 
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        {
+            switch (widgetIndex)
+            {
                 case widx::paint_mode:
                 {
                     isPaintMode = !isPaintMode;
                     tabReset(&self);
+                    break;
                 }
             }
         }
@@ -1642,7 +1649,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void initEvents()
         {
             events.onClose = onClose;
-            events.onMouseUp = Common::onMouseUp;
+            events.onMouseUp = onMouseUp;
             events.onResize = onResize;
             events.onMouseDown = onMouseDown;
             events.onDropdown = onDropdown;

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -1144,7 +1144,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             makeWidget({ 49, 45 }, { 64, 44 }, WidgetType::wt_3, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_adjust_land_tool),
             makeWidget({ 50, 46 }, { 16, 16 }, WidgetType::toolbarTab, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_adjust_land_area),
             makeWidget({ 96, 72 }, { 16, 16 }, WidgetType::toolbarTab, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_adjust_land_area),
-            makeWidget({ 57, 92 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::construction_slope_up),
+            makeWidget({ 57, 92 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::construction_slope_up, StringIds::mountainModeTooltip),
             makeWidget({ 83, 92 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::paintbrush, StringIds::tooltip_paint_landscape_tool),
             makeWidget({ 112, 94 }, { 20, 20 }, WidgetType::wt_6, WindowColour::primary),
             widgetEnd(),

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -1273,6 +1273,18 @@ namespace OpenLoco::Ui::Windows::Terraform
         {
             switch (widgetIndex)
             {
+                case Common::widx::close_button:
+                    WindowManager::close(&self);
+                    break;
+
+                case Common::widx::tab_adjust_land:
+                case Common::widx::tab_adjust_water:
+                case Common::widx::tab_build_walls:
+                case Common::widx::tab_clear_area:
+                case Common::widx::tab_plant_trees:
+                    Common::switchTab(&self, widgetIndex);
+                    break;
+
                 case widx::mountain_mode:
                 {
                     isMountainMode = !isMountainMode;

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -1605,28 +1605,18 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             self.widgets[widx::tool_area].image = _adjustToolSize + ImageIds::tool_area;
 
-            // CHANGE: Allows the player to select which material is used in the adjust land tool outside of editor mode.
-            if (_adjustToolSize != 0)
+            auto landObj = ObjectManager::get<LandObject>(_lastSelectedLand);
+            auto pixelColour = static_cast<Colour>(Gfx::getG1Element(landObj->mapPixelImage)->offset[0]);
+            self.widgets[widx::paint_mode].image = Gfx::recolour2(ImageIds::paintbrush, Colour::white, pixelColour);
+
+            if (isPaintMode)
             {
-                auto landObj = ObjectManager::get<LandObject>(_lastSelectedLand);
-                auto pixelColour = static_cast<Colour>(Gfx::getG1Element(landObj->mapPixelImage)->offset[0]);
-
-                self.widgets[widx::paint_mode].type = WidgetType::buttonWithImage;
-                self.widgets[widx::paint_mode].image = Gfx::recolour2(ImageIds::paintbrush, Colour::white, pixelColour);
-
-                if (isPaintMode)
-                {
-                    self.widgets[widx::land_material].type = WidgetType::wt_6;
-                    self.widgets[widx::land_material].image = landObj->mapPixelImage + OpenLoco::Land::ImageIds::landscape_generator_tile_icon;
-                }
-                else
-                {
-                    self.widgets[widx::land_material].type = WidgetType::none;
-                }
+                self.widgets[widx::land_material].type = WidgetType::wt_6;
+                self.widgets[widx::land_material].image = landObj->mapPixelImage + OpenLoco::Land::ImageIds::landscape_generator_tile_icon;
             }
             else
             {
-                self.widgets[widx::paint_mode].type = WidgetType::none;
+                self.widgets[widx::land_material].type = WidgetType::none;
             }
 
             Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls);

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -1795,8 +1795,8 @@ namespace OpenLoco::Ui::Windows::Terraform
                 case widx::increase_area:
                 {
                     _adjustToolSize++;
-                    if (_adjustToolSize > 10)
-                        _adjustToolSize = 10;
+                    if (_adjustToolSize > 64)
+                        _adjustToolSize = 64;
                     _adjustWaterToolSize = _adjustToolSize;
                     self.invalidate();
                     break;
@@ -1969,7 +1969,10 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             self.activatedWidgets |= (1ULL << widx::tool_area);
 
-            self.widgets[widx::tool_area].image = _adjustToolSize + ImageIds::tool_area;
+            if (_adjustToolSize <= 10)
+                self.widgets[widx::tool_area].image = _adjustToolSize + ImageIds::tool_area;
+            else
+                self.widgets[widx::tool_area].image = Widget::kContentNull;
 
             Widget::leftAlignTabs(self, Common::widx::tab_clear_area, Common::widx::tab_build_walls);
         }
@@ -1982,10 +1985,21 @@ namespace OpenLoco::Ui::Windows::Terraform
             self.draw(rt);
             Common::drawTabs(&self, rt);
 
-            auto xPos = self.widgets[widx::tool_area].left + self.widgets[widx::tool_area].right;
-            xPos /= 2;
-            xPos += self.x;
-            auto yPos = self.widgets[widx::tool_area].bottom + self.y + 5;
+            auto& toolArea = self.widgets[widx::tool_area];
+
+            // Draw as a number if we can't fit a sprite
+            if (_adjustToolSize > 10)
+            {
+                auto xPos = toolArea.midX() + self.x;
+                auto yPos = toolArea.midY() + self.y - 5;
+
+                auto args = FormatArguments();
+                args.push<uint16_t>(_adjustToolSize);
+                drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::tile_inspector_coord, &args);
+            }
+
+            auto xPos = toolArea.midX() + self.x;
+            auto yPos = toolArea.bottom + self.y + 5;
 
             if (_raiseWaterCost != 0x80000000)
             {

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -1128,7 +1128,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             makeWidget({ 34 + 16, 46 }, { 16, 16 }, WidgetType::toolbarTab, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_adjust_land_area),
             makeWidget({ 80 + 16, 72 }, { 16, 16 }, WidgetType::toolbarTab, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_adjust_land_area),
             makeWidget({ 69 + 16, 92 }, { 20, 20 }, WidgetType::wt_6, WindowColour::primary),
-            makeWidget({ 39 + 16, 92 }, { 28, 28 }, WidgetType::buttonWithImage, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_paint_landscape_tool),
+            makeWidget({ 39 + 16, 92 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::paintbrush, StringIds::tooltip_paint_landscape_tool),
             widgetEnd(),
         };
 
@@ -1577,14 +1577,18 @@ namespace OpenLoco::Ui::Windows::Terraform
             self.widgets[widx::tool_area].image = _adjustToolSize + ImageIds::tool_area;
 
             self.widgets[widx::land_material].type = WidgetType::none;
+            self.widgets[widx::paint_mode].type = WidgetType::none;
 
             // CHANGE: Allows the player to select which material is used in the adjust land tool outside of editor mode.
             if (_adjustToolSize != 0)
             {
-                self.widgets[widx::land_material].type = WidgetType::wt_6;
-
                 auto landObj = ObjectManager::get<LandObject>(_lastSelectedLand);
+                auto pixelColour = static_cast<Colour>(Gfx::getG1Element(landObj->mapPixelImage)->offset[0]);
 
+                self.widgets[widx::paint_mode].type = WidgetType::buttonWithImage;
+                self.widgets[widx::paint_mode].image = Gfx::recolour2(ImageIds::paintbrush, Colour::white, pixelColour);
+
+                self.widgets[widx::land_material].type = WidgetType::wt_6;
                 self.widgets[widx::land_material].image = landObj->mapPixelImage + OpenLoco::Land::ImageIds::landscape_generator_tile_icon;
             }
 
@@ -1595,11 +1599,6 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void draw(Window& self, Gfx::RenderTarget* rt)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-
-            auto skin = ObjectManager::get<InterfaceSkinObject>();
-            auto imgId = skin->img;
-            self.widgets[widx::paint_mode].image = imgId + InterfaceSkin::ImageIds::tab_colour_scheme_frame0;
-
             self.draw(rt);
 
             Common::drawTabs(&self, rt);

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -1245,8 +1245,8 @@ namespace OpenLoco::Ui::Windows::Terraform
                 case widx::increase_area:
                 {
                     _adjustToolSize++;
-                    if (_adjustToolSize > 10)
-                        _adjustToolSize = 10;
+                    if (_adjustToolSize > 64)
+                        _adjustToolSize = 64;
                     _adjustLandToolSize = _adjustToolSize;
                     self.invalidate();
                     break;
@@ -1630,35 +1630,49 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             auto& toolArea = self.widgets[widx::tool_area];
 
-            // For mountain mode, we first draw the background grid
-            if (isMountainMode)
+            // Draw land tool size as a grid
+            if (_adjustToolSize < 10)
             {
-                auto areaImage = ImageId(ImageIds::tool_area);
-                Ui::Point placeForImage(toolArea.left + self.x, toolArea.top + self.y);
-
-                if ((_adjustToolSize & 1) == 0)
+                // For mountain mode, we first draw the background grid
+                if (isMountainMode)
                 {
-                    // For even sizes, we need to draw the image twice
-                    // TODO: replace with proper grid images
-                    placeForImage -= { 4, 0 };
-                    drawingCtx.drawImage(*rt, placeForImage, areaImage);
+                    auto areaImage = ImageId(ImageIds::tool_area);
+                    Ui::Point placeForImage(toolArea.left + self.x, toolArea.top + self.y);
 
-                    placeForImage += { 8, 0 };
-                    drawingCtx.drawImage(*rt, placeForImage, areaImage);
+                    if ((_adjustToolSize & 1) == 0)
+                    {
+                        // For even sizes, we need to draw the image twice
+                        // TODO: replace with proper grid images
+                        placeForImage -= { 4, 0 };
+                        drawingCtx.drawImage(*rt, placeForImage, areaImage);
+
+                        placeForImage += { 8, 0 };
+                        drawingCtx.drawImage(*rt, placeForImage, areaImage);
+                    }
+                    else
+                    {
+                        // For odd sizes, we just need the one
+                        drawingCtx.drawImage(*rt, placeForImage, areaImage);
+                    }
                 }
-                else
+
+                // Draw tool size
+                if (!isMountainMode || _adjustToolSize > 1)
                 {
-                    // For odd sizes, we just need the one
+                    auto areaImage = ImageId(ImageIds::tool_area).withIndexOffset(_adjustToolSize);
+                    Ui::Point placeForImage(toolArea.left + self.x, toolArea.top + self.y);
                     drawingCtx.drawImage(*rt, placeForImage, areaImage);
                 }
             }
-
-            // Draw tool size
-            if (!isMountainMode || _adjustToolSize > 1)
+            // Or draw as a number, if we can't fit a sprite
+            else
             {
-                auto areaImage = ImageId(ImageIds::tool_area).withIndexOffset(_adjustToolSize);
-                Ui::Point placeForImage(toolArea.left + self.x, toolArea.top + self.y);
-                drawingCtx.drawImage(*rt, placeForImage, areaImage);
+                auto xPos = toolArea.midX() + self.x;
+                auto yPos = toolArea.midY() + self.y - 5;
+
+                auto args = FormatArguments();
+                args.push<uint16_t>(_adjustToolSize);
+                drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::tile_inspector_coord, &args);
             }
 
             auto xPos = toolArea.midX() + self.x;

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -1126,12 +1126,12 @@ namespace OpenLoco::Ui::Windows::Terraform
 
         Widget widgets[] = {
             commonWidgets(130, 105, StringIds::title_adjust_land),
-            makeWidget({ 33 + 16, 45 }, { 64, 44 }, WidgetType::wt_3, WindowColour::secondary, ImageIds::tool_area, StringIds::tooltip_adjust_land_tool),
-            makeWidget({ 34 + 16, 46 }, { 16, 16 }, WidgetType::toolbarTab, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_adjust_land_area),
-            makeWidget({ 80 + 16, 72 }, { 16, 16 }, WidgetType::toolbarTab, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_adjust_land_area),
-            makeWidget({ 33, 92 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::construction_slope_up),
-            makeWidget({ 39 + 16, 92 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::paintbrush, StringIds::tooltip_paint_landscape_tool),
-            makeWidget({ 69 + 16, 92 }, { 20, 20 }, WidgetType::wt_6, WindowColour::primary),
+            makeWidget({ 49, 45 }, { 64, 44 }, WidgetType::wt_3, WindowColour::secondary, ImageIds::tool_area, StringIds::tooltip_adjust_land_tool),
+            makeWidget({ 50, 46 }, { 16, 16 }, WidgetType::toolbarTab, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_adjust_land_area),
+            makeWidget({ 96, 72 }, { 16, 16 }, WidgetType::toolbarTab, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_adjust_land_area),
+            makeWidget({ 57, 92 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::construction_slope_up),
+            makeWidget({ 83, 92 }, { 24, 24 }, WidgetType::buttonWithImage, WindowColour::secondary, ImageIds::paintbrush, StringIds::tooltip_paint_landscape_tool),
+            makeWidget({ 112, 94 }, { 20, 20 }, WidgetType::wt_6, WindowColour::primary),
             widgetEnd(),
         };
 

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -1290,6 +1290,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     isMountainMode = !isMountainMode;
                     isPaintMode = false;
                     tabReset(&self);
+                    self.invalidate();
                     break;
                 }
 
@@ -1298,6 +1299,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     isMountainMode = false;
                     isPaintMode = !isPaintMode;
                     tabReset(&self);
+                    self.invalidate();
                     break;
                 }
             }


### PR DESCRIPTION
This PR brings various improvements to the terraform tools:

- The mountain tool is now a toggle, rather than size 0, making it possible to specify the mountain's table size.
- The landscape 'paint mode' button now uses a slightly paintbrush image.
- The landscape texture selection is now hidden until the 'paint' mode is activated.
- Increases max tool sizes from 10x10 to 64x64. Larger tool sizes will show a number instead of a grid sprite.

<img width="703" alt="Screenshot_2023-12-25_at_00 59 30" src="https://github.com/OpenLoco/OpenLoco/assets/604665/74e94665-4cc5-4dec-8822-28280d57d730">
