### PR TITLE
Move edge scrolling section to NewConfig struct and reorder

### DIFF
--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -284,6 +284,8 @@ namespace OpenLoco::Config
 
         if (config["edgeScrolling"])
             _newConfig.edgeScrolling = config["edgeScrolling"].as<bool>();
+        if (config["edgeScrollingSpeed"])
+            _newConfig.edgeScrollingSpeed = config["edgeScrollingSpeed"].as<int32_t>();
 
         auto& scNode = config["shortcuts"];
         // Protect from empty shortcuts
@@ -360,6 +362,7 @@ namespace OpenLoco::Config
         node["cashPopupRendering"] = _newConfig.cashPopupRendering;
         node["disableVehicleLoadPenaltyCheat"] = _newConfig.disableVehicleLoadPenaltyCheat;
         node["edgeScrolling"] = _newConfig.edgeScrolling;
+        node["edgeScrollingSpeed"] = _newConfig.edgeScrollingSpeed;
 
         // Shortcuts
         const auto& shortcuts = _newConfig.shortcuts;

--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -282,6 +282,9 @@ namespace OpenLoco::Config
         if (config["disableVehicleLoadPenaltyCheat"])
             _newConfig.disableVehicleLoadPenaltyCheat = config["disableVehicleLoadPenaltyCheat"].as<bool>();
 
+        if (config["edgeScrolling"])
+            _newConfig.edgeScrolling = config["edgeScrolling"].as<bool>();
+
         auto& scNode = config["shortcuts"];
         // Protect from empty shortcuts
         readShortcutConfig(scNode ? scNode : YAML::Node{});
@@ -356,6 +359,7 @@ namespace OpenLoco::Config
         node["invertRightMouseViewPan"] = _newConfig.invertRightMouseViewPan;
         node["cashPopupRendering"] = _newConfig.cashPopupRendering;
         node["disableVehicleLoadPenaltyCheat"] = _newConfig.disableVehicleLoadPenaltyCheat;
+        node["edgeScrolling"] = _newConfig.edgeScrolling;
 
         // Shortcuts
         const auto& shortcuts = _newConfig.shortcuts;

--- a/src/OpenLoco/src/Config.h
+++ b/src/OpenLoco/src/Config.h
@@ -188,6 +188,7 @@ namespace OpenLoco::Config
         bool allowMultipleInstances = false;
         bool disableVehicleLoadPenaltyCheat = false;
         bool edgeScrolling = true;
+        int32_t edgeScrollingSpeed = 12;
         LocoConfig old;
 
         constexpr bool hasFlags(Flags flagsToTest) const

--- a/src/OpenLoco/src/Config.h
+++ b/src/OpenLoco/src/Config.h
@@ -187,6 +187,7 @@ namespace OpenLoco::Config
         bool cashPopupRendering = true;
         bool allowMultipleInstances = false;
         bool disableVehicleLoadPenaltyCheat = false;
+        bool edgeScrolling = true;
         LocoConfig old;
 
         constexpr bool hasFlags(Flags flagsToTest) const

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -415,7 +415,7 @@ namespace OpenLoco::Input
         if (Tutorial::state() != Tutorial::State::none)
             return;
 
-        if (Config::get().old.edgeScrolling == 0)
+        if (!Config::get().edgeScrolling)
             return;
 
         if (Input::state() != State::normal && Input::state() != State::dropdownActive)

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -428,16 +428,16 @@ namespace OpenLoco::Input
         auto cursor = getMouseLocation();
 
         if (cursor.x == 0)
-            delta.x -= 12;
+            delta.x -= Config::get().edgeScrollingSpeed;
 
         if (cursor.x == Ui::width() - 1)
-            delta.x += 12;
+            delta.x += Config::get().edgeScrollingSpeed;
 
         if (cursor.y == 0)
-            delta.y -= 12;
+            delta.y -= Config::get().edgeScrollingSpeed;
 
         if (cursor.y == Ui::height() - 1)
-            delta.y += 12;
+            delta.y += Config::get().edgeScrollingSpeed;
 
         if (delta.x == 0 && delta.y == 0)
             return;
@@ -474,16 +474,16 @@ namespace OpenLoco::Input
         Ui::Point delta = { 0, 0 };
 
         if (_keyboardState[SDL_SCANCODE_LEFT] & 0x80)
-            delta.x -= 8;
+            delta.x -= Config::get().edgeScrollingSpeed;
 
         if (_keyboardState[SDL_SCANCODE_UP] & 0x80)
-            delta.y -= 8;
+            delta.y -= Config::get().edgeScrollingSpeed;
 
         if (_keyboardState[SDL_SCANCODE_DOWN] & 0x80)
-            delta.y += 8;
+            delta.y += Config::get().edgeScrollingSpeed;
 
         if (_keyboardState[SDL_SCANCODE_RIGHT] & 0x80)
-            delta.x += 8;
+            delta.x += Config::get().edgeScrollingSpeed;
 
         if (delta.x == 0 && delta.y == 0)
             return;

--- a/src/OpenLoco/src/Windows/Options.cpp
+++ b/src/OpenLoco/src/Windows/Options.cpp
@@ -1817,7 +1817,7 @@ namespace OpenLoco::Ui::Windows::Options
             w.widgets[Common::Widx::close_button].right = w.width - 15 + 12;
 
             w.activatedWidgets &= ~(1 << Widx::edge_scrolling | 1 << Widx::zoom_to_cursor | 1 << Widx::invertRightMouseViewPan);
-            if (Config::get().old.edgeScrolling)
+            if (Config::get().edgeScrolling)
             {
                 w.activatedWidgets |= (1 << Widx::edge_scrolling);
             }
@@ -1879,7 +1879,7 @@ namespace OpenLoco::Ui::Windows::Options
         // 0x004C117A
         static void edgeScrollingMouseUp(Window* w)
         {
-            auto& cfg = OpenLoco::Config::get().old;
+            auto& cfg = OpenLoco::Config::get();
             cfg.edgeScrolling = !cfg.edgeScrolling;
             Config::write();
 


### PR DESCRIPTION
There are three ways to pan the viewport in OpenLoco: putting the cursor to the canvas/window edge, right-click dragging, and using the arrow keys. The latter has been commented to be relatively slow, which this PR addresses.

This PR changes the arrow key scroll speed to match that of the edge scroll speed, effectively changing it from 8px to 12px at a time. Inspired by OpenRCT2, I have also made the speed configurable in the config file, making the scroll speed a new 'hidden' setting.