### PR TITLE
Refactor NewConfig struct reading and writing

### DIFF
--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -239,13 +239,13 @@ namespace OpenLoco::Config
         if (networkNode && networkNode.IsMap())
         {
             auto& networkConfig = _newConfig.network;
-            networkConfig.enabled = networkNode["enabled"] && networkNode["enabled"].as<bool>(false);
+            networkConfig.enabled = networkNode["enabled"].as<bool>(false);
         }
 
         // General
-        _newConfig.locoInstallPath = config["loco_install_path"].as<std::string>();
-        _newConfig.lastSavePath = config["last_save_path"].as<std::string>();
-        _newConfig.language = config["language"].as<std::string>();
+        _newConfig.locoInstallPath = config["loco_install_path"].as<std::string>("");
+        _newConfig.lastSavePath = config["last_save_path"].as<std::string>("");
+        _newConfig.language = config["language"].as<std::string>("en-GB");
 
         // Rendering
         _newConfig.scaleFactor = config["scale_factor"].as<float>(1.0f);

--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -213,80 +213,68 @@ namespace OpenLoco::Config
 
         const auto& config = _configYaml;
 
+        // Display settings
         auto& displayNode = config["display"];
         if (displayNode && displayNode.IsMap())
         {
             auto& displayConfig = _newConfig.display;
             displayConfig.mode = displayNode["mode"].as<ScreenMode>(ScreenMode::window);
             displayConfig.index = displayNode["index"].as<int32_t>(0);
-            displayConfig.windowResolution = displayNode["window_resolution"].as<Resolution>();
-            displayConfig.fullscreenResolution = displayNode["fullscreen_resolution"].as<Resolution>();
+            displayConfig.windowResolution = displayNode["window_resolution"].as<Resolution>(Resolution{ 800, 600 });
+            displayConfig.fullscreenResolution = displayNode["fullscreen_resolution"].as<Resolution>(Resolution{ 1920, 1080 });
         }
 
+        // Audio settings
         auto& audioNode = config["audio"];
         if (audioNode && audioNode.IsMap())
         {
             auto& audioConfig = _newConfig.audio;
             audioConfig.device = audioNode["device"].as<std::string>("");
-            if (audioNode["play_title_music"])
-                audioConfig.playTitleMusic = audioNode["play_title_music"].as<bool>();
-            if (audioNode["play_news_sounds"])
-                audioConfig.playNewsSounds = audioNode["play_news_sounds"].as<bool>();
+            audioConfig.playTitleMusic = audioNode["play_title_music"].as<bool>(true);
+            audioConfig.playNewsSounds = audioNode["play_news_sounds"].as<bool>(true);
         }
 
+        // Network settings
         auto& networkNode = config["network"];
         if (networkNode && networkNode.IsMap())
         {
             auto& networkConfig = _newConfig.network;
-            networkConfig.enabled = networkNode["enabled"] && networkNode["enabled"].as<bool>();
+            networkConfig.enabled = networkNode["enabled"] && networkNode["enabled"].as<bool>(false);
         }
 
-        if (config["allow_multiple_instances"])
-            _newConfig.allowMultipleInstances = config["allow_multiple_instances"].as<bool>();
-        if (config["loco_install_path"])
-            _newConfig.locoInstallPath = config["loco_install_path"].as<std::string>();
-        if (config["last_save_path"])
-            _newConfig.lastSavePath = config["last_save_path"].as<std::string>();
-        if (config["language"])
-            _newConfig.language = config["language"].as<std::string>();
-        if (config["breakdowns_disabled"])
-            _newConfig.breakdownsDisabled = config["breakdowns_disabled"].as<bool>();
-        if (config["trainsReverseAtSignals"])
-            _newConfig.trainsReverseAtSignals = config["trainsReverseAtSignals"].as<bool>();
-        if (config["cheats_menu_enabled"])
-            _newConfig.cheatsMenuEnabled = config["cheats_menu_enabled"].as<bool>();
-        if (config["companyAIDisabled"])
-            _newConfig.companyAIDisabled = config["companyAIDisabled"].as<bool>();
-        if (config["townGrowthDisabled"])
-            _newConfig.townGrowthDisabled = config["townGrowthDisabled"].as<bool>();
-        if (config["scale_factor"])
-            _newConfig.scaleFactor = config["scale_factor"].as<float>();
-        if (config["zoom_to_cursor"])
-            _newConfig.zoomToCursor = config["zoom_to_cursor"].as<bool>();
-        if (config["autosave_frequency"])
-            _newConfig.autosaveFrequency = config["autosave_frequency"].as<int32_t>();
-        if (config["autosave_amount"])
-            _newConfig.autosaveAmount = config["autosave_amount"].as<int32_t>();
-        if (config["showFPS"])
-            _newConfig.showFPS = config["showFPS"].as<bool>();
-        if (config["uncapFPS"])
-            _newConfig.uncapFPS = config["uncapFPS"].as<bool>();
-        if (config["displayLockedVehicles"])
-            _newConfig.displayLockedVehicles = config["displayLockedVehicles"].as<bool>();
-        if (config["buildLockedVehicles"])
-            _newConfig.buildLockedVehicles = config["buildLockedVehicles"].as<bool>();
-        if (config["invertRightMouseViewPan"])
-            _newConfig.invertRightMouseViewPan = config["invertRightMouseViewPan"].as<bool>();
-        if (config["cashPopupRendering"])
-            _newConfig.cashPopupRendering = config["cashPopupRendering"].as<bool>();
-        if (config["disableVehicleLoadPenaltyCheat"])
-            _newConfig.disableVehicleLoadPenaltyCheat = config["disableVehicleLoadPenaltyCheat"].as<bool>();
+        // General
+        _newConfig.locoInstallPath = config["loco_install_path"].as<std::string>();
+        _newConfig.lastSavePath = config["last_save_path"].as<std::string>();
+        _newConfig.language = config["language"].as<std::string>();
 
-        if (config["edgeScrolling"])
-            _newConfig.edgeScrolling = config["edgeScrolling"].as<bool>();
-        if (config["edgeScrollingSpeed"])
-            _newConfig.edgeScrollingSpeed = config["edgeScrollingSpeed"].as<int32_t>();
+        // Rendering
+        _newConfig.scaleFactor = config["scale_factor"].as<float>(1.0f);
+        _newConfig.showFPS = config["showFPS"].as<bool>(false);
+        _newConfig.uncapFPS = config["uncapFPS"].as<bool>(false);
 
+        // General UI
+        _newConfig.allowMultipleInstances = config["allow_multiple_instances"].as<bool>(false);
+        _newConfig.cashPopupRendering = config["cashPopupRendering"].as<bool>(true);
+        _newConfig.edgeScrolling = config["edgeScrolling"].as<bool>(true);
+        _newConfig.edgeScrollingSpeed = config["edgeScrollingSpeed"].as<int32_t>(12);
+        _newConfig.zoomToCursor = config["zoom_to_cursor"].as<bool>(true);
+
+        // Autosaves
+        _newConfig.autosaveAmount = config["autosave_amount"].as<int32_t>(12);
+        _newConfig.autosaveFrequency = config["autosave_frequency"].as<int32_t>(1);
+
+        // Cheats
+        _newConfig.breakdownsDisabled = config["breakdowns_disabled"].as<bool>(false);
+        _newConfig.buildLockedVehicles = config["buildLockedVehicles"].as<bool>(false);
+        _newConfig.cheatsMenuEnabled = config["cheats_menu_enabled"].as<bool>(false);
+        _newConfig.companyAIDisabled = config["companyAIDisabled"].as<bool>(false);
+        _newConfig.disableVehicleLoadPenaltyCheat = config["disableVehicleLoadPenaltyCheat"].as<bool>(false);
+        _newConfig.displayLockedVehicles = config["displayLockedVehicles"].as<bool>(false);
+        _newConfig.invertRightMouseViewPan = config["invertRightMouseViewPan"].as<bool>(false);
+        _newConfig.townGrowthDisabled = config["townGrowthDisabled"].as<bool>(false);
+        _newConfig.trainsReverseAtSignals = config["trainsReverseAtSignals"].as<bool>(false);
+
+        // Shortcuts
         auto& scNode = config["shortcuts"];
         // Protect from empty shortcuts
         readShortcutConfig(scNode ? scNode : YAML::Node{});

--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -329,28 +329,37 @@ namespace OpenLoco::Config
         networkNode["enabled"] = networkConfig.enabled;
         node["network"] = networkNode;
 
-        node["allow_multiple_instances"] = _newConfig.allowMultipleInstances;
+        // General
         node["loco_install_path"] = _newConfig.locoInstallPath;
         node["last_save_path"] = _newConfig.lastSavePath;
         node["language"] = _newConfig.language;
-        node["breakdowns_disabled"] = _newConfig.breakdownsDisabled;
-        node["trainsReverseAtSignals"] = _newConfig.trainsReverseAtSignals;
-        node["cheats_menu_enabled"] = _newConfig.cheatsMenuEnabled;
-        node["companyAIDisabled"] = _newConfig.companyAIDisabled;
-        node["townGrowthDisabled"] = _newConfig.townGrowthDisabled;
+
+        // Rendering
         node["scale_factor"] = _newConfig.scaleFactor;
-        node["zoom_to_cursor"] = _newConfig.zoomToCursor;
-        node["autosave_frequency"] = _newConfig.autosaveFrequency;
-        node["autosave_amount"] = _newConfig.autosaveAmount;
         node["showFPS"] = _newConfig.showFPS;
         node["uncapFPS"] = _newConfig.uncapFPS;
-        node["displayLockedVehicles"] = _newConfig.displayLockedVehicles;
-        node["buildLockedVehicles"] = _newConfig.buildLockedVehicles;
-        node["invertRightMouseViewPan"] = _newConfig.invertRightMouseViewPan;
+
+        // General UI
+        node["allow_multiple_instances"] = _newConfig.allowMultipleInstances;
         node["cashPopupRendering"] = _newConfig.cashPopupRendering;
-        node["disableVehicleLoadPenaltyCheat"] = _newConfig.disableVehicleLoadPenaltyCheat;
         node["edgeScrolling"] = _newConfig.edgeScrolling;
         node["edgeScrollingSpeed"] = _newConfig.edgeScrollingSpeed;
+        node["zoom_to_cursor"] = _newConfig.zoomToCursor;
+
+        // Autosaves
+        node["autosave_amount"] = _newConfig.autosaveAmount;
+        node["autosave_frequency"] = _newConfig.autosaveFrequency;
+
+        // Cheats
+        node["breakdowns_disabled"] = _newConfig.breakdownsDisabled;
+        node["buildLockedVehicles"] = _newConfig.buildLockedVehicles;
+        node["cheats_menu_enabled"] = _newConfig.cheatsMenuEnabled;
+        node["companyAIDisabled"] = _newConfig.companyAIDisabled;
+        node["disableVehicleLoadPenaltyCheat"] = _newConfig.disableVehicleLoadPenaltyCheat;
+        node["displayLockedVehicles"] = _newConfig.displayLockedVehicles;
+        node["invertRightMouseViewPan"] = _newConfig.invertRightMouseViewPan;
+        node["townGrowthDisabled"] = _newConfig.townGrowthDisabled;
+        node["trainsReverseAtSignals"] = _newConfig.trainsReverseAtSignals;
 
         // Shortcuts
         const auto& shortcuts = _newConfig.shortcuts;

--- a/src/OpenLoco/src/Config.h
+++ b/src/OpenLoco/src/Config.h
@@ -169,26 +169,32 @@ namespace OpenLoco::Config
         std::string locoInstallPath;
         std::string lastSavePath;
         std::string language = "en-GB";
-        bool cheatsMenuEnabled = false;
-        bool breakdownsDisabled = false;
-        bool trainsReverseAtSignals = true;
-        bool companyAIDisabled = false;
-        bool townGrowthDisabled = false;
+
         float scaleFactor = 1.0f;
-        bool zoomToCursor = true;
-        int32_t autosaveFrequency = 1;
-        int32_t autosaveAmount = 12;
         bool showFPS = false;
         bool uncapFPS = false;
-        std::map<Input::Shortcut, KeyboardShortcut> shortcuts;
-        bool displayLockedVehicles = false;
-        bool buildLockedVehicles = false;
-        bool invertRightMouseViewPan = false;
-        bool cashPopupRendering = true;
+
         bool allowMultipleInstances = false;
-        bool disableVehicleLoadPenaltyCheat = false;
+        bool cashPopupRendering = true;
         bool edgeScrolling = true;
         int32_t edgeScrollingSpeed = 12;
+        bool zoomToCursor = true;
+
+        int32_t autosaveAmount = 12;
+        int32_t autosaveFrequency = 1;
+
+        bool breakdownsDisabled = false;
+        bool buildLockedVehicles = false;
+        bool cheatsMenuEnabled = false;
+        bool companyAIDisabled = false;
+        bool disableVehicleLoadPenaltyCheat = false;
+        bool displayLockedVehicles = false;
+        bool invertRightMouseViewPan = false;
+        bool townGrowthDisabled = false;
+        bool trainsReverseAtSignals = true;
+
+        std::map<Input::Shortcut, KeyboardShortcut> shortcuts;
+
         LocoConfig old;
 
         constexpr bool hasFlags(Flags flagsToTest) const


### PR DESCRIPTION
This PR makes the config reading and writing more resilient by explicitly defaults for the YAML reader to fall back to. Added benefit is that we can omit all the `if` blocks checking whether nodes exist in the YAML file that is being read. This drastically increases legibility.

I've also changed the order of the NewConfig struct attributes, grouping them together logically. I'd like this struct to be split into smaller structs in another PR. Doing so would ideally be compatible with existing configs, though -- at least for a while. We might opt to addressing this along with a change in config format (TOML?), but that needs discussing first.

~NB: this PR is based on the work from #2229, so I'm filing this as a draft for now.~