### PR TITLE
Turn window-specific handleInput functions into keyUp events

### DIFF
--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -312,6 +312,20 @@ namespace OpenLoco::Input
                 continue;
             }
 
+            auto ti = WindowManager::find(WindowType::editKeyboardShortcut);
+            if (ti != nullptr)
+            {
+                editShortcut(nextKey);
+                continue;
+            }
+
+            if (tryShortcut(Shortcut::screenshot, nextKey->keyCode, _keyModifier))
+                continue;
+
+            if (WindowManager::callKeyUpEventBackToFront(nextKey->charCode, nextKey->keyCode))
+                continue;
+
+            /*
             auto ti = WindowManager::find(WindowType::textInput);
             if (ti != nullptr)
             {
@@ -364,13 +378,7 @@ namespace OpenLoco::Input
                 Ui::Windows::BuildVehicle::handleInput(nextKey->charCode, nextKey->keyCode);
                 continue;
             }
-
-            ti = WindowManager::find(WindowType::editKeyboardShortcut);
-            if (ti != nullptr)
-            {
-                editShortcut(nextKey);
-                continue;
-            }
+            */
 
             if (Tutorial::state() == Tutorial::State::playing)
             {

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -325,61 +325,6 @@ namespace OpenLoco::Input
             if (WindowManager::callKeyUpEventBackToFront(nextKey->charCode, nextKey->keyCode))
                 continue;
 
-            /*
-            auto ti = WindowManager::find(WindowType::textInput);
-            if (ti != nullptr)
-            {
-                if (tryShortcut(Shortcut::screenshot, nextKey->keyCode, _keyModifier))
-                    continue;
-
-                Ui::Windows::TextInput::handleInput(nextKey->charCode, nextKey->keyCode);
-                continue;
-            }
-
-            if (*_modalWindowType == WindowType::fileBrowserPrompt)
-            {
-                ti = WindowManager::find(WindowType::fileBrowserPrompt);
-                if (ti != nullptr)
-                {
-                    if (tryShortcut(Shortcut::screenshot, nextKey->keyCode, _keyModifier))
-                        continue;
-
-                    Ui::Windows::PromptBrowse::handleInput(nextKey->charCode, nextKey->keyCode);
-                    continue;
-                }
-            }
-
-            if (*_modalWindowType == WindowType::confirmationPrompt)
-            {
-                ti = WindowManager::find(WindowType::confirmationPrompt);
-                if (ti != nullptr)
-                {
-                    Ui::Windows::PromptOkCancel::handleInput(nextKey->charCode, nextKey->keyCode);
-                    continue;
-                }
-            }
-
-            ti = WindowManager::find(WindowType::objectSelection);
-            if (ti != nullptr)
-            {
-                if (tryShortcut(Shortcut::screenshot, nextKey->keyCode, _keyModifier))
-                    continue;
-
-                Ui::Windows::ObjectSelectionWindow::handleInput(nextKey->charCode, nextKey->keyCode);
-                continue;
-            }
-
-            ti = WindowManager::find(WindowType::buildVehicle);
-            if (ti != nullptr)
-            {
-                if (tryShortcut(Shortcut::screenshot, nextKey->keyCode, _keyModifier))
-                    continue;
-
-                Ui::Windows::BuildVehicle::handleInput(nextKey->charCode, nextKey->keyCode);
-                continue;
-            }
-            */
-
             if (Tutorial::state() == Tutorial::State::playing)
             {
                 Tutorial::stop();

--- a/src/OpenLoco/src/Ui/TextInput.cpp
+++ b/src/OpenLoco/src/Ui/TextInput.cpp
@@ -34,8 +34,8 @@ namespace OpenLoco::Ui::TextInput
         {
             if (cursorPosition == 0)
             {
-                // Cursor is at beginning
-                return false;
+                // Cursor is at beginning. No change required, but consume input
+                return true;
             }
 
             buffer.erase(cursorPosition - 1, 1);
@@ -45,7 +45,8 @@ namespace OpenLoco::Ui::TextInput
         {
             if (cursorPosition == buffer.length())
             {
-                return false;
+                // Cursor is at end. No change required, but consume input
+                return true;
             }
 
             buffer.erase(cursorPosition, 1);
@@ -62,8 +63,8 @@ namespace OpenLoco::Ui::TextInput
         {
             if (cursorPosition == 0)
             {
-                // Cursor is at beginning
-                return false;
+                // Cursor is at beginning. No change required, but consume input
+                return true;
             }
 
             cursorPosition -= 1;
@@ -72,8 +73,8 @@ namespace OpenLoco::Ui::TextInput
         {
             if (cursorPosition == buffer.length())
             {
-                // Cursor is at end
-                return false;
+                // Cursor is at end. No change required, but consume input
+                return true;
             }
 
             cursorPosition += 1;

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -1298,6 +1298,16 @@ namespace OpenLoco::Ui::WindowManager
         }
     }
 
+    bool callKeyUpEventBackToFront(uint32_t charCode, uint32_t keyCode)
+    {
+        for (Ui::Window* w = _windowsEnd - 1; w >= _windows; w--)
+        {
+            if (w->callKeyUp(charCode, keyCode))
+                return true;
+        }
+        return false;
+    }
+
     // 0x004CD296
     void relocateWindows()
     {

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -365,7 +365,6 @@ namespace OpenLoco::Ui::Windows
         void openTextInput(Ui::Window* w, StringId title, StringId message, StringId value, int callingWidget, void* valueArgs, uint32_t inputSize = StringManager::kUserStringSize - 1);
         void sub_4CE6C9(WindowType type, WindowNumber_t number);
         void cancel();
-        void handleInput(uint32_t charCode, uint32_t keyCode);
         void sub_4CE6FF();
     }
 

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -132,7 +132,6 @@ namespace OpenLoco::Ui::Windows
         Window* open(uint32_t vehicle, uint32_t flags);
         void sub_4B92A5(Ui::Window* window);
         void drawVehicleOverview(Gfx::RenderTarget* rt, int16_t vehicleTypeIdx, CompanyId company, uint8_t eax, uint8_t esi, Ui::Point offset);
-        void handleInput(uint32_t charCode, uint32_t keyCode);
         void registerHooks();
     }
 

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -75,6 +75,7 @@ namespace OpenLoco::Ui::WindowManager
     void callEvent8OnAllWindows();
     void callEvent9OnAllWindows();
     void callViewportRotateEventOnAllWindows();
+    bool callKeyUpEventBackToFront(uint32_t charCode, uint32_t keyCode);
     void relocateWindows();
     void sub_4CEE0B(Window* self);
     void sub_4B93A5(WindowNumber_t number);

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -313,7 +313,6 @@ namespace OpenLoco::Ui::Windows
     namespace PromptOkCancel
     {
         bool open(StringId captionId, StringId descriptionId, FormatArguments& descriptionArgs, StringId okButtonStringId);
-        void handleInput(uint32_t charCode, uint32_t keyCode);
     }
 
     namespace PromptSaveWindow

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -308,7 +308,6 @@ namespace OpenLoco::Ui::Windows
             save = 2
         };
         bool open(browse_type type, char* path, const char* filter, StringId titleId);
-        void handleInput(uint32_t charCode, uint32_t keyCode);
     }
 
     namespace PromptOkCancel

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -276,7 +276,6 @@ namespace OpenLoco::Ui::Windows
     {
         Window* open();
         bool tryCloseWindow();
-        void handleInput(uint32_t charCode, uint32_t keyCode);
     }
 
     namespace Options

--- a/src/OpenLoco/src/Window.cpp
+++ b/src/OpenLoco/src/Window.cpp
@@ -1169,6 +1169,14 @@ namespace OpenLoco::Ui
         eventHandlers->drawScroll(*this, *rt, scrollIndex);
     }
 
+    bool Window::callKeyUp(uint32_t charCode, uint32_t keyCode)
+    {
+        if (eventHandlers->keyUp == nullptr)
+            return false;
+
+        return eventHandlers->keyUp(*this, charCode, keyCode);
+    }
+
     // 0x004CA4DF
     void Window::draw(Gfx::RenderTarget* rt)
     {

--- a/src/OpenLoco/src/Window.h
+++ b/src/OpenLoco/src/Window.h
@@ -130,6 +130,7 @@ namespace OpenLoco::Ui
         void (*prepareDraw)(Window&) = nullptr;
         void (*draw)(Window&, Gfx::RenderTarget*) = nullptr;
         void (*drawScroll)(Window&, Gfx::RenderTarget&, const uint32_t scrollIndex) = nullptr;
+        bool (*keyUp)(Window&, uint32_t charCode, uint32_t keyCode) = nullptr;
     };
 
     struct SavedViewSimple
@@ -408,6 +409,7 @@ namespace OpenLoco::Ui
         void callPrepareDraw();                                                                        // 26
         void callDraw(Gfx::RenderTarget* rt);                                                          // 27
         void callDrawScroll(Gfx::RenderTarget* rt, uint32_t scrollIndex);                              // 28
+        bool callKeyUp(uint32_t charCode, uint32_t keyCode);                                           // 29
 
         WidgetIndex_t firstActivatedWidgetInRange(WidgetIndex_t minIndex, WidgetIndex_t maxIndex);
         WidgetIndex_t prevAvailableWidgetInRange(WidgetIndex_t minIndex, WidgetIndex_t maxIndex);

--- a/src/OpenLoco/src/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Windows/BuildVehicle.cpp
@@ -1796,14 +1796,10 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         return regs.cx;
     }
 
-    void handleInput(uint32_t charCode, uint32_t keyCode)
+    static bool keyUp(Window& w, uint32_t charCode, uint32_t keyCode)
     {
-        auto* w = WindowManager::find(WindowType::buildVehicle);
-        if (w == nullptr)
-            return;
-
         if (!inputSession.handleInput(charCode, keyCode))
-            return;
+            return false;
 
         int containerWidth = _widgets[widx::searchBox].width() - 2;
         if (inputSession.needsReoffsetting(containerWidth))
@@ -1811,10 +1807,11 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
 
         inputSession.cursorFrame = 0;
 
-        sub_4B92A5(w);
+        sub_4B92A5(&w);
 
-        w->initScrollWidgets();
-        w->invalidate();
+        w.initScrollWidgets();
+        w.invalidate();
+        return true;
     }
 
     static void initEvents()
@@ -1832,5 +1829,6 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         _events.prepareDraw = prepareDraw;
         _events.draw = draw;
         _events.drawScroll = drawScroll;
+        _events.keyUp = keyUp;
     }
 }

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -1436,14 +1436,10 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         }
     }
 
-    void handleInput(uint32_t charCode, uint32_t keyCode)
+    static bool keyUp(Window& w, uint32_t charCode, uint32_t keyCode)
     {
-        auto* w = WindowManager::find(WindowType::objectSelection);
-        if (w == nullptr)
-            return;
-
         if (!inputSession.handleInput(charCode, keyCode))
-            return;
+            return false;
 
         int containerWidth = widgets[widx::textInput].width() - 2;
         if (inputSession.needsReoffsetting(containerWidth))
@@ -1451,10 +1447,11 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         inputSession.cursorFrame = 0;
 
-        applyFilterToObjectList(FilterFlags(w->var_858));
+        applyFilterToObjectList(FilterFlags(w.var_858));
 
-        w->initScrollWidgets();
-        w->invalidate();
+        w.initScrollWidgets();
+        w.invalidate();
+        return true;
     }
 
     static void initEvents()
@@ -1471,5 +1468,6 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         _events.prepareDraw = prepareDraw;
         _events.draw = draw;
         _events.drawScroll = drawScroll;
+        _events.keyUp = keyUp;
     }
 }

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -633,34 +633,32 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x0044685C
-    void handleInput(uint32_t charCode, uint32_t keyCode)
+    static bool keyUp(Window& w, uint32_t charCode, uint32_t keyCode)
     {
-        auto w = WindowManager::find(WindowType::fileBrowserPrompt);
-        if (w == nullptr)
-            return;
-
         if (keyCode == SDLK_RETURN)
         {
-            w->callOnMouseUp(widx::ok_button);
-            return;
+            w.callOnMouseUp(widx::ok_button);
+            return true;
         }
         else if (keyCode == SDLK_ESCAPE)
         {
-            w->callOnMouseUp(widx::close_button);
-            return;
+            w.callOnMouseUp(widx::close_button);
+            return true;
         }
         else if (!inputSession.handleInput(charCode, keyCode))
         {
-            return;
+            return false;
         }
 
         // 0x00446A6E
-        auto containerWidth = w->widgets[widx::text_filename].width() - 2;
+        auto containerWidth = w.widgets[widx::text_filename].width() - 2;
         if (inputSession.needsReoffsetting(containerWidth))
         {
             inputSession.calculateTextOffset(containerWidth);
         }
-        w->invalidate();
+        w.invalidate();
+
+        return true;
     }
 
     static fs::path getDirectory(const fs::path& path)
@@ -938,5 +936,6 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         _events.prepareDraw = prepareDraw;
         _events.draw = draw;
         _events.drawScroll = drawScroll;
+        _events.keyUp = keyUp;
     }
 }

--- a/src/OpenLoco/src/Windows/PromptOkCancelWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptOkCancelWindow.cpp
@@ -92,14 +92,14 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
     }
 
     // 0x00447125
-    void handleInput([[maybe_unused]] uint32_t charCode, uint32_t keyCode)
+    bool keyUp(Window& w, [[maybe_unused]] uint32_t charCode, uint32_t keyCode)
     {
-        auto window = WindowManager::find(WindowType::confirmationPrompt);
-        if (window == nullptr)
-            return;
-
         if (keyCode == SDLK_ESCAPE)
-            window->callOnMouseUp(widx::closeButton);
+        {
+            w.callOnMouseUp(widx::closeButton);
+            return true;
+        }
+        return false;
     }
 
     // 0x00447093
@@ -146,5 +146,6 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
         _events.draw = draw;
         _events.onMouseUp = onMouseUp;
         _events.prepareDraw = prepareDraw;
+        _events.keyUp = keyUp;
     }
 }

--- a/src/OpenLoco/src/Windows/PromptOkCancelWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptOkCancelWindow.cpp
@@ -92,7 +92,7 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
     }
 
     // 0x00447125
-    bool keyUp(Window& w, [[maybe_unused]] uint32_t charCode, uint32_t keyCode)
+    static bool keyUp(Window& w, [[maybe_unused]] uint32_t charCode, uint32_t keyCode)
     {
         if (keyCode == SDLK_ESCAPE)
         {

--- a/src/OpenLoco/src/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Windows/TextInputWindow.cpp
@@ -88,6 +88,7 @@ namespace OpenLoco::Ui::Windows::TextInput
     static void draw(Ui::Window& window, Gfx::RenderTarget* rt);
     static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex);
     static void onUpdate(Ui::Window& window);
+    static void initEvents();
 
     /**
      * 0x004CE523
@@ -110,10 +111,7 @@ namespace OpenLoco::Ui::Windows::TextInput
         // Close any previous text input window
         cancel();
 
-        _events.draw = draw;
-        _events.prepareDraw = prepareDraw;
-        _events.onMouseUp = onMouseUp;
-        _events.onUpdate = onUpdate;
+        initEvents();
 
         auto window = WindowManager::createWindowCentred(
             WindowType::textInput,
@@ -303,27 +301,21 @@ namespace OpenLoco::Ui::Windows::TextInput
     }
 
     // 0x004CE910
-    void handleInput(uint32_t charCode, uint32_t keyCode)
+    static bool keyUp(Window& w, uint32_t charCode, uint32_t keyCode)
     {
-        auto w = WindowManager::find(WindowType::textInput);
-        if (w == nullptr)
-        {
-            return;
-        }
-
         if (charCode == SDLK_RETURN)
         {
-            w->callOnMouseUp(Widx::ok);
-            return;
+            w.callOnMouseUp(Widx::ok);
+            return true;
         }
         else if (charCode == SDLK_ESCAPE)
         {
-            w->callOnMouseUp(Widx::close);
-            return;
+            w.callOnMouseUp(Widx::close);
+            return true;
         }
         else if (!inputSession.handleInput(charCode, keyCode))
         {
-            return;
+            return false;
         }
 
         WindowManager::invalidate(WindowType::textInput, 0);
@@ -334,5 +326,16 @@ namespace OpenLoco::Ui::Windows::TextInput
         {
             inputSession.calculateTextOffset(containerWidth);
         }
+
+        return true;
+    }
+
+    static void initEvents()
+    {
+        _events.draw = draw;
+        _events.prepareDraw = prepareDraw;
+        _events.onMouseUp = onMouseUp;
+        _events.onUpdate = onUpdate;
+        _events.keyUp = keyUp;
     }
 }


### PR DESCRIPTION
This adds a new event to windows, `keyUp`, allowing window text input to be handled in a uniform way with less code.

Bonus: this now allows shortcuts to be executed if input is not consumed by a window with a keyUp event. (Changelog worthy?)