### PR TITLE
Implement remaining shortcut functions

### DIFF
--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -374,7 +374,7 @@ namespace OpenLoco::Input::Shortcuts
     // 0x004BF3AB
     static void makeScreenshot()
     {
-        call(0x004BF3AB);
+        Input::triggerScreenshotCountdown(2, Input::ScreenshotType::regular);
     }
 
     // 0x004BF3B3

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -37,7 +37,16 @@ namespace OpenLoco::Input::Shortcuts
     // 0x004BF0BC
     static void cancelConstructionMode()
     {
-        call(0x004BF0BC);
+        if (auto* w = WindowManager::find(WindowType::error))
+        {
+            WindowManager::close(w);
+            return;
+        }
+
+        if (!Ui::Windows::Vehicle::cancelVehicleTools())
+        {
+            Input::toolCancel();
+        }
     }
 
     // 0x004BF0E6

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -28,19 +28,19 @@ namespace OpenLoco::Input::Shortcuts
         WindowManager::closeTopmost();
     }
 
-    // 004BF0B6
+    // 0x004BF0B6
     static void closeAllFloatingWindows()
     {
         WindowManager::closeAllFloatingWindows();
     }
 
-    // 0x4BF0BC
+    // 0x004BF0BC
     static void cancelConstructionMode()
     {
         call(0x004BF0BC);
     }
 
-    // 0x4BF0E6
+    // 0x004BF0E6
     static void pauseUnpauseGame()
     {
         if (isEditorMode())

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -421,13 +421,8 @@ namespace OpenLoco::Input::Shortcuts
             if (caller == nullptr)
                 return;
 
-            WindowManager::close(WindowType::multiplayer);
-
-            FormatArguments args{};
-            args.push(StringIds::the_other_player);
-
-            const int callingWidget = 4;
-            Ui::Windows::TextInput::openTextInput(caller, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, callingWidget, const_cast<void*>(&args));
+            const WidgetIndex_t callingWidget = 4;
+            Windows::TitleMenu::beginSendChatMessage(caller, callingWidget);
         }
         else
         {
@@ -435,12 +430,8 @@ namespace OpenLoco::Input::Shortcuts
             if (caller == nullptr)
                 return;
 
-            const auto* opponent = CompanyManager::getOpponent();
-            FormatArguments args{};
-            args.push(opponent->name);
-
-            const int callingWidget = 2;
-            Ui::Windows::TextInput::openTextInput(caller, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, callingWidget, const_cast<void*>(&args));
+            const WidgetIndex_t callingWidget = 2;
+            Windows::TimePanel::beginSendChatMessage(caller, callingWidget);
         }
     }
 

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -39,7 +39,8 @@ namespace OpenLoco::Input::Shortcuts
     // 0x004BF0BC
     static void cancelConstructionMode()
     {
-        if (auto* w = WindowManager::find(WindowType::error))
+        auto* w = WindowManager::find(WindowType::error);
+        if (w != nullptr)
         {
             WindowManager::close(w);
             return;

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -4,9 +4,11 @@
 #include "GameCommands/General/TogglePause.h"
 #include "Input.h"
 #include "LastGameOptionManager.h"
+#include "Localisation/FormatArguments.hpp"
 #include "Localisation/StringIds.h"
 #include "S5/S5.h"
 #include "SceneManager.h"
+#include "Ui/TextInput.h"
 #include "Ui/WindowManager.h"
 #include "Windows/Construction/Construction.h"
 #include "World/CompanyManager.h"
@@ -406,7 +408,39 @@ namespace OpenLoco::Input::Shortcuts
     // 0x004BF3DC
     static void sendMessage()
     {
-        call(0x004BF3DC);
+        if (isEditorMode())
+            return;
+
+        if (!isNetworked())
+            return;
+
+        if (isTitleMode())
+        {
+            auto* caller = WindowManager::find(WindowType::titleMenu);
+            if (caller == nullptr)
+                return;
+
+            WindowManager::close(WindowType::multiplayer);
+
+            FormatArguments args{};
+            args.push(StringIds::the_other_player);
+
+            const int callingWidget = 4;
+            Ui::Windows::TextInput::openTextInput(caller, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, callingWidget, const_cast<void*>(&args));
+        }
+        else
+        {
+            auto* caller = WindowManager::find(WindowType::timeToolbar);
+            if (caller == nullptr)
+                return;
+
+            const auto* opponent = CompanyManager::getOpponent();
+            FormatArguments args{};
+            args.push(opponent->name);
+
+            const int callingWidget = 2;
+            Ui::Windows::TextInput::openTextInput(caller, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, callingWidget, const_cast<void*>(&args));
+        }
     }
 
     static void constructionPreviousTab()

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -421,8 +421,7 @@ namespace OpenLoco::Input::Shortcuts
             if (caller == nullptr)
                 return;
 
-            const WidgetIndex_t callingWidget = 4;
-            Windows::TitleMenu::beginSendChatMessage(caller, callingWidget);
+            Windows::TitleMenu::beginSendChatMessage(caller);
         }
         else
         {
@@ -430,8 +429,7 @@ namespace OpenLoco::Input::Shortcuts
             if (caller == nullptr)
                 return;
 
-            const WidgetIndex_t callingWidget = 2;
-            Windows::TimePanel::beginSendChatMessage(caller, callingWidget);
+            Windows::TimePanel::beginSendChatMessage(caller);
         }
     }
 

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -377,6 +377,7 @@ namespace OpenLoco::Ui::Windows
     {
         Window* open();
         void invalidateFrame();
+        void beginSendChatMessage(Window* self, WidgetIndex_t callingWidget);
     }
 
     namespace TitleExit
@@ -393,6 +394,7 @@ namespace OpenLoco::Ui::Windows
     {
         Window* open();
         void editorInit();
+        void beginSendChatMessage(Window* self, WidgetIndex_t callingWidget);
     }
 
     namespace TitleOptions

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -466,6 +466,7 @@ namespace OpenLoco::Ui::Windows
             int16_t sub_4B743B(uint8_t al, uint8_t ah, int16_t cx, int16_t dx, Vehicles::VehicleBase* vehicle, Gfx::RenderTarget* const pDrawpixelinfo);
         }
         bool rotate();
+        bool cancelVehicleTools();
     }
 
     namespace VehicleList

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -377,7 +377,7 @@ namespace OpenLoco::Ui::Windows
     {
         Window* open();
         void invalidateFrame();
-        void beginSendChatMessage(Window* self, WidgetIndex_t callingWidget);
+        void beginSendChatMessage(Window* self);
     }
 
     namespace TitleExit
@@ -394,7 +394,7 @@ namespace OpenLoco::Ui::Windows
     {
         Window* open();
         void editorInit();
-        void beginSendChatMessage(Window* self, WidgetIndex_t callingWidget);
+        void beginSendChatMessage(Window* self);
     }
 
     namespace TitleOptions

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -248,14 +248,14 @@ namespace OpenLoco::Ui::Windows::TimePanel
         }
     }
 
-    void beginSendChatMessage(Window* self, WidgetIndex_t callingWidget)
+    void beginSendChatMessage(Window* self)
     {
         const auto* opponent = CompanyManager::getOpponent();
         FormatArguments args{};
         args.push(opponent->name);
 
         // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments
-        TextInput::openTextInput(self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, callingWidget, const_cast<void*>(&args));
+        TextInput::openTextInput(self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::map_chat_menu, const_cast<void*>(&args));
     }
 
     // 0x0043A72F
@@ -269,7 +269,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
             switch (itemIndex)
             {
                 case 0:
-                    beginSendChatMessage(self, Widx::map_chat_menu);
+                    beginSendChatMessage(self);
                     break;
                 case 1:
                     MapWindow::open();

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -248,10 +248,14 @@ namespace OpenLoco::Ui::Windows::TimePanel
         }
     }
 
-    static void beginSendChatMessage(Window* self)
+    void beginSendChatMessage(Window* self, WidgetIndex_t callingWidget)
     {
-        _commonFormatArgs[4] = StringIds::empty;
-        TextInput::openTextInput(self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::map_chat_menu, &*_commonFormatArgs);
+        const auto* opponent = CompanyManager::getOpponent();
+        FormatArguments args{};
+        args.push(opponent->name);
+
+        // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments
+        TextInput::openTextInput(self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, callingWidget, const_cast<void*>(&args));
     }
 
     // 0x0043A72F
@@ -265,7 +269,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
             switch (itemIndex)
             {
                 case 0:
-                    beginSendChatMessage(self);
+                    beginSendChatMessage(self, Widx::map_chat_menu);
                     break;
                 case 1:
                     MapWindow::open();

--- a/src/OpenLoco/src/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Windows/TitleMenu.cpp
@@ -338,7 +338,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
                 sub_43910A();
                 break;
             case Widx::chat_btn:
-                beginSendChatMessage(&window, widgetIndex);
+                beginSendChatMessage(&window);
                 break;
             case Widx::multiplayer_toggle_btn:
                 showMultiplayer(&window);
@@ -446,7 +446,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
             0x80);
     }
 
-    void beginSendChatMessage(Window* self, WidgetIndex_t callingWidget)
+    void beginSendChatMessage(Window* self)
     {
         WindowManager::close(WindowType::multiplayer);
 
@@ -454,7 +454,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
         args.push(StringIds::the_other_player);
 
         // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments
-        TextInput::openTextInput(self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, callingWidget, const_cast<void*>(&args));
+        TextInput::openTextInput(self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::chat_btn, const_cast<void*>(&args));
     }
 
     static void sub_43918F(const char* string)

--- a/src/OpenLoco/src/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Windows/TitleMenu.cpp
@@ -10,6 +10,7 @@
 #include "Gui.h"
 #include "Input.h"
 #include "Intro.h"
+#include "Localisation/FormatArguments.hpp"
 #include "Localisation/StringIds.h"
 #include "Logging.h"
 #include "Map/Tile.h"
@@ -139,7 +140,6 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     static void sub_4391DA();
     static void sub_4391E2();
     static void sub_43910A();
-    static void sub_439163(Ui::Window* callingWindow, WidgetIndex_t callingWidget);
     static void showMultiplayer(Window* window);
     static void multiplayerConnect(std::string_view host);
     static void sub_46E328();
@@ -338,7 +338,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
                 sub_43910A();
                 break;
             case Widx::chat_btn:
-                sub_439163(&window, widgetIndex);
+                beginSendChatMessage(&window, widgetIndex);
                 break;
             case Widx::multiplayer_toggle_btn:
                 showMultiplayer(&window);
@@ -446,14 +446,15 @@ namespace OpenLoco::Ui::Windows::TitleMenu
             0x80);
     }
 
-    static void sub_439163(Ui::Window* callingWindow, WidgetIndex_t callingWidget)
+    void beginSendChatMessage(Window* self, WidgetIndex_t callingWidget)
     {
         WindowManager::close(WindowType::multiplayer);
 
-        addr<0x112C826 + 8, StringId>() = StringIds::the_other_player;
+        FormatArguments args{};
+        args.push(StringIds::the_other_player);
 
         // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments
-        TextInput::openTextInput(callingWindow, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, callingWidget, (void*)0x112C826);
+        TextInput::openTextInput(self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, callingWidget, const_cast<void*>(&args));
     }
 
     static void sub_43918F(const char* string)

--- a/src/OpenLoco/src/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Windows/Vehicle.cpp
@@ -4564,6 +4564,26 @@ namespace OpenLoco::Ui::Windows::Vehicle
         return false;
     }
 
+    // 0x004B944A
+    bool cancelVehicleTools()
+    {
+        if (Input::isToolActive(WindowType::vehicle))
+        {
+            auto* w = WindowManager::find(WindowType::vehicle, ToolManager::getToolWindowNumber());
+            if (w->currentTab == (Common::widx::tabMain - Common::widx::tabMain))
+            {
+                w->callOnMouseUp(Common::widx::tabDetails);
+                return true;
+            }
+            else if (w->currentTab == (Common::widx::tabRoute - Common::widx::tabMain))
+            {
+                w->callOnMouseUp(Common::widx::tabMain);
+                return true;
+            }
+        }
+        return false;
+    }
+
     void registerHooks()
     {
         Main::initEvents();


### PR DESCRIPTION
This implements the three remaining shortcut functions, `makeScreenshot`, `cancelConstructionMode`, and `sendMessage`. The latter requires networking, though, and has not been tested.