### PR TITLE
Land tool: disable surface corner selection in mountain or paint mode

### DIFF
--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -1436,16 +1436,16 @@ namespace OpenLoco::Ui::Windows::Terraform
                 auto res = Ui::ViewportInteraction::getSurfaceLocFromUi({ x, y });
                 if (res)
                 {
-                    if (_adjustLandToolSize != 1)
+                    if (_adjustLandToolSize == 1 && !(isMountainMode || isPaintMode))
                     {
-                        auto count = TileManager::setMapSelectionTiles(res->first, 4);
+                        auto count = TileManager::setMapSelectionSingleTile(res->first, true);
 
                         if (!count)
                             return;
                     }
                     else
                     {
-                        auto count = TileManager::setMapSelectionSingleTile(res->first, true);
+                        auto count = TileManager::setMapSelectionTiles(res->first, 4);
 
                         if (!count)
                             return;


### PR DESCRIPTION
The changes from #2228 had an unintended consequence in that the single-tile mountain tool now allowed for corner selection. The selected corner isn't used, however, so this should be disabled. Investigating this, I found the same to be true for the land type paint tool, so it is disabled for this tool as well now.