### PR TITLE
Fix #2238: Scroll on map edge doesn't work for bottom and right edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Feature: [#1238]: Mountain tool is now a toggle, making it possible to specify the mountain table size.
 - Feature: [#2228]: Max terraform tool sizes have been increased from 10x10 to 64x64.
 - Fix: [#2231] Height mark shortcuts for land and tracks are swapped in some cases.
+- Fix: [#2238] Scroll on map edge doesn't work for bottom and right edges.
 - Change: [#1180] Separate track/road see-through toggles.
 - Change: [#2231] Separate trees/buildings/scenery see-through toggles.
 - Change: [#2228]: The landscape 'paint mode' button now uses a different paintbrush image.

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -378,7 +378,7 @@ namespace OpenLoco::Input
             return;
 
         Ui::Point delta = { 0, 0 };
-        auto cursor = getMouseLocation();
+        auto cursor = getCursorPosScaled();
 
         if (cursor.x == 0)
             delta.x -= Config::get().edgeScrollingSpeed;

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -383,13 +383,13 @@ namespace OpenLoco::Input
         if (cursor.x == 0)
             delta.x -= Config::get().edgeScrollingSpeed;
 
-        if (cursor.x == Ui::width() - 1)
+        if (cursor.x >= Ui::width() - 1)
             delta.x += Config::get().edgeScrollingSpeed;
 
         if (cursor.y == 0)
             delta.y -= Config::get().edgeScrollingSpeed;
 
-        if (cursor.y == Ui::height() - 1)
+        if (cursor.y >= Ui::height() - 1)
             delta.y += Config::get().edgeScrollingSpeed;
 
         if (delta.x == 0 && delta.y == 0)


### PR DESCRIPTION
Issue caused by not scaling the mouse cursor position before checking it against the UI dimensions.

We really need do a thorough check of all cursor position users, with #1839 in mind as well.