### PR TITLE
Render cargo behind station pillars

### DIFF
--- a/src/OpenLoco/src/Paint/PaintStation.cpp
+++ b/src/OpenLoco/src/Paint/PaintStation.cpp
@@ -200,18 +200,20 @@ namespace OpenLoco::Paint
         // Paint Back part of platform
         {
             World::Pos3 bbOffset = platformImages.back.bbOffset + heightOffset;
-            session.addToPlotList4FD150(imageBase.withIndexOffset(platformImages.back.imageId), heightOffset, bbOffset, platformImages.back.bbSize);
 
             paintStationCargo(session, elStation, cargoFlags[0], 0xFFFFFFFF, cargoOffsets, elStation.baseHeight(), bbOffset, platformImages.back.bbSize);
             paintStationCargo(session, elStation, cargoFlags[1], 0xFFFFFFFF, cargoOffsets, elStation.baseHeight(), bbOffset, platformImages.back.bbSize);
+
+            session.addToPlotList4FD150(imageBase.withIndexOffset(platformImages.back.imageId), heightOffset, bbOffset, platformImages.back.bbSize);
         }
         // Paint Front part of platform
         {
             World::Pos3 bbOffset = platformImages.front.bbOffset + heightOffset;
-            session.addToPlotList4FD150(imageBase.withIndexOffset(platformImages.front.imageId), heightOffset, bbOffset, platformImages.front.bbSize);
 
             paintStationCargo(session, elStation, cargoFlags[2], 0xFFFFFFFF, cargoOffsets, elStation.baseHeight(), bbOffset, platformImages.front.bbSize);
             paintStationCargo(session, elStation, cargoFlags[3], 0xFFFFFFFF, cargoOffsets, elStation.baseHeight(), bbOffset, platformImages.front.bbSize);
+
+            session.addToPlotList4FD150(imageBase.withIndexOffset(platformImages.front.imageId), heightOffset, bbOffset, platformImages.front.bbSize);
         }
 
         // Paint Canopy of platform


### PR DESCRIPTION
Verified that cargo overlapping with station pillars exists in both vanilla (!) and early versions of OpenLoco. Aside from vanilla, I tested v21.07, but should apply to any version before v22.04, that is before #1432. Reverting `paintStation` to a call to `0x0048B313` has identical results to the 'before' state.

(Click thumbnails to enlarge)

### Before

[<img src="https://github.com/OpenLoco/OpenLoco/assets/604665/eb1d630b-f495-4aa6-aa9d-4eca29a64e8b" alt="" width="350">](https://github.com/OpenLoco/OpenLoco/assets/604665/eb1d630b-f495-4aa6-aa9d-4eca29a64e8b) [<img src="https://github.com/OpenLoco/OpenLoco/assets/604665/80fd2ee4-a93a-4c90-983f-de1fe7511f89" alt="" width="350">](https://github.com/OpenLoco/OpenLoco/assets/604665/80fd2ee4-a93a-4c90-983f-de1fe7511f89)

### After

[<img src="https://github.com/OpenLoco/OpenLoco/assets/604665/874fd158-c633-4765-8555-15be1d7209aa" alt="" width="350">](https://github.com/OpenLoco/OpenLoco/assets/604665/874fd158-c633-4765-8555-15be1d7209aa) [<img src="https://github.com/OpenLoco/OpenLoco/assets/604665/1faa765a-1c36-40e5-aca3-329388e6b0bb" alt="" width="350">](https://github.com/OpenLoco/OpenLoco/assets/604665/1faa765a-1c36-40e5-aca3-329388e6b0bb)
