### PR TITLE
Refactor screenshot logic out of Input namespace

### DIFF
--- a/src/OpenLoco/src/Input.h
+++ b/src/OpenLoco/src/Input.h
@@ -30,13 +30,6 @@ namespace OpenLoco::Input
         scrollRight,       // 9
     };
 
-    // TODO: move this
-    enum class ScreenshotType : uint8_t
-    {
-        regular = 0,
-        giant = 1,
-    };
-
     enum class Flags : uint32_t
     {
         none = 0U,
@@ -118,8 +111,6 @@ namespace OpenLoco::Input
     bool hasMapSelectionFlag(MapSelectionFlags flags);
     void setMapSelectionFlags(MapSelectionFlags flags);
     void resetMapSelectionFlag(MapSelectionFlags flags);
-
-    void triggerScreenshotCountdown(int8_t numTicks, ScreenshotType type);
 
     void handleKeyboard();
     void handleMouse(int16_t x, int16_t y, MouseButton button);

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -41,7 +41,6 @@ namespace OpenLoco::Input
     static void loc_4BED04();
     static void loc_4BED79();
 
-    static loco_global<int8_t, 0x00508F16> _screenshotCountdown;
     static loco_global<KeyModifier, 0x00508F18> _keyModifier;
     static loco_global<Ui::WindowType, 0x005233B6> _modalWindowType;
     static loco_global<char[16], 0x0112C826> _commonFormatArgs;
@@ -52,8 +51,6 @@ namespace OpenLoco::Input
     static loco_global<uint32_t, 0x00525380> _keyQueueWriteIndex;
     static loco_global<uint8_t[256], 0x01140740> _keyboardState;
     static loco_global<uint8_t, 0x011364A4> _editingShortcutIndex;
-
-    static ScreenshotType _screenshotType = ScreenshotType::regular;
 
     static const std::pair<std::string, std::function<void()>> kCheats[] = {
         { "DRIVER", loc_4BECDE },
@@ -459,38 +456,10 @@ namespace OpenLoco::Input
         Input::setFlag(Flags::viewportScrolling);
     }
 
-    void triggerScreenshotCountdown(int8_t numTicks, ScreenshotType type)
-    {
-        _screenshotCountdown = numTicks;
-        _screenshotType = type;
-    }
-
     // 0x004BE92A
     void handleKeyboard()
     {
-        if (_screenshotCountdown != 0)
-        {
-            _screenshotCountdown--;
-            if (_screenshotCountdown == 0)
-            {
-                try
-                {
-                    std::string fileName;
-                    if (_screenshotType == ScreenshotType::giant)
-                        fileName = saveGiantScreenshot();
-                    else
-                        fileName = saveScreenshot();
-
-                    *((const char**)(&_commonFormatArgs[0])) = fileName.c_str();
-                    Windows::showError(StringIds::screenshot_saved_as, StringIds::null, false);
-                }
-                catch (const std::exception&)
-                {
-                    Windows::showError(StringIds::screenshot_failed);
-                }
-            }
-        }
-
+        handleScreenshotCountdown();
         edgeScroll();
 
         _keyModifier = _keyModifier & ~(KeyModifier::shift | KeyModifier::control | KeyModifier::unknown);

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -8,6 +8,7 @@
 #include "Localisation/StringIds.h"
 #include "S5/S5.h"
 #include "SceneManager.h"
+#include "Ui/Screenshot.h"
 #include "Ui/TextInput.h"
 #include "Ui/WindowManager.h"
 #include "Windows/Construction/Construction.h"

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -420,7 +420,7 @@ namespace OpenLoco::Input::Shortcuts
     // 0x004BF3AB
     static void makeScreenshot()
     {
-        Input::triggerScreenshotCountdown(2, Input::ScreenshotType::regular);
+        Ui::triggerScreenshotCountdown(2, Ui::ScreenshotType::regular);
     }
 
     // 0x004BF3B3

--- a/src/OpenLoco/src/Ui/Screenshot.cpp
+++ b/src/OpenLoco/src/Ui/Screenshot.cpp
@@ -20,7 +20,7 @@
 using namespace OpenLoco::Interop;
 using namespace OpenLoco::Ui;
 
-namespace OpenLoco::Input
+namespace OpenLoco::Ui
 {
     static loco_global<int8_t, 0x00508F16> _screenshotCountdown;
 

--- a/src/OpenLoco/src/Ui/Screenshot.cpp
+++ b/src/OpenLoco/src/Ui/Screenshot.cpp
@@ -32,6 +32,9 @@ namespace OpenLoco::Ui
         _screenshotType = type;
     }
 
+    static std::string saveScreenshot();
+    static std::string saveGiantScreenshot();
+
     void handleScreenshotCountdown()
     {
         if (_screenshotCountdown != 0)
@@ -165,7 +168,7 @@ namespace OpenLoco::Ui
         return fileName;
     }
 
-    std::string saveScreenshot()
+    static std::string saveScreenshot()
     {
         auto& rt = Gfx::getScreenRT();
         return prepareSaveScreenshot(rt);
@@ -195,7 +198,7 @@ namespace OpenLoco::Ui
         return viewport;
     }
 
-    std::string saveGiantScreenshot()
+    static std::string saveGiantScreenshot()
     {
         const auto& main = WindowManager::getMainWindow();
         const auto zoomLevel = main->viewports[0]->zoom;

--- a/src/OpenLoco/src/Ui/Screenshot.h
+++ b/src/OpenLoco/src/Ui/Screenshot.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <string>
 
-namespace OpenLoco::Input
+namespace OpenLoco::Ui
 {
     enum class ScreenshotType : uint8_t
     {

--- a/src/OpenLoco/src/Ui/Screenshot.h
+++ b/src/OpenLoco/src/Ui/Screenshot.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 
 namespace OpenLoco::Ui
 {
@@ -13,7 +12,4 @@ namespace OpenLoco::Ui
 
     void triggerScreenshotCountdown(int8_t numTicks, ScreenshotType type);
     void handleScreenshotCountdown();
-
-    std::string saveScreenshot();
-    std::string saveGiantScreenshot();
 }

--- a/src/OpenLoco/src/Ui/Screenshot.h
+++ b/src/OpenLoco/src/Ui/Screenshot.h
@@ -5,6 +5,15 @@
 
 namespace OpenLoco::Input
 {
+    enum class ScreenshotType : uint8_t
+    {
+        regular = 0,
+        giant = 1,
+    };
+
+    void triggerScreenshotCountdown(int8_t numTicks, ScreenshotType type);
+    void handleScreenshotCountdown();
+
     std::string saveScreenshot();
     std::string saveGiantScreenshot();
 }

--- a/src/OpenLoco/src/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Windows/ToolbarTop.cpp
@@ -253,11 +253,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                 break;
 
             case LoadSaveDropdownId::screenshot:
-                Input::triggerScreenshotCountdown(10, Input::ScreenshotType::regular);
+                triggerScreenshotCountdown(10, ScreenshotType::regular);
                 break;
 
             case LoadSaveDropdownId::giantScreenshot:
-                Input::triggerScreenshotCountdown(10, Input::ScreenshotType::giant);
+                triggerScreenshotCountdown(10, ScreenshotType::giant);
                 break;
 
             case LoadSaveDropdownId::server:

--- a/src/OpenLoco/src/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Windows/ToolbarTop.cpp
@@ -23,6 +23,7 @@
 #include "SceneManager.h"
 #include "ToolbarTopCommon.h"
 #include "Ui/Dropdown.h"
+#include "Ui/Screenshot.h"
 #include "Ui/WindowManager.h"
 #include "Vehicles/Vehicle.h"
 #include "Vehicles/VehicleManager.h"

--- a/src/OpenLoco/src/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Windows/ToolbarTopAlt.cpp
@@ -20,6 +20,7 @@
 #include "S5/S5.h"
 #include "ToolbarTopCommon.h"
 #include "Ui/Dropdown.h"
+#include "Ui/Screenshot.h"
 #include "Ui/WindowManager.h"
 #include "Vehicles/Vehicle.h"
 #include "Widget.h"

--- a/src/OpenLoco/src/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Windows/ToolbarTopAlt.cpp
@@ -176,11 +176,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
                 break;
 
             case 5:
-                Input::triggerScreenshotCountdown(10, Input::ScreenshotType::regular);
+                triggerScreenshotCountdown(10, ScreenshotType::regular);
                 break;
 
             case 6:
-                Input::triggerScreenshotCountdown(10, Input::ScreenshotType::giant);
+                triggerScreenshotCountdown(10, ScreenshotType::giant);
                 break;
 
             case 8:


### PR DESCRIPTION
This is the start of moving things out of the Input namespace. Many functions should be moved to Ui, particularly into the ToolManager and WindowManager.