### PR TITLE
Fix #2210. Prevent drawing invalid pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Feature: [#1238]: Mountain tool is now a toggle, making it possible to specify the mountain table size.
 - Feature: [#2228]: Max terraform tool sizes have been increased from 10x10 to 64x64.
 - Fix: [#2162] Build Vehicle window is not properly reset if opened for new or existing vehicle.
+- Fix: [#2210] Current language is not drawn correctly in options window.
 - Fix: [#2231] Height mark shortcuts for land and tracks are swapped in some cases.
 - Fix: [#2238] Scroll on map edge doesn't work for bottom and right edges.
 - Change: [#1180] Separate track/road see-through toggles.

--- a/src/OpenLoco/src/Localisation/Languages.cpp
+++ b/src/OpenLoco/src/Localisation/Languages.cpp
@@ -64,7 +64,7 @@ namespace OpenLoco::Localisation
         return languageDescriptors;
     }
 
-    const LanguageDescriptor& getDescriptorForLanguage(std::string target_locale)
+    const LanguageDescriptor& getDescriptorForLanguage(std::string_view target_locale)
     {
         for (auto& ld : languageDescriptors)
         {

--- a/src/OpenLoco/src/Localisation/Languages.h
+++ b/src/OpenLoco/src/Localisation/Languages.h
@@ -36,5 +36,5 @@ namespace OpenLoco::Localisation
 
     void enumerateLanguages();
     std::vector<LanguageDescriptor>& getLanguageDescriptors();
-    const LanguageDescriptor& getDescriptorForLanguage(std::string targetLocale);
+    const LanguageDescriptor& getDescriptorForLanguage(std::string_view targetLocale);
 }

--- a/src/OpenLoco/src/Windows/Options.cpp
+++ b/src/OpenLoco/src/Windows/Options.cpp
@@ -42,6 +42,12 @@ namespace OpenLoco::Ui::Windows::Options
     static loco_global<ObjectManager::SelectedObjectsFlags*, 0x011364A0> __11364A0;
     static loco_global<uint16_t, 0x0112C185> _112C185;
 
+    // TODO: This shouldn't be required but its due to how the lifetime
+    // of the string needs to exist beyond a prepare draw function and
+    // into a draw function. Rework when custom formatter can store full
+    // strings or widgets can store dynamically allocated strings.
+    static std::string _chosenLanguage;
+
     static std::span<ObjectManager::SelectedObjectsFlags> getLoadedSelectedObjectFlags()
     {
         return std::span<ObjectManager::SelectedObjectsFlags>(*__11364A0, ObjectManager::getNumInstalledObjects());
@@ -1354,7 +1360,8 @@ namespace OpenLoco::Ui::Windows::Options
             FormatArguments args = {};
 
             auto& language = Localisation::getDescriptorForLanguage(Config::get().language);
-            args.push(language.nativeName.c_str());
+            _chosenLanguage = language.nativeName;
+            args.push(_chosenLanguage.c_str());
 
             StringId current_height_units = StringIds::height_units;
             if (!OpenLoco::Config::get().hasFlags(Config::Flags::showHeightAsUnits))

--- a/src/OpenLoco/src/Windows/Options.cpp
+++ b/src/OpenLoco/src/Windows/Options.cpp
@@ -1353,7 +1353,7 @@ namespace OpenLoco::Ui::Windows::Options
 
             FormatArguments args = {};
 
-            auto language = Localisation::getDescriptorForLanguage(Config::get().language);
+            auto& language = Localisation::getDescriptorForLanguage(Config::get().language);
             args.push(language.nativeName.c_str());
 
             StringId current_height_units = StringIds::height_units;


### PR DESCRIPTION
As language was being copied the nativeName would be allocated and free'd before drawing. Most of the time this would just mean it didn't draw correctly but it could do anything.