### PR TITLE
Add missing registers backups

### DIFF
--- a/src/OpenLoco/src/Interop/Hooks.cpp
+++ b/src/OpenLoco/src/Interop/Hooks.cpp
@@ -593,32 +593,42 @@ static void registerAudioHooks()
     writeRet(0x00404B40);
     registerHook(
         0x0048A18C,
-        [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            registers backup = regs;
             Audio::updateSounds();
+            regs = backup;
             return 0;
         });
     registerHook(
         0x00489C6A,
-        [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            registers backup = regs;
             Audio::stopVehicleNoise();
+            regs = backup;
             return 0;
         });
     registerHook(
         0x0048A4BF,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            registers backup = regs;
             Audio::playSound(X86Pointer<Vehicles::Vehicle2or6>(regs.esi));
+            regs = backup;
             return 0;
         });
     registerHook(
         0x00489CB5,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            registers backup = regs;
             Audio::playSound((Audio::SoundId)regs.eax, { regs.cx, regs.dx, regs.bp }, regs.ebx);
+            regs = backup;
             return 0;
         });
     registerHook(
         0x00489F1B,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            registers backup = regs;
             Audio::playSound((Audio::SoundId)regs.eax, { regs.cx, regs.dx, regs.bp }, regs.edi, regs.ebx);
+            regs = backup;
             return 0;
         });
 }
@@ -648,6 +658,7 @@ void OpenLoco::Interop::registerHooks()
     registerHook(
         0x004416B5,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            registers backup = regs;
             using namespace OpenLoco::Environment;
 
             auto buffer = (char*)0x009D0D72;
@@ -655,7 +666,7 @@ void OpenLoco::Interop::registerHooks()
 
             // TODO: use Utility::strlcpy with the buffer size instead of std::strcpy, if possible
             std::strcpy(buffer, path.make_preferred().u8string().c_str());
-
+            regs = backup;
             regs.ebx = X86Pointer(buffer);
             return 0;
         });
@@ -663,23 +674,29 @@ void OpenLoco::Interop::registerHooks()
     // Replace Ui::update() with our own
     registerHook(
         0x004524C1,
-        [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            registers backup = regs;
             Ui::update();
+            regs = backup;
             return 0;
         });
 
     registerHook(
         0x00407BA3,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            registers backup = regs;
             auto cursor = (Ui::CursorId)regs.edx;
             Ui::setCursor(cursor);
+            regs = backup;
             return 0;
         });
 
     registerHook(
         0x00407231,
-        [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            registers backup = regs;
             OpenLoco::Input::sub_407231();
+            regs = backup;
             return 0;
         });
 
@@ -700,7 +717,9 @@ void OpenLoco::Interop::registerHooks()
     registerHook(
         0x00490F6C,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            registers backup = regs;
             Ui::Windows::StationList::open(CompanyId(regs.ax));
+            regs = backup;
             return 0;
         });
 
@@ -718,8 +737,10 @@ void OpenLoco::Interop::registerHooks()
 
     registerHook(
         0x00438A6C,
-        [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            registers backup = regs;
             Gui::init();
+            regs = backup;
             return 0;
         });
 
@@ -801,16 +822,19 @@ void OpenLoco::Interop::registerHooks()
     registerHook(
         0x004AB655,
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            registers backup = regs;
             Vehicles::VehicleBase* v = X86Pointer<Vehicles::VehicleBase>(regs.esi);
             v->asVehicleBody()->secondaryAnimationUpdate();
-
+            regs = backup;
             return 0;
         });
 
     registerHook(
         0x004392BD,
-        []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+        [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            registers backup = regs;
             Gui::resize();
+            regs = backup;
             return 0;
         });
 

--- a/src/OpenLoco/src/Map/AnimationManager.cpp
+++ b/src/OpenLoco/src/Map/AnimationManager.cpp
@@ -120,7 +120,9 @@ namespace OpenLoco::World::AnimationManager
         registerHook(
             0x004612A6,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 createAnimation(regs.dh, { regs.ax, regs.cx }, regs.dl);
+                regs = backup;
                 return 0;
             });
     }

--- a/src/OpenLoco/src/Map/TileManager.cpp
+++ b/src/OpenLoco/src/Map/TileManager.cpp
@@ -1469,21 +1469,29 @@ namespace OpenLoco::World::TileManager
         registerHook(
             0x004BE048,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                regs.dx = countSurroundingTrees({ regs.ax, regs.cx });
+                registers backup = regs;
+                const auto count = countSurroundingTrees({ regs.ax, regs.cx });
+                regs = backup;
+                regs.dx = count;
                 return 0;
             });
 
         registerHook(
             0x004C5596,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                regs.dx = countSurroundingWaterTiles({ regs.ax, regs.cx });
+                registers backup = regs;
+                const auto count = countSurroundingWaterTiles({ regs.ax, regs.cx });
+                regs = backup;
+                regs.dx = count;
                 return 0;
             });
 
         registerHook(
             0x0046902E,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 removeSurfaceIndustry({ regs.ax, regs.cx });
+                regs = backup;
                 return 0;
             });
     }

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -810,14 +810,20 @@ namespace OpenLoco::S5
         registerHook(
             0x00441C26,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 auto path = fs::u8path(std::string(_savePath));
-                return exportGameStateToFile(path, static_cast<SaveFlags>(regs.eax)) ? 0 : X86_FLAG_CARRY;
+                const auto res = exportGameStateToFile(path, static_cast<SaveFlags>(regs.eax)) ? 0 : X86_FLAG_CARRY;
+                regs = backup;
+                return res;
             });
         registerHook(
             0x00441FA7,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 auto path = fs::u8path(std::string(_savePath));
-                return importSaveToGameState(path, static_cast<LoadFlags>(regs.eax)) ? X86_FLAG_CARRY : 0;
+                const auto res = importSaveToGameState(path, static_cast<LoadFlags>(regs.eax)) ? X86_FLAG_CARRY : 0;
+                regs = backup;
+                return res;
             });
     }
 }

--- a/src/OpenLoco/src/Title.cpp
+++ b/src/OpenLoco/src/Title.cpp
@@ -257,14 +257,18 @@ namespace OpenLoco::Title
     {
         registerHook(
             0x0046AD7D,
-            [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 start();
+                regs = backup;
                 return 0;
             });
         registerHook(
             0x004442C4,
-            [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 loadTitle();
+                regs = backup;
                 return 0;
             });
     }

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -96,9 +96,10 @@ namespace OpenLoco::Ui::WindowManager
 
         registerHook(
             0x0043CB9F,
-            [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 Windows::TitleMenu::editorInit();
-
+                regs = backup;
                 return 0;
             });
 
@@ -302,6 +303,7 @@ namespace OpenLoco::Ui::WindowManager
         registerHook(
             0x004C9B56,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 Ui::Window* w;
                 if (regs.cx & FindFlag::byType)
                 {
@@ -311,7 +313,7 @@ namespace OpenLoco::Ui::WindowManager
                 {
                     w = find((WindowType)regs.cx, regs.dx);
                 }
-
+                regs = backup;
                 regs.esi = X86Pointer(w);
                 if (w == nullptr)
                 {
@@ -394,8 +396,10 @@ namespace OpenLoco::Ui::WindowManager
 
         registerHook(
             0x004CD3D0,
-            [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+            [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 dispatchUpdateAll();
+                regs = backup;
                 return 0;
             });
 
@@ -412,8 +416,9 @@ namespace OpenLoco::Ui::WindowManager
         registerHook(
             0x004CE438,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 auto w = getMainWindow();
-
+                regs = backup;
                 regs.esi = X86Pointer(w);
                 if (w == nullptr)
                 {

--- a/src/OpenLoco/src/ViewportManager.cpp
+++ b/src/OpenLoco/src/ViewportManager.cpp
@@ -364,73 +364,95 @@ namespace OpenLoco::Ui::ViewportManager
         registerHook(
             0x004CBA2D,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 invalidate((Station*)regs.esi);
+                regs = backup;
                 return 0;
             });
         registerHook(
             0x004CBB01,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 invalidate((EntityBase*)regs.esi, ZoomLevel::eighth);
+                regs = backup;
                 return 0;
             });
         registerHook(
             0x004CBBD2,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 invalidate((EntityBase*)regs.esi, ZoomLevel::quarter);
+                regs = backup;
                 return 0;
             });
         registerHook(
             0x004CBCAC,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 invalidate((EntityBase*)regs.esi, ZoomLevel::half);
+                regs = backup;
                 return 0;
             });
         registerHook(
             0x004CBD86,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 invalidate((EntityBase*)regs.esi, ZoomLevel::full);
+                regs = backup;
                 return 0;
             });
         registerHook(
             0x004CBE5F,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 auto pos = World::Pos2(regs.ax, regs.cx);
                 World::TileManager::mapInvalidateTileFull(pos);
+                regs = backup;
                 return 0;
             });
         registerHook(
             0x004CBFBF,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 auto pos = World::Pos2(regs.ax, regs.cx);
                 invalidate(pos, regs.di, regs.si, ZoomLevel::eighth, 56);
+                regs = backup;
                 return 0;
             });
         registerHook(
             0x004CC098,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 auto pos = World::Pos2(regs.ax, regs.cx);
                 invalidate(pos, regs.di, regs.si, ZoomLevel::eighth);
+                regs = backup;
                 return 0;
             });
         registerHook(
             0x004CC20F,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 auto pos = World::Pos2(regs.ax, regs.cx);
                 invalidate(pos, regs.di, regs.si, ZoomLevel::full);
+                regs = backup;
                 return 0;
             });
         registerHook(
             0x004CC390,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 auto pos = World::Pos2(regs.ax, regs.cx);
                 invalidate(pos, regs.di, regs.si, ZoomLevel::half);
+                regs = backup;
                 return 0;
             });
         registerHook(
             0x004CC511,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 auto pos = World::Pos2(regs.ax, regs.cx);
                 invalidate(pos, regs.di, regs.si, ZoomLevel::quarter);
+                regs = backup;
                 return 0;
             });
         registerHook(

--- a/src/OpenLoco/src/Windows/Error.cpp
+++ b/src/OpenLoco/src/Windows/Error.cpp
@@ -193,14 +193,18 @@ namespace OpenLoco::Ui::Windows::Error
         registerHook(
             0x00431A8A,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 Ui::Windows::Error::open(regs.bx, regs.dx);
+                regs = backup;
                 return 0;
             });
 
         registerHook(
             0x00431908,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 Ui::Windows::Error::openWithCompetitor(regs.bx, regs.dx, CompanyId(regs.al));
+                regs = backup;
                 return 0;
             });
     }

--- a/src/OpenLoco/src/Windows/ToolTip.cpp
+++ b/src/OpenLoco/src/Windows/ToolTip.cpp
@@ -51,13 +51,17 @@ namespace OpenLoco::Ui::Windows::ToolTip
         registerHook(
             0x004C906B,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 Ui::Windows::ToolTip::open((Ui::Window*)regs.esi, regs.edx, regs.ax, regs.bx);
+                regs = backup;
                 return 0;
             });
         registerHook(
             0x004C9216,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 Ui::Windows::ToolTip::update((Ui::Window*)regs.esi, regs.edx, regs.di, regs.ax, regs.bx);
+                regs = backup;
                 return 0;
             });
     }

--- a/src/OpenLoco/src/World/StationManager.cpp
+++ b/src/OpenLoco/src/World/StationManager.cpp
@@ -542,8 +542,11 @@ namespace OpenLoco::StationManager
         registerHook(
             0x048F988,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 auto stationId = (reinterpret_cast<Station*>(regs.esi))->id();
-                regs.bx = generateNewStationName(stationId, TownId(regs.ebx), World::Pos3(regs.ax, regs.cx, regs.dh), regs.dl);
+                const auto newName = generateNewStationName(stationId, TownId(regs.ebx), World::Pos3(regs.ax, regs.cx, regs.dh), regs.dl);
+                regs = backup;
+                regs.bx = newName;
                 return 0;
             });
     }

--- a/src/OpenLoco/src/World/TownManager.cpp
+++ b/src/OpenLoco/src/World/TownManager.cpp
@@ -228,7 +228,9 @@ namespace OpenLoco::TownManager
         registerHook(
             0x00497348,
             []([[maybe_unused]] registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
+                registers backup = regs;
                 resetBuildingsInfluence();
+                regs = backup;
                 return 0;
             });
 


### PR DESCRIPTION
This adds registers backups to all hook functions (apart from one for signal removal as i can't quite work out what it should do). Might solve some mysterious bugs.