### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ indent_size = 4
 charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
-end_of_line = lf
+end_of_line = crlf
 
 [*.txt]
 trim_trailing_whitespace = false


### PR DESCRIPTION
While opening some files which I have edited previously in Visual Studio, it prompts me that line ending is not consistent.
I noticed that **.editorconfig** has `end_of_line = lf`, so I changed it to `crlf`, to match existing files, which ends with carriage return + line feed.