### PR TITLE
Change Window functions parameters from pointer to reference

### DIFF
--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -1238,7 +1238,7 @@ namespace OpenLoco::Input
             return;
         }
 
-        window = WindowManager::bringToFront(window);
+        window = WindowManager::bringToFront(*window);
         if (widgetIndex == -1)
         {
             return;
@@ -1334,7 +1334,7 @@ namespace OpenLoco::Input
             return;
         }
 
-        window = WindowManager::bringToFront(window);
+        window = WindowManager::bringToFront(*window);
 
         if (widgetIndex == -1)
         {

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -464,7 +464,7 @@ namespace OpenLoco::Input::Shortcuts
             if (caller == nullptr)
                 return;
 
-            Windows::TimePanel::beginSendChatMessage(caller);
+            Windows::TimePanel::beginSendChatMessage(*caller);
         }
     }
 

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -124,7 +124,7 @@ namespace OpenLoco::Input::Shortcuts
         window = WindowManager::find(WindowType::townList);
         if (window != nullptr)
         {
-            if (Ui::Windows::TownList::rotate(window))
+            if (Ui::Windows::TownList::rotate(*window))
                 return;
         }
 

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -117,7 +117,7 @@ namespace OpenLoco::Input::Shortcuts
         window = WindowManager::find(WindowType::construction);
         if (window != nullptr)
         {
-            if (Ui::Windows::Construction::rotate(window))
+            if (Ui::Windows::Construction::rotate(*window))
                 return;
         }
 

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -109,7 +109,7 @@ namespace OpenLoco::Input::Shortcuts
         auto window = WindowManager::find(WindowType::terraform);
         if (window != nullptr)
         {
-            if (Ui::Windows::Terraform::rotate(window))
+            if (Ui::Windows::Terraform::rotate(*window))
                 return;
         }
 

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -456,7 +456,7 @@ namespace OpenLoco::Input::Shortcuts
             if (caller == nullptr)
                 return;
 
-            Windows::TitleMenu::beginSendChatMessage(caller);
+            Windows::TitleMenu::beginSendChatMessage(*caller);
         }
         else
         {

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -1258,7 +1258,7 @@ namespace OpenLoco::Ui::ViewportInteraction
                 auto* road = tileElement->as<RoadElement>();
                 if (road != nullptr)
                 {
-                    Ui::Windows::Construction::setToRoadExtra(window, road, interaction.modId, interaction.pos);
+                    Ui::Windows::Construction::setToRoadExtra(*window, road, interaction.modId, interaction.pos);
                 }
                 break;
             }

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -1249,7 +1249,7 @@ namespace OpenLoco::Ui::ViewportInteraction
                 auto* track = tileElement->as<TrackElement>();
                 if (track != nullptr)
                 {
-                    Ui::Windows::Construction::setToTrackExtra(window, track, interaction.modId, interaction.pos);
+                    Ui::Windows::Construction::setToTrackExtra(*window, track, interaction.modId, interaction.pos);
                 }
                 break;
             }

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -1235,7 +1235,7 @@ namespace OpenLoco::Ui::ViewportInteraction
                     auto roadObject = ObjectManager::get<RoadObject>(road->roadObjectId());
                     if (owner == CompanyManager::getControllingId() || owner == CompanyId::neutral || roadObject->hasFlags(RoadObjectFlags::unk_03))
                     {
-                        Ui::Windows::Construction::openAtRoad(window, road, interaction.pos);
+                        Ui::Windows::Construction::openAtRoad(*window, road, interaction.pos);
                     }
                     else
                     {

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -1216,7 +1216,7 @@ namespace OpenLoco::Ui::ViewportInteraction
                 {
                     if (track->owner() == CompanyManager::getControllingId())
                     {
-                        Ui::Windows::Construction::openAtTrack(window, track, interaction.pos);
+                        Ui::Windows::Construction::openAtTrack(*window, track, interaction.pos);
                     }
                     else
                     {

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -1567,11 +1567,11 @@ namespace OpenLoco::Ui::WindowManager
     }
 
     // 0x004C628E
-    static bool windowWheelInput(Window* window, int wheel)
+    static bool windowWheelInput(Window& window, int wheel)
     {
         int widgetIndex = -1;
         int scrollIndex = -1;
-        for (Widget* widget = window->widgets; widget->type != WidgetType::end; widget++)
+        for (Widget* widget = window.widgets; widget->type != WidgetType::end; widget++)
         {
             widgetIndex++;
 
@@ -1580,9 +1580,9 @@ namespace OpenLoco::Ui::WindowManager
 
             scrollIndex++;
             constexpr ScrollFlags scrollbarFlags = ScrollFlags::hscrollbarVisible | ScrollFlags::vscrollbarVisible;
-            if (window->scrollAreas[scrollIndex].hasFlags(scrollbarFlags))
+            if (window.scrollAreas[scrollIndex].hasFlags(scrollbarFlags))
             {
-                windowScrollWheelInput(*window, widgetIndex, wheel);
+                windowScrollWheelInput(window, widgetIndex, wheel);
                 return true;
             }
         }
@@ -1636,7 +1636,7 @@ namespace OpenLoco::Ui::WindowManager
                         return;
                     }
 
-                    if (windowWheelInput(window, wheel))
+                    if (windowWheelInput(*window, wheel))
                     {
                         return;
                     }
@@ -1646,7 +1646,7 @@ namespace OpenLoco::Ui::WindowManager
 
         for (Ui::Window* w = _windowsEnd - 1; w >= _windows; w--)
         {
-            if (windowWheelInput(w, wheel))
+            if (windowWheelInput(*w, wheel))
             {
                 return;
             }

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -496,13 +496,13 @@ namespace OpenLoco::Ui::WindowManager
         return &_windows[index];
     }
 
-    size_t indexOf(Window* pWindow)
+    size_t indexOf(const Window& pWindow)
     {
         int i = 0;
 
         for (Ui::Window* w = &_windows[0]; w != _windowsEnd; w++)
         {
-            if (w == pWindow)
+            if (w == &pWindow)
                 return i;
 
             i++;
@@ -1824,7 +1824,7 @@ namespace OpenLoco::Ui::WindowManager
             // skip current window and non-intersecting windows
             if (viewport == window->viewports[0] || viewport == window->viewports[1] || viewport->x + viewport->width <= window->x || viewport->x >= window->x + window->width || viewport->y + viewport->height <= window->y || viewport->y >= window->y + window->height)
             {
-                size_t nextWindowIndex = WindowManager::indexOf(window) + 1;
+                size_t nextWindowIndex = WindowManager::indexOf(*window) + 1;
                 auto nextWindow = nextWindowIndex >= count() ? nullptr : get(nextWindowIndex);
                 viewportRedrawAfterShift(nextWindow, viewport, x, y);
                 return;
@@ -2140,7 +2140,7 @@ namespace OpenLoco::Ui::WindowManager
         // Draw the window in this region
         Ui::WindowManager::drawSingle(rt, w, left, top, right, bottom);
 
-        for (uint32_t index = indexOf(w) + 1; index < count(); index++)
+        for (uint32_t index = indexOf(*w) + 1; index < count(); index++)
         {
             auto v = get(index);
 
@@ -2171,7 +2171,7 @@ namespace OpenLoco::Ui::WindowManager
     static bool windowDrawSplit(Gfx::RenderTarget* rt, Ui::Window* w, int16_t left, int16_t top, int16_t right, int16_t bottom)
     {
         // Divide the draws up for only the visible regions of the window recursively
-        for (uint32_t index = indexOf(w) + 1; index < count(); index++)
+        for (uint32_t index = indexOf(*w) + 1; index < count(); index++)
         {
             auto topwindow = get(index);
 

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -1455,13 +1455,13 @@ namespace OpenLoco::Ui::WindowManager
         }
     }
 
-    static void windowScrollWheelInput(Ui::Window* window, WidgetIndex_t widgetIndex, int wheel)
+    static void windowScrollWheelInput(Ui::Window& window, WidgetIndex_t widgetIndex, int wheel)
     {
-        int scrollIndex = window->getScrollDataIndex(widgetIndex);
-        ScrollArea* scroll = &window->scrollAreas[scrollIndex];
-        Ui::Widget* widget = &window->widgets[widgetIndex];
+        int scrollIndex = window.getScrollDataIndex(widgetIndex);
+        ScrollArea* scroll = &window.scrollAreas[scrollIndex];
+        Ui::Widget* widget = &window.widgets[widgetIndex];
 
-        if (window->scrollAreas[scrollIndex].hasFlags(ScrollFlags::vscrollbarVisible))
+        if (window.scrollAreas[scrollIndex].hasFlags(ScrollFlags::vscrollbarVisible))
         {
             int size = widget->bottom - widget->top - 1;
             if (scroll->hasFlags(ScrollFlags::hscrollbarVisible))
@@ -1469,7 +1469,7 @@ namespace OpenLoco::Ui::WindowManager
             size = std::max(0, scroll->contentHeight - size);
             scroll->contentOffsetY = std::clamp(scroll->contentOffsetY + wheel, 0, size);
         }
-        else if (window->scrollAreas[scrollIndex].hasFlags(ScrollFlags::hscrollbarVisible))
+        else if (window.scrollAreas[scrollIndex].hasFlags(ScrollFlags::hscrollbarVisible))
         {
             int size = widget->right - widget->left - 1;
             if (scroll->hasFlags(ScrollFlags::vscrollbarVisible))
@@ -1478,8 +1478,8 @@ namespace OpenLoco::Ui::WindowManager
             scroll->contentOffsetX = std::clamp(scroll->contentOffsetX + wheel, 0, size);
         }
 
-        Ui::ScrollView::updateThumbs(window, widgetIndex);
-        invalidateWidget(window->type, window->number, widgetIndex);
+        Ui::ScrollView::updateThumbs(&window, widgetIndex);
+        invalidateWidget(window.type, window.number, widgetIndex);
     }
 
     static bool isStepperGroup(Window& w, WidgetIndex_t index, WidgetType buttonType)
@@ -1582,7 +1582,7 @@ namespace OpenLoco::Ui::WindowManager
             constexpr ScrollFlags scrollbarFlags = ScrollFlags::hscrollbarVisible | ScrollFlags::vscrollbarVisible;
             if (window->scrollAreas[scrollIndex].hasFlags(scrollbarFlags))
             {
-                windowScrollWheelInput(window, widgetIndex, wheel);
+                windowScrollWheelInput(*window, widgetIndex, wheel);
                 return true;
             }
         }
@@ -1626,7 +1626,7 @@ namespace OpenLoco::Ui::WindowManager
                         constexpr ScrollFlags scrollbarFlags = ScrollFlags::hscrollbarVisible | ScrollFlags::vscrollbarVisible;
                         if (window->scrollAreas[scrollIndex].hasFlags(scrollbarFlags))
                         {
-                            windowScrollWheelInput(window, widgetIndex, wheel);
+                            windowScrollWheelInput(*window, widgetIndex, wheel);
                             return;
                         }
                     }

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -807,11 +807,11 @@ namespace OpenLoco::Ui::WindowManager
 
     // 0x004CC750
     // TODO: hook
-    Window* bringToFront(Window* w)
+    Window* bringToFront(Window& w)
     {
-        if (w->hasFlags(WindowFlags::stickToBack | WindowFlags::stickToFront))
+        if (w.hasFlags(WindowFlags::stickToBack | WindowFlags::stickToFront))
         {
-            return w;
+            return &w;
         }
 
         Window* frontMostWnd = nullptr;
@@ -823,30 +823,32 @@ namespace OpenLoco::Ui::WindowManager
                 break;
             }
         }
-        if (frontMostWnd != nullptr && frontMostWnd != &_windows[0] && frontMostWnd != w)
+
+        Window* window = &w;
+        if (frontMostWnd != nullptr && frontMostWnd != &_windows[0] && frontMostWnd != window)
         {
-            std::swap(*frontMostWnd, *w);
-            w = frontMostWnd;
-            w->invalidate();
+            std::swap(*frontMostWnd, w);
+            window = frontMostWnd;
+            window->invalidate();
         }
 
-        const auto right = w->x + w->width;
+        const auto right = window->x + window->width;
         // If window is almost offscreen to the left
         if (right < 20)
         {
-            const auto shiftRight = 20 - w->x;
-            w->x = 20;
-            for (auto* vp : w->viewports)
+            const auto shiftRight = 20 - window->x;
+            window->x = 20;
+            for (auto* vp : window->viewports)
             {
                 if (vp != nullptr)
                 {
                     vp->x += shiftRight;
                 }
             }
-            w->invalidate();
+            window->invalidate();
         }
 
-        return w;
+        return window;
     }
 
     // 0x004CD3A9
@@ -859,7 +861,7 @@ namespace OpenLoco::Ui::WindowManager
         window->flags |= WindowFlags::whiteBorderMask;
         window->invalidate();
 
-        return bringToFront(window);
+        return bringToFront(*window);
     }
 
     /**

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -433,7 +433,7 @@ namespace OpenLoco::Ui::WindowManager
             0x004CEE0B,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 registers backup = regs;
-                sub_4CEE0B((Ui::Window*)regs.esi);
+                sub_4CEE0B(*(Ui::Window*)regs.esi);
                 regs = backup;
 
                 return 0;
@@ -1357,16 +1357,16 @@ namespace OpenLoco::Ui::WindowManager
     }
 
     // 0x004CEE0B
-    void sub_4CEE0B(Window* self)
+    void sub_4CEE0B(const Window& self)
     {
-        int left = self->x;
-        int right = self->x + self->width;
-        int top = self->y;
-        int bottom = self->y + self->height;
+        int left = self.x;
+        int right = self.x + self.width;
+        int top = self.y;
+        int bottom = self.y + self.height;
 
         for (Ui::Window* w = &_windows[0]; w != _windowsEnd; w++)
         {
-            if (w == self)
+            if (w == &self)
                 continue;
 
             if (w->hasFlags(WindowFlags::stickToBack))

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -156,7 +156,7 @@ namespace OpenLoco::Ui::Windows
     namespace Construction
     {
         Window* openWithFlags(uint32_t flags);
-        Window* openAtTrack(Window* main, World::TrackElement* track, const World::Pos2 pos);
+        Window* openAtTrack(const Window& main, World::TrackElement* track, const World::Pos2 pos);
         Window* openAtRoad(Window* main, World::RoadElement* track, const World::Pos2 pos);
         void setToTrackExtra(Window* main, World::TrackElement* track, const uint8_t bh, const World::Pos2 pos);
         void setToRoadExtra(Window* main, World::RoadElement* track, const uint8_t bh, const World::Pos2 pos);

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -157,7 +157,7 @@ namespace OpenLoco::Ui::Windows
     {
         Window* openWithFlags(uint32_t flags);
         Window* openAtTrack(const Window& main, World::TrackElement* track, const World::Pos2 pos);
-        Window* openAtRoad(Window* main, World::RoadElement* track, const World::Pos2 pos);
+        Window* openAtRoad(const Window& main, World::RoadElement* track, const World::Pos2 pos);
         void setToTrackExtra(Window* main, World::TrackElement* track, const uint8_t bh, const World::Pos2 pos);
         void setToRoadExtra(Window* main, World::RoadElement* track, const uint8_t bh, const World::Pos2 pos);
         void sub_4A6FAC();

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -164,7 +164,7 @@ namespace OpenLoco::Ui::Windows
         bool isStationTabOpen();
         bool isOverheadTabOpen();
         bool isSignalTabOpen();
-        bool rotate(Window* self);
+        bool rotate(Window& self);
         void removeConstructionGhosts();
         void registerHooks();
         uint16_t getLastSelectedMods();

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -391,7 +391,7 @@ namespace OpenLoco::Ui::Windows
     {
         Window* open();
         void editorInit();
-        void beginSendChatMessage(Window* self);
+        void beginSendChatMessage(Window& self);
     }
 
     namespace TitleOptions

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -44,7 +44,7 @@ namespace OpenLoco::Ui::WindowManager
     WindowType getCurrentModalType();
     void setCurrentModalType(WindowType type);
     Window* get(size_t index);
-    size_t indexOf(Window* pWindow);
+    size_t indexOf(const Window& pWindow);
     size_t count();
 
     void updateViewports();

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -57,7 +57,7 @@ namespace OpenLoco::Ui::WindowManager
     Window* findAt(int16_t x, int16_t y);
     Window* findAt(Ui::Point point);
     Window* findAtAlt(int16_t x, int16_t y);
-    Window* bringToFront(Window* window);
+    Window* bringToFront(Window& window);
     Window* bringToFront(WindowType type, uint16_t id = 0);
     void invalidate(WindowType type);
     void invalidate(WindowType type, WindowNumber_t number);

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -374,7 +374,7 @@ namespace OpenLoco::Ui::Windows
     {
         Window* open();
         void invalidateFrame();
-        void beginSendChatMessage(Window* self);
+        void beginSendChatMessage(Window& self);
     }
 
     namespace TitleExit

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -159,7 +159,7 @@ namespace OpenLoco::Ui::Windows
         Window* openAtTrack(const Window& main, World::TrackElement* track, const World::Pos2 pos);
         Window* openAtRoad(const Window& main, World::RoadElement* track, const World::Pos2 pos);
         void setToTrackExtra(const Window& main, World::TrackElement* track, const uint8_t bh, const World::Pos2 pos);
-        void setToRoadExtra(Window* main, World::RoadElement* track, const uint8_t bh, const World::Pos2 pos);
+        void setToRoadExtra(const Window& main, World::RoadElement* track, const uint8_t bh, const World::Pos2 pos);
         void sub_4A6FAC();
         bool isStationTabOpen();
         bool isOverheadTabOpen();

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -348,7 +348,7 @@ namespace OpenLoco::Ui::Windows
         void openAdjustWater();
         void openPlantTrees();
         void openBuildWalls();
-        bool rotate(Window*);
+        bool rotate(Window&);
         void setAdjustLandToolSize(uint8_t size);
         void setAdjustWaterToolSize(uint8_t size);
         void setClearAreaToolSize(uint8_t size);

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -158,7 +158,7 @@ namespace OpenLoco::Ui::Windows
         Window* openWithFlags(uint32_t flags);
         Window* openAtTrack(const Window& main, World::TrackElement* track, const World::Pos2 pos);
         Window* openAtRoad(const Window& main, World::RoadElement* track, const World::Pos2 pos);
-        void setToTrackExtra(Window* main, World::TrackElement* track, const uint8_t bh, const World::Pos2 pos);
+        void setToTrackExtra(const Window& main, World::TrackElement* track, const uint8_t bh, const World::Pos2 pos);
         void setToRoadExtra(Window* main, World::RoadElement* track, const uint8_t bh, const World::Pos2 pos);
         void sub_4A6FAC();
         bool isStationTabOpen();

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -439,7 +439,7 @@ namespace OpenLoco::Ui::Windows
         Window* open();
         void removeTown(TownId);
         void reset();
-        bool rotate(Window* self);
+        bool rotate(Window& self);
     }
 
     namespace Tutorial

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -77,7 +77,7 @@ namespace OpenLoco::Ui::WindowManager
     void callViewportRotateEventOnAllWindows();
     bool callKeyUpEventBackToFront(uint32_t charCode, uint32_t keyCode);
     void relocateWindows();
-    void sub_4CEE0B(Window* self);
+    void sub_4CEE0B(const Window& self);
     void sub_4B93A5(WindowNumber_t number);
     void closeConstructionWindows();
     void closeTopmost();

--- a/src/OpenLoco/src/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Windows/Construction/Common.cpp
@@ -208,9 +208,9 @@ namespace OpenLoco::Ui::Windows::Construction
     }
 
     // 0x004A0EAD
-    Window* openAtTrack(Window* main, TrackElement* track, const Pos2 pos)
+    Window* openAtTrack(const Window& main, TrackElement* track, const Pos2 pos)
     {
-        auto* viewport = main->viewports[0];
+        auto* viewport = main.viewports[0];
         _backupTileElement = *reinterpret_cast<TileElement*>(track);
         auto* copyElement = (*_backupTileElement).as<TrackElement>();
         if (copyElement == nullptr)

--- a/src/OpenLoco/src/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Windows/Construction/Common.cpp
@@ -1538,23 +1538,23 @@ namespace OpenLoco::Ui::Windows::Construction
         }
     }
 
-    bool rotate(Window* self)
+    bool rotate(Window& self)
     {
-        switch (self->currentTab)
+        switch (self.currentTab)
         {
             case Common::widx::tab_construction - Common::widx::tab_construction:
                 if (_constructionHover == 1)
                 {
-                    self->callOnMouseUp(Construction::widx::rotate_90);
+                    self.callOnMouseUp(Construction::widx::rotate_90);
                     removeConstructionGhosts();
                     return true;
                 }
                 break;
 
             case Common::widx::tab_station - Common::widx::tab_construction:
-                if (self->widgets[Station::widx::rotate].type != WidgetType::none)
+                if (self.widgets[Station::widx::rotate].type != WidgetType::none)
                 {
-                    self->callOnMouseUp(Station::widx::rotate);
+                    self.callOnMouseUp(Station::widx::rotate);
                     return true;
                 }
                 break;

--- a/src/OpenLoco/src/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Windows/Construction/Common.cpp
@@ -392,10 +392,10 @@ namespace OpenLoco::Ui::Windows::Construction
     }
 
     // 0x004A1303
-    void setToTrackExtra(Window* main, TrackElement* track, const uint8_t bh, const Pos2 pos)
+    void setToTrackExtra(const Window& main, TrackElement* track, const uint8_t bh, const Pos2 pos)
     {
         registers regs{};
-        regs.esi = X86Pointer(main);
+        regs.esi = X86Pointer(&main);
         regs.edx = X86Pointer(track);
         regs.bh = bh;
         regs.ax = pos.x;

--- a/src/OpenLoco/src/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Windows/Construction/Common.cpp
@@ -404,10 +404,10 @@ namespace OpenLoco::Ui::Windows::Construction
     }
 
     // 0x004A13C1
-    void setToRoadExtra(Window* main, RoadElement* road, const uint8_t bh, const Pos2 pos)
+    void setToRoadExtra(const Window& main, RoadElement* road, const uint8_t bh, const Pos2 pos)
     {
         registers regs{};
-        regs.esi = X86Pointer(main);
+        regs.esi = X86Pointer(&main);
         regs.edx = X86Pointer(road);
         regs.bh = bh;
         regs.ax = pos.x;

--- a/src/OpenLoco/src/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Windows/Construction/Common.cpp
@@ -303,9 +303,9 @@ namespace OpenLoco::Ui::Windows::Construction
     }
 
     // 0x004A147F
-    Window* openAtRoad(Window* main, RoadElement* road, const Pos2 pos)
+    Window* openAtRoad(const Window& main, RoadElement* road, const Pos2 pos)
     {
-        auto* viewport = main->viewports[0];
+        auto* viewport = main.viewports[0];
         _backupTileElement = *reinterpret_cast<TileElement*>(road);
         auto* copyElement = (*_backupTileElement).as<RoadElement>();
         if (copyElement == nullptr)

--- a/src/OpenLoco/src/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Windows/Construction/Common.cpp
@@ -1094,7 +1094,7 @@ namespace OpenLoco::Ui::Windows::Construction
             auto skin = ObjectManager::get<InterfaceSkinObject>();
             window->setColour(WindowColour::secondary, skin->colour_0D);
 
-            WindowManager::sub_4CEE0B(window);
+            WindowManager::sub_4CEE0B(*window);
             Windows::Main::showDirectionArrows();
             Windows::Main::showGridlines();
 

--- a/src/OpenLoco/src/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Windows/IndustryList.cpp
@@ -546,7 +546,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
             Common::refreshIndustryList(window);
 
-            WindowManager::sub_4CEE0B(window);
+            WindowManager::sub_4CEE0B(*window);
 
             window->minWidth = IndustryList::kMinDimensions.width;
             window->minHeight = IndustryList::kMinDimensions.height;

--- a/src/OpenLoco/src/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Windows/MessageWindow.cpp
@@ -329,7 +329,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             window->rowHover = -1;
             window->disabledWidgets = 0;
 
-            WindowManager::sub_4CEE0B(window);
+            WindowManager::sub_4CEE0B(*window);
 
             window->minWidth = Messages::kMinWindowSize.width;
             window->minHeight = Messages::kMinWindowSize.height;

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -870,7 +870,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             window->savedView.mapX = 0;
             _treeClusterType = PlantTrees::treeCluster::none;
 
-            WindowManager::sub_4CEE0B(window);
+            WindowManager::sub_4CEE0B(*window);
 
             window->minWidth = PlantTrees::kWindowSize.width;
             window->minHeight = PlantTrees::kWindowSize.height;

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -2781,15 +2781,15 @@ namespace OpenLoco::Ui::Windows::Terraform
         terraformWindow->callOnMouseUp(Common::widx::tab_build_walls);
     }
 
-    bool rotate(Window* self)
+    bool rotate(Window& self)
     {
-        if (self->currentTab == Common::widx::tab_plant_trees - Common::widx::tab_clear_area)
+        if (self.currentTab == Common::widx::tab_plant_trees - Common::widx::tab_clear_area)
         {
-            if (!self->isDisabled(PlantTrees::widx::rotate_object))
+            if (!self.isDisabled(PlantTrees::widx::rotate_object))
             {
-                if (self->widgets[PlantTrees::widx::rotate_object].type != WidgetType::none)
+                if (self.widgets[PlantTrees::widx::rotate_object].type != WidgetType::none)
                 {
-                    self->callOnMouseUp(PlantTrees::widx::rotate_object);
+                    self.callOnMouseUp(PlantTrees::widx::rotate_object);
                     return true;
                 }
             }

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -248,14 +248,14 @@ namespace OpenLoco::Ui::Windows::TimePanel
         }
     }
 
-    void beginSendChatMessage(Window* self)
+    void beginSendChatMessage(Window& self)
     {
         const auto* opponent = CompanyManager::getOpponent();
         FormatArguments args{};
         args.push(opponent->name);
 
         // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments
-        TextInput::openTextInput(self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::map_chat_menu, const_cast<void*>(&args));
+        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::map_chat_menu, const_cast<void*>(&args));
     }
 
     // 0x0043A72F
@@ -269,7 +269,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
             switch (itemIndex)
             {
                 case 0:
-                    beginSendChatMessage(self);
+                    beginSendChatMessage(*self);
                     break;
                 case 1:
                     MapWindow::open();

--- a/src/OpenLoco/src/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Windows/TitleMenu.cpp
@@ -338,7 +338,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
                 sub_43910A();
                 break;
             case Widx::chat_btn:
-                beginSendChatMessage(&window);
+                beginSendChatMessage(window);
                 break;
             case Widx::multiplayer_toggle_btn:
                 showMultiplayer(&window);
@@ -444,7 +444,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
             0x80);
     }
 
-    void beginSendChatMessage(Window* self)
+    void beginSendChatMessage(Window& self)
     {
         WindowManager::close(WindowType::multiplayer);
 
@@ -452,7 +452,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
         args.push(StringIds::the_other_player);
 
         // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments
-        TextInput::openTextInput(self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::chat_btn, const_cast<void*>(&args));
+        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::chat_btn, const_cast<void*>(&args));
     }
 
     static void sub_43918F(const char* string)

--- a/src/OpenLoco/src/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Windows/TownList.cpp
@@ -549,7 +549,7 @@ namespace OpenLoco::Ui::Windows::TownList
 
             Common::refreshTownList(window);
 
-            WindowManager::sub_4CEE0B(window);
+            WindowManager::sub_4CEE0B(*window);
 
             window->minWidth = TownList::kMinDimensions.width;
             window->minHeight = TownList::kMinDimensions.height;

--- a/src/OpenLoco/src/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Windows/TownList.cpp
@@ -1466,15 +1466,15 @@ namespace OpenLoco::Ui::Windows::TownList
         }
     }
 
-    bool rotate(Window* self)
+    bool rotate(Window& self)
     {
-        if (self->currentTab >= Common::widx::tab_build_buildings - Common::widx::tab_town_list)
+        if (self.currentTab >= Common::widx::tab_build_buildings - Common::widx::tab_town_list)
         {
-            if (!self->isDisabled(BuildBuildings::widx::rotate_object))
+            if (!self.isDisabled(BuildBuildings::widx::rotate_object))
             {
-                if (self->widgets[BuildBuildings::widx::rotate_object].type != WidgetType::none)
+                if (self.widgets[BuildBuildings::widx::rotate_object].type != WidgetType::none)
                 {
-                    self->callOnMouseUp(BuildBuildings::widx::rotate_object);
+                    self.callOnMouseUp(BuildBuildings::widx::rotate_object);
                     return true;
                 }
             }

--- a/src/OpenLoco/src/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Windows/Vehicle.cpp
@@ -2986,7 +2986,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     {
                         addNewOrder(toolWindow, *order);
                     }
-                    WindowManager::bringToFront(toolWindow);
+                    WindowManager::bringToFront(*toolWindow);
                 }
                 else
                 {
@@ -2994,7 +2994,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     Audio::playSound(Audio::SoundId::waypoint, Input::getDragLastLocation().x);
                     auto clonedOrder = selectedOrder->clone();
                     addNewOrder(toolWindow, *clonedOrder);
-                    WindowManager::bringToFront(toolWindow);
+                    WindowManager::bringToFront(*toolWindow);
                 }
                 return;
             }


### PR DESCRIPTION
This PR refers to issue #1590.

I have changed the parameter of `WindowManager::bringToFront()` from pointer to reference. If I understand correctly this a good practice since a reference doesn't need `nullptr` check. Is this correct? Are there other reasons?
