### PR TITLE
Refactor various window (manager) bits

### DIFF
--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -22,7 +22,6 @@
 
 using namespace OpenLoco::Interop;
 using namespace OpenLoco::Ui;
-using namespace OpenLoco::Ui::Windows;
 
 namespace OpenLoco::EditorController
 {
@@ -132,7 +131,7 @@ namespace OpenLoco::EditorController
                 WindowManager::closeAllFloatingWindows();
                 S5::sub_4BAEC4();
                 S5::getOptions().editorStep = Step::landscapeEditor;
-                LandscapeGeneration::open();
+                Windows::LandscapeGeneration::open();
                 break;
 
             case Step::saveScenario:
@@ -179,7 +178,7 @@ namespace OpenLoco::EditorController
 
             case Step::objectSelection:
             {
-                if (!ObjectSelectionWindow::tryCloseWindow())
+                if (!Windows::ObjectSelectionWindow::tryCloseWindow())
                 {
                     // Try close has failed so do not allow changing step!
                     return;
@@ -194,7 +193,7 @@ namespace OpenLoco::EditorController
                 Scenario::initialiseSnowLine();
                 S5::sub_4BAEC4();
                 S5::getOptions().editorStep = Step::landscapeEditor;
-                LandscapeGeneration::open();
+                Windows::LandscapeGeneration::open();
                 if ((S5::getOptions().scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) != Scenario::ScenarioFlags::none)
                 {
                     if ((addr<0x00525E28, uint32_t>() & 1) == 0)
@@ -228,7 +227,7 @@ namespace OpenLoco::EditorController
                 WindowManager::closeAllFloatingWindows();
                 Scenario::initialiseDate(S5::getOptions().scenarioStartYear);
                 Scenario::initialiseSnowLine();
-                ScenarioOptions::open();
+                Windows::ScenarioOptions::open();
                 S5::getOptions().editorStep = Step::scenarioOptions;
                 break;
             }
@@ -259,7 +258,7 @@ namespace OpenLoco::EditorController
 
                 if (!success)
                 {
-                    showError(StringIds::scenario_save_failed);
+                    Windows::Error::open(StringIds::scenario_save_failed);
                     S5::getOptions().editorStep = Step::scenarioOptions;
                     break;
                 }

--- a/src/OpenLoco/src/Game.cpp
+++ b/src/OpenLoco/src/Game.cpp
@@ -231,7 +231,7 @@ namespace OpenLoco::Game
 
                 Title::start();
 
-                Ui::Windows::Error::open(StringIds::error_the_other_player_has_exited_the_game, StringIds::null);
+                Ui::Windows::Error::open(StringIds::error_the_other_player_has_exited_the_game);
 
                 throw GameException::Interrupt;
             }
@@ -347,7 +347,7 @@ namespace OpenLoco::Game
 
         bool saveResult = !S5::exportGameStateToFile(path, S5::SaveFlags::scenario);
         if (saveResult)
-            Ui::Windows::Error::open(StringIds::landscape_save_failed, StringIds::null);
+            Ui::Windows::Error::open(StringIds::landscape_save_failed);
 
         return saveResult;
     }

--- a/src/OpenLoco/src/GameCommands/GameCommands.cpp
+++ b/src/OpenLoco/src/GameCommands/GameCommands.cpp
@@ -429,7 +429,7 @@ namespace OpenLoco::GameCommands
 
         if (_gGameCommandErrorText != 0xFFFE)
         {
-            Windows::showError(_gGameCommandErrorTitle, _gGameCommandErrorText);
+            Windows::Error::open(_gGameCommandErrorTitle, _gGameCommandErrorText);
             return GameCommands::FAILURE;
         }
 

--- a/src/OpenLoco/src/Gui.cpp
+++ b/src/OpenLoco/src/Gui.cpp
@@ -20,9 +20,6 @@ namespace OpenLoco::Gui
     {
         Windows::Main::open();
 
-        Windows::Main::resetGridlines();
-        Windows::Main::resetDirectionArrows();
-
         Windows::Terraform::setAdjustLandToolSize(1);
         Windows::Terraform::setAdjustWaterToolSize(1);
         Windows::Terraform::setClearAreaToolSize(2);

--- a/src/OpenLoco/src/Gui.cpp
+++ b/src/OpenLoco/src/Gui.cpp
@@ -23,9 +23,9 @@ namespace OpenLoco::Gui
         Windows::Main::resetGridlines();
         Windows::Main::resetDirectionArrows();
 
-        addr<0x009c870E, int8_t>() = 1;
-        addr<0x009c870F, int8_t>() = 2;
-        addr<0x009c8710, int8_t>() = 1;
+        Windows::Terraform::setAdjustLandToolSize(1);
+        Windows::Terraform::setAdjustWaterToolSize(1);
+        Windows::Terraform::setClearAreaToolSize(2);
 
         if (OpenLoco::isTitleMode())
         {

--- a/src/OpenLoco/src/Gui.cpp
+++ b/src/OpenLoco/src/Gui.cpp
@@ -20,8 +20,9 @@ namespace OpenLoco::Gui
     {
         Windows::Main::open();
 
-        addr<0x00F2533F, int8_t>() = 0; // grid lines
-        addr<0x0112C2e1, int8_t>() = 0;
+        Windows::Main::resetGridlines();
+        Windows::Main::resetDirectionArrows();
+
         addr<0x009c870E, int8_t>() = 1;
         addr<0x009c870F, int8_t>() = 2;
         addr<0x009c8710, int8_t>() = 1;

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -799,7 +799,7 @@ namespace OpenLoco
             {
                 StringId title = _loadErrorMessage;
                 StringId message = StringIds::null;
-                Ui::Windows::showError(title, message);
+                Ui::Windows::Error::open(title, message);
             }
             else
             {

--- a/src/OpenLoco/src/Ui/Screenshot.cpp
+++ b/src/OpenLoco/src/Ui/Screenshot.cpp
@@ -51,7 +51,7 @@ namespace OpenLoco::Ui
                         fileName = saveScreenshot();
 
                     FormatArguments::common(fileName.c_str());
-                    Windows::Error::open(StringIds::screenshot_saved_as, StringIds::null, false);
+                    Windows::Error::openQuiet(StringIds::screenshot_saved_as, StringIds::null);
                 }
                 catch (const std::exception&)
                 {

--- a/src/OpenLoco/src/Ui/Screenshot.cpp
+++ b/src/OpenLoco/src/Ui/Screenshot.cpp
@@ -51,11 +51,11 @@ namespace OpenLoco::Ui
                         fileName = saveScreenshot();
 
                     FormatArguments::common(fileName.c_str());
-                    Windows::showError(StringIds::screenshot_saved_as, StringIds::null, false);
+                    Windows::Error::open(StringIds::screenshot_saved_as);
                 }
                 catch (const std::exception&)
                 {
-                    Windows::showError(StringIds::screenshot_failed);
+                    Windows::Error::open(StringIds::screenshot_failed);
                 }
             }
         }

--- a/src/OpenLoco/src/Ui/Screenshot.cpp
+++ b/src/OpenLoco/src/Ui/Screenshot.cpp
@@ -51,7 +51,7 @@ namespace OpenLoco::Ui
                         fileName = saveScreenshot();
 
                     FormatArguments::common(fileName.c_str());
-                    Windows::Error::open(StringIds::screenshot_saved_as);
+                    Windows::Error::open(StringIds::screenshot_saved_as, StringIds::null, false);
                 }
                 catch (const std::exception&)
                 {

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -1,6 +1,5 @@
 #include "WindowManager.h"
 #include "Audio/Audio.h"
-#include "Config.h"
 #include "Drawing/SoftwareDrawingEngine.h"
 #include "Entities/EntityManager.h"
 #include "GameCommands/GameCommands.h"
@@ -2234,87 +2233,6 @@ namespace OpenLoco::Ui::WindowManager
                 continue;
 
             windowDraw(&rt, w, rect);
-        }
-    }
-}
-
-namespace OpenLoco::Ui::Windows
-{
-    static loco_global<int8_t, 0x00F2533F> _gridlinesState;
-    static loco_global<uint8_t, 0x0112C2E1> _directionArrowsState;
-
-    // 0x00468FD3
-    void showGridlines()
-    {
-        if (!_gridlinesState)
-        {
-            auto window = WindowManager::getMainWindow();
-            if (window != nullptr)
-            {
-                if (!window->viewports[0]->hasFlags(ViewportFlags::gridlines_on_landscape))
-                {
-                    window->invalidate();
-                }
-                window->viewports[0]->flags |= ViewportFlags::gridlines_on_landscape;
-            }
-        }
-        _gridlinesState++;
-    }
-
-    // 0x00468FFE
-    void hideGridlines()
-    {
-        _gridlinesState--;
-        if (!_gridlinesState)
-        {
-            if (!Config::get().hasFlags(Config::Flags::gridlinesOnLandscape))
-            {
-                auto window = WindowManager::getMainWindow();
-                if (window != nullptr)
-                {
-                    if (window->viewports[0]->hasFlags(ViewportFlags::gridlines_on_landscape))
-                    {
-                        window->invalidate();
-                    }
-                    window->viewports[0]->flags &= ~ViewportFlags::gridlines_on_landscape;
-                }
-            }
-        }
-    }
-
-    // 0x004793C4
-    void showDirectionArrows()
-    {
-        if (!_directionArrowsState)
-        {
-            auto mainWindow = WindowManager::getMainWindow();
-            if (mainWindow != nullptr)
-            {
-                if (!mainWindow->viewports[0]->hasFlags(ViewportFlags::one_way_direction_arrows))
-                {
-                    mainWindow->viewports[0]->flags |= ViewportFlags::one_way_direction_arrows;
-                    mainWindow->invalidate();
-                }
-            }
-        }
-        _directionArrowsState++;
-    }
-
-    // 0x004793EF
-    void hideDirectionArrows()
-    {
-        _directionArrowsState--;
-        if (!_directionArrowsState)
-        {
-            auto mainWindow = WindowManager::getMainWindow();
-            if (mainWindow != nullptr)
-            {
-                if (mainWindow->viewports[0]->hasFlags(ViewportFlags::one_way_direction_arrows))
-                {
-                    mainWindow->viewports[0]->flags &= ~ViewportFlags::one_way_direction_arrows;
-                    mainWindow->invalidate();
-                }
-            }
         }
     }
 }

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -2240,22 +2240,8 @@ namespace OpenLoco::Ui::WindowManager
 
 namespace OpenLoco::Ui::Windows
 {
-    static loco_global<uint8_t, 0x00508F09> _suppressErrorSound;
     static loco_global<int8_t, 0x00F2533F> _gridlinesState;
     static loco_global<uint8_t, 0x0112C2E1> _directionArrowsState;
-
-    // 0x00431A8A
-    void showError(StringId title, StringId message, bool sound)
-    {
-        if (!sound)
-        {
-            _suppressErrorSound = true;
-        }
-
-        Windows::Error::open(title, message);
-
-        _suppressErrorSound = false;
-    }
 
     // 0x00468FD3
     void showGridlines()

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -182,7 +182,8 @@ namespace OpenLoco::Ui::Windows
 
     namespace Error
     {
-        void open(StringId title, StringId message = StringIds::null, bool playSound = true);
+        void open(StringId title, StringId message = StringIds::null);
+        void openQuiet(StringId title, StringId message = StringIds::null);
         void openWithCompetitor(StringId title, StringId message, CompanyId competitorId);
         void registerHooks();
     }

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -110,8 +110,6 @@ namespace OpenLoco::Vehicles
 
 namespace OpenLoco::Ui::Windows
 {
-    void showError(StringId title, StringId message = StringIds::null, bool sound = true);
-
     void showGridlines();
     void hideGridlines();
     void showDirectionArrows();
@@ -189,7 +187,7 @@ namespace OpenLoco::Ui::Windows
 
     namespace Error
     {
-        void open(StringId title, StringId message);
+        void open(StringId title, StringId message = StringIds::null);
         void openWithCompetitor(StringId title, StringId message, CompanyId competitorId);
         void registerHooks();
     }

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -182,7 +182,7 @@ namespace OpenLoco::Ui::Windows
 
     namespace Error
     {
-        void open(StringId title, StringId message = StringIds::null);
+        void open(StringId title, StringId message = StringIds::null, bool playSound = true);
         void openWithCompetitor(StringId title, StringId message, CompanyId competitorId);
         void registerHooks();
     }

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -110,11 +110,6 @@ namespace OpenLoco::Vehicles
 
 namespace OpenLoco::Ui::Windows
 {
-    void showGridlines();
-    void hideGridlines();
-    void showDirectionArrows();
-    void hideDirectionArrows();
-
     namespace About
     {
         void open();
@@ -222,6 +217,10 @@ namespace OpenLoco::Ui::Windows
     namespace Main
     {
         void open();
+        void showGridlines();
+        void hideGridlines();
+        void showDirectionArrows();
+        void hideDirectionArrows();
     }
 
     namespace MapToolTip

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -219,10 +219,8 @@ namespace OpenLoco::Ui::Windows
         void open();
         void showGridlines();
         void hideGridlines();
-        void resetGridlines();
         void showDirectionArrows();
         void hideDirectionArrows();
-        void resetDirectionArrows();
     }
 
     namespace MapToolTip

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -219,8 +219,10 @@ namespace OpenLoco::Ui::Windows
         void open();
         void showGridlines();
         void hideGridlines();
+        void resetGridlines();
         void showDirectionArrows();
         void hideDirectionArrows();
+        void resetDirectionArrows();
     }
 
     namespace MapToolTip

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -350,6 +350,9 @@ namespace OpenLoco::Ui::Windows
         void openPlantTrees();
         void openBuildWalls();
         bool rotate(Window*);
+        void setAdjustLandToolSize(uint8_t size);
+        void setAdjustWaterToolSize(uint8_t size);
+        void setClearAreaToolSize(uint8_t size);
         void setLastPlacedTree(World::TreeElement* elTree);
     }
 

--- a/src/OpenLoco/src/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Windows/CompanyWindow.cpp
@@ -1067,7 +1067,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex)
         {
             removeHeadquarterGhost();
-            Ui::Windows::hideGridlines();
+            Ui::Windows::Main::hideGridlines();
         }
 
         static void onClose(Window& self)

--- a/src/OpenLoco/src/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Windows/Construction/Common.cpp
@@ -987,8 +987,8 @@ namespace OpenLoco::Ui::Windows::Construction
             World::mapInvalidateMapSelectionTiles();
             World::resetMapSelectionFlag(World::MapSelectionFlags::enableConstruct);
             World::resetMapSelectionFlag(World::MapSelectionFlags::enableConstructionArrow);
-            hideDirectionArrows();
-            hideGridlines();
+            Windows::Main::hideDirectionArrows();
+            Windows::Main::hideGridlines();
         }
 
         // 0x0049E437, 0x0049E76F, 0x0049ECD1
@@ -1095,8 +1095,8 @@ namespace OpenLoco::Ui::Windows::Construction
             window->setColour(WindowColour::secondary, skin->colour_0D);
 
             WindowManager::sub_4CEE0B(window);
-            Ui::Windows::showDirectionArrows();
-            Ui::Windows::showGridlines();
+            Windows::Main::showDirectionArrows();
+            Windows::Main::showGridlines();
 
             Common::initEvents();
         }

--- a/src/OpenLoco/src/Windows/Error.cpp
+++ b/src/OpenLoco/src/Windows/Error.cpp
@@ -173,10 +173,17 @@ namespace OpenLoco::Ui::Windows::Error
     }
 
     // 0x00431A8A
-    void open(StringId title, StringId message, bool playSound)
+    void open(StringId title, StringId message)
     {
         _errorCompetitorId = CompanyId::null;
-        _suppressErrorSound |= !playSound;
+
+        createErrorWindow(title, message);
+    }
+
+    void openQuiet(StringId title, StringId message)
+    {
+        _errorCompetitorId = CompanyId::null;
+        _suppressErrorSound = true;
 
         createErrorWindow(title, message);
 
@@ -187,7 +194,6 @@ namespace OpenLoco::Ui::Windows::Error
     void openWithCompetitor(StringId title, StringId message, CompanyId competitorId)
     {
         _errorCompetitorId = competitorId;
-        _suppressErrorSound = false;
 
         createErrorWindow(title, message);
     }

--- a/src/OpenLoco/src/Windows/Error.cpp
+++ b/src/OpenLoco/src/Windows/Error.cpp
@@ -18,7 +18,6 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::Error
 {
-    static loco_global<uint8_t, 0x00508F09> _suppressErrorSound;
     static loco_global<char[512], 0x009C64B3> _errorText;
     static loco_global<uint16_t, 0x009C66B3> _linebreakCount;
     static loco_global<CompanyId, 0x009C68EC> _errorCompetitorId;
@@ -86,7 +85,7 @@ namespace OpenLoco::Ui::Windows::Error
         return ptr;
     }
 
-    static void createErrorWindow(StringId title, StringId message)
+    static void createErrorWindow(StringId title, StringId message, bool playSound)
     {
         WindowManager::close(WindowType::error);
 
@@ -164,7 +163,7 @@ namespace OpenLoco::Ui::Windows::Error
             error->widgets[Error::widx::frame].bottom = frameHeight;
             error->var_846 = 0;
 
-            if (!(_suppressErrorSound & (1 << 0)))
+            if (playSound)
             {
                 int32_t pan = (error->width / 2) + error->x;
                 Audio::playSound(Audio::SoundId::error, pan);
@@ -173,11 +172,11 @@ namespace OpenLoco::Ui::Windows::Error
     }
 
     // 0x00431A8A
-    void open(StringId title, StringId message)
+    void open(StringId title, StringId message, bool playSound)
     {
         _errorCompetitorId = CompanyId::null;
 
-        createErrorWindow(title, message);
+        createErrorWindow(title, message, playSound);
     }
 
     // 0x00431908
@@ -185,7 +184,7 @@ namespace OpenLoco::Ui::Windows::Error
     {
         _errorCompetitorId = competitorId;
 
-        createErrorWindow(title, message);
+        createErrorWindow(title, message, true);
     }
 
     void registerHooks()
@@ -194,7 +193,7 @@ namespace OpenLoco::Ui::Windows::Error
             0x00431A8A,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 registers backup = regs;
-                Ui::Windows::Error::open(regs.bx, regs.dx);
+                Ui::Windows::Error::open(regs.bx, regs.dx, true);
                 regs = backup;
                 return 0;
             });

--- a/src/OpenLoco/src/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Windows/IndustryList.cpp
@@ -1097,7 +1097,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex)
         {
             removeIndustryGhost();
-            Ui::Windows::hideGridlines();
+            Ui::Windows::Main::hideGridlines();
         }
 
         // 0x0045845F
@@ -1188,7 +1188,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
             ToolManager::toolSet(self, Common::widx::tab_new_industry, CursorId::placeFactory);
 
             Input::setFlag(Input::Flags::flag6);
-            Ui::Windows::showGridlines();
+            Ui::Windows::Main::showGridlines();
             _industryGhostPlaced = false;
             _dword_E0C39C = 0x80000000;
 

--- a/src/OpenLoco/src/Windows/Main.cpp
+++ b/src/OpenLoco/src/Windows/Main.cpp
@@ -10,9 +10,6 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::Main
 {
-    static loco_global<bool, 0x00F2533F> _showingGridlines;
-    static loco_global<bool, 0x0112C2E1> _showingDirectionArrows;
-
     namespace widx
     {
         enum
@@ -71,86 +68,44 @@ namespace OpenLoco::Ui::Windows::Main
     // 0x00468FD3
     void showGridlines()
     {
-        if (_showingGridlines)
-        {
-            return;
-        }
-
         auto window = WindowManager::getMainWindow();
         if (window == nullptr || window->viewports[0]->hasFlags(ViewportFlags::gridlines_on_landscape))
-        {
             return;
-        }
 
         window->viewports[0]->flags |= ViewportFlags::gridlines_on_landscape;
         window->invalidate();
-        _showingGridlines = true;
     }
 
     // 0x00468FFE
     void hideGridlines()
     {
-        if (!_showingGridlines)
-        {
-            return;
-        }
-
         auto window = WindowManager::getMainWindow();
         if (window == nullptr || !window->viewports[0]->hasFlags(ViewportFlags::gridlines_on_landscape))
-        {
             return;
-        }
 
         window->viewports[0]->flags &= ~ViewportFlags::gridlines_on_landscape;
         window->invalidate();
-        _showingGridlines = false;
-    }
-
-    void resetGridlines()
-    {
-        _showingGridlines = false;
     }
 
     // 0x004793C4
     void showDirectionArrows()
     {
-        if (_showingDirectionArrows)
-        {
-            return;
-        }
-
         auto mainWindow = WindowManager::getMainWindow();
         if (mainWindow == nullptr || mainWindow->viewports[0]->hasFlags(ViewportFlags::one_way_direction_arrows))
-        {
             return;
-        }
 
         mainWindow->viewports[0]->flags |= ViewportFlags::one_way_direction_arrows;
         mainWindow->invalidate();
-        _showingDirectionArrows = true;
     }
 
     // 0x004793EF
     void hideDirectionArrows()
     {
-        if (!_showingDirectionArrows)
-        {
-            return;
-        }
-
         auto mainWindow = WindowManager::getMainWindow();
         if (mainWindow == nullptr || !mainWindow->viewports[0]->hasFlags(ViewportFlags::one_way_direction_arrows))
-        {
             return;
-        }
 
         mainWindow->viewports[0]->flags &= ~ViewportFlags::one_way_direction_arrows;
         mainWindow->invalidate();
-        _showingDirectionArrows = false;
-    }
-
-    void resetDirectionArrows()
-    {
-        _showingDirectionArrows = false;
     }
 }

--- a/src/OpenLoco/src/Windows/Main.cpp
+++ b/src/OpenLoco/src/Windows/Main.cpp
@@ -1,3 +1,4 @@
+#include "Config.h"
 #include "Graphics/Gfx.h"
 #include "Map/Tile.h"
 #include "Ui/WindowManager.h"
@@ -9,6 +10,9 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::Main
 {
+    static loco_global<int8_t, 0x00F2533F> _gridlinesState;
+    static loco_global<uint8_t, 0x0112C2E1> _directionArrowsState;
+
     namespace widx
     {
         enum
@@ -63,4 +67,80 @@ namespace OpenLoco::Ui::Windows::Main
     {
         _events.draw = draw;
     }
+
+    // 0x00468FD3
+    void showGridlines()
+    {
+        if (!_gridlinesState)
+        {
+            auto window = WindowManager::getMainWindow();
+            if (window != nullptr)
+            {
+                if (!window->viewports[0]->hasFlags(ViewportFlags::gridlines_on_landscape))
+                {
+                    window->invalidate();
+                }
+                window->viewports[0]->flags |= ViewportFlags::gridlines_on_landscape;
+            }
+        }
+        _gridlinesState++;
+    }
+
+    // 0x00468FFE
+    void hideGridlines()
+    {
+        _gridlinesState--;
+        if (!_gridlinesState)
+        {
+            if (!Config::get().hasFlags(Config::Flags::gridlinesOnLandscape))
+            {
+                auto window = WindowManager::getMainWindow();
+                if (window != nullptr)
+                {
+                    if (window->viewports[0]->hasFlags(ViewportFlags::gridlines_on_landscape))
+                    {
+                        window->invalidate();
+                    }
+                    window->viewports[0]->flags &= ~ViewportFlags::gridlines_on_landscape;
+                }
+            }
+        }
+    }
+
+    // 0x004793C4
+    void showDirectionArrows()
+    {
+        if (!_directionArrowsState)
+        {
+            auto mainWindow = WindowManager::getMainWindow();
+            if (mainWindow != nullptr)
+            {
+                if (!mainWindow->viewports[0]->hasFlags(ViewportFlags::one_way_direction_arrows))
+                {
+                    mainWindow->viewports[0]->flags |= ViewportFlags::one_way_direction_arrows;
+                    mainWindow->invalidate();
+                }
+            }
+        }
+        _directionArrowsState++;
+    }
+
+    // 0x004793EF
+    void hideDirectionArrows()
+    {
+        _directionArrowsState--;
+        if (!_directionArrowsState)
+        {
+            auto mainWindow = WindowManager::getMainWindow();
+            if (mainWindow != nullptr)
+            {
+                if (mainWindow->viewports[0]->hasFlags(ViewportFlags::one_way_direction_arrows))
+                {
+                    mainWindow->viewports[0]->flags &= ~ViewportFlags::one_way_direction_arrows;
+                    mainWindow->invalidate();
+                }
+            }
+        }
+    }
+
 }

--- a/src/OpenLoco/src/Windows/Main.cpp
+++ b/src/OpenLoco/src/Windows/Main.cpp
@@ -10,8 +10,8 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::Main
 {
-    static loco_global<int8_t, 0x00F2533F> _gridlinesState;
-    static loco_global<uint8_t, 0x0112C2E1> _directionArrowsState;
+    static loco_global<bool, 0x00F2533F> _showingGridlines;
+    static loco_global<bool, 0x0112C2E1> _showingDirectionArrows;
 
     namespace widx
     {
@@ -71,76 +71,76 @@ namespace OpenLoco::Ui::Windows::Main
     // 0x00468FD3
     void showGridlines()
     {
-        if (!_gridlinesState)
+        if (_showingGridlines)
         {
-            auto window = WindowManager::getMainWindow();
-            if (window != nullptr)
-            {
-                if (!window->viewports[0]->hasFlags(ViewportFlags::gridlines_on_landscape))
-                {
-                    window->invalidate();
-                }
-                window->viewports[0]->flags |= ViewportFlags::gridlines_on_landscape;
-            }
+            return;
         }
-        _gridlinesState++;
+
+        auto window = WindowManager::getMainWindow();
+        if (window == nullptr || window->viewports[0]->hasFlags(ViewportFlags::gridlines_on_landscape))
+        {
+            return;
+        }
+
+        window->viewports[0]->flags |= ViewportFlags::gridlines_on_landscape;
+        window->invalidate();
+        _showingGridlines = true;
     }
 
     // 0x00468FFE
     void hideGridlines()
     {
-        _gridlinesState--;
-        if (!_gridlinesState)
+        if (!_showingGridlines)
         {
-            if (!Config::get().hasFlags(Config::Flags::gridlinesOnLandscape))
-            {
-                auto window = WindowManager::getMainWindow();
-                if (window != nullptr)
-                {
-                    if (window->viewports[0]->hasFlags(ViewportFlags::gridlines_on_landscape))
-                    {
-                        window->invalidate();
-                    }
-                    window->viewports[0]->flags &= ~ViewportFlags::gridlines_on_landscape;
-                }
-            }
+            return;
         }
+
+        auto window = WindowManager::getMainWindow();
+        if (window == nullptr || !window->viewports[0]->hasFlags(ViewportFlags::gridlines_on_landscape))
+        {
+            return;
+        }
+
+        window->viewports[0]->flags &= ~ViewportFlags::gridlines_on_landscape;
+        window->invalidate();
+        _showingGridlines = false;
     }
 
     // 0x004793C4
     void showDirectionArrows()
     {
-        if (!_directionArrowsState)
+        if (_showingDirectionArrows)
         {
-            auto mainWindow = WindowManager::getMainWindow();
-            if (mainWindow != nullptr)
-            {
-                if (!mainWindow->viewports[0]->hasFlags(ViewportFlags::one_way_direction_arrows))
-                {
-                    mainWindow->viewports[0]->flags |= ViewportFlags::one_way_direction_arrows;
-                    mainWindow->invalidate();
-                }
-            }
+            return;
         }
-        _directionArrowsState++;
+
+        auto mainWindow = WindowManager::getMainWindow();
+        if (mainWindow == nullptr || mainWindow->viewports[0]->hasFlags(ViewportFlags::one_way_direction_arrows))
+        {
+            return;
+        }
+
+        mainWindow->viewports[0]->flags |= ViewportFlags::one_way_direction_arrows;
+        mainWindow->invalidate();
+        _showingDirectionArrows = true;
     }
 
     // 0x004793EF
     void hideDirectionArrows()
     {
-        _directionArrowsState--;
-        if (!_directionArrowsState)
+        if (!_showingDirectionArrows)
         {
-            auto mainWindow = WindowManager::getMainWindow();
-            if (mainWindow != nullptr)
-            {
-                if (mainWindow->viewports[0]->hasFlags(ViewportFlags::one_way_direction_arrows))
-                {
-                    mainWindow->viewports[0]->flags &= ~ViewportFlags::one_way_direction_arrows;
-                    mainWindow->invalidate();
-                }
-            }
+            return;
         }
-    }
 
+        auto mainWindow = WindowManager::getMainWindow();
+        if (mainWindow == nullptr || !mainWindow->viewports[0]->hasFlags(ViewportFlags::one_way_direction_arrows))
+        {
+            return;
+        }
+
+        mainWindow->viewports[0]->flags &= ~ViewportFlags::one_way_direction_arrows;
+        mainWindow->invalidate();
+        _showingDirectionArrows = false;
+    }
 }

--- a/src/OpenLoco/src/Windows/Main.cpp
+++ b/src/OpenLoco/src/Windows/Main.cpp
@@ -106,6 +106,11 @@ namespace OpenLoco::Ui::Windows::Main
         _showingGridlines = false;
     }
 
+    void resetGridlines()
+    {
+        _showingGridlines = false;
+    }
+
     // 0x004793C4
     void showDirectionArrows()
     {
@@ -141,6 +146,11 @@ namespace OpenLoco::Ui::Windows::Main
 
         mainWindow->viewports[0]->flags &= ~ViewportFlags::one_way_direction_arrows;
         mainWindow->invalidate();
+        _showingDirectionArrows = false;
+    }
+
+    void resetDirectionArrows()
+    {
         _showingDirectionArrows = false;
     }
 }

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -828,7 +828,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         {
             if (filenameContainsInvalidChars())
             {
-                showError(StringIds::error_invalid_filename);
+                Error::open(StringIds::error_invalid_filename);
                 return;
             }
 

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -244,7 +244,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void onClose([[maybe_unused]] Window& self)
         {
             removeTreeGhost();
-            Ui::Windows::hideGridlines();
+            Ui::Windows::Main::hideGridlines();
         }
 
         // 0x004BBC7D
@@ -880,7 +880,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             // End of 0x004BB586
 
-            Ui::Windows::showGridlines();
+            Ui::Windows::Main::showGridlines();
             _treeRotation = 2;
 
             Common::initEvents();
@@ -935,7 +935,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BC671
         static void onClose([[maybe_unused]] Window& self)
         {
-            Ui::Windows::hideGridlines();
+            Ui::Windows::Main::hideGridlines();
         }
 
         // 0x004BBBC7
@@ -1159,7 +1159,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BC9D1
         static void onClose([[maybe_unused]] Window& self)
         {
-            Ui::Windows::hideGridlines();
+            Ui::Windows::Main::hideGridlines();
         }
 
         // 0x004BBBF7
@@ -1776,7 +1776,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BCDAE
         static void onClose([[maybe_unused]] Window& self)
         {
-            Ui::Windows::hideGridlines();
+            Ui::Windows::Main::hideGridlines();
         }
 
         // 0x004BBC46
@@ -2149,7 +2149,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void onClose([[maybe_unused]] Window& self)
         {
             removeWallGhost();
-            Ui::Windows::hideGridlines();
+            Ui::Windows::Main::hideGridlines();
         }
 
         // 0x004BBCBF

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -98,6 +98,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         };
         OPENLOCO_ENABLE_ENUM_OPERATORS(GhostPlacedFlags);
     }
+
     static loco_global<int16_t, 0x0052337A> _dragLastY;
     static loco_global<uint8_t, 0x009C870E> _adjustLandToolSize;
     static loco_global<uint8_t, 0x009C870F> _clearAreaToolSize;
@@ -123,6 +124,7 @@ namespace OpenLoco::Ui::Windows::Terraform
     static loco_global<uint8_t, 0x0113649D> _terraformGhostQuadrant; // tree
     static loco_global<uint32_t, 0x0113652C> _raiseWaterCost;
     static loco_global<uint32_t, 0x01136528> _lowerWaterCost;
+
     namespace PlantTrees
     {
         static constexpr Ui::Size kWindowSize = { 634, 162 };
@@ -2794,6 +2796,21 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         return false;
+    }
+
+    void setAdjustLandToolSize(uint8_t size)
+    {
+        _adjustLandToolSize = size;
+    }
+
+    void setAdjustWaterToolSize(uint8_t size)
+    {
+        _adjustWaterToolSize = size;
+    }
+
+    void setClearAreaToolSize(uint8_t size)
+    {
+        _clearAreaToolSize = size;
     }
 
     void setLastPlacedTree(World::TreeElement* elTree)

--- a/src/OpenLoco/src/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Windows/TitleMenu.cpp
@@ -411,10 +411,11 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     // 0x0043CB9F
     void editorInit()
     {
-        Main::open();
+        Windows::Main::open();
 
-        addr<0x00F2533F, int8_t>() = 0; // grid lines
-        addr<0x0112C2e1, int8_t>() = 0;
+        Windows::Main::resetGridlines();
+        Windows::Main::resetDirectionArrows();
+
         addr<0x009c870E, int8_t>() = 0;
         addr<0x009c870F, int8_t>() = 2;
         addr<0x009c8710, int8_t>() = 1;

--- a/src/OpenLoco/src/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Windows/TitleMenu.cpp
@@ -416,9 +416,9 @@ namespace OpenLoco::Ui::Windows::TitleMenu
         Windows::Main::resetGridlines();
         Windows::Main::resetDirectionArrows();
 
-        addr<0x009c870E, int8_t>() = 0;
-        addr<0x009c870F, int8_t>() = 2;
-        addr<0x009c8710, int8_t>() = 1;
+        Windows::Terraform::setAdjustLandToolSize(1);
+        Windows::Terraform::setAdjustWaterToolSize(1);
+        Windows::Terraform::setClearAreaToolSize(2);
 
         ToolbarTop::Editor::open();
         ToolbarBottom::Editor::open();

--- a/src/OpenLoco/src/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Windows/TitleMenu.cpp
@@ -413,9 +413,6 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     {
         Windows::Main::open();
 
-        Windows::Main::resetGridlines();
-        Windows::Main::resetDirectionArrows();
-
         Windows::Terraform::setAdjustLandToolSize(1);
         Windows::Terraform::setAdjustWaterToolSize(1);
         Windows::Terraform::setClearAreaToolSize(2);

--- a/src/OpenLoco/src/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Windows/TownList.cpp
@@ -711,7 +711,7 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049A7C1
         static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex)
         {
-            Ui::Windows::hideGridlines();
+            Ui::Windows::Main::hideGridlines();
         }
 
         // 0x0049A710
@@ -793,7 +793,7 @@ namespace OpenLoco::Ui::Windows::TownList
             self->height = kWindowSize.height;
             ToolManager::toolSet(self, Common::widx::tab_build_town, CursorId::placeTown);
             Input::setFlag(Input::Flags::flag6);
-            Ui::Windows::showGridlines();
+            Ui::Windows::Main::showGridlines();
         }
 
         static void initEvents()
@@ -1014,7 +1014,7 @@ namespace OpenLoco::Ui::Windows::TownList
         static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex)
         {
             removeBuildingGhost();
-            Ui::Windows::hideGridlines();
+            Ui::Windows::Main::hideGridlines();
         }
 
         // 0x0049B32A
@@ -1428,7 +1428,7 @@ namespace OpenLoco::Ui::Windows::TownList
 
             ToolManager::toolSet(self, tab, CursorId::placeBuilding);
             Input::setFlag(Input::Flags::flag6);
-            Ui::Windows::showGridlines();
+            Ui::Windows::Main::showGridlines();
 
             static loco_global<uint8_t, 0x01135C60> _byte_1135C60;
             _byte_1135C60 = 0;


### PR DESCRIPTION
Move {show,hide}{Gridlines,DirectionArrows} into Main window. These methods always apply to the main window, so best to keep them there as well.

Rewrite {show,hide}{Gridlines,DirectionArrows}. The new functions use the viewport flags, rather than rely on an additional boolean state.

~~Add resetGridlines, resetDirectionArrows methods to replace direct memory access. This allows resetting the state logic for the above without amending flags. Previously, this relied on setting vanilla memory space.~~ And removed them again.

Add terraform tool size setter methods to replace direct memory access. Similar to above, but for each of the terraform tool sizes.

Consolidate Windows::showError into Windows::Error::open. The former appears to be a duplicate of the latter, with an extra sound parameter that's used to suppress screenshot message sounds. I've added this optional parameter to the Windows::Error::open signature to keep functionality as-is. This still uses a loco_global, as it appears to be used to suppress game command errors in some hacky way.