### PR TITLE
Fix town size very small crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#2277] Window invalidation mistake when using drag and drop vehicle.
 - Fix: [#2282] Crash when generating landscape with smallest town size.
+- Fix: [#2282] Town size selection does not match vanilla size selection.
 - Fix: [#2283] Bankrupt ai companies not being removed from the game.
 
 24.01.1 (2024-01-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 24.01.1+ (???)
 ------------------------------------------------------------------------
 - Fix: [#2277] Window invalidation mistake when using drag and drop vehicle.
+- Fix: [#2282] Crash when generating landscape with smallest town size.
 - Fix: [#2283] Bankrupt ai companies not being removed from the game.
 
 24.01.1 (2024-01-17)

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -378,7 +378,9 @@ namespace OpenLoco::World::MapGenerator
             // NB: vanilla was calling the game command directly; we're using the runner.
             GameCommands::TownPlacementArgs args{};
             args.pos = { -1, -1 };
-            args.size = getGameState().rng.randNext(1, S5::getOptions().maxTownSize);
+            const auto maxTownSize = S5::getOptions().maxTownSize;
+
+            args.size = maxTownSize > 1 ? getGameState().rng.randNext(1, maxTownSize) : 1;
             GameCommands::doCommand(args, GameCommands::Flags::apply);
         }
     }

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -1041,13 +1041,13 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             StringIds::town_size_8,
         };
 
-        // 0x0043EBF8
+        // 0x0043EA28
         static void onDropdown(Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
         {
             if (widgetIndex != widx::max_town_size_btn || itemIndex == -1)
                 return;
 
-            S5::getOptions().maxTownSize = itemIndex;
+            S5::getOptions().maxTownSize = itemIndex + 1;
             window.invalidate();
         }
 


### PR DESCRIPTION
#2209 had an issue when town size was 0 (1 in the ui). When it was zero the randnext function will go wrong as the min is larger than the max and will end up returning invalid numbers. #2282 also mentions that there might be a mistake in the sizes as well. Perhaps needs further investigation.

Edit. Yes the ui code also had a mistake. So its fixed twice. Once in Ui to match vanilla and again to fix the crash (that can't happen anymore unless you hex edit your saves).