### PR TITLE
Fix invisible files in browse window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 24.01.1+ (???)
 ------------------------------------------------------------------------
 - Fix: [#2277] Window invalidation mistake when using drag and drop vehicle.
+- Fix: [#2255] Browse window fails to show all files.
 - Fix: [#2282] Crash when generating landscape with smallest town size.
 - Fix: [#2282] Town size selection does not match vanilla size selection.
 - Fix: [#2283] Bankrupt ai companies not being removed from the game.

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -200,6 +200,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             case widx::parent_button:
                 upOneLevel();
                 window.var_85A = -1;
+                window.initScrollWidgets();
                 window.invalidate();
                 break;
             case widx::ok_button:
@@ -240,6 +241,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         {
             changeDirectory(entry);
             self.var_85A = -1;
+            self.initScrollWidgets();
             self.invalidate();
             return;
         }


### PR DESCRIPTION
This was a funny one. Its caused by the scroll bar being incorrect after changing directory.