### PR TITLE
Fix #2287: Scroll wheel not working in load/save window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: [#2282] Crash when generating landscape with smallest town size.
 - Fix: [#2282] Town size selection does not match vanilla size selection.
 - Fix: [#2283] Bankrupt ai companies not being removed from the game.
+- Fix: [#2287] Scroll wheel not working in load/save window.
 - Fix: [#2290] Construction arrow not being correctly invalidated.
 
 24.01.1 (2024-01-17)

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -155,6 +155,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                     Audio::updateSounds();
                     WindowManager::dispatchUpdateAll();
                     Input::processKeyboardInput();
+                    Input::processMouseWheel();
                     WindowManager::update();
                     Ui::minimalHandleInput();
                     Gfx::renderAndUpdate();


### PR DESCRIPTION
In #2225, we refactored mouse input such that certain handling is split off to `Input::processMouseWheel`. This new function is called in the main event loop. However, the load/save window uses its own event loop. Ideally, we get rid of that eventually. For now, I have just added the call, fixing the issue.