### PR TITLE
Fix #2293: see-through trees flag is ignored when right-clicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Fix: [#2287] Scroll wheel not working in load/save window.
 - Fix: [#2290] Construction arrow not being correctly invalidated.
 - Fix: [#2291] Signals fail to be placed when selecting one end of large curve track.
+- Fix: [#2293] See-through trees flag is ignored when right-clicking a viewport.
+- Change: [#2294] Track and road elements are now ignored when they are see-through.
 
 24.01.1 (2024-01-17)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -928,7 +928,7 @@ namespace OpenLoco::Ui::ViewportInteraction
                     }
                     if (vp->hasFlags(ViewportFlags::seeThroughTracks))
                     {
-                        interactionsToExclude |= InteractionItemFlags::track | InteractionItemFlags::trackExtra | InteractionItemFlags::station | InteractionItemFlags::signal;
+                        interactionsToExclude |= InteractionItemFlags::track | InteractionItemFlags::trackExtra | InteractionItemFlags::signal;
                     }
                     if (vp->hasFlags(ViewportFlags::seeThroughRoads))
                     {

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -926,6 +926,14 @@ namespace OpenLoco::Ui::ViewportInteraction
                     {
                         interactionsToExclude |= InteractionItemFlags::wall;
                     }
+                    if (vp->hasFlags(ViewportFlags::seeThroughTracks))
+                    {
+                        interactionsToExclude |= InteractionItemFlags::track | InteractionItemFlags::trackExtra | InteractionItemFlags::station | InteractionItemFlags::signal;
+                    }
+                    if (vp->hasFlags(ViewportFlags::seeThroughRoads))
+                    {
+                        interactionsToExclude |= InteractionItemFlags::roadAndTram | InteractionItemFlags::roadAndTramExtra;
+                    }
                 }
             }
         }

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -918,9 +918,13 @@ namespace OpenLoco::Ui::ViewportInteraction
                     {
                         interactionsToExclude |= InteractionItemFlags::building | InteractionItemFlags::headquarterBuilding | InteractionItemFlags::industry;
                     }
+                    if (vp->hasFlags(ViewportFlags::seeThroughTrees))
+                    {
+                        interactionsToExclude |= InteractionItemFlags::tree;
+                    }
                     if (vp->hasFlags(ViewportFlags::seeThroughScenery))
                     {
-                        interactionsToExclude |= InteractionItemFlags::tree | InteractionItemFlags::wall;
+                        interactionsToExclude |= InteractionItemFlags::wall;
                     }
                 }
             }


### PR DESCRIPTION
This PR addresses two issues. First and foremost, it fixes #2293, which meant the see-through trees flag was ignored when right-clicking on a viewport.

Second, it adds ignore flags for track and road elements when either of them is made see-through.