### PR TITLE
Apply initial clang tidy checks to codebase

### DIFF
--- a/src/Core/include/OpenLoco/Core/FileStream.h
+++ b/src/Core/include/OpenLoco/Core/FileStream.h
@@ -18,7 +18,7 @@ namespace OpenLoco
     public:
         FileStream() = default;
         FileStream(const std::filesystem::path& path, StreamMode mode);
-        ~FileStream();
+        ~FileStream() override;
 
         bool open(const std::filesystem::path& path, StreamMode mode);
 

--- a/src/Core/include/OpenLoco/Core/MemoryStream.h
+++ b/src/Core/include/OpenLoco/Core/MemoryStream.h
@@ -16,7 +16,7 @@ namespace OpenLoco
         size_t _capacity{};
 
     public:
-        ~MemoryStream();
+        ~MemoryStream() override;
 
         void reserve(size_t len);
 

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -277,7 +277,7 @@ namespace OpenLoco
 
     static void initialise()
     {
-        std::srand(std::time(0));
+        std::srand(std::time(nullptr));
         addr<0x0050C18C, int32_t>() = addr<0x00525348, int32_t>();
         call(0x004078BE); // getSystemTime unused dead code?
         World::TileManager::allocateMapElements();

--- a/src/OpenLoco/src/Paint/Paint.cpp
+++ b/src/OpenLoco/src/Paint/Paint.cpp
@@ -337,8 +337,8 @@ namespace OpenLoco::Paint
         }
         _quadrantBackIndex = std::numeric_limits<uint32_t>::max();
         _quadrantFrontIndex = 0;
-        _lastPaintString = 0;
-        _paintStringHead = 0;
+        _lastPaintString = nullptr;
+        _paintStringHead = nullptr;
 
         _viewFlags = options.viewFlags;
         currentRotation = options.rotation;

--- a/src/OpenLoco/src/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Windows/BuildVehicle.cpp
@@ -734,8 +734,8 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 }
 
                 auto curViewport = window.viewports[0];
-                window.viewports[0] = 0;
-                if (curViewport != 0)
+                window.viewports[0] = nullptr;
+                if (curViewport != nullptr)
                 {
                     curViewport->width = 0;
                 }

--- a/src/OpenLoco/src/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Windows/IndustryList.cpp
@@ -1111,7 +1111,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         static void updateActiveThumb(Window* self)
         {
             uint16_t scrollHeight = 0;
-            self->callGetScrollSize(0, 0, &scrollHeight);
+            self->callGetScrollSize(0, nullptr, &scrollHeight);
             self->scrollAreas[0].contentHeight = scrollHeight;
 
             auto i = 0;

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -1616,7 +1616,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
         auto ptr = malloc(kMapSize * 8);
 
-        if (ptr == NULL)
+        if (ptr == nullptr)
             return;
 
         _dword_F253A8 = static_cast<uint8_t*>(ptr);

--- a/src/OpenLoco/src/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Windows/MessageWindow.cpp
@@ -361,7 +361,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         window->initScrollWidgets();
 
         uint16_t scrollHeight = 0;
-        window->callGetScrollSize(0, 0, &scrollHeight);
+        window->callGetScrollSize(0, nullptr, &scrollHeight);
 
         scrollHeight -= window->widgets[Messages::widx::scrollview].height();
 

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -182,7 +182,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void updateActiveThumb(Window* self)
         {
             uint16_t scrollHeight = 0;
-            self->callGetScrollSize(0, 0, &scrollHeight);
+            self->callGetScrollSize(0, nullptr, &scrollHeight);
             self->scrollAreas[0].contentHeight = scrollHeight;
 
             auto i = 0;
@@ -2088,7 +2088,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void updateActiveThumb(Window* self)
         {
             uint16_t scrollHeight = 0;
-            self->callGetScrollSize(0, 0, &scrollHeight);
+            self->callGetScrollSize(0, nullptr, &scrollHeight);
             self->scrollAreas[0].contentHeight = scrollHeight;
 
             auto i = 0;

--- a/src/OpenLoco/src/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Windows/TownList.cpp
@@ -1160,7 +1160,7 @@ namespace OpenLoco::Ui::Windows::TownList
         static void updateActiveThumb(Window* self)
         {
             uint16_t scrollHeight = 0;
-            self->callGetScrollSize(0, 0, &scrollHeight);
+            self->callGetScrollSize(0, nullptr, &scrollHeight);
             self->scrollAreas[0].contentHeight = scrollHeight;
 
             auto i = 0;

--- a/src/Platform/src/Platform.Windows.cpp
+++ b/src/Platform/src/Platform.Windows.cpp
@@ -69,7 +69,7 @@ namespace OpenLoco::Platform
 
         // Initialize COM and get a pointer to the shell memory allocator
         LPMALLOC lpMalloc;
-        if (SUCCEEDED(CoInitializeEx(0, COINIT_APARTMENTTHREADED)) && SUCCEEDED(SHGetMalloc(&lpMalloc)))
+        if (SUCCEEDED(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED)) && SUCCEEDED(SHGetMalloc(&lpMalloc)))
         {
             auto titleW = Utility::toUtf16(title);
             BROWSEINFOW bi{};
@@ -255,7 +255,7 @@ namespace OpenLoco::Platform
 
         for (auto i = 0; i < argc; ++i)
         {
-            int length = WideCharToMultiByte(CP_UTF8, 0, argw[i], -1, 0, 0, NULL, NULL);
+            int length = WideCharToMultiByte(CP_UTF8, 0, argw[i], -1, nullptr, 0, nullptr, nullptr);
 
             if (length == 0)
             {
@@ -266,7 +266,7 @@ namespace OpenLoco::Platform
             // When resizing a std::string the null termination is handled implicitly. i.e. resize to true length not null terminated length.
             argvStrs[i].resize(length - 1);
 
-            if (WideCharToMultiByte(CP_UTF8, 0, argw[i], -1, argvStrs[i].data(), length, NULL, NULL) == 0)
+            if (WideCharToMultiByte(CP_UTF8, 0, argw[i], -1, argvStrs[i].data(), length, nullptr, nullptr) == 0)
             {
                 std::cerr << "Failed to convert cmdline argument to utf8.";
             }


### PR DESCRIPTION
This apply the checks from #2296 on the codebase. (Note it doesn't do anything about macros though)