### PR TITLE
Move vehicle load penalty cheat into Options window

### DIFF
--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2376,3 +2376,4 @@ strings:
   2321: "See-through tracks toggle"
   2322: "See-through trees toggle"
   2323: "{SMALLFONT}{COLOUR BLACK}Enable to smoothen the outer edges of land raised. Useful for creating mountains."
+  2324: "Vehicle/track behaviour"

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1937,6 +1937,7 @@ namespace OpenLoco::StringIds
     constexpr StringId shortcutSeeThroughTracks = 2321;
     constexpr StringId shortcutSeeThroughTrees = 2322;
     constexpr StringId mountainModeTooltip = 2323;
+    constexpr StringId vehicleTrackBehaviour = 2324;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Windows/Cheats.cpp
@@ -636,7 +636,7 @@ namespace OpenLoco::Ui::Windows::Cheats
 
     namespace Vehicles
     {
-        static constexpr Ui::Size kWindowSize = { 250, 173 };
+        static constexpr Ui::Size kWindowSize = { 250, 152 };
 
         namespace Widx
         {
@@ -648,7 +648,6 @@ namespace OpenLoco::Ui::Windows::Cheats
                 vehicle_locked_group,
                 checkbox_display_locked_vehicles,
                 checkbox_build_locked_vehicles,
-                checkbox_disable_vehicle_load_penalty,
             };
         }
 
@@ -657,14 +656,13 @@ namespace OpenLoco::Ui::Windows::Cheats
             makeWidget({ 4, 48 }, { kWindowSize.width - 8, 49 }, WidgetType::groupbox, WindowColour::secondary, StringIds::cheat_set_vehicle_reliability),
             makeWidget({ 10, 62 }, { kWindowSize.width - 20, 12 }, WidgetType::button, WindowColour::secondary, StringIds::cheat_reliability_zero),
             makeWidget({ 10, 78 }, { kWindowSize.width - 20, 12 }, WidgetType::button, WindowColour::secondary, StringIds::cheat_reliability_hundred),
-            makeWidget({ 4, 102 }, { kWindowSize.width - 8, 49 }, WidgetType::groupbox, WindowColour::secondary, StringIds::cheat_build_vehicle_window),
+            makeWidget({ 4, 102 }, { kWindowSize.width - 8, 45 }, WidgetType::groupbox, WindowColour::secondary, StringIds::cheat_build_vehicle_window),
             makeWidget({ 10, 116 }, { 200, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::display_locked_vehicles, StringIds::tooltip_display_locked_vehicles),
             makeWidget({ 25, 130 }, { 200, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::allow_building_locked_vehicles, StringIds::tooltip_build_locked_vehicles),
-            makeWidget({ 10, 156 }, { 200, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disableVehicleLoadingPenalty, StringIds::disableVehicleLoadingPenaltyTip),
             widgetEnd(),
         };
 
-        static uint64_t enabledWidgets = Common::enabledWidgets | (1 << Widx::reliablity_all_to_zero) | (1 << Widx::reliablity_all_to_hundred) | (1 << Widx::checkbox_display_locked_vehicles) | (1 << Widx::checkbox_build_locked_vehicles) | (1 << Widx::checkbox_disable_vehicle_load_penalty);
+        static uint64_t enabledWidgets = Common::enabledWidgets | (1 << Widx::reliablity_all_to_zero) | (1 << Widx::reliablity_all_to_hundred) | (1 << Widx::checkbox_display_locked_vehicles) | (1 << Widx::checkbox_build_locked_vehicles);
 
         static void prepareDraw(Window& self)
         {
@@ -688,15 +686,6 @@ namespace OpenLoco::Ui::Windows::Cheats
             else
             {
                 self.activatedWidgets &= ~(1 << Widx::checkbox_build_locked_vehicles);
-            }
-
-            if (Config::get().disableVehicleLoadPenaltyCheat)
-            {
-                self.activatedWidgets |= (1 << Widx::checkbox_disable_vehicle_load_penalty);
-            }
-            else
-            {
-                self.activatedWidgets &= ~(1 << Widx::checkbox_disable_vehicle_load_penalty);
             }
         }
 
@@ -764,11 +753,6 @@ namespace OpenLoco::Ui::Windows::Cheats
                         WindowManager::invalidateWidget(self.type, self.number, Widx::checkbox_build_locked_vehicles);
                         WindowManager::invalidate(WindowType::buildVehicle);
                     }
-                    break;
-
-                case Widx::checkbox_disable_vehicle_load_penalty:
-                    Config::get().disableVehicleLoadPenaltyCheat = !Config::get().disableVehicleLoadPenaltyCheat;
-                    WindowManager::invalidateWidget(self.type, self.number, Widx::checkbox_disable_vehicle_load_penalty);
                     break;
             }
         }

--- a/src/OpenLoco/src/Windows/Options.cpp
+++ b/src/OpenLoco/src/Windows/Options.cpp
@@ -1947,7 +1947,7 @@ namespace OpenLoco::Ui::Windows::Options
 
     namespace Misc
     {
-        static constexpr Ui::Size kWindowSize = { 420, 266 };
+        static constexpr Ui::Size kWindowSize = { 420, 301 };
 
         namespace Widx
         {
@@ -1955,13 +1955,18 @@ namespace OpenLoco::Ui::Windows::Options
             {
                 groupCheats = 10,
                 enableCheatsToolbarButton,
-                disable_vehicle_breakdowns,
-                trainsReverseAtSignals,
                 disableAICompanies,
                 disableTownExpansion,
+
+                groupVehicleBehaviour,
+                disable_vehicle_breakdowns,
+                trainsReverseAtSignals,
+                disable_vehicle_load_penalty,
+
                 groupPreferredOwnerName,
                 use_preferred_owner_name,
                 change_btn,
+
                 groupSaveOptions,
                 autosave_frequency,
                 autosave_frequency_btn,
@@ -1972,29 +1977,33 @@ namespace OpenLoco::Ui::Windows::Options
             };
         }
 
-        static constexpr uint64_t enabledWidgets = Common::enabledWidgets | (1 << Widx::enableCheatsToolbarButton) | (1 << Widx::disable_vehicle_breakdowns) | (1 << Widx::trainsReverseAtSignals) | (1 << Widx::disableAICompanies) | (1 << Widx::disableAICompanies) | (1 << Widx::use_preferred_owner_name) | (1 << Widx::change_btn) | (1 << Widx::export_plugin_objects) | (1 << Widx::disableTownExpansion) | (1 << Widx::autosave_amount) | (1 << Widx::autosave_amount_down_btn) | (1 << Widx::autosave_amount_up_btn) | (1 << Widx::autosave_frequency_btn);
+        static constexpr uint64_t enabledWidgets = Common::enabledWidgets | (1 << Widx::enableCheatsToolbarButton) | (1 << Widx::disable_vehicle_breakdowns) | (1 << Widx::trainsReverseAtSignals) | (1 << Widx::disableAICompanies) | (1 << Widx::disableAICompanies) | (1 << Widx::use_preferred_owner_name) | (1 << Widx::change_btn) | (1 << Widx::export_plugin_objects) | (1 << Widx::disableTownExpansion) | (1 << Widx::autosave_amount) | (1 << Widx::autosave_amount_down_btn) | (1 << Widx::autosave_amount_up_btn) | (1 << Widx::autosave_frequency_btn) | (1 << Widx::disable_vehicle_load_penalty);
 
         static Widget _widgets[] = {
             common_options_widgets(kWindowSize, StringIds::options_title_miscellaneous),
 
-            // Cheats group
-            makeWidget({ 4, 49 }, { 412, 93 }, WidgetType::groupbox, WindowColour::secondary, StringIds::gameplay_tweaks),
+            // Gameplay tweaks group
+            makeWidget({ 4, 49 }, { 412, 62 }, WidgetType::groupbox, WindowColour::secondary, StringIds::gameplay_tweaks),
             makeWidget({ 10, 64 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::option_cheat_menu_enable, StringIds::tooltip_option_cheat_menu_enable),
-            makeWidget({ 10, 79 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disable_vehicle_breakdowns),
-            makeWidget({ 10, 94 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::trainsReverseAtSignals),
-            makeWidget({ 10, 109 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disableAICompanies, StringIds::disableAICompanies_tip),
-            makeWidget({ 10, 124 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disableTownExpansion, StringIds::disableTownExpansion_tip),
+            makeWidget({ 10, 79 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disableAICompanies, StringIds::disableAICompanies_tip),
+            makeWidget({ 10, 94 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disableTownExpansion, StringIds::disableTownExpansion_tip),
+
+            // Vehicle behaviour
+            makeWidget({ 4, 115 }, { 412, 62 }, WidgetType::groupbox, WindowColour::secondary, StringIds::vehicleTrackBehaviour),
+            makeWidget({ 10, 130 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disable_vehicle_breakdowns),
+            makeWidget({ 10, 145 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::trainsReverseAtSignals),
+            makeWidget({ 10, 160 }, { 200, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::disableVehicleLoadingPenalty, StringIds::disableVehicleLoadingPenaltyTip),
 
             // Preferred owner name group
-            makeWidget({ 4, 145 }, { 412, 47 }, WidgetType::groupbox, WindowColour::secondary, StringIds::preferred_owner),
-            makeWidget({ 10, 160 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::use_preferred_owner_name, StringIds::use_preferred_owner_name_tip),
-            makeWidget({ 335, 174 }, { 75, 12 }, WidgetType::button, WindowColour::secondary, StringIds::change),
+            makeWidget({ 4, 181 }, { 412, 47 }, WidgetType::groupbox, WindowColour::secondary, StringIds::preferred_owner),
+            makeWidget({ 10, 196 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::use_preferred_owner_name, StringIds::use_preferred_owner_name_tip),
+            makeWidget({ 335, 211 }, { 75, 12 }, WidgetType::button, WindowColour::secondary, StringIds::change),
 
             // Save options group
-            makeWidget({ 4, 196 }, { 412, 65 }, WidgetType::groupbox, WindowColour::secondary, StringIds::autosave_preferences),
-            makeDropdownWidgets({ 250, 212 }, { 156, 12 }, WidgetType::combobox, WindowColour::secondary, StringIds::empty),
-            makeStepperWidgets({ 250, 227 }, { 156, 12 }, WidgetType::textbox, WindowColour::secondary, StringIds::empty),
-            makeWidget({ 10, 243 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::export_plugin_objects, StringIds::export_plugin_objects_tip),
+            makeWidget({ 4, 232 }, { 412, 65 }, WidgetType::groupbox, WindowColour::secondary, StringIds::autosave_preferences),
+            makeDropdownWidgets({ 250, 247 }, { 156, 12 }, WidgetType::combobox, WindowColour::secondary, StringIds::empty),
+            makeStepperWidgets({ 250, 262 }, { 156, 12 }, WidgetType::textbox, WindowColour::secondary, StringIds::empty),
+            makeWidget({ 10, 277 }, { 400, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::export_plugin_objects, StringIds::export_plugin_objects_tip),
             widgetEnd(),
         };
 
@@ -2041,6 +2050,11 @@ namespace OpenLoco::Ui::Windows::Options
                 w.activatedWidgets |= (1 << Widx::trainsReverseAtSignals);
             else
                 w.activatedWidgets &= ~(1 << Widx::trainsReverseAtSignals);
+
+            if (Config::get().disableVehicleLoadPenaltyCheat)
+                w.activatedWidgets |= (1 << Widx::disable_vehicle_load_penalty);
+            else
+                w.activatedWidgets &= ~(1 << Widx::disable_vehicle_load_penalty);
 
             if (Config::get().companyAIDisabled)
                 w.activatedWidgets |= (1 << Widx::disableAICompanies);
@@ -2241,6 +2255,11 @@ namespace OpenLoco::Ui::Windows::Options
 
                 case Widx::trainsReverseAtSignals:
                     trainsReverseAtSignalsMouseUp(&w);
+                    break;
+
+                case Widx::disable_vehicle_load_penalty:
+                    Config::get().disableVehicleLoadPenaltyCheat = !Config::get().disableVehicleLoadPenaltyCheat;
+                    WindowManager::invalidateWidget(w.type, w.number, Widx::disable_vehicle_load_penalty);
                     break;
 
                 case Widx::disableAICompanies:


### PR DESCRIPTION
This PR adds a new 'Vehicle behaviour' group to the options window, separating some settings from the from 'Gameplay tweaks' group. It also moves the 'Disable vehicle load penalty' cheat into this new 'Vehicle behaviour' group.

I also considered introducing a new tab for both affected groups. However, I'd like to tackle #132 eventually as well, which means it might be better to move the preferred company name settings to another tab instead.

Before:
![Screenshot](https://github.com/OpenLoco/OpenLoco/assets/604665/3244bd01-163f-409b-8e51-3c14f44ea9bc)

After:
![Screenshot (1)](https://github.com/OpenLoco/OpenLoco/assets/604665/0a690b9a-4bfe-4833-97f4-aa20a24a11f9)