### PR TITLE
Re-add missing resize event to news window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 24.02.1+ (???)
 ------------------------------------------------------------------------
 - Fix: [#2312] Object selection allowing deselection of in-use objects, leading to crashes.
+- Fix: [#2316, #2321] Vehicles do not rotate in announcement for their invention.
 
 24.02.1 (2024-02-28)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Windows/News/News.cpp
@@ -851,6 +851,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
         static constexpr WindowEventList kEvents = {
             .onMouseUp = onMouseUp,
+            .onResize = initViewport,
             .onUpdate = onUpdate,
             .viewportRotate = initViewport,
             .draw = draw,


### PR DESCRIPTION
Regression from #2304. Should fix #2316, #2321.