### PR TITLE
Replace remaining commonFormatArgs with FormatArguments

### DIFF
--- a/src/OpenLoco/src/Effects/MoneyEffect.cpp
+++ b/src/OpenLoco/src/Effects/MoneyEffect.cpp
@@ -119,8 +119,10 @@ namespace OpenLoco
 
             StringId strFormat = (amount < 0) ? StringIds::format_currency_expense_red_negative : StringIds::format_currency_income_green;
             char buffer[255] = {};
-            auto args = FormatArguments::common(amount);
+            FormatArguments args{};
+            args.push(amount);
             StringManager::formatString(buffer, strFormat, &args);
+
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
             drawingCtx.setCurrentFontSpriteBase(Font::medium_bold);
             m->offsetX = -drawingCtx.getStringWidth(buffer) / 2;

--- a/src/OpenLoco/src/GameCommands/Company/RenameCompanyName.cpp
+++ b/src/OpenLoco/src/GameCommands/Company/RenameCompanyName.cpp
@@ -3,7 +3,6 @@
 #include "Engine/Limits.h"
 #include "GameCommands/GameCommands.h"
 #include "Graphics/Gfx.h"
-#include "Localisation/FormatArguments.hpp"
 #include "Localisation/Formatting.h"
 #include "Localisation/StringIds.h"
 #include "Localisation/StringManager.h"

--- a/src/OpenLoco/src/GameCommands/Company/RenameCompanyOwner.cpp
+++ b/src/OpenLoco/src/GameCommands/Company/RenameCompanyOwner.cpp
@@ -4,7 +4,6 @@
 #include "Engine/Limits.h"
 #include "GameCommands/GameCommands.h"
 #include "Graphics/Gfx.h"
-#include "Localisation/FormatArguments.hpp"
 #include "Localisation/Formatting.h"
 #include "Localisation/StringIds.h"
 #include "Localisation/StringManager.h"

--- a/src/OpenLoco/src/GameCommands/GameCommands.cpp
+++ b/src/OpenLoco/src/GameCommands/GameCommands.cpp
@@ -108,7 +108,6 @@ namespace OpenLoco::GameCommands
     static loco_global<StringId, 0x009C68E8> _gGameCommandErrorTitle;
     static loco_global<uint8_t, 0x009C68EA> _gGameCommandExpenditureType; // premultiplied by 4
     static loco_global<CompanyId, 0x009C68EE> _errorCompanyId;
-    static loco_global<StringId[8], 0x112C826> _commonFormatArgs;
 
     using GameCommandFunc = void (*)(registers& regs);
 

--- a/src/OpenLoco/src/GameCommands/General/RenameStation.cpp
+++ b/src/OpenLoco/src/GameCommands/General/RenameStation.cpp
@@ -61,7 +61,8 @@ namespace OpenLoco::GameCommands
         // Figure out the current name for this station.
         char currentStationName[256] = "";
         auto station = StationManager::get(_stationId);
-        auto fArgs = FormatArguments::common(station->town);
+        FormatArguments fArgs{};
+        fArgs.push(station->town);
         StringManager::formatString(currentStationName, station->name, &fArgs);
 
         // Verify the new name actually differs from the old one.

--- a/src/OpenLoco/src/GameCommands/Industries/CreateIndustry.cpp
+++ b/src/OpenLoco/src/GameCommands/Industries/CreateIndustry.cpp
@@ -4,7 +4,6 @@
 #include "GameCommands/GameCommands.h"
 #include "GameCommands/Terraform/CreateWall.h"
 #include "Graphics/Colour.h"
-#include "Localisation/FormatArguments.hpp"
 #include "Localisation/Formatting.h"
 #include "Localisation/StringIds.h"
 #include "Map/AnimationManager.h"

--- a/src/OpenLoco/src/GameCommands/Industries/RenameIndustry.cpp
+++ b/src/OpenLoco/src/GameCommands/Industries/RenameIndustry.cpp
@@ -65,7 +65,8 @@ namespace OpenLoco::GameCommands
         // Figure out the current name for this industry.
         char currentIndustryName[256] = "";
         auto industry = IndustryManager::get(_industryId);
-        auto fargs = FormatArguments::common(industry->town);
+        FormatArguments fargs{};
+        fargs.push(industry->town);
         StringManager::formatString(currentIndustryName, industry->name, &fargs);
 
         // Verify the new name actually differs from the old one.

--- a/src/OpenLoco/src/GameCommands/Terraform/LowerLand.cpp
+++ b/src/OpenLoco/src/GameCommands/Terraform/LowerLand.cpp
@@ -2,7 +2,6 @@
 #include "Audio/Audio.h"
 #include "Economy/Expenditures.h"
 #include "GameCommands/GameCommands.h"
-#include "Localisation/FormatArguments.hpp"
 #include "Localisation/StringIds.h"
 #include "Map/RoadElement.h"
 #include "Map/SurfaceData.h"

--- a/src/OpenLoco/src/GameCommands/Terraform/LowerWater.cpp
+++ b/src/OpenLoco/src/GameCommands/Terraform/LowerWater.cpp
@@ -2,7 +2,6 @@
 #include "Audio/Audio.h"
 #include "Economy/Expenditures.h"
 #include "GameCommands/GameCommands.h"
-#include "Localisation/FormatArguments.hpp"
 #include "Localisation/StringIds.h"
 #include "Map/SurfaceElement.h"
 #include "Map/TileLoop.hpp"

--- a/src/OpenLoco/src/GameCommands/Terraform/RaiseLand.cpp
+++ b/src/OpenLoco/src/GameCommands/Terraform/RaiseLand.cpp
@@ -2,7 +2,6 @@
 #include "Audio/Audio.h"
 #include "Economy/Expenditures.h"
 #include "GameCommands/GameCommands.h"
-#include "Localisation/FormatArguments.hpp"
 #include "Localisation/StringIds.h"
 #include "Map/RoadElement.h"
 #include "Map/SurfaceData.h"

--- a/src/OpenLoco/src/GameCommands/Terraform/RaiseWater.cpp
+++ b/src/OpenLoco/src/GameCommands/Terraform/RaiseWater.cpp
@@ -2,7 +2,6 @@
 #include "Audio/Audio.h"
 #include "Economy/Expenditures.h"
 #include "GameCommands/GameCommands.h"
-#include "Localisation/FormatArguments.hpp"
 #include "Localisation/StringIds.h"
 #include "Map/SurfaceElement.h"
 #include "Map/TileLoop.hpp"

--- a/src/OpenLoco/src/GameCommands/Town/RenameTown.cpp
+++ b/src/OpenLoco/src/GameCommands/Town/RenameTown.cpp
@@ -3,7 +3,6 @@
 #include "GameCommands/GameCommands.h"
 #include "GameCommands/Town/RenameTown.h"
 #include "Graphics/Gfx.h"
-#include "Localisation/FormatArguments.hpp"
 #include "Localisation/Formatting.h"
 #include "Localisation/StringIds.h"
 #include "Localisation/StringManager.h"

--- a/src/OpenLoco/src/GameCommands/Vehicles/RenameVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/RenameVehicle.cpp
@@ -65,8 +65,10 @@ namespace OpenLoco::GameCommands
         renameStringBuffer[36] = '\0';
 
         char existingVehicleName[512];
-        auto fArgs = FormatArguments::common(vehicleHead->ordinalNumber);
+        FormatArguments fArgs{};
+        fArgs.push(vehicleHead->ordinalNumber);
         StringManager::formatString(existingVehicleName, vehicleHead->name, &fArgs);
+
         if (strcmp(existingVehicleName, renameStringBuffer) == 0)
         {
             return 0;

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -43,7 +43,6 @@ namespace OpenLoco::Input
     static void loc_4BED79();
 
     static loco_global<KeyModifier, 0x00508F18> _keyModifier;
-    static loco_global<char[16], 0x0112C826> _commonFormatArgs;
     static std::string _cheatBuffer; // 0x0011364A5
     static loco_global<Key[64], 0x0113E300> _keyQueue;
     static loco_global<uint32_t, 0x00525388> _keyQueueLastWrite;

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -4,7 +4,6 @@
 #include "GameCommands/General/TogglePause.h"
 #include "Input.h"
 #include "LastGameOptionManager.h"
-#include "Localisation/FormatArguments.hpp"
 #include "Localisation/StringIds.h"
 #include "S5/S5.h"
 #include "SceneManager.h"

--- a/src/OpenLoco/src/Map/TileManager.cpp
+++ b/src/OpenLoco/src/Map/TileManager.cpp
@@ -1128,7 +1128,7 @@ namespace OpenLoco::World::TileManager
                     else
                     {
                         auto* trackObj = ObjectManager::get<TrackObject>(trackEl->trackObjectId());
-                        FormatArguments args{};
+                        auto args = FormatArguments::common();
                         args.push(trackObj->name);
                         GameCommands::setErrorText(StringIds::stringid_requires_a_bridge);
                         return GameCommands::FAILURE;
@@ -1152,7 +1152,7 @@ namespace OpenLoco::World::TileManager
                     else
                     {
                         auto* roadObj = ObjectManager::get<RoadObject>(roadEl->roadObjectId());
-                        FormatArguments args{};
+                        auto args = FormatArguments::common();
                         args.push(roadObj->name);
                         GameCommands::setErrorText(StringIds::stringid_requires_a_bridge);
                         return GameCommands::FAILURE;

--- a/src/OpenLoco/src/Objects/CompetitorObject.cpp
+++ b/src/OpenLoco/src/Objects/CompetitorObject.cpp
@@ -35,7 +35,7 @@ namespace OpenLoco
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
         Ui::Point rowPosition = { x, y };
         {
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push<uint16_t>(intelligence);
             args.push(aiRatingToLevel(intelligence));
 
@@ -43,7 +43,7 @@ namespace OpenLoco
             rowPosition.y += kDescriptionRowHeight;
         }
         {
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push<uint16_t>(aggressiveness);
             args.push(aiRatingToLevel(aggressiveness));
 
@@ -51,7 +51,7 @@ namespace OpenLoco
             rowPosition.y += kDescriptionRowHeight;
         }
         {
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push<uint16_t>(competitiveness);
             args.push(aiRatingToLevel(competitiveness));
 

--- a/src/OpenLoco/src/Paint/Paint.cpp
+++ b/src/OpenLoco/src/Paint/Paint.cpp
@@ -4,7 +4,6 @@
 #include "GameStateFlags.h"
 #include "Graphics/Gfx.h"
 #include "Graphics/PaletteMap.h"
-#include "Localisation/FormatArguments.hpp"
 #include "Localisation/Formatting.h"
 #include "Localisation/StringManager.h"
 #include "Map/SurfaceElement.h"

--- a/src/OpenLoco/src/Ui/Dropdown.cpp
+++ b/src/OpenLoco/src/Ui/Dropdown.cpp
@@ -106,7 +106,7 @@ namespace OpenLoco::Ui::Dropdown
         }
     }
 
-    void add(size_t index, StringId title, FormatArguments& fArgs)
+    void add(size_t index, StringId title, const FormatArguments& fArgs)
     {
         add(index, title);
         std::byte* args = _dropdownItemArgs[index];
@@ -176,7 +176,7 @@ namespace OpenLoco::Ui::Dropdown
             self.invalidate();
         }
 
-        static void dropdownFormatArgsToFormatArgs(uint8_t itemIndex, FormatArguments args)
+        static void dropdownFormatArgsToFormatArgs(uint8_t itemIndex, FormatArguments& args)
         {
             args.push(*reinterpret_cast<uint32_t*>(&_dropdownItemArgs[itemIndex][0]));
             args.push(*reinterpret_cast<uint32_t*>(&_dropdownItemArgs[itemIndex][4]));

--- a/src/OpenLoco/src/Ui/Dropdown.h
+++ b/src/OpenLoco/src/Ui/Dropdown.h
@@ -60,7 +60,7 @@ namespace OpenLoco::Ui::Dropdown
     void add(size_t index, StringId title);
     void add(size_t index, StringId title, std::initializer_list<format_arg> l);
     void add(size_t index, StringId title, format_arg l);
-    void add(size_t index, StringId title, FormatArguments& fArgs);
+    void add(size_t index, StringId title, const FormatArguments& fArgs);
     int16_t getHighlightedItem();
     void setItemDisabled(size_t index);
     void setHighlightedItem(size_t index);

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -359,7 +359,7 @@ namespace OpenLoco::Ui::Windows
     {
         void registerHooks();
 
-        void openTextInput(Ui::Window* w, StringId title, StringId message, StringId value, int callingWidget, void* valueArgs, uint32_t inputSize = StringManager::kUserStringSize - 1);
+        void openTextInput(Ui::Window* w, StringId title, StringId message, StringId value, int callingWidget, const void* valueArgs, uint32_t inputSize = StringManager::kUserStringSize - 1);
         void sub_4CE6C9(WindowType type, WindowNumber_t number);
         void cancel();
         void sub_4CE6FF();

--- a/src/OpenLoco/src/Widget.cpp
+++ b/src/OpenLoco/src/Widget.cpp
@@ -34,8 +34,6 @@ namespace OpenLoco::Ui
         return (this->bottom - this->top) + 1;
     }
 
-    static loco_global<char[2], 0x005045F8> _strCheckmark;
-
     void draw_11_c(Gfx::RenderTarget* rt, const Window* window, Widget* widget, AdvancedColour colour, bool disabled, int16_t x, int16_t y, StringId string);
     void draw_14(Gfx::RenderTarget* rt, Widget* widget, AdvancedColour colour, bool disabled, int16_t x, int16_t y, StringId string);
 
@@ -896,8 +894,9 @@ namespace OpenLoco::Ui
 
         if (activated)
         {
+            static constexpr char strCheckmark[] = "\xAC";
             drawingCtx.setCurrentFontSpriteBase(Font::medium_bold);
-            drawingCtx.drawString(*rt, window->x + left, window->y + top, colour.opaque(), _strCheckmark);
+            drawingCtx.drawString(*rt, window->x + left, window->y + top, colour.opaque(), strCheckmark);
         }
     }
 

--- a/src/OpenLoco/src/Widget.cpp
+++ b/src/OpenLoco/src/Widget.cpp
@@ -3,6 +3,7 @@
 #include "Graphics/Colour.h"
 #include "Graphics/ImageIds.h"
 #include "Input.h"
+#include "Localisation/FormatArguments.hpp"
 #include "Localisation/Formatting.h"
 #include "Ui/ScrollView.h"
 #include "Window.h"
@@ -32,8 +33,6 @@ namespace OpenLoco::Ui
     {
         return (this->bottom - this->top) + 1;
     }
-
-    static loco_global<char[1], 0x112C826> _commonFormatArgs;
 
     static loco_global<char[2], 0x005045F8> _strCheckmark;
 
@@ -543,7 +542,7 @@ namespace OpenLoco::Ui
         int16_t centreX = window->x + (widget->left + widget->right + 1) / 2 - 1;
         int16_t width = widget->right - widget->left - 2;
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        drawingCtx.drawStringCentredClipped(*rt, centreX, y, width, colour, string, _commonFormatArgs);
+        drawingCtx.drawStringCentredClipped(*rt, centreX, y, width, colour, string, &FormatArguments::common());
     }
 
     // 0x004CB263
@@ -559,7 +558,7 @@ namespace OpenLoco::Ui
 
         int width = widget->right - widget->left - 2;
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        drawingCtx.drawStringLeftClipped(*rt, x, y, width, colour, string, _commonFormatArgs);
+        drawingCtx.drawStringLeftClipped(*rt, x, y, width, colour, string, &FormatArguments::common());
     }
 
     // 0x4CB2D6
@@ -581,7 +580,7 @@ namespace OpenLoco::Ui
 
         int width = this->right - this->left - 2;
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        drawingCtx.drawStringLeftClipped(*rt, window->x + left + 1, window->y + top, width, colour, text, _commonFormatArgs);
+        drawingCtx.drawStringLeftClipped(*rt, window->x + left + 1, window->y + top, width, colour, text, &FormatArguments::common());
     }
 
     // 0x4CB29C
@@ -608,7 +607,7 @@ namespace OpenLoco::Ui
         int16_t y = t + 1;
         int16_t x = l + 2 + (width / 2);
 
-        drawingCtx.drawStringCentredClipped(*rt, x, y, width, AdvancedColour(Colour::white).outline(), text, _commonFormatArgs);
+        drawingCtx.drawStringCentredClipped(*rt, x, y, width, AdvancedColour(Colour::white).outline(), text, &FormatArguments::common());
     }
 
     // 0x004CA750
@@ -616,7 +615,7 @@ namespace OpenLoco::Ui
     {
         char stringBuffer[512];
         stringBuffer[0] = ControlCodes::Colour::black;
-        StringManager::formatString(&stringBuffer[1], text, _commonFormatArgs);
+        StringManager::formatString(&stringBuffer[1], text, &FormatArguments::common());
 
         int16_t width = right - left - 4 - 14;
         int16_t x = left + window->x + 2 + (width / 2);
@@ -638,7 +637,7 @@ namespace OpenLoco::Ui
     {
         char stringBuffer[512];
         stringBuffer[0] = ControlCodes::windowColour1;
-        StringManager::formatString(&stringBuffer[1], text, _commonFormatArgs);
+        StringManager::formatString(&stringBuffer[1], text, &FormatArguments::common());
 
         int16_t x = left + window->x + 2;
         int16_t width = right - left - 4 - 14;
@@ -657,7 +656,7 @@ namespace OpenLoco::Ui
     {
         char stringBuffer[512];
         stringBuffer[0] = ControlCodes::Colour::white;
-        StringManager::formatString(&stringBuffer[1], text, _commonFormatArgs);
+        StringManager::formatString(&stringBuffer[1], text, &FormatArguments::common());
 
         int16_t x = left + window->x + 2;
         int16_t width = right - left - 4 - 14;
@@ -918,7 +917,7 @@ namespace OpenLoco::Ui
         }
 
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        drawingCtx.drawStringLeft(*rt, window->x + left + 14, window->y + top, colour, text, _commonFormatArgs);
+        drawingCtx.drawStringLeft(*rt, window->x + left + 14, window->y + top, colour, text, &FormatArguments::common());
     }
 
     // 0x004CA679

--- a/src/OpenLoco/src/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Windows/BuildVehicle.cpp
@@ -1215,12 +1215,12 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         if (!clipped)
             return;
 
-        FormatArguments args{};
-        args.push(StringIds::buffer_2039);
-
         auto drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
         // Draw search box input buffer
+        FormatArguments args{};
+        args.push(StringIds::buffer_2039);
+
         Ui::Point position = { inputSession.xOffset, 1 };
         drawingCtx.drawStringLeft(*clipped, &position, Colour::black, StringIds::black_stringid, &args);
 
@@ -1267,7 +1267,11 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         if (_cargoSupportedFilter != 0xFF && _cargoSupportedFilter != 0xFE)
         {
             auto cargoObj = ObjectManager::get<CargoObject>(_cargoSupportedFilter);
-            auto args = FormatArguments::common(StringIds::cargoIdSprite, cargoObj->name, cargoObj->unitInlineSprite);
+
+            FormatArguments args{};
+            args.push(StringIds::cargoIdSprite);
+            args.push(cargoObj->name);
+            args.push(cargoObj->unitInlineSprite);
 
             auto& widget = window.widgets[widx::cargoLabel];
             drawingCtx.drawStringLeftClipped(*rt, window.x + widget.left + 2, window.y + widget.top, widget.width() - 15, Colour::black, StringIds::wcolour2_stringid, &args);

--- a/src/OpenLoco/src/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Windows/Cheats.cpp
@@ -231,7 +231,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     Colour::black,
                     StringIds::cheat_amount);
 
-                auto args = FormatArguments::common();
+                FormatArguments args{};
                 args.push(_cashIncreaseStep);
                 drawingCtx.drawStringLeft(
                     *rt,
@@ -253,7 +253,8 @@ namespace OpenLoco::Ui::Windows::Cheats
                     StringIds::company_current_loan);
 
                 auto company = CompanyManager::getPlayerCompany();
-                auto args = FormatArguments::common();
+
+                FormatArguments args{};
                 args.push(company->currentLoan);
 
                 drawingCtx.drawStringLeft(
@@ -275,8 +276,9 @@ namespace OpenLoco::Ui::Windows::Cheats
                     Colour::black,
                     StringIds::cheat_year);
 
-                auto args = FormatArguments::common();
+                FormatArguments args{};
                 args.push(_date.year);
+
                 drawingCtx.drawStringLeft(
                     *rt,
                     self.x + widget.left + 1,
@@ -296,8 +298,9 @@ namespace OpenLoco::Ui::Windows::Cheats
                     Colour::black,
                     StringIds::cheat_month);
 
-                auto args = FormatArguments::common();
-                args.push((StringId)OpenLoco::StringManager::monthToString(_date.month).second);
+                FormatArguments args{};
+                args.push((StringId)StringManager::monthToString(_date.month).second);
+
                 drawingCtx.drawStringLeft(
                     *rt,
                     self.x + widget.left + 1,
@@ -317,8 +320,9 @@ namespace OpenLoco::Ui::Windows::Cheats
                     Colour::black,
                     StringIds::cheat_day);
 
-                auto args = FormatArguments::common();
+                FormatArguments args{};
                 args.push(_date.day + 1); // +1 since days in game are 0-based, but IRL they are 1-based
+
                 drawingCtx.drawStringLeft(
                     *rt,
                     self.x + widget.left + 1,

--- a/src/OpenLoco/src/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Windows/CompanyFaceSelection.cpp
@@ -193,7 +193,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     {
         const auto company = CompanyManager::get(self.owner);
 
-        FormatArguments args{};
+        auto args = FormatArguments::common();
         args.push(company->name);
     }
 

--- a/src/OpenLoco/src/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Windows/CompanyList.cpp
@@ -196,14 +196,14 @@ namespace OpenLoco::Ui::Windows::CompanyList
         {
             char lhsString[256] = { 0 };
             {
-                auto args = FormatArguments();
+                FormatArguments args{};
                 auto statusString = CompanyManager::getOwnerStatus(lhs.id(), args);
                 StringManager::formatString(lhsString, statusString, &args);
             }
 
             char rhsString[256] = { 0 };
             {
-                auto args = FormatArguments();
+                FormatArguments args{};
                 auto statusString = CompanyManager::getOwnerStatus(rhs.id(), args);
                 StringManager::formatString(rhsString, statusString, &args);
             }
@@ -435,7 +435,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             self.draw(rt);
             Common::drawTabs(&self, rt);
 
-            auto args = FormatArguments();
+            FormatArguments args{};
             if (self.var_83C == 1)
                 args.push(StringIds::company_singular);
             else
@@ -485,7 +485,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 auto imageId = Gfx::recolour(competitorObj->images[enumValue(company->ownerEmotion)], company->mainColours.primary);
 
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push(StringIds::table_item_company);
                     args.push(imageId);
                     args.push(company->name);
@@ -494,7 +494,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 }
 
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.skip(sizeof(StringId));
                     StringId ownerStatus = CompanyManager::getOwnerStatus(company->id(), args);
                     args.rewind();
@@ -516,7 +516,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 }
 
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
 
                     args.push(performanceStringId);
                     formatPerformanceIndex(company->performanceIndex, args);
@@ -525,7 +525,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 }
 
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
 
                     args.push(StringIds::company_value_currency);
                     args.push(company->companyValueHistory[0]);
@@ -1133,7 +1133,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             x = self.x + 8;
             y = self.widgets[Common::widx::panel].top + self.y + 1;
 
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push<uint16_t>(100);
             args.push<uint16_t>(10);
 
@@ -1246,7 +1246,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 if (recordSpeed == 0_mph)
                     continue;
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push(recordSpeed);
 
                     const StringId string[] = {
@@ -1276,7 +1276,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     x = self.x + 33;
                     y += 7;
 
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push(company->name);
                     args.push<uint16_t>(0);
                     args.push(CompanyManager::getRecords().date[i]);
@@ -1678,7 +1678,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     drawingCtx.fillRect(*rt, x, y + 3, x + 4, y + 7, colour, Drawing::RectFlags::none);
                 }
 
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push(company.name);
 
                 drawingCtx.drawStringLeftClipped(*rt, x + 6, y, 94, Colour::black, stringId, &args);

--- a/src/OpenLoco/src/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Windows/CompanyWindow.cpp
@@ -139,7 +139,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // Set company name in title.
             auto company = CompanyManager::get(CompanyId(self.number));
-            FormatArguments args{};
+            auto args = FormatArguments::common();
             args.push(company->name);
 
             self.disabledWidgets &= ~((1 << widx::centre_on_viewport) | (1 << widx::face));
@@ -234,7 +234,9 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // Draw owner name
             {
-                auto args = FormatArguments::common(company->ownerName);
+                FormatArguments args{};
+                args.push(company->ownerName);
+
                 auto& widget = self.widgets[widx::change_owner_name];
                 auto origin = Ui::Point(self.x + (widget.left + widget.right) / 2, self.y + widget.top + 5);
                 drawingCtx.drawStringCentredWrapped(
@@ -369,7 +371,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
             strcpy(buffer, input);
 
-            auto args = FormatArguments::common(StringIds::buffer_2039);
+            FormatArguments args{};
+            args.push(StringIds::buffer_2039);
             // Add the ' Transport' suffix to the company name, and rename the company.
             StringManager::formatString(buffer, StringIds::company_owner_name_transport, const_cast<void*>(&args));
             Common::renameCompany(self, buffer);
@@ -695,8 +698,9 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // Set company name.
             auto company = CompanyManager::get(CompanyId(self.number));
-            FormatArguments args{};
+            auto args = FormatArguments::common();
             args.push(company->name);
+
             auto companyColour = CompanyManager::getCompanyColour(CompanyId(self.number));
             auto skin = ObjectManager::get<InterfaceSkinObject>();
             uint32_t image = skin->img + InterfaceSkin::ImageIds::build_headquarters;
@@ -790,7 +794,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             auto x = self.x + 3;
             auto y = self.y + 48;
             {
-                auto args = FormatArguments::common(company->startedDate);
+                FormatArguments args{};
+                args.push(company->startedDate);
                 drawingCtx.drawStringLeft(*rt, x, y, Colour::black, StringIds::company_details_started, &args);
                 y += 10;
             }
@@ -813,7 +818,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             }
 
             {
-                auto args = FormatArguments::common(company->ownerName);
+                FormatArguments args{};
+                args.push(company->ownerName);
                 drawingCtx.drawStringLeftClipped(*rt, x, y, 213, Colour::black, StringIds::owner_label, &args);
                 y += 10;
             }
@@ -830,7 +836,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     auto count = company->transportTypeCount[i];
                     if (count != 0)
                     {
-                        auto args = FormatArguments::common(count);
+                        FormatArguments args{};
+                        args.push(count);
                         drawingCtx.drawStringLeft(*rt, x, y, Colour::black, transportTypeCountString[i], &args);
                         y += 10;
                     }
@@ -1799,7 +1806,9 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     drawingCtx.fillRect(*rt, self.x + 4, y, self.x + 129, y + 9, colour, Drawing::RectFlags::crossHatching);
                 }
 
-                auto args = FormatArguments::common(ExpenditureLabels[i]);
+                FormatArguments args{};
+                args.push(ExpenditureLabels[i]);
+
                 drawingCtx.drawStringLeft(
                     *rt,
                     self.x + 5,
@@ -1838,7 +1847,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             // 'Cash' label with value
             {
                 // Set cash value in format args.
-                auto args = FormatArguments::common(company->cash);
+                FormatArguments args{};
+                args.push(company->cash);
 
                 auto cashFormat = StringIds::cash_positive;
                 if ((company->challengeFlags & CompanyFlags::bankrupt) != CompanyFlags::none)
@@ -1858,7 +1868,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             // 'Company value' label with value
             {
                 // Set company value in format args.
-                auto args = FormatArguments::common(company->companyValueHistory[0]);
+                FormatArguments args{};
+                args.push(company->companyValueHistory[0]);
 
                 drawingCtx.drawStringLeft(
                     *rt,
@@ -1872,7 +1883,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             // 'Profit from vehicles' label with value
             {
                 // Set company value in format args.
-                auto args = FormatArguments::common(company->vehicleProfit);
+                FormatArguments args{};
+                args.push(company->vehicleProfit);
 
                 drawingCtx.drawStringLeft(
                     *rt,
@@ -1886,7 +1898,9 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
         static void drawFinanceYear(Gfx::RenderTarget* rt, int16_t x, int16_t& y, uint16_t columnYear, uint16_t currentYear)
         {
-            auto args = FormatArguments::common(StringIds::uint16_raw, columnYear);
+            FormatArguments args{};
+            args.push(StringIds::uint16_raw);
+            args.push(columnYear);
 
             StringId format = StringIds::wcolour2_stringid;
             if (columnYear != currentYear)
@@ -1917,7 +1931,9 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
                 if (expenditures != 0)
                 {
-                    auto args = FormatArguments::common(StringIds::currency48, expenditures);
+                    FormatArguments args{};
+                    args.push(StringIds::currency48);
+                    args.push(expenditures);
 
                     drawingCtx.drawStringRight(
                         *rt,
@@ -1943,7 +1959,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 mainFormat = StringIds::red_stringid;
                 sumFormat = StringIds::currency48;
             }
-            auto args = FormatArguments::common(sumFormat, sum);
+
+            FormatArguments args{};
+            args.push(sumFormat);
+            args.push(sum);
 
             y += 4;
 
@@ -2213,7 +2232,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // Set company name.
             auto company = CompanyManager::get(CompanyId(self.number));
-            FormatArguments args{};
+            auto args = FormatArguments::common();
             args.push(company->name);
 
             self.widgets[Common::widx::frame].right = self.width - 1;
@@ -2401,7 +2420,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // Set company name.
             auto company = CompanyManager::get(CompanyId(self.number));
-            FormatArguments args{};
+            auto args = FormatArguments::common();
             args.push(company->name);
 
             self.widgets[Common::widx::frame].right = self.width - 1;
@@ -2443,8 +2462,9 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             y += 10;
 
             {
-                FormatArguments args = {};
+                FormatArguments args{};
                 Scenario::formatChallengeArguments(Scenario::getObjective(), Scenario::getObjectiveProgress(), args);
+
                 y = drawingCtx.drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::challenge_value, &args);
                 y += 5;
             }
@@ -2456,7 +2476,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 uint16_t years = Scenario::getObjectiveProgress().completedChallengeInMonths / 12;
                 uint16_t months = Scenario::getObjectiveProgress().completedChallengeInMonths % 12;
 
-                auto args = FormatArguments::common(years, months);
+                FormatArguments args{};
+                args.push(years);
+                args.push(months);
+
                 drawingCtx.drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::success_you_completed_the_challenge_in_years_months, &args);
                 return;
             }
@@ -2494,7 +2517,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 uint16_t years = monthsLeft / 12;
                 uint16_t months = monthsLeft % 12;
 
-                auto args = FormatArguments::common(years, months);
+                FormatArguments args{};
+                args.push(years);
+                args.push(months);
+
                 drawingCtx.drawStringLeftWrapped(*rt, self.x + 5, y, self.width + 10, Colour::black, StringIds::time_remaining_years_months, &args);
                 return;
             }

--- a/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
@@ -2656,7 +2656,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         {
             if (_trackCost != 0)
             {
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push<uint32_t>(_trackCost);
                 drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::build_cost, &args);
             }

--- a/src/OpenLoco/src/Windows/Construction/OverheadTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/OverheadTab.cpp
@@ -412,7 +412,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
             auto trackType = _trackType & ~(1 << 7);
             auto roadObj = ObjectManager::get<RoadObject>(trackType);
 
-            auto args = FormatArguments();
+            auto args = FormatArguments::common();
             args.push(roadObj->name);
 
             for (auto i = 0; i < 2; i++)
@@ -428,7 +428,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
         {
             auto trackObj = ObjectManager::get<TrackObject>(_trackType);
 
-            auto args = FormatArguments();
+            auto args = FormatArguments::common();
             args.push(trackObj->name);
 
             for (auto i = 0; i < 4; i++)
@@ -522,7 +522,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
 
         if (_modCost != 0x80000000 && _modCost != 0)
         {
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push<uint32_t>(_modCost);
 
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();

--- a/src/OpenLoco/src/Windows/Construction/SignalTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/SignalTab.cpp
@@ -288,7 +288,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
 
         auto trackObj = ObjectManager::get<TrackObject>(_trackType);
 
-        auto args = FormatArguments();
+        auto args = FormatArguments::common();
         args.push(trackObj->name);
 
         auto trainSignalObject = ObjectManager::get<TrainSignalObject>(_lastSelectedSignal);
@@ -313,7 +313,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
         auto width = 130;
 
         {
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push(trainSignalObject->description);
 
             drawingCtx.drawStringLeftWrapped(*rt, xPos, yPos, width, Colour::black, StringIds::signal_black, &args);
@@ -335,7 +335,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
 
         if (_signalCost != 0x80000000 && _signalCost != 0)
         {
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push<uint32_t>(_signalCost);
 
             xPos = self.x + 69;

--- a/src/OpenLoco/src/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/StationTab.cpp
@@ -873,7 +873,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
         self.widgets[widx::rotate].type = WidgetType::none;
 
-        auto args = FormatArguments();
+        auto args = FormatArguments::common();
 
         if (_byte_1136063 & (1 << 7))
         {
@@ -982,7 +982,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
             xPos = self.x + 69;
             yPos = self.widgets[widx::image].bottom + self.y + 4;
 
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push<uint32_t>(_stationCost);
 
             drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::build_cost, &args);
@@ -996,7 +996,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         if ((_ghostVisibilityFlags & GhostVisibilityFlags::station) == GhostVisibilityFlags::none)
             return;
 
-        auto args = FormatArguments();
+        FormatArguments args{};
 
         // Todo: change globals type to be StationId and make this StationId::null
         if (_constructingStationId == 0xFFFFFFFF)

--- a/src/OpenLoco/src/Windows/Error.cpp
+++ b/src/OpenLoco/src/Windows/Error.cpp
@@ -89,7 +89,7 @@ namespace OpenLoco::Ui::Windows::Error
 
         char* buffer = _errorText;
 
-        auto args = FormatArguments();
+        auto args = FormatArguments::common();
 
         buffer = formatErrorString(title, message, args, buffer);
 

--- a/src/OpenLoco/src/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Windows/IndustryList.cpp
@@ -140,10 +140,11 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
             self.draw(rt);
             Common::drawTabs(&self, rt);
-            auto args = FormatArguments();
+
             auto xPos = self.x + 4;
             auto yPos = self.y + self.height - 12;
 
+            FormatArguments args{};
             if (self.var_83C == 1)
                 args.push(StringIds::status_num_industries_singular);
             else
@@ -416,7 +417,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
                 // Industry Name
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push(industry->name);
                     args.push(industry->town);
 
@@ -427,7 +428,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     const char* buffer = StringManager::getString(StringIds::buffer_1250);
                     industry->getStatusString((char*)buffer);
 
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push(StringIds::buffer_1250);
 
                     drawingCtx.drawStringLeftClipped(rt, 200, yPos, 238, Colour::black, text_colour_id, &args);
@@ -442,7 +443,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
                     auto productionTransported = getAverageTransportedCargo(*industry);
 
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push<uint16_t>(productionTransported);
 
                     drawingCtx.drawStringLeftClipped(rt, 440, yPos, 138, Colour::black, StringIds::production_transported_percent, &args);
@@ -680,7 +681,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
             {
                 industryCost = Economy::getInflationAdjustedCost(industryObj->costFactor, industryObj->costIndex, 3);
             }
-            auto args = FormatArguments();
+
+            FormatArguments args{};
             args.push(industryCost);
 
             auto widthOffset = 0;

--- a/src/OpenLoco/src/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Windows/IndustryWindow.cpp
@@ -143,7 +143,7 @@ namespace OpenLoco::Ui::Windows::Industry
             auto industry = IndustryManager::get(IndustryId(self.number));
             industry->getStatusString(const_cast<char*>(buffer));
 
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push(StringIds::buffer_1250);
 
             auto widget = &self.widgets[widx::status_bar];
@@ -472,7 +472,7 @@ namespace OpenLoco::Ui::Windows::Industry
                     if (receivedCargoType != 0xFF)
                     {
                         auto cargoObj = ObjectManager::get<CargoObject>(receivedCargoType);
-                        auto args = FormatArguments();
+                        FormatArguments args{};
 
                         if (industry->receivedCargoQuantityPreviousMonth[cargoNumber] == 1)
                         {
@@ -505,7 +505,7 @@ namespace OpenLoco::Ui::Windows::Industry
                     if (producedCargoType != 0xFF)
                     {
                         auto cargoObj = ObjectManager::get<CargoObject>(producedCargoType);
-                        auto args = FormatArguments();
+                        FormatArguments args{};
 
                         if (industry->producedCargoQuantityPreviousMonth[cargoNumber] == 1)
                         {
@@ -593,7 +593,7 @@ namespace OpenLoco::Ui::Windows::Industry
             const auto cargoObj = ObjectManager::get<CargoObject>(industryObj->producedCargoType[0]);
 
             {
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push(cargoObj->unitsAndCargoName);
 
                 int16_t x = self.x + 2;
@@ -607,7 +607,7 @@ namespace OpenLoco::Ui::Windows::Industry
             int32_t yTick = 0;
             for (int16_t yPos = graphBottom; yPos >= self.y + 68; yPos -= 20)
             {
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push(yTick);
 
                 drawingCtx.drawRect(*rt, self.x + 41, yPos, 239, 1, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4), Drawing::RectFlags::none);
@@ -634,7 +634,7 @@ namespace OpenLoco::Ui::Windows::Industry
                 {
                     if (yearSkip == 0)
                     {
-                        auto args = FormatArguments();
+                        FormatArguments args{};
                         args.push(year);
 
                         drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::population_graph_year, &args);
@@ -715,7 +715,7 @@ namespace OpenLoco::Ui::Windows::Industry
 
             // Put industry name in place.
             auto industry = IndustryManager::get(IndustryId(self.number));
-            auto args = FormatArguments();
+            auto args = FormatArguments::common();
             args.push(industry->name);
             args.push(industry->town);
 
@@ -779,7 +779,7 @@ namespace OpenLoco::Ui::Windows::Industry
                     return;
             }
 
-            auto args = FormatArguments();
+            auto args = FormatArguments::common();
             args.push<int64_t>(0);
             args.push(industry->name);
             args.push(industry->town);

--- a/src/OpenLoco/src/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Windows/KeyboardShortcuts.cpp
@@ -180,7 +180,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
                 getBindingString(shortcut.keyCode, buffer, std::size(buffer));
             }
 
-            auto formatter = FormatArguments::common();
+            FormatArguments formatter{};
             formatter.push(StringIds::keyboard_shortcut_list_format);
             formatter.push(ShortcutManager::getName(static_cast<Shortcut>(i)));
             formatter.push(modifierStringId);

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -485,18 +485,22 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                 drawingCtx.drawImage(&rt, 2, yPos + 1, imageId);
 
                 // Draw land description.
-                FormatArguments args{};
-                args.push(landObject->name);
-                drawingCtx.drawStringLeftClipped(rt, 24, yPos + 5, 121, Colour::black, StringIds::wcolour2_stringid, &args);
+                {
+                    FormatArguments args{};
+                    args.push(landObject->name);
+                    drawingCtx.drawStringLeftClipped(rt, 24, yPos + 5, 121, Colour::black, StringIds::wcolour2_stringid, &args);
+                }
 
                 // Draw rectangle.
                 drawingCtx.fillRectInset(rt, 150, yPos + 5, 340, yPos + 16, window.getColour(WindowColour::secondary), Drawing::RectInsetFlags::borderInset | Drawing::RectInsetFlags::fillDarker);
 
                 // Draw current distribution setting.
-                const StringId distributionId = landDistributionLabelIds[enumValue(S5::getOptions().landDistributionPatterns[i])];
-                args.rewind();
-                args.push(distributionId);
-                drawingCtx.drawStringLeftClipped(rt, 151, yPos + 5, 177, Colour::black, StringIds::black_stringid, &args);
+                {
+                    FormatArguments args{};
+                    const StringId distributionId = landDistributionLabelIds[enumValue(S5::getOptions().landDistributionPatterns[i])];
+                    args.push(distributionId);
+                    drawingCtx.drawStringLeftClipped(rt, 151, yPos + 5, 177, Colour::black, StringIds::black_stringid, &args);
+                }
 
                 // Draw rectangle (knob).
                 const Drawing::RectInsetFlags flags = window.rowHover == i ? Drawing::RectInsetFlags::borderInset | Drawing::RectInsetFlags::fillDarker : Drawing::RectInsetFlags::none;

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -31,8 +31,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
     static constexpr size_t kMaxLandObjects = ObjectManager::getMaxObjects(ObjectType::land);
 
-    static loco_global<uint16_t[10], 0x0112C826> _commonFormatArgs;
-
     namespace Common
     {
         enum widx
@@ -201,7 +199,9 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         {
             Common::prepareDraw(window);
 
-            _commonFormatArgs[0] = S5::getOptions().scenarioStartYear;
+            auto args = FormatArguments::common();
+            args.push<uint16_t>(S5::getOptions().scenarioStartYear);
+
             auto& options = S5::getOptions();
             window.widgets[widx::generator].text = generatorIds[static_cast<uint8_t>(options.generator)];
 
@@ -485,16 +485,18 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                 drawingCtx.drawImage(&rt, 2, yPos + 1, imageId);
 
                 // Draw land description.
-                _commonFormatArgs[0] = landObject->name;
-                drawingCtx.drawStringLeftClipped(rt, 24, yPos + 5, 121, Colour::black, StringIds::wcolour2_stringid, &*_commonFormatArgs);
+                FormatArguments args{};
+                args.push(landObject->name);
+                drawingCtx.drawStringLeftClipped(rt, 24, yPos + 5, 121, Colour::black, StringIds::wcolour2_stringid, &args);
 
                 // Draw rectangle.
                 drawingCtx.fillRectInset(rt, 150, yPos + 5, 340, yPos + 16, window.getColour(WindowColour::secondary), Drawing::RectInsetFlags::borderInset | Drawing::RectInsetFlags::fillDarker);
 
                 // Draw current distribution setting.
                 const StringId distributionId = landDistributionLabelIds[enumValue(S5::getOptions().landDistributionPatterns[i])];
-                _commonFormatArgs[0] = distributionId;
-                drawingCtx.drawStringLeftClipped(rt, 151, yPos + 5, 177, Colour::black, StringIds::black_stringid, &*_commonFormatArgs);
+                args.rewind();
+                args.push(distributionId);
+                drawingCtx.drawStringLeftClipped(rt, 151, yPos + 5, 177, Colour::black, StringIds::black_stringid, &args);
 
                 // Draw rectangle (knob).
                 const Drawing::RectInsetFlags flags = window.rowHover == i ? Drawing::RectInsetFlags::borderInset | Drawing::RectInsetFlags::fillDarker : Drawing::RectInsetFlags::none;
@@ -676,10 +678,11 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         {
             Common::prepareDraw(window);
 
-            _commonFormatArgs[0] = getGameState().seaLevel;
+            auto args = FormatArguments::common();
             auto& options = S5::getOptions();
-            _commonFormatArgs[1] = options.minLandHeight;
-            _commonFormatArgs[2] = options.hillDensity;
+            args.push<uint16_t>(getGameState().seaLevel);
+            args.push<uint16_t>(options.minLandHeight);
+            args.push<uint16_t>(options.hillDensity);
 
             window.widgets[widx::topography_style].text = topographyStyleIds[static_cast<uint8_t>(options.topographyStyle)];
 
@@ -972,14 +975,16 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             Common::prepareDraw(window);
 
             auto& options = S5::getOptions();
-            _commonFormatArgs[0] = options.numberOfForests;
-            _commonFormatArgs[1] = options.minForestRadius;
-            _commonFormatArgs[2] = options.maxForestRadius;
-            _commonFormatArgs[3] = options.minForestDensity * 14;
-            _commonFormatArgs[4] = options.maxForestDensity * 14;
-            _commonFormatArgs[5] = options.numberRandomTrees;
-            _commonFormatArgs[6] = options.minAltitudeForTrees;
-            _commonFormatArgs[7] = options.maxAltitudeForTrees;
+            auto args = FormatArguments::common();
+
+            args.push<uint16_t>(options.numberOfForests);
+            args.push<uint16_t>(options.minForestRadius);
+            args.push<uint16_t>(options.maxForestRadius);
+            args.push<uint16_t>(options.minForestDensity * 14);
+            args.push<uint16_t>(options.maxForestDensity * 14);
+            args.push<uint16_t>(options.numberRandomTrees);
+            args.push<uint16_t>(options.minAltitudeForTrees);
+            args.push<uint16_t>(options.maxAltitudeForTrees);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -1128,7 +1133,8 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         {
             Common::prepareDraw(window);
 
-            _commonFormatArgs[0] = S5::getOptions().numberOfTowns;
+            auto args = FormatArguments::common();
+            args.push<uint16_t>(S5::getOptions().numberOfTowns);
 
             widgets[widx::max_town_size].text = townSizeLabels[S5::getOptions().maxTownSize - 1];
         }

--- a/src/OpenLoco/src/Windows/LandscapeGenerationConfirm.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGenerationConfirm.cpp
@@ -2,6 +2,7 @@
 #include "Graphics/Colour.h"
 #include "Graphics/Gfx.h"
 #include "Input.h"
+#include "Localisation/FormatArguments.hpp"
 #include "Localisation/StringIds.h"
 #include "Objects/InterfaceSkinObject.h"
 #include "Objects/ObjectManager.h"
@@ -41,12 +42,14 @@ namespace OpenLoco::Ui::Windows::LandscapeGenerationConfirm
 
         window.draw(rt);
 
-        static loco_global<StringId, 0x0112C826> _commonFormatArgs;
-        StringId prompt = window.var_846 == 0 ? StringIds::prompt_confirm_generate_landscape : StringIds::prompt_confirm_random_landscape;
-        *_commonFormatArgs = prompt;
+        FormatArguments args{};
+        if (window.var_846 == 0)
+            args.push(StringIds::prompt_confirm_generate_landscape);
+        else
+            args.push(StringIds::prompt_confirm_random_landscape);
 
         auto origin = Ui::Point(window.x + (window.width / 2), window.y + 41);
-        drawingCtx.drawStringCentredWrapped(*rt, origin, window.width, Colour::black, StringIds::wcolour2_stringid, (const char*)&*_commonFormatArgs);
+        drawingCtx.drawStringCentredWrapped(*rt, origin, window.width, Colour::black, StringIds::wcolour2_stringid, &args);
     }
 
     // 0x004C18E4

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -577,7 +577,8 @@ namespace OpenLoco::Ui::Windows::MapWindow
             {
                 drawingCtx.drawRect(*rt, x, *y + 3, 5, 5, colour, Drawing::RectFlags::none);
             }
-            auto args = FormatArguments();
+
+            FormatArguments args{};
             args.push(lineNames[i]);
 
             auto stringId = StringIds::small_black_string;
@@ -625,7 +626,8 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
                 drawingCtx.drawRect(*rt, x, *y + 3, 5, 5, colour, Drawing::RectFlags::none);
             }
-            auto args = FormatArguments();
+
+            FormatArguments args{};
             args.push(lineNames[i]);
 
             auto stringId = StringIds::small_black_string;
@@ -674,7 +676,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 drawingCtx.drawRect(*rt, x, *y + 3, 5, 5, colour, Drawing::RectFlags::none);
             }
 
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push(industry->name);
 
             auto stringId = StringIds::small_black_string;
@@ -726,7 +728,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 }
             }
 
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push(routeType);
 
             auto stringId = StringIds::small_black_string;
@@ -757,7 +759,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 drawingCtx.drawRect(*rt, x, *y + 3, 5, 5, colour, Drawing::RectFlags::none);
             }
 
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push(company.name);
 
             auto stringId = StringIds::small_black_string;
@@ -774,7 +776,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046D81F
-    static void formatVehicleString(Window* self, FormatArguments args)
+    static void formatVehicleString(Window* self, FormatArguments& args)
     {
         static const StringId vehicleStringSingular[] = {
             StringIds::num_trains_singular,
@@ -826,7 +828,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046D87C
-    static void formatIndustryString(Window* self, FormatArguments args)
+    static void formatIndustryString(Window* self, FormatArguments& args)
     {
         int16_t industryIndex = Numerics::bitScanForward(self->var_854);
 
@@ -942,7 +944,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             self.minHeight = y;
         }
 
-        auto args = FormatArguments();
+        FormatArguments args{};
 
         switch (self.currentTab + widx::tabOverall)
         {

--- a/src/OpenLoco/src/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Windows/News/News.cpp
@@ -507,7 +507,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
         // 0x0042A036
         static void drawViewportString(Gfx::RenderTarget* rt, uint16_t x, uint16_t y, uint16_t width, MessageItemArgumentType itemType, uint16_t itemIndex)
         {
-            auto args = FormatArguments();
+            FormatArguments args{};
 
             switch (itemType)
             {

--- a/src/OpenLoco/src/Windows/ObjectLoadError.cpp
+++ b/src/OpenLoco/src/Windows/ObjectLoadError.cpp
@@ -203,7 +203,7 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
 
             auto& header = _loadErrorObjectsList[i];
 
-            FormatArguments args;
+            FormatArguments args{};
             args.push(StringIds::buffer_2039);
 
             // Copy object name to buffer

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -501,7 +501,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             widgets[widx::closeButton].type = WidgetType::none;
         }
 
-        auto args = FormatArguments();
+        auto args = FormatArguments::common();
         args.push(_tabDisplayInfo[self.currentTab].name);
 
         const auto& tabFlags = _tabDisplayInfo[self.currentTab].flags;
@@ -840,6 +840,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         {
             auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
             strncpy(buffer, indexEntry._filename, strlen(indexEntry._filename) + 1);
+
             FormatArguments args{};
             args.push<StringId>(StringIds::buffer_1250);
             drawingCtx.drawStringLeft(*clipped, 18, height - kDescriptionRowHeight * 3 - 4, Colour::black, StringIds::object_selection_filename, &args);

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -1058,7 +1058,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                     checkColour = checkColour.inset();
                 }
 
-                drawingCtx.drawString(rt, x, y, checkColour, _strCheckmark);
+                static constexpr char strCheckmark[] = "\xAC";
+                drawingCtx.drawString(rt, x, y, checkColour, strCheckmark);
             }
 
             char buffer[512]{};

--- a/src/OpenLoco/src/Windows/Options.cpp
+++ b/src/OpenLoco/src/Windows/Options.cpp
@@ -582,7 +582,7 @@ namespace OpenLoco::Ui::Windows::Options
             }
             w.widgets[Widx::screen_mode].text = screenModeStringId;
 
-            FormatArguments args = {};
+            auto args = FormatArguments::common();
             args.skip(0x10);
             auto& resolution = Config::get().display.fullscreenResolution;
             args.push<uint16_t>(resolution.width);
@@ -757,7 +757,7 @@ namespace OpenLoco::Ui::Windows::Options
             w.widgets[Common::Widx::close_button].left = w.width - 15;
             w.widgets[Common::Widx::close_button].right = w.width - 15 + 12;
 
-            FormatArguments args = {};
+            auto args = FormatArguments::common();
 
             auto audioDeviceName = Audio::getCurrentDeviceName();
             if (audioDeviceName != nullptr)
@@ -975,7 +975,7 @@ namespace OpenLoco::Ui::Windows::Options
                 songName = Audio::getMusicInfo(_currentSong)->titleId;
             }
 
-            FormatArguments args = {};
+            auto args = FormatArguments::common();
             args.push(songName);
 
             static const StringId playlist_string_ids[] = {
@@ -1361,7 +1361,7 @@ namespace OpenLoco::Ui::Windows::Options
             w.widgets[Common::Widx::close_button].left = w.width - 15;
             w.widgets[Common::Widx::close_button].right = w.width - 15 + 12;
 
-            FormatArguments args = {};
+            auto args = FormatArguments::common();
 
             auto& language = Localisation::getDescriptorForLanguage(Config::get().language);
             _chosenLanguage = language.nativeName;
@@ -2094,7 +2094,7 @@ namespace OpenLoco::Ui::Windows::Options
             auto drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
             auto& widget = w->widgets[widgetIndex];
-            FormatArguments args = {};
+            FormatArguments args{};
             args.push(stringId);
             args.push(value);
             drawingCtx.drawStringLeft(*rt, w->x + widget.left + 1, w->y + widget.top + 1, Colour::black, StringIds::black_stringid, &args);
@@ -2113,7 +2113,7 @@ namespace OpenLoco::Ui::Windows::Options
             strcpy(buffer, playerName);
             buffer[strlen(playerName)] = '\0';
 
-            FormatArguments args = {};
+            FormatArguments args{};
             args.push(StringIds::buffer_2039);
             drawingCtx.drawStringLeft(*rt, w.x + 24, w.y + w.widgets[Widx::change_btn].top + 1, Colour::black, StringIds::wcolour2_preferred_owner_name, &args);
 

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -333,9 +333,11 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         self.widgets[widx::parent_button].right = self.width - 3;
 
         // Get width of the base 'Folder:' string
-        auto args = FormatArguments::common(StringIds::empty);
         char folderBuffer[256]{};
+        FormatArguments args{};
+        args.push(StringIds::empty);
         StringManager::formatString(folderBuffer, StringIds::window_browse_folder, &args);
+
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
         drawingCtx.setCurrentFontSpriteBase(Font::medium_bold);
         const auto folderLabelWidth = drawingCtx.getStringWidth(folderBuffer);

--- a/src/OpenLoco/src/Windows/PromptSaveWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptSaveWindow.cpp
@@ -4,7 +4,6 @@
 #include "GameCommands/General/LoadSaveQuit.h"
 #include "Graphics/Colour.h"
 #include "Input.h"
-#include "Localisation/FormatArguments.hpp"
 #include "Localisation/StringIds.h"
 #include "SceneManager.h"
 #include "Ui.h"

--- a/src/OpenLoco/src/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioOptions.cpp
@@ -198,8 +198,9 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             int16_t yPos = window.y + widgets[widx::check_time_limit].bottom + 10;
             drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::challenge_label);
 
-            FormatArguments args = {};
+            FormatArguments args{};
             OpenLoco::Scenario::formatChallengeArguments(Scenario::getObjective(), Scenario::getObjectiveProgress(), args);
+
             yPos += 10;
             drawingCtx.drawStringLeftWrapped(*rt, xPos, yPos, window.width - 10, Colour::black, StringIds::challenge_value, &args);
         }
@@ -424,7 +425,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             widgets[widx::time_limit_value_down].type = WidgetType::none;
             widgets[widx::time_limit_value_up].type = WidgetType::none;
 
-            auto args = FormatArguments();
+            auto args = FormatArguments::common();
 
             switch (Scenario::getObjective().type)
             {
@@ -808,7 +809,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         {
             Common::prepareDraw(self);
 
-            auto args = FormatArguments();
+            auto args = FormatArguments::common();
             args.push<uint16_t>(CompanyManager::getMaxCompetingCompanies());
             args.push<uint16_t>(CompanyManager::getCompetitorStartDelay());
 
@@ -959,7 +960,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         {
             Common::prepareDraw(self);
 
-            auto args = FormatArguments();
+            auto args = FormatArguments::common();
 
             uint32_t loanSizeInCurrency = getLoanSizeInCurrency();
             args.push<uint32_t>(loanSizeInCurrency);
@@ -1014,11 +1015,11 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             Common::draw(window, rt);
 
             {
-                auto args = FormatArguments();
-
                 // Prepare scenario name text.
                 char* buffer = (char*)StringManager::getString(StringIds::buffer_2039);
                 strncpy(buffer, S5::getOptions().scenarioName, 512);
+
+                FormatArguments args{};
                 args.push(StringIds::buffer_2039);
 
                 auto* stex = ObjectManager::get<ScenarioTextObject>();
@@ -1047,11 +1048,11 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             }
 
             {
-                auto args = FormatArguments();
-
                 // Prepare scenario details text.
                 char* buffer = (char*)StringManager::getString(StringIds::buffer_2039);
                 strncpy(buffer, S5::getOptions().scenarioDetails, 512);
+
+                FormatArguments args{};
                 args.push(StringIds::buffer_2039);
 
                 auto* stex = ObjectManager::get<ScenarioTextObject>();

--- a/src/OpenLoco/src/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioSelect.cpp
@@ -226,7 +226,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             auto str = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
             strncpy(str, scenarioInfo->scenarioName, std::size(scenarioInfo->scenarioName));
 
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push(StringIds::buffer_2039);
 
             x += colWidth / 2;
@@ -278,7 +278,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             x += 64;
             y += 59;
 
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push(StringIds::randomly_generated_landscape);
 
             // Overlay random map note.
@@ -294,7 +294,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             auto str = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
             strncpy(str, scenarioInfo->description, std::size(scenarioInfo->description));
 
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push(StringIds::buffer_2039);
             y = drawingCtx.drawStringLeftWrapped(*rt, x, y, 170, Colour::black, StringIds::black_stringid, &args);
 
@@ -377,7 +377,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
                 auto str = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
                 strncpy(str, scenarioInfo->scenarioName, std::size(scenarioInfo->scenarioName));
 
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push(StringIds::buffer_2039);
 
                 const int16_t x = 210;
@@ -399,7 +399,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
                 auto str = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
                 strncpy(str, scenarioInfo->highscoreName, std::size(scenarioInfo->highscoreName));
 
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push(StringIds::completed_by_name_in_years_months);
                 args.push(StringIds::buffer_2039);
                 args.push<uint16_t>(scenarioInfo->completedMonths / 12);

--- a/src/OpenLoco/src/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Windows/StationList.cpp
@@ -449,31 +449,37 @@ namespace OpenLoco::Ui::Windows::StationList
             auto station = StationManager::get(stationId);
 
             // First, draw the town name.
-            auto args = FormatArguments{};
-            args.push(StringIds::stringid_stringid);
-            args.push(station->name);
-            args.push<uint16_t>(enumValue(station->town));
-            args.push<uint16_t>(getTransportIconsFromStationFlags(station->flags));
+            {
+                auto args = FormatArguments{};
+                args.push(StringIds::stringid_stringid);
+                args.push(station->name);
+                args.push<uint16_t>(enumValue(station->town));
+                args.push<uint16_t>(getTransportIconsFromStationFlags(station->flags));
 
-            drawingCtx.drawStringLeftClipped(rt, 0, yPos, 198, Colour::black, text_colour_id, &args);
+                drawingCtx.drawStringLeftClipped(rt, 0, yPos, 198, Colour::black, text_colour_id, &args);
+            }
 
-            // Then the station's current status.
             char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
             station->getStatusString(buffer);
 
-            args.rewind();
-            args.push(StringIds::buffer_1250);
-            drawingCtx.drawStringLeftClipped(rt, 200, yPos, 198, Colour::black, text_colour_id, &args);
+            // Then the station's current status.
+            {
+                auto args = FormatArguments{};
+                args.push(StringIds::buffer_1250);
+                drawingCtx.drawStringLeftClipped(rt, 200, yPos, 198, Colour::black, text_colour_id, &args);
+            }
 
             // Total units waiting.
-            uint16_t totalUnits = 0;
-            for (const auto& stats : station->cargoStats)
-                totalUnits += stats.quantity;
+            {
+                uint16_t totalUnits = 0;
+                for (const auto& stats : station->cargoStats)
+                    totalUnits += stats.quantity;
 
-            args.rewind();
-            args.push(StringIds::num_units);
-            args.push<uint32_t>(totalUnits);
-            drawingCtx.drawStringLeftClipped(rt, 400, yPos, 88, Colour::black, text_colour_id, &args);
+                auto args = FormatArguments{};
+                args.push(StringIds::num_units);
+                args.push<uint32_t>(totalUnits);
+                drawingCtx.drawStringLeftClipped(rt, 400, yPos, 88, Colour::black, text_colour_id, &args);
+            }
 
             // And, finally, what goods the station accepts.
             char* ptr = buffer;
@@ -492,9 +498,11 @@ namespace OpenLoco::Ui::Windows::StationList
                 ptr = StringManager::formatString(ptr, ObjectManager::get<CargoObject>(cargoId)->name);
             }
 
-            args.rewind();
-            args.push(StringIds::buffer_1250);
-            drawingCtx.drawStringLeftClipped(rt, 490, yPos, 118, Colour::black, text_colour_id, &args);
+            {
+                auto args = FormatArguments{};
+                args.push(StringIds::buffer_1250);
+                drawingCtx.drawStringLeftClipped(rt, 490, yPos, 118, Colour::black, text_colour_id, &args);
+            }
 
             yPos += kRowHeight;
         }

--- a/src/OpenLoco/src/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Windows/StationWindow.cpp
@@ -126,7 +126,7 @@ namespace OpenLoco::Ui::Windows::Station
             const char* buffer = StringManager::getString(StringIds::buffer_1250);
             station->getStatusString((char*)buffer);
 
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push(StringIds::buffer_1250);
 
             const auto& widget = self.widgets[widx::status_bar];
@@ -509,28 +509,33 @@ namespace OpenLoco::Ui::Windows::Station
                 if (cargo.quantity != 1)
                     cargoName = cargoObj->unitNamePlural;
 
-                auto args = FormatArguments();
-                args.push(cargoName);
-                args.push<uint32_t>(cargo.quantity);
-                auto cargoStr = StringIds::station_cargo;
-
-                if (cargo.origin != StationId(self.number))
-                    cargoStr = StringIds::station_cargo_en_route_start;
                 const auto& widget = self.widgets[widx::scrollview];
                 auto xPos = widget.width() - 14;
 
-                drawingCtx.drawStringRight(rt, xPos, y, AdvancedColour(Colour::black).outline(), cargoStr, &args);
-                y += 10;
+                {
+                    FormatArguments args{};
+                    args.push(cargoName);
+                    args.push<uint32_t>(cargo.quantity);
+
+                    auto cargoStr = StringIds::station_cargo;
+                    if (cargo.origin != StationId(self.number))
+                        cargoStr = StringIds::station_cargo_en_route_start;
+
+                    drawingCtx.drawStringRight(rt, xPos, y, AdvancedColour(Colour::black).outline(), cargoStr, &args);
+                    y += 10;
+                }
+
                 if (cargo.origin != StationId(self.number))
                 {
                     auto originStation = StationManager::get(cargo.origin);
-                    auto args2 = FormatArguments();
-                    args2.push(originStation->name);
-                    args2.push(originStation->town);
+                    FormatArguments args{};
+                    args.push(originStation->name);
+                    args.push(originStation->town);
 
-                    drawingCtx.drawStringRight(rt, xPos, y, AdvancedColour(Colour::black).outline(), StringIds::station_cargo_en_route_end, &args2);
+                    drawingCtx.drawStringRight(rt, xPos, y, AdvancedColour(Colour::black).outline(), StringIds::station_cargo_en_route_end, &args);
                     y += 10;
                 }
+
                 y += 2;
                 cargoId++;
             }
@@ -541,7 +546,7 @@ namespace OpenLoco::Ui::Windows::Station
 
             if (totalUnits == 0)
             {
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push(StringIds::nothing_waiting);
                 drawingCtx.drawStringLeft(rt, 1, 0, Colour::black, StringIds::black_stringid, &args);
             }

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -733,7 +733,8 @@ namespace OpenLoco::Ui::Windows::Terraform
             {
                 treeCost = Economy::getInflationAdjustedCost(treeObj->buildCostFactor, treeObj->costIndex, 12);
             }
-            auto args = FormatArguments();
+
+            FormatArguments args{};
             args.push<uint32_t>(treeCost);
 
             if (!isEditorMode())
@@ -1087,7 +1088,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 auto xPos = toolArea.midX() + self.x;
                 auto yPos = toolArea.midY() + self.y - 5;
 
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push<uint16_t>(_adjustToolSize);
                 drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::tile_inspector_coord, &args);
             }
@@ -1101,7 +1102,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             auto xPos = toolArea.midX() + self.x;
             auto yPos = toolArea.bottom + self.y + 5;
 
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push<uint32_t>(_raiseLandCost);
 
             drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::clear_land_cost, &args);
@@ -1229,7 +1230,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 if (i == _lastSelectedLand)
                     Dropdown::setHighlightedItem(landIndex);
 
-                auto args = FormatArguments();
+                auto args = FormatArguments::common();
                 args.push(landObj->mapPixelImage + Land::ImageIds::landscape_generator_tile_icon);
                 args.push<uint16_t>(i);
 
@@ -1702,7 +1703,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 auto xPos = toolArea.midX() + self.x;
                 auto yPos = toolArea.midY() + self.y - 5;
 
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push<uint16_t>(_adjustToolSize);
                 drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::tile_inspector_coord, &args);
             }
@@ -1714,7 +1715,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             {
                 if (_raiseLandCost != 0)
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push<uint32_t>(_raiseLandCost);
                     drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::increase_height_cost, &args);
                 }
@@ -1726,7 +1727,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             {
                 if (_lowerLandCost != 0)
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push<uint32_t>(_lowerLandCost);
                     drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::decrease_height_cost, &args);
                 }
@@ -2012,7 +2013,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 auto xPos = toolArea.midX() + self.x;
                 auto yPos = toolArea.midY() + self.y - 5;
 
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push<uint16_t>(_adjustToolSize);
                 drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::tile_inspector_coord, &args);
             }
@@ -2024,7 +2025,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             {
                 if (_raiseWaterCost != 0)
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push<uint32_t>(_raiseWaterCost);
 
                     drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::increase_height_cost, &args);
@@ -2037,7 +2038,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             {
                 if (_lowerWaterCost != 0)
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push<uint32_t>(_lowerWaterCost);
 
                     drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::decrease_height_cost, &args);

--- a/src/OpenLoco/src/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Windows/TextInputWindow.cpp
@@ -241,7 +241,7 @@ namespace OpenLoco::Ui::Windows::TextInput
         const uint16_t numCharacters = static_cast<uint16_t>(inputSession.cursorPosition);
         const uint16_t maxNumCharacters = inputSession.inputLenLimit;
 
-        auto args = FormatArguments();
+        FormatArguments args{};
         args.push<uint16_t>(numCharacters);
         args.push<uint16_t>(maxNumCharacters);
 

--- a/src/OpenLoco/src/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Windows/TextInputWindow.cpp
@@ -93,7 +93,7 @@ namespace OpenLoco::Ui::Windows::TextInput
      * @param value @<cx>
      * @param callingWidget @<dx>
      */
-    void openTextInput(Ui::Window* caller, StringId title, StringId message, StringId value, int callingWidget, void* valueArgs, uint32_t inputSize)
+    void openTextInput(Ui::Window* caller, StringId title, StringId message, StringId value, int callingWidget, const void* valueArgs, uint32_t inputSize)
     {
         _title = title;
         _message = message;

--- a/src/OpenLoco/src/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Windows/TileInspector.cpp
@@ -93,8 +93,6 @@ namespace OpenLoco::Ui::Windows::TileInspector
         widgetEnd(),
     };
 
-    static loco_global<char[2], 0x005045F8> _strCheckmark;
-
     static void activateMapSelectionTool(Window* const self)
     {
         ToolManager::toolSet(self, widx::panel, CursorId::crosshair);
@@ -406,7 +404,8 @@ namespace OpenLoco::Ui::Windows::TileInspector
             widget = &self.widgets[widx::ghostHeader];
             if (element.isGhost())
             {
-                drawingCtx.drawString(rt, widget->left - 4, yPos, Colour::white, _strCheckmark);
+                static constexpr char strCheckmark[] = "\xAC";
+                drawingCtx.drawString(rt, widget->left - 4, yPos, Colour::white, strCheckmark);
             }
 
             rowNum++;

--- a/src/OpenLoco/src/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Windows/TileInspector.cpp
@@ -146,25 +146,27 @@ namespace OpenLoco::Ui::Windows::TileInspector
 
         // Coord X/Y labels
         {
-            auto args = FormatArguments::common(StringIds::tile_inspector_x_coord);
+            FormatArguments args{};
+            args.push(StringIds::tile_inspector_x_coord);
             auto& widget = self.widgets[widx::xPos];
             drawingCtx.drawStringLeft(*rt, self.x + widget.left - 15, self.y + widget.top + 1, Colour::black, StringIds::wcolour2_stringid, &args);
         }
         {
-            auto args = FormatArguments::common(StringIds::tile_inspector_y_coord);
+            FormatArguments args{};
+            args.push(StringIds::tile_inspector_y_coord);
             auto& widget = self.widgets[widx::yPos];
             drawingCtx.drawStringLeft(*rt, self.x + widget.left - 15, self.y + widget.top + 1, Colour::black, StringIds::wcolour2_stringid, &args);
         }
 
         // Coord X/Y values
         {
-            FormatArguments args = {};
+            FormatArguments args{};
             args.push<int16_t>(_currentPosition.x);
             auto& widget = self.widgets[widx::xPos];
             drawingCtx.drawStringLeft(*rt, self.x + widget.left + 2, self.y + widget.top + 1, Colour::black, StringIds::tile_inspector_coord, &args);
         }
         {
-            FormatArguments args = {};
+            FormatArguments args{};
             args.push<int16_t>(_currentPosition.y);
             auto& widget = self.widgets[widx::yPos];
             drawingCtx.drawStringLeft(*rt, self.x + widget.left + 2, self.y + widget.top + 1, Colour::black, StringIds::tile_inspector_coord, &args);
@@ -176,7 +178,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
             auto tile = TileManager::get(_currentPosition)[self.var_842];
             const auto data = tile->rawData();
 
-            char buffer[32] = {};
+            char buffer[32]{};
             buffer[0] = ControlCodes::windowColour2;
             snprintf(&buffer[1], std::size(buffer) - 1, "Data: %02x %02x %02x %02x %02x %02x %02x %02x", data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
 

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -234,7 +234,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
         args.push(opponent->name);
 
         // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments
-        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::map_chat_menu, const_cast<void*>(&args));
+        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::map_chat_menu, &args);
     }
 
     // 0x0043A72F

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -61,8 +61,6 @@ namespace OpenLoco::Ui::Windows::TimePanel
 
     static loco_global<uint16_t, 0x0050A004> _50A004;
 
-    static loco_global<uint16_t[8], 0x112C826> _commonFormatArgs;
-
     static const WindowEventList& getEvents();
 
     Window* open()
@@ -162,9 +160,10 @@ namespace OpenLoco::Ui::Windows::TimePanel
 
         drawingCtx.drawRectInset(*rt, self.x + frame.left + 1, self.y + frame.top + 1, frame.width() - 2, frame.height() - 2, self.getColour(WindowColour::secondary), Drawing::RectInsetFlags::borderInset | Drawing::RectInsetFlags::fillNone);
 
-        *(uint32_t*)&_commonFormatArgs[0] = getCurrentDay();
-        StringId format = StringIds::date_daymonthyear;
+        FormatArguments args{};
+        args.push<uint32_t>(getCurrentDay());
 
+        StringId format = StringIds::date_daymonthyear;
         if (isPaused() && (getPauseFlags() & (1 << 2)) == 0)
         {
             if (self.var_856 >= 30)
@@ -178,7 +177,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
         {
             c = Colour::white;
         }
-        drawingCtx.drawStringCentred(*rt, self.x + _widgets[Widx::date_btn].midX(), self.y + _widgets[Widx::date_btn].top + 1, c, format, &*_commonFormatArgs);
+        drawingCtx.drawStringCentred(*rt, self.x + _widgets[Widx::date_btn].midX(), self.y + _widgets[Widx::date_btn].top + 1, c, format, &args);
 
         auto skin = ObjectManager::get<InterfaceSkinObject>();
         drawingCtx.drawImage(rt, self.x + _widgets[Widx::map_chat_menu].left - 2, self.y + _widgets[Widx::map_chat_menu].top - 1, skin->img + map_sprites_by_rotation[WindowManager::getCurrentRotation()]);

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -229,7 +229,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     void beginSendChatMessage(Window& self)
     {
         const auto* opponent = CompanyManager::getOpponent();
-        FormatArguments args{};
+        auto args = FormatArguments::common();
         args.push(opponent->name);
 
         // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments

--- a/src/OpenLoco/src/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Windows/TitleMenu.cpp
@@ -431,7 +431,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
         args.push(StringIds::the_other_player);
 
         // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments
-        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::chat_btn, const_cast<void*>(&args));
+        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::chat_btn, &args);
     }
 
     static void sub_43918F(const char* string)

--- a/src/OpenLoco/src/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Windows/TitleMenu.cpp
@@ -427,7 +427,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     {
         WindowManager::close(WindowType::multiplayer);
 
-        FormatArguments args{};
+        auto args = FormatArguments::common();
         args.push(StringIds::the_other_player);
 
         // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments

--- a/src/OpenLoco/src/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Windows/TownList.cpp
@@ -177,21 +177,21 @@ namespace OpenLoco::Ui::Windows::TownList
 
                 // Town Name
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push(town->name);
 
                     drawingCtx.drawStringLeftClipped(rt, 0, yPos, 198, Colour::black, text_colour_id, &args);
                 }
                 // Town Type
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push(town->getTownSizeString());
 
                     drawingCtx.drawStringLeftClipped(rt, 200, yPos, 278, Colour::black, text_colour_id, &args);
                 }
                 // Town Population
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push(StringIds::int_32);
                     args.push(town->population);
 
@@ -199,7 +199,7 @@ namespace OpenLoco::Ui::Windows::TownList
                 }
                 // Town Stations
                 {
-                    auto args = FormatArguments();
+                    FormatArguments args{};
                     args.push(StringIds::int_32);
                     args.push<int32_t>(town->numStations);
 
@@ -216,10 +216,11 @@ namespace OpenLoco::Ui::Windows::TownList
 
             self.draw(rt);
             Common::drawTabs(&self, rt);
-            auto args = FormatArguments();
+
             auto xPos = self.x + 4;
             auto yPos = self.y + self.height - 12;
 
+            FormatArguments args{};
             if (self.var_83C == 1)
                 args.push(StringIds::status_towns_singular);
             else

--- a/src/OpenLoco/src/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Windows/TownWindow.cpp
@@ -138,7 +138,7 @@ namespace OpenLoco::Ui::Windows::Town
 
             auto town = TownManager::get(TownId(self.number));
 
-            auto args = FormatArguments();
+            FormatArguments args{};
             args.push(town->getTownSizeString());
             args.push(town->population);
 
@@ -411,7 +411,7 @@ namespace OpenLoco::Ui::Windows::Town
             int32_t yTick = town->historyMinPopulation;
             for (int16_t yPos = self.height - 57; yPos >= 14; yPos -= 20)
             {
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push(yTick);
 
                 const uint16_t xPos = 39;
@@ -436,7 +436,7 @@ namespace OpenLoco::Ui::Windows::Town
                 {
                     if (yearSkip == 0)
                     {
-                        auto args = FormatArguments();
+                        FormatArguments args{};
                         args.push(year);
 
                         drawingCtx.drawStringCentred(*clipped, xPos, yPos, Colour::black, StringIds::population_graph_year, &args);
@@ -556,7 +556,7 @@ namespace OpenLoco::Ui::Windows::Town
                 else
                     rank = StringIds::town_rating_appalling;
 
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push(CompanyManager::get(CompanyId(i))->name);
                 args.push<int16_t>(0);
                 args.push(rating);

--- a/src/OpenLoco/src/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Windows/TownWindow.cpp
@@ -32,8 +32,6 @@ namespace OpenLoco::Ui::Windows::Town
 {
     static constexpr Ui::Size kWindowSize = { 223, 161 };
 
-    static loco_global<uint16_t[10], 0x0112C826> _commonFormatArgs;
-
     namespace Common
     {
         enum widx
@@ -648,7 +646,8 @@ namespace OpenLoco::Ui::Windows::Town
             self.activatedWidgets |= (1ULL << widgetIndex);
 
             // Put town name in place.
-            _commonFormatArgs[0] = TownManager::get(TownId(self.number))->name;
+            FormatArguments args{};
+            args.push(TownManager::get(TownId(self.number))->name);
 
             // Resize common widgets.
             self.widgets[Common::widx::frame].right = self.width - 1;
@@ -701,10 +700,13 @@ namespace OpenLoco::Ui::Windows::Town
         static void renameTownPrompt(Window* self, WidgetIndex_t widgetIndex)
         {
             auto town = TownManager::get(TownId(self->number));
-            _commonFormatArgs[4] = town->name;
-            _commonFormatArgs[8] = town->name;
 
-            TextInput::openTextInput(self, StringIds::title_town_name, StringIds::prompt_type_new_town_name, town->name, widgetIndex, &_commonFormatArgs);
+            FormatArguments args{};
+            args.skip(4);
+            args.push(town->name);
+            args.push(town->name);
+
+            TextInput::openTextInput(self, StringIds::title_town_name, StringIds::prompt_type_new_town_name, town->name, widgetIndex, &args);
         }
 
         // 0x004991BC

--- a/src/OpenLoco/src/Windows/Tutorial.cpp
+++ b/src/OpenLoco/src/Windows/Tutorial.cpp
@@ -68,7 +68,9 @@ namespace OpenLoco::Ui::Windows::Tutorial
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
         auto tutorialNumber = OpenLoco::Tutorial::getTutorialNumber();
-        auto args = FormatArguments::common(titleStringIds[tutorialNumber]);
+
+        FormatArguments args{};
+        args.push(titleStringIds[tutorialNumber]);
 
         auto& widget = self.widgets[Widx::frame];
         auto yPos = self.y + widget.top + 4;

--- a/src/OpenLoco/src/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Windows/Vehicle.cpp
@@ -684,12 +684,13 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             auto [errorTitle, mode] = itemToGameCommandInfo[item];
             GameCommands::setErrorTitle(errorTitle);
-            FormatArguments args{};
             auto head = Common::getVehicle(self);
             if (head == nullptr)
             {
                 return;
             }
+
+            auto args = FormatArguments::common();
             args.skip(6);
             args.push(head->name);
             args.push(head->ordinalNumber);
@@ -1485,7 +1486,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             {
                 return;
             }
-            auto args = FormatArguments();
+
+            auto args = FormatArguments::common();
             args.push(head->name);
             args.push(head->ordinalNumber);
 
@@ -2075,7 +2077,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     format = StringIds::dropdown_stringid_selected;
                 }
 
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push<StringId>(cargoObject->unitNamePlural);
                 args.push<uint32_t>(Vehicles::getNumUnitsForCargo(maxPrimaryCargo, primaryCargoId, cargoId));
                 args.push<uint16_t>(cargoId);
@@ -2264,7 +2266,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             {
                 return;
             }
-            auto args = FormatArguments();
+
+            auto args = FormatArguments::common();
             args.push(vehicle->name);
             args.push(vehicle->ordinalNumber);
 
@@ -2298,10 +2301,13 @@ namespace OpenLoco::Ui::Windows::Vehicle
             auto veh1 = train.veh1;
             if (veh1->lastIncome.day != -1)
             {
-                auto args = FormatArguments();
-                args.push<uint32_t>(veh1->lastIncome.day);
-                // Last income on: {DATE DMY}
-                drawingCtx.drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::last_income_on_date, &args);
+                {
+                    FormatArguments args{};
+                    args.push<uint32_t>(veh1->lastIncome.day);
+                    // Last income on: {DATE DMY}
+                    drawingCtx.drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::last_income_on_date, &args);
+                }
+
                 pos.y += 10;
                 for (int i = 0; i < 4; i++)
                 {
@@ -2313,7 +2319,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
                     auto str = veh1->lastIncome.cargoQtys[i] == 1 ? cargoObject->unitNameSingular : cargoObject->unitNamePlural;
 
-                    args = FormatArguments();
+                    FormatArguments args{};
                     args.push(str);
                     args.push<uint32_t>(veh1->lastIncome.cargoQtys[i]);
                     args.push(veh1->lastIncome.cargoDistances[i]);
@@ -2338,7 +2344,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             if (head->lastAverageSpeed != 0_mph)
             {
                 // Last journey average speed: {VELOCITY}
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push(head->lastAverageSpeed);
                 drawingCtx.drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::last_journey_average_speed, &args);
                 pos.y += 10 + 5;
@@ -2346,7 +2352,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             {
                 // Monthly Running Cost: {CURRENCY32}
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push(head->calculateRunningCost());
                 drawingCtx.drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::vehicle_monthly_running_cost, &args);
                 pos.y += 10;
@@ -2354,7 +2360,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             {
                 // Monthly Profit: {CURRENCY32}
-                auto args = FormatArguments();
+                FormatArguments args{};
                 auto monthlyProfit = (train.veh2->totalRecentProfit()) / 4;
                 args.push(monthlyProfit);
                 drawingCtx.drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::vehicle_monthly_profit, &args);
@@ -2363,7 +2369,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             {
                 // Sale value of vehicle: {CURRENCY32}
-                auto args = FormatArguments();
+                FormatArguments args{};
                 args.push(train.head->totalRefundCost);
                 pos.y = self.y + self.height - 14;
                 drawingCtx.drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::sale_value_of_vehicle, &args);

--- a/src/OpenLoco/src/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Windows/VehicleList.cpp
@@ -206,12 +206,14 @@ namespace OpenLoco::Ui::Windows::VehicleList
     static bool orderByName(const VehicleHead& lhs, const VehicleHead& rhs)
     {
         char lhsString[256] = { 0 };
-        auto args = FormatArguments::common(lhs.ordinalNumber);
-        StringManager::formatString(lhsString, lhs.name, &args);
+        FormatArguments lhsArgs{};
+        lhsArgs.push(lhs.ordinalNumber);
+        StringManager::formatString(lhsString, lhs.name, &lhsArgs);
 
         char rhsString[256] = { 0 };
-        args = FormatArguments::common(rhs.ordinalNumber);
-        StringManager::formatString(rhsString, rhs.name, &args);
+        FormatArguments rhsArgs{};
+        rhsArgs.push(rhs.ordinalNumber);
+        StringManager::formatString(rhsString, rhs.name, &rhsArgs);
 
         return Utility::strlogicalcmp(lhsString, rhsString) < 0;
     }
@@ -627,13 +629,13 @@ namespace OpenLoco::Ui::Windows::VehicleList
             { StringIds::num_ships_singular, StringIds::num_ships_plural },
         };
 
-        FormatArguments args = {};
-
         {
             auto& footerStringPair = typeToFooterStringIds[self.currentTab];
             StringId footerStringId = self.var_83C == 1 ? footerStringPair.first : footerStringPair.second;
 
-            args = FormatArguments::common(footerStringId, self.var_83C);
+            FormatArguments args{};
+            args.push(footerStringId);
+            args.push(self.var_83C);
             drawingCtx.drawStringLeft(*rt, self.x + 3, self.y + self.height - 13, Colour::black, StringIds::black_stringid, &args);
         }
 
@@ -645,8 +647,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
         {
             // Show current filter type
-            StringId filter = typeToFilterStringIds[self.var_88A];
-            args = FormatArguments::common(filter);
+            FormatArguments args{};
+            args.push(typeToFilterStringIds[self.var_88A]);
             auto* widget = &self.widgets[Widx::filter_type];
             drawingCtx.drawStringLeftClipped(*rt, self.x + widget->left + 1, self.y + widget->top, widget->width() - 15, Colour::black, StringIds::wcolour2_stringid, &args);
         }
@@ -654,6 +656,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         auto* widget = &self.widgets[Widx::cargo_type];
         auto xPos = self.x + widget->left + 1;
         bool filterActive = false;
+        FormatArguments args{};
 
         if (isStationFilterActive(&self, false))
         {
@@ -661,11 +664,12 @@ namespace OpenLoco::Ui::Windows::VehicleList
             if (self.var_88C != -1)
             {
                 auto station = StationManager::get(StationId(self.var_88C));
-                args = FormatArguments::common(station->name, station->town);
+                args.push(station->name);
+                args.push(station->town);
             }
             else
             {
-                args = FormatArguments::common(StringIds::no_station_selected);
+                args.push(StringIds::no_station_selected);
             }
         }
 
@@ -676,14 +680,16 @@ namespace OpenLoco::Ui::Windows::VehicleList
             {
                 // Show current cargo
                 auto cargoObj = ObjectManager::get<CargoObject>(self.var_88C);
-                args = FormatArguments::common(StringIds::carrying_cargoid_sprite, cargoObj->name, cargoObj->unitInlineSprite);
+                args.push(StringIds::carrying_cargoid_sprite);
+                args.push(cargoObj->name);
+                args.push(cargoObj->unitInlineSprite);
 
                 // NB: the -9 in the xpos is to compensate for a hack due to the cargo dropdown limitation (only three args per item)
                 xPos = self.x + widget->left - 9;
             }
             else
             {
-                args = FormatArguments::common(StringIds::no_cargo_selected);
+                args.push(StringIds::no_cargo_selected);
             }
         }
 
@@ -1092,7 +1098,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
                 stopFormat = StringIds::vehicle_list_tooltip_stops_at_stringid;
 
             // Append station name to the tooltip buffer
-            auto args = FormatArguments::common();
+            FormatArguments args{};
             stopOrder->setFormatArguments(args);
             buffer = StringManager::formatString(buffer, stopFormat, &args);
 

--- a/src/OpenLoco/src/World/CompanyManager.cpp
+++ b/src/OpenLoco/src/World/CompanyManager.cpp
@@ -635,7 +635,8 @@ namespace OpenLoco::CompanyManager
         // Prepare '{NAME} Transport' in a buffer.
         {
             char companyName[256] = { 0 };
-            auto args = FormatArguments::common(StringIds::buffer_2039);
+            FormatArguments args{};
+            args.push(StringIds::buffer_2039);
             StringManager::formatString(companyName, StringIds::company_owner_name_transport, &args);
 
             // Now, set the company name.

--- a/src/OpenLoco/src/World/Station.cpp
+++ b/src/OpenLoco/src/World/Station.cpp
@@ -1,6 +1,7 @@
 #include "Station.h"
 #include "CompanyManager.h"
 #include "IndustryManager.h"
+#include "Localisation/FormatArguments.hpp"
 #include "Localisation/Formatting.h"
 #include "Localisation/StringIds.h"
 #include "Map/BuildingElement.h"
@@ -594,12 +595,12 @@ namespace OpenLoco
             if (*buffer != '\0')
                 ptr = StringManager::formatString(ptr, StringIds::waiting_cargo_separator);
 
-            loco_global<uint32_t, 0x112C826> _commonFormatArgs;
-            *_commonFormatArgs = stationCargoStat.quantity;
+            FormatArguments args{};
+            args.push<uint32_t>(stationCargoStat.quantity);
 
             auto cargo = ObjectManager::get<CargoObject>(cargoId);
             auto unitName = stationCargoStat.quantity == 1 ? cargo->unitNameSingular : cargo->unitNamePlural;
-            ptr = StringManager::formatString(ptr, unitName, &*_commonFormatArgs);
+            ptr = StringManager::formatString(ptr, unitName, &args);
         }
 
         StringId suffix = *buffer == '\0' ? StringIds::nothing_waiting : StringIds::waiting;

--- a/src/OpenLoco/src/World/StationManager.cpp
+++ b/src/OpenLoco/src/World/StationManager.cpp
@@ -388,7 +388,8 @@ namespace OpenLoco::StationManager
 
         // Default to an ordinal string instead, e.g. 'Station 42'.
         char stationName[256] = "";
-        auto args = FormatArguments::common(stationId);
+        FormatArguments args{};
+        args.push(stationId);
         StringManager::formatString(stationName, StringIds::station_name_ordinal, &args);
         return StringManager::userStringAllocate(stationName, 0);
     }


### PR DESCRIPTION
This PR replaces the remaining direct uses of the commonFormatArgs globals with FormatArguments instances. This is just the first step towards getting rid of the global entirely.

In addition, we now consistently use `FormatArguments::common()` when the args object is not immediately consumed by a drawing call. This is the case in e.g. a `prepareDraw` event.

Conversely, 11 includes of the `FormatArguments.hpp` header are removed from files where no instance was actually present.

Exempted from the refactor is the TextInputWindow, which is copying back and forth from a backup buffer. Our FormatArguments implementation doesn't (and imo shouldn't) support this. Instead, I suggest we introduce a new window event that works on a `FormatArguments&` instance in between events, and refactor this window then as well.