### PR TITLE
Ignore music playing state when game is paused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Change: [#2473] Progress bars no longer pop up for autosaves.
 - Change: [#2509] The options window can now be opened with a keyboard shortcut (unassigned by default).
+- Fix: [#2180] In-game music does not restart when the game is resumed from pause.
 - Fix: [#2463] Allow removing protected structures (e.g. electricity pylons) when sandbox mode is enabled.
 
 24.05.1 (2024-05-09)

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -1100,7 +1100,7 @@ namespace OpenLoco::Audio
     void playBackgroundMusic()
     {
         auto& cfg = Config::get().old;
-        if (cfg.musicPlaying == 0 || isTitleMode() || isEditorMode())
+        if (cfg.musicPlaying == 0 || isTitleMode() || isEditorMode() || isPaused())
         {
             return;
         }

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -1131,7 +1131,7 @@ namespace OpenLoco::Audio
 
             // Load info on the song to play.
             const auto& mi = kMusicInfo[_currentSong];
-            cfg.musicPlaying = playMusic(mi.pathId, cfg.volume, false);
+            playMusic(mi.pathId, cfg.volume, false);
 
             WindowManager::invalidate(WindowType::options);
         }
@@ -1141,17 +1141,17 @@ namespace OpenLoco::Audio
 
     // 0x0048AC66
     // previously called void playTitleScreenMusic()
-    bool playMusic(PathId sample, int32_t volume, bool loop)
+    void playMusic(PathId sample, int32_t volume, bool loop)
     {
         auto* channel = getChannel(ChannelId::music);
         if (!_audioInitialised || _audioIsPaused || !_audioIsEnabled || channel == nullptr)
         {
-            return false;
+            return;
         }
 
         if (currentTrackPathId == sample)
         {
-            return true;
+            return;
         }
 
         currentTrackPathId = sample;
@@ -1161,10 +1161,8 @@ namespace OpenLoco::Audio
         if (channel->load(*musicSample))
         {
             channel->setVolume(volume);
-            return channel->play(loop);
+            channel->play(loop);
         }
-
-        return false;
     }
 
     // 0x0048AAD2

--- a/src/OpenLoco/src/Audio/Audio.h
+++ b/src/OpenLoco/src/Audio/Audio.h
@@ -132,7 +132,7 @@ namespace OpenLoco::Audio
     void resetMusic();
     void playBackgroundMusic();
     void stopMusic();
-    bool playMusic(Environment::PathId sample, int32_t volume, bool loop);
+    void playMusic(Environment::PathId sample, int32_t volume, bool loop);
 
     void resetSoundObjects();
 


### PR DESCRIPTION
As reported in https://github.com/OpenLoco/OpenLoco/issues/2180, the music doesn't restart when the game is resumed from pause.

This PR fixes it by preventing _Play music_ option to be unselected by `cfg.musicPlaying = playMusic(mi.pathId, cfg.volume, false);` in `playBackgroundMusic()` when game `isPaused()`.

But there is still a problem: when resuming in Locomotion the music is actually resumed, while in OpenLoco it restarts from the beginning.

Moreover I have noticed that clicking _Load Saved Game_ in main menu also stops the music.

I don't know if we should solve everything in one PR or you can review and merge this little fix only.