### PR TITLE
Fix crash when using format args in dropdowns

### DIFF
--- a/src/OpenLoco/src/Localisation/FormatArguments.hpp
+++ b/src/OpenLoco/src/Localisation/FormatArguments.hpp
@@ -71,7 +71,12 @@ namespace OpenLoco
             _buffer = _bufferStart;
         }
 
-        const void* operator&()
+        const void* operator&() const
+        {
+            return _bufferStart;
+        }
+
+        const std::byte* getBufferStart() const
         {
             return _bufferStart;
         }

--- a/src/OpenLoco/src/Ui/Dropdown.cpp
+++ b/src/OpenLoco/src/Ui/Dropdown.cpp
@@ -113,7 +113,7 @@ namespace OpenLoco::Ui::Dropdown
 
         int32_t copyLength = std::min(fArgs.getLength(), sizeof(_dropdownItemArgs[index]));
 
-        memcpy(args, &fArgs, copyLength);
+        memcpy(args, fArgs.getBufferStart(), copyLength);
         copyLength = std::min(fArgs.getLength() - sizeof(_dropdownItemArgs[index]), sizeof(_dropdownItemArgs2[index]));
         if (copyLength > 0)
         {

--- a/src/OpenLoco/src/Vehicles/OrderManager.cpp
+++ b/src/OpenLoco/src/Vehicles/OrderManager.cpp
@@ -141,6 +141,7 @@ namespace OpenLoco::Vehicles::OrderManager
     // 0x004704AB
     void insertOrder(VehicleHead* head, uint16_t orderOffset, const Order* order)
     {
+        assert(order->getType() != OrderType::End && orderOffset < head->sizeOfOrderTable);
         auto insOrderLength = kOrderSizes[enumValue(order->getType())];
 
         // Shift current order to compensate for the new order.
@@ -169,6 +170,7 @@ namespace OpenLoco::Vehicles::OrderManager
     // 0x004705C0
     void deleteOrder(VehicleHead* head, uint16_t orderOffset)
     {
+        assert(orderOffset < head->sizeOfOrderTable);
         // Find out what type the selected order is
         OrderRingView orders(head->orderTableOffset, orderOffset);
         auto& selectedOrder = *(orders.begin());

--- a/src/OpenLoco/src/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Windows/BuildVehicle.cpp
@@ -1021,7 +1021,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         Audio::playSound(Audio::SoundId::clickDown, pan);
         auto item = window.rowInfo[scrollItem];
         auto vehicleObj = ObjectManager::get<VehicleObject>(item);
-        FormatArguments args{};
+        auto args = FormatArguments::common();
         // Skip 5 * 2 bytes
         args.skip(10);
         args.push(vehicleObj->name);


### PR DESCRIPTION
We really need to get rid of all of the void* string functions they might be hiding more instances of this going wrong. We should also avoid using the operator& on format arguments as it converts it to a void* which means it will be used with functions taking a void* which means the function might accidentally be passed a FormatArguments*