### PR TITLE
Move tile squareSearch algorithm into its own header

### DIFF
--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -507,6 +507,7 @@ set(OLOCO_HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/TileElementBase.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/TileLoop.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/TileManager.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/TileSquareSearch.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/Track/SubpositionData.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/Track/Track.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/Track/TrackData.h"

--- a/src/OpenLoco/src/Map/TileSquareSearch.hpp
+++ b/src/OpenLoco/src/Map/TileSquareSearch.hpp
@@ -1,0 +1,68 @@
+#include <OpenLoco/Engine/World.hpp>
+#include <cassert>
+
+namespace OpenLoco::World
+{
+    template<size_t searchSize>
+    constexpr auto kSquareSearchRange = []() {
+        /* Searches in a square of increasing size
+         * X, Y, Z, J, K
+         *
+         *     -4-3-2-1 0 1 2 3 4 5
+         *     ____________________
+         *  4 | K K K K K K K K K K
+         *  3 | K J J J J J J J J K
+         *  2 | K J Z Z Z Z Z Z J K
+         *  1 | K J Z Y Y Y Y Z J K
+         *  0 | K J Z Y X X Y Z J K
+         * -1 | K J Z Y X X Y Z J K
+         * -2 | K J Z Y Y Y Y Z J K
+         * -3 | K J Z Z Z Z Z Z J K
+         * -4 | K J J J J J J J J K
+         * -5 | K K K K K K K K K K
+         */
+        static_assert((searchSize % 2) == 1, "Must not be an even value");
+        std::array<World::TilePos2, (searchSize + 1) * (searchSize + 1)> range{};
+        // 0x00503C6C
+        std::array<World::TilePos2, 4> kDirections = {
+            World::TilePos2{ -1, 0 },
+            World::TilePos2{ 0, 1 },
+            World::TilePos2{ 1, 0 },
+            World::TilePos2{ 0, -1 },
+        };
+
+        World::TilePos2 pos{ 0, 0 };
+        uint8_t k = 0;
+        for (uint8_t i = 1; i <= searchSize; i += 2)
+        {
+            for (uint8_t direction = 0; direction < 4; ++direction)
+            {
+                for (auto j = i; j != 0; --j)
+                {
+                    range[k++] = pos;
+                    pos += kDirections[direction];
+                }
+            }
+            pos += World::TilePos2{ 1, -1 };
+        }
+        return range;
+    }();
+
+    // 0x00463BD2
+    template<typename Func>
+    static void squareSearch(const World::Pos2& centre, [[maybe_unused]] uint8_t searchSize, Func&& predicate)
+    {
+        assert(searchSize == 9);
+        for (auto& offset : kSquareSearchRange<9>)
+        {
+            const World::Pos2 pos = World::toWorldSpace(offset) + centre;
+            if (World::validCoords(pos))
+            {
+                if (!predicate(pos))
+                {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/OpenLoco/src/Map/TileSquareSearch.hpp
+++ b/src/OpenLoco/src/Map/TileSquareSearch.hpp
@@ -1,4 +1,5 @@
 #include <OpenLoco/Engine/World.hpp>
+#include <array>
 #include <cassert>
 
 namespace OpenLoco::World

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -6,6 +6,7 @@
 #include "Map/RoadElement.h"
 #include "Map/SurfaceElement.h"
 #include "Map/TileManager.h"
+#include "Map/TileSquareSearch.hpp"
 #include "Map/Track/TrackData.h"
 #include "Objects/ObjectManager.h"
 #include "Objects/RoadObject.h"
@@ -213,69 +214,6 @@ namespace OpenLoco
         return StringIds::town_size_hamlet;
     }
 
-    template<size_t searchSize>
-    constexpr auto kSquareSearchRange = []() {
-        /* Searches in a square of increasing size
-         * X, Y, Z, J, K
-         *
-         *     -4-3-2-1 0 1 2 3 4 5
-         *     ____________________
-         *  4 | K K K K K K K K K K
-         *  3 | K J J J J J J J J K
-         *  2 | K J Z Z Z Z Z Z J K
-         *  1 | K J Z Y Y Y Y Z J K
-         *  0 | K J Z Y X X Y Z J K
-         * -1 | K J Z Y X X Y Z J K
-         * -2 | K J Z Y Y Y Y Z J K
-         * -3 | K J Z Z Z Z Z Z J K
-         * -4 | K J J J J J J J J K
-         * -5 | K K K K K K K K K K
-         */
-        static_assert((searchSize % 2) == 1, "Must not be an even value");
-        std::array<World::TilePos2, (searchSize + 1) * (searchSize + 1)> range{};
-        // 0x00503C6C
-        std::array<World::TilePos2, 4> kDirections = {
-            World::TilePos2{ -1, 0 },
-            World::TilePos2{ 0, 1 },
-            World::TilePos2{ 1, 0 },
-            World::TilePos2{ 0, -1 },
-        };
-
-        World::TilePos2 pos{ 0, 0 };
-        uint8_t k = 0;
-        for (uint8_t i = 1; i <= searchSize; i += 2)
-        {
-            for (uint8_t direction = 0; direction < 4; ++direction)
-            {
-                for (auto j = i; j != 0; --j)
-                {
-                    range[k++] = pos;
-                    pos += kDirections[direction];
-                }
-            }
-            pos += World::TilePos2{ 1, -1 };
-        }
-        return range;
-    }();
-
-    // 0x00463BD2
-    template<typename Func>
-    static void squareSearch(const World::Pos2& centre, [[maybe_unused]] uint8_t searchSize, Func&& predicate)
-    {
-        assert(searchSize == 9);
-        for (auto& offset : kSquareSearchRange<9>)
-        {
-            const World::Pos2 pos = World::toWorldSpace(offset) + centre;
-            if (World::validCoords(pos))
-            {
-                if (!predicate(pos))
-                {
-                    return;
-                }
-            }
-        }
-    }
-
     // 0x00497FFC
     std::optional<RoadExtentResult> Town::findRoadExtent() const
     {
@@ -336,7 +274,7 @@ namespace OpenLoco
             }
             return true;
         };
-        squareSearch({ x, y }, 9, validRoad);
+        World::squareSearch({ x, y }, 9, validRoad);
 
         if (!res.has_value())
         {
@@ -445,6 +383,6 @@ namespace OpenLoco
             args.roadObjectId = roadObjId.value();
             return GameCommands::doCommand(args, GameCommands::Flags::apply) == GameCommands::FAILURE;
         };
-        squareSearch({ x, y }, 9, placeRoadAtTile);
+        World::squareSearch({ x, y }, 9, placeRoadAtTile);
     }
 }


### PR DESCRIPTION
This moves the tile squareSearch algorithm into its own header. Currently only used in `Town.cpp`. However, I intend to use the algorithm for `MapGenerator::generateMiscBuildingType1` in #2344.

References to `0x503C6C` also occur in `CompanyAi.cpp` and `VehicleHead.cpp`, so they should probably be refactored to use `squareSearch`, or its `kDirection` at least.