### PR TITLE
Add protection to order game commands

### DIFF
--- a/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
@@ -50,8 +50,7 @@ namespace OpenLoco::GameCommands
     static loco_global<int16_t, 0x01136250> _backupX;
     static loco_global<int16_t, 0x01136254> _backupY;
     static loco_global<uint8_t, 0x01136258> _backupZ;
-    static loco_global<EntityId, 0x0113642A> _113642A;                   // used by build window and others
-    static loco_global<uint8_t[Limits::kMaxOrders], 0x00987C5C> _987C5C; // ?orders? ?routing related?
+    static loco_global<EntityId, 0x0113642A> _113642A; // used by build window and others
 
     // 0x004B1D96
     static bool aiIsBelowVehicleLimit()
@@ -392,15 +391,6 @@ namespace OpenLoco::GameCommands
         return true;
     }
 
-    static void sub_470312(VehicleHead* const newHead)
-    {
-        _987C5C[OrderManager::orderTableLength()] = 0;
-        newHead->orderTableOffset = OrderManager::orderTableLength();
-        OrderManager::orderTableLength()++;
-        newHead->currentOrder = 0;
-        newHead->sizeOfOrderTable = 1;
-    }
-
     // 0x004B64F9
     static uint16_t createUniqueTypeNumber(const VehicleType type)
     {
@@ -461,7 +451,7 @@ namespace OpenLoco::GameCommands
         newHead->totalRefundCost = 0;
         newHead->lastAverageSpeed = 0_mph;
         newHead->var_79 = 0;
-        sub_470312(newHead);
+        OrderManager::allocateOrders(*newHead);
         return newHead;
     }
 

--- a/src/OpenLoco/src/GameCommands/Vehicles/VehicleOrderDelete.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/VehicleOrderDelete.cpp
@@ -26,6 +26,10 @@ namespace OpenLoco::GameCommands
             return 0;
         }
 
+        if (args.orderOffset > head->sizeOfOrderTable)
+        {
+            return FAILURE;
+        }
         Ui::WindowManager::sub_4B93A5(enumValue(head->id));
 
         Vehicles::OrderManager::deleteOrder(head, args.orderOffset);

--- a/src/OpenLoco/src/GameCommands/Vehicles/VehicleOrderDown.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/VehicleOrderDown.cpp
@@ -25,6 +25,11 @@ namespace OpenLoco::GameCommands
             return 0;
         }
 
+        if (args.orderOffset > head->sizeOfOrderTable)
+        {
+            return FAILURE;
+        }
+
         Ui::WindowManager::sub_4B93A5(enumValue(head->id));
 
         // Figure out which orders to swap

--- a/src/OpenLoco/src/GameCommands/Vehicles/VehicleOrderInsert.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/VehicleOrderInsert.cpp
@@ -71,6 +71,11 @@ namespace OpenLoco::GameCommands
             return FAILURE;
         }
 
+        if (args.orderOffset > head->sizeOfOrderTable)
+        {
+            return FAILURE;
+        }
+
         if (!(flags & GameCommands::Flags::apply))
         {
             return 0;

--- a/src/OpenLoco/src/GameCommands/Vehicles/VehicleOrderUp.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/VehicleOrderUp.cpp
@@ -25,6 +25,10 @@ namespace OpenLoco::GameCommands
             return 0;
         }
 
+        if (args.orderOffset > head->sizeOfOrderTable)
+        {
+            return FAILURE;
+        }
         Ui::WindowManager::sub_4B93A5(enumValue(head->id));
 
         // Can't move up if the order is already at the start of the table

--- a/src/OpenLoco/src/Vehicles/OrderManager.cpp
+++ b/src/OpenLoco/src/Vehicles/OrderManager.cpp
@@ -230,6 +230,25 @@ namespace OpenLoco::Vehicles::OrderManager
         orderTableLength() -= head->sizeOfOrderTable;
     }
 
+    // 0x00470312
+    void allocateOrders(VehicleHead& head)
+    {
+        OrderEnd end{};
+        constexpr auto insOrderLength = kOrderSizes[enumValue(OrderEnd::kType)];
+
+        head.orderTableOffset = orderTableLength();
+        // Bookkeeping: change order table size
+        orderTableLength() += insOrderLength;
+
+        head.currentOrder = 0;
+        head.sizeOfOrderTable = insOrderLength;
+
+        // Calculate destination offset and copy data
+        auto rawOrder = end.getRaw();
+        auto dest = reinterpret_cast<uint8_t*>(orders() + head.orderTableOffset);
+        std::memcpy(dest, &rawOrder, insOrderLength);
+    }
+
     // 0x00470B76
     std::pair<World::Pos3, std::string> generateOrderUiStringAndLoc(uint32_t orderOffset, uint8_t orderNum)
     {

--- a/src/OpenLoco/src/Vehicles/OrderManager.h
+++ b/src/OpenLoco/src/Vehicles/OrderManager.h
@@ -130,6 +130,7 @@ namespace OpenLoco::Vehicles::OrderManager
     void zeroUnusedOrderTable();
     void reset();
     void freeOrders(VehicleHead* const head);
+    void allocateOrders(VehicleHead& head);
 
     std::pair<World::Pos3, std::string> generateOrderUiStringAndLoc(uint32_t orderOffset, uint8_t orderNum);
     void generateNumDisplayFrames(Vehicles::VehicleHead* head);

--- a/src/OpenLoco/src/Vehicles/Orders.h
+++ b/src/OpenLoco/src/Vehicles/Orders.h
@@ -60,6 +60,10 @@ namespace OpenLoco::Vehicles
     struct OrderEnd : Order
     {
         static constexpr OrderType kType = OrderType::End;
+        OrderEnd()
+        {
+            setType(kType);
+        }
     };
 
     struct OrderStation : Order


### PR DESCRIPTION
This stops https://github.com/OpenLoco/OpenLoco/issues/2336 from crashing but it doesn't fix the source of the ai issuing bad game commands. I'm still unsure if that is a vanilla issue or an OpenLoco one. Eithere way the ai is not currently validating game command results so sending bad game commands could be caused by many things.