### PR TITLE
Use of Ui::Point uniformly in drawString signatures

### DIFF
--- a/src/OpenLoco/src/Drawing/DrawingContext.h
+++ b/src/OpenLoco/src/Drawing/DrawingContext.h
@@ -47,14 +47,16 @@ namespace OpenLoco::Drawing
             Gfx::RenderTarget& rt,
             Ui::Point& origin,
             AdvancedColour colour,
-            const char* str) = 0;
+            const char* str)
+            = 0;
 
         virtual void drawStringLeft(
             Gfx::RenderTarget& rt,
             Ui::Point& origin,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) = 0;
+            const void* args = nullptr)
+            = 0;
 
         virtual void drawStringLeftClipped(
             Gfx::RenderTarget& rt,
@@ -62,14 +64,16 @@ namespace OpenLoco::Drawing
             int16_t width,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) = 0;
+            const void* args = nullptr)
+            = 0;
 
         virtual void drawStringLeftUnderline(
             Gfx::RenderTarget& rt,
             Ui::Point& origin,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) = 0;
+            const void* args = nullptr)
+            = 0;
 
         virtual int16_t drawStringLeftWrapped(
             Gfx::RenderTarget& rt,
@@ -77,14 +81,16 @@ namespace OpenLoco::Drawing
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) = 0;
+            const void* args = nullptr)
+            = 0;
 
         virtual void drawStringCentred(
             Gfx::RenderTarget& rt,
             Ui::Point& origin,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) = 0;
+            const void* args = nullptr)
+            = 0;
 
         virtual void drawStringCentredClipped(
             Gfx::RenderTarget& rt,
@@ -92,14 +98,16 @@ namespace OpenLoco::Drawing
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) = 0;
+            const void* args = nullptr)
+            = 0;
 
         virtual void drawStringCentredRaw(
             Gfx::RenderTarget& rt,
             Ui::Point& origin,
             int16_t linebreakCount,
             AdvancedColour colour,
-            const char* wrappedStr) = 0;
+            const char* wrappedStr)
+            = 0;
 
         virtual uint16_t drawStringCentredWrapped(
             Gfx::RenderTarget& rt,
@@ -107,21 +115,24 @@ namespace OpenLoco::Drawing
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) = 0;
+            const void* args = nullptr)
+            = 0;
 
         virtual void drawStringRight(
             Gfx::RenderTarget& rt,
             Ui::Point& origin,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) = 0;
+            const void* args = nullptr)
+            = 0;
 
         virtual void drawStringRightUnderline(
             Gfx::RenderTarget& rt,
             Ui::Point& origin,
             AdvancedColour colour,
             StringId stringId,
-            const void* args) = 0;
+            const void* args)
+            = 0;
 
         virtual void drawStringYOffsets(Gfx::RenderTarget& rt, const Ui::Point& loc, AdvancedColour colour, const void* args, const int8_t* yOffsets) = 0;
 

--- a/src/OpenLoco/src/Drawing/DrawingContext.h
+++ b/src/OpenLoco/src/Drawing/DrawingContext.h
@@ -43,90 +43,63 @@ namespace OpenLoco::Drawing
         virtual uint16_t getStringWidth(const char* buffer) = 0;
         virtual uint16_t getMaxStringWidth(const char* buffer) = 0;
 
-        virtual Ui::Point drawString(Gfx::RenderTarget& rt, int16_t x, int16_t y, AdvancedColour colour, const char* str) = 0;
-
-        virtual int16_t drawStringLeftWrapped(
+        virtual Ui::Point drawString(
             Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
-            int16_t width,
+            Ui::Point& origin,
             AdvancedColour colour,
-            StringId stringId,
-            const void* args = nullptr)
-            = 0;
+            const char* str) = 0;
 
         virtual void drawStringLeft(
             Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
+            Ui::Point& origin,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr)
-            = 0;
-
-        virtual void drawStringLeft(
-            Gfx::RenderTarget& rt,
-            Ui::Point* origin,
-            AdvancedColour colour,
-            StringId stringId,
-            const void* args = nullptr)
-            = 0;
+            const void* args = nullptr) = 0;
 
         virtual void drawStringLeftClipped(
             Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
+            Ui::Point& origin,
             int16_t width,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr)
-            = 0;
-
-        virtual void drawStringRight(
-            Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
-            AdvancedColour colour,
-            StringId stringId,
-            const void* args = nullptr)
-            = 0;
-
-        virtual void drawStringRightUnderline(
-            Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
-            AdvancedColour colour,
-            StringId stringId,
-            const void* args)
-            = 0;
+            const void* args = nullptr) = 0;
 
         virtual void drawStringLeftUnderline(
             Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
+            Ui::Point& origin,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr)
-            = 0;
+            const void* args = nullptr) = 0;
+
+        virtual int16_t drawStringLeftWrapped(
+            Gfx::RenderTarget& rt,
+            Ui::Point& origin,
+            uint16_t width,
+            AdvancedColour colour,
+            StringId stringId,
+            const void* args = nullptr) = 0;
 
         virtual void drawStringCentred(
             Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
+            Ui::Point& origin,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr)
-            = 0;
+            const void* args = nullptr) = 0;
 
         virtual void drawStringCentredClipped(
             Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
-            int16_t width,
+            Ui::Point& origin,
+            uint16_t width,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr)
-            = 0;
+            const void* args = nullptr) = 0;
+
+        virtual void drawStringCentredRaw(
+            Gfx::RenderTarget& rt,
+            Ui::Point& origin,
+            int16_t linebreakCount,
+            AdvancedColour colour,
+            const char* wrappedStr) = 0;
 
         virtual uint16_t drawStringCentredWrapped(
             Gfx::RenderTarget& rt,
@@ -134,17 +107,21 @@ namespace OpenLoco::Drawing
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr)
-            = 0;
+            const void* args = nullptr) = 0;
 
-        virtual void drawStringCentredRaw(
+        virtual void drawStringRight(
             Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
-            int16_t linebreakCount,
+            Ui::Point& origin,
             AdvancedColour colour,
-            const char* wrappedStr)
-            = 0;
+            StringId stringId,
+            const void* args = nullptr) = 0;
+
+        virtual void drawStringRightUnderline(
+            Gfx::RenderTarget& rt,
+            Ui::Point& origin,
+            AdvancedColour colour,
+            StringId stringId,
+            const void* args) = 0;
 
         virtual void drawStringYOffsets(Gfx::RenderTarget& rt, const Ui::Point& loc, AdvancedColour colour, const void* args, const int8_t* yOffsets) = 0;
 

--- a/src/OpenLoco/src/Drawing/DrawingContext.h
+++ b/src/OpenLoco/src/Drawing/DrawingContext.h
@@ -43,7 +43,7 @@ namespace OpenLoco::Drawing
         virtual uint16_t getStringWidth(const char* buffer) = 0;
         virtual uint16_t getMaxStringWidth(const char* buffer) = 0;
 
-        virtual Ui::Point drawString(
+        virtual void drawString(
             Gfx::RenderTarget& rt,
             Ui::Point origin,
             AdvancedColour colour,

--- a/src/OpenLoco/src/Drawing/DrawingContext.h
+++ b/src/OpenLoco/src/Drawing/DrawingContext.h
@@ -61,7 +61,7 @@ namespace OpenLoco::Drawing
         virtual void drawStringLeftClipped(
             Gfx::RenderTarget& rt,
             Ui::Point& origin,
-            int16_t width,
+            uint16_t width,
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr)
@@ -104,7 +104,7 @@ namespace OpenLoco::Drawing
         virtual void drawStringCentredRaw(
             Gfx::RenderTarget& rt,
             Ui::Point& origin,
-            int16_t linebreakCount,
+            uint16_t linebreakCount,
             AdvancedColour colour,
             const char* wrappedStr)
             = 0;
@@ -136,7 +136,7 @@ namespace OpenLoco::Drawing
 
         virtual void drawStringYOffsets(Gfx::RenderTarget& rt, const Ui::Point& loc, AdvancedColour colour, const void* args, const int8_t* yOffsets) = 0;
 
-        virtual void drawStringTicker(Gfx::RenderTarget& rt, const Ui::Point& origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width) = 0;
+        virtual void drawStringTicker(Gfx::RenderTarget& rt, Ui::Point& origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width) = 0;
 
         virtual uint16_t getStringWidthNewLined(const char* buffer) = 0;
 

--- a/src/OpenLoco/src/Drawing/DrawingContext.h
+++ b/src/OpenLoco/src/Drawing/DrawingContext.h
@@ -45,14 +45,14 @@ namespace OpenLoco::Drawing
 
         virtual Ui::Point drawString(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             AdvancedColour colour,
             const char* str)
             = 0;
 
         virtual void drawStringLeft(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr)
@@ -60,7 +60,7 @@ namespace OpenLoco::Drawing
 
         virtual void drawStringLeftClipped(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
@@ -69,7 +69,7 @@ namespace OpenLoco::Drawing
 
         virtual void drawStringLeftUnderline(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr)
@@ -77,7 +77,7 @@ namespace OpenLoco::Drawing
 
         virtual int16_t drawStringLeftWrapped(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
@@ -86,7 +86,7 @@ namespace OpenLoco::Drawing
 
         virtual void drawStringCentred(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr)
@@ -94,7 +94,7 @@ namespace OpenLoco::Drawing
 
         virtual void drawStringCentredClipped(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
@@ -103,7 +103,7 @@ namespace OpenLoco::Drawing
 
         virtual void drawStringCentredRaw(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             uint16_t linebreakCount,
             AdvancedColour colour,
             const char* wrappedStr)
@@ -111,7 +111,7 @@ namespace OpenLoco::Drawing
 
         virtual uint16_t drawStringCentredWrapped(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
@@ -120,7 +120,7 @@ namespace OpenLoco::Drawing
 
         virtual void drawStringRight(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr)
@@ -128,15 +128,15 @@ namespace OpenLoco::Drawing
 
         virtual void drawStringRightUnderline(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args)
             = 0;
 
-        virtual void drawStringYOffsets(Gfx::RenderTarget& rt, const Ui::Point& loc, AdvancedColour colour, const void* args, const int8_t* yOffsets) = 0;
+        virtual void drawStringYOffsets(Gfx::RenderTarget& rt, Ui::Point loc, AdvancedColour colour, const void* args, const int8_t* yOffsets) = 0;
 
-        virtual void drawStringTicker(Gfx::RenderTarget& rt, Ui::Point& origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width) = 0;
+        virtual void drawStringTicker(Gfx::RenderTarget& rt, Ui::Point origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width) = 0;
 
         virtual uint16_t getStringWidthNewLined(const char* buffer) = 0;
 

--- a/src/OpenLoco/src/Drawing/FPSCounter.cpp
+++ b/src/OpenLoco/src/Drawing/FPSCounter.cpp
@@ -54,11 +54,10 @@ namespace OpenLoco::Drawing
 
         // Draw text
         const int stringWidth = drawingCtx.getStringWidth(buffer);
-        const auto x = Ui::width() / 2 - (stringWidth / 2);
-        const auto y = 2;
-        drawingCtx.drawString(rt, x, y, Colour::black, buffer);
+        auto point = Ui::Point(Ui::width() / 2 - (stringWidth / 2), 2);
+        drawingCtx.drawString(rt, point, Colour::black, buffer);
 
         // Make area dirty so the text doesn't get drawn over the last
-        Gfx::invalidateRegion(x - 16, y - 4, x + 16, 16);
+        Gfx::invalidateRegion(point.x - 16, point.y - 4, point.x + 16, 16);
     }
 }

--- a/src/OpenLoco/src/Drawing/SoftwareDrawingContext.cpp
+++ b/src/OpenLoco/src/Drawing/SoftwareDrawingContext.cpp
@@ -1262,9 +1262,9 @@ namespace OpenLoco::Drawing
             drawString(rt, point, colour, buffer);
 
             // Draw underline
-            drawRect(rt, origin.x - width, origin.y + 11, width, 1, _textColours[1], RectFlags::none);
+            drawRect(rt, point.x, point.y + 11, width, 1, _textColours[1], RectFlags::none);
             if (_textColours[2] != 0)
-                drawRect(rt, origin.x - width, origin.y + 12, width, 1, _textColours[2], RectFlags::none);
+                drawRect(rt, point.x, point.y + 12, width, 1, _textColours[2], RectFlags::none);
         }
 
         // 0x00494D78

--- a/src/OpenLoco/src/Drawing/SoftwareDrawingContext.cpp
+++ b/src/OpenLoco/src/Drawing/SoftwareDrawingContext.cpp
@@ -984,35 +984,38 @@ namespace OpenLoco::Drawing
          * @param rt @<edi>
          * @param text @<esi>
          */
-        static Ui::Point drawString(RenderTarget& rt, Ui::Point origin, AdvancedColour colour, const char* str)
+        static void drawString(RenderTarget& rt, Ui::Point origin, AdvancedColour colour, const char* str)
         {
             if (colour.isFE())
             {
-                return loopNewline(&rt, origin, str);
+                loopNewline(&rt, origin, str);
+                return;
             }
 
             if (colour.isFD())
             {
                 _currentFontFlags = TextDrawFlags::none;
                 setTextColour(0);
-                return loopNewline(&rt, origin, str);
+                loopNewline(&rt, origin, str);
+                return;
             }
 
             if (origin.x >= rt.x + rt.width)
-                return origin;
+                return;
 
             if (origin.x < rt.x - 1280)
-                return origin;
+                return;
 
             if (origin.y >= rt.y + rt.height)
-                return origin;
+                return;
 
             if (origin.y < rt.y - 90)
-                return origin;
+                return;
 
             if (colour.isFF())
             {
-                return loopNewline(&rt, origin, str);
+                loopNewline(&rt, origin, str);
+                return;
             }
 
             _currentFontFlags = TextDrawFlags::none;
@@ -1071,7 +1074,7 @@ namespace OpenLoco::Drawing
                 setTextColours(Colours::getShade(colour.c(), 9), PaletteIndex::index_0A, PaletteIndex::index_0A);
             }
 
-            return loopNewline(&rt, origin, str);
+            loopNewline(&rt, origin, str);
         }
 
         // Use only with buffer mangled by wrapString
@@ -1180,7 +1183,7 @@ namespace OpenLoco::Drawing
             StringManager::formatString(buffer, std::size(buffer), stringId, args);
 
             _currentFontSpriteBase = Font::medium_bold;
-            origin = drawString(rt, origin, colour, buffer);
+            drawString(rt, origin, colour, buffer);
         }
 
         // 0x00494BBF
@@ -2386,7 +2389,7 @@ namespace OpenLoco::Drawing
         return Impl::getMaxStringWidth(buffer);
     }
 
-    Ui::Point SoftwareDrawingContext::drawString(Gfx::RenderTarget& rt, Ui::Point origin, AdvancedColour colour, const char* str)
+    void SoftwareDrawingContext::drawString(Gfx::RenderTarget& rt, Ui::Point origin, AdvancedColour colour, const char* str)
     {
         return Impl::drawString(rt, origin, colour, str);
     }

--- a/src/OpenLoco/src/Drawing/SoftwareDrawingContext.cpp
+++ b/src/OpenLoco/src/Drawing/SoftwareDrawingContext.cpp
@@ -1127,7 +1127,7 @@ namespace OpenLoco::Drawing
         // dx: y
         // esi: args
         // edi: rt
-        static int32_t drawStringLeftWrapped(
+        static int16_t drawStringLeftWrapped(
             RenderTarget& rt,
             Point origin,
             int16_t width,
@@ -1390,10 +1390,11 @@ namespace OpenLoco::Drawing
             basePoint.y -= (lineHeight / 2) * (breakCount - 1);
 
             const char* ptr = buffer;
+            uint16_t lineWidth{};
 
             for (auto i = 0; ptr != nullptr && i < breakCount; i++)
             {
-                uint16_t lineWidth = getStringWidth(ptr);
+                lineWidth = getStringWidth(ptr);
 
                 auto point = basePoint;
                 point.x -= lineWidth / 2;
@@ -1404,7 +1405,7 @@ namespace OpenLoco::Drawing
                 basePoint.y += lineHeight;
             }
 
-            return basePoint.y;
+            return lineWidth;
         }
 
         // 0x00494E33

--- a/src/OpenLoco/src/Drawing/SoftwareDrawingContext.cpp
+++ b/src/OpenLoco/src/Drawing/SoftwareDrawingContext.cpp
@@ -984,7 +984,7 @@ namespace OpenLoco::Drawing
          * @param rt @<edi>
          * @param text @<esi>
          */
-        static Ui::Point drawString(RenderTarget& rt, Ui::Point& origin, AdvancedColour colour, const char* str)
+        static Ui::Point drawString(RenderTarget& rt, Ui::Point origin, AdvancedColour colour, const char* str)
         {
             if (colour.isFE())
             {
@@ -1126,7 +1126,7 @@ namespace OpenLoco::Drawing
         // edi: rt
         static int32_t drawStringLeftWrapped(
             RenderTarget& rt,
-            Point& origin,
+            Point origin,
             int16_t width,
             AdvancedColour colour,
             StringId stringId,
@@ -1171,7 +1171,7 @@ namespace OpenLoco::Drawing
          */
         static void drawStringLeft(
             RenderTarget& rt,
-            Point& origin,
+            Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args)
@@ -1193,7 +1193,7 @@ namespace OpenLoco::Drawing
         // bp: width
         static void drawStringLeftClipped(
             RenderTarget& rt,
-            Point& origin,
+            Point origin,
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
@@ -1217,7 +1217,7 @@ namespace OpenLoco::Drawing
         // edi: rt
         static void drawStringRight(
             RenderTarget& rt,
-            Point& origin,
+            Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args)
@@ -1243,7 +1243,7 @@ namespace OpenLoco::Drawing
         // edi: rt
         static void drawStringRightUnderline(
             RenderTarget& rt,
-            Point& origin,
+            Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args)
@@ -1273,7 +1273,7 @@ namespace OpenLoco::Drawing
         // edi: rt
         static void drawStringLeftUnderline(
             RenderTarget& rt,
-            Point& origin,
+            Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args)
@@ -1301,7 +1301,7 @@ namespace OpenLoco::Drawing
         // edi: rt
         static void drawStringCentred(
             RenderTarget& rt,
-            Point& origin,
+            Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args)
@@ -1331,7 +1331,7 @@ namespace OpenLoco::Drawing
         // edi: rt
         static void drawStringCentredClipped(
             RenderTarget& rt,
-            Point& origin,
+            Point origin,
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
@@ -1360,7 +1360,7 @@ namespace OpenLoco::Drawing
          */
         static uint16_t drawStringCentredWrapped(
             RenderTarget& rt,
-            Point& origin,
+            Point origin,
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
@@ -1414,7 +1414,7 @@ namespace OpenLoco::Drawing
         // edi: rt
         static void drawStringCentredRaw(
             RenderTarget& rt,
-            Point& origin,
+            Point origin,
             uint16_t linebreakCount,
             AdvancedColour colour,
             const char* wrappedStr)
@@ -1692,7 +1692,7 @@ namespace OpenLoco::Drawing
         }
 
         // 0x004950EF
-        static void drawStringTicker(Gfx::RenderTarget& rt, Ui::Point& origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width)
+        static void drawStringTicker(Gfx::RenderTarget& rt, Ui::Point origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width)
         {
             _currentFontSpriteBase = Font::medium_bold;
             // Setup the text colours (FIXME: This should be a separate function)
@@ -2386,67 +2386,67 @@ namespace OpenLoco::Drawing
         return Impl::getMaxStringWidth(buffer);
     }
 
-    Ui::Point SoftwareDrawingContext::drawString(Gfx::RenderTarget& rt, Ui::Point& origin, AdvancedColour colour, const char* str)
+    Ui::Point SoftwareDrawingContext::drawString(Gfx::RenderTarget& rt, Ui::Point origin, AdvancedColour colour, const char* str)
     {
         return Impl::drawString(rt, origin, colour, str);
     }
 
-    void SoftwareDrawingContext::drawStringLeft(Gfx::RenderTarget& rt, Ui::Point& origin, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
+    void SoftwareDrawingContext::drawStringLeft(Gfx::RenderTarget& rt, Ui::Point origin, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
     {
         return Impl::drawStringLeft(rt, origin, colour, stringId, args);
     }
 
-    void SoftwareDrawingContext::drawStringLeftClipped(Gfx::RenderTarget& rt, Ui::Point& origin, uint16_t width, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
+    void SoftwareDrawingContext::drawStringLeftClipped(Gfx::RenderTarget& rt, Ui::Point origin, uint16_t width, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
     {
         return Impl::drawStringLeftClipped(rt, origin, width, colour, stringId, args);
     }
 
-    void SoftwareDrawingContext::drawStringLeftUnderline(Gfx::RenderTarget& rt, Ui::Point& origin, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
+    void SoftwareDrawingContext::drawStringLeftUnderline(Gfx::RenderTarget& rt, Ui::Point origin, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
     {
         return Impl::drawStringLeftUnderline(rt, origin, colour, stringId, args);
     }
 
-    int16_t SoftwareDrawingContext::drawStringLeftWrapped(Gfx::RenderTarget& rt, Ui::Point& origin, uint16_t width, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
+    int16_t SoftwareDrawingContext::drawStringLeftWrapped(Gfx::RenderTarget& rt, Ui::Point origin, uint16_t width, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
     {
         return Impl::drawStringLeftWrapped(rt, origin, width, colour, stringId, args);
     }
 
-    void SoftwareDrawingContext::drawStringCentred(Gfx::RenderTarget& rt, Ui::Point& origin, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
+    void SoftwareDrawingContext::drawStringCentred(Gfx::RenderTarget& rt, Ui::Point origin, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
     {
         return Impl::drawStringCentred(rt, origin, colour, stringId, args);
     }
 
-    void SoftwareDrawingContext::drawStringCentredClipped(Gfx::RenderTarget& rt, Ui::Point& origin, uint16_t width, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
+    void SoftwareDrawingContext::drawStringCentredClipped(Gfx::RenderTarget& rt, Ui::Point origin, uint16_t width, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
     {
         return Impl::drawStringCentredClipped(rt, origin, width, colour, stringId, args);
     }
 
-    void SoftwareDrawingContext::drawStringCentredRaw(Gfx::RenderTarget& rt, Ui::Point& origin, uint16_t linebreakCount, AdvancedColour colour, const char* wrappedStr)
+    void SoftwareDrawingContext::drawStringCentredRaw(Gfx::RenderTarget& rt, Ui::Point origin, uint16_t linebreakCount, AdvancedColour colour, const char* wrappedStr)
     {
         return Impl::drawStringCentredRaw(rt, origin, linebreakCount, colour, wrappedStr);
     }
 
-    uint16_t SoftwareDrawingContext::drawStringCentredWrapped(Gfx::RenderTarget& rt, Ui::Point& origin, uint16_t width, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
+    uint16_t SoftwareDrawingContext::drawStringCentredWrapped(Gfx::RenderTarget& rt, Ui::Point origin, uint16_t width, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
     {
         return Impl::drawStringCentredWrapped(rt, origin, width, colour, stringId, args);
     }
 
-    void SoftwareDrawingContext::drawStringRight(Gfx::RenderTarget& rt, Ui::Point& origin, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
+    void SoftwareDrawingContext::drawStringRight(Gfx::RenderTarget& rt, Ui::Point origin, AdvancedColour colour, StringId stringId, const void* args /*= nullptr*/)
     {
         return Impl::drawStringRight(rt, origin, colour, stringId, args);
     }
 
-    void SoftwareDrawingContext::drawStringRightUnderline(Gfx::RenderTarget& rt, Ui::Point& origin, AdvancedColour colour, StringId stringId, const void* args)
+    void SoftwareDrawingContext::drawStringRightUnderline(Gfx::RenderTarget& rt, Ui::Point origin, AdvancedColour colour, StringId stringId, const void* args)
     {
         return Impl::drawStringRightUnderline(rt, origin, colour, stringId, args);
     }
 
-    void SoftwareDrawingContext::drawStringYOffsets(Gfx::RenderTarget& rt, const Ui::Point& loc, AdvancedColour colour, const void* args, const int8_t* yOffsets)
+    void SoftwareDrawingContext::drawStringYOffsets(Gfx::RenderTarget& rt, Ui::Point loc, AdvancedColour colour, const void* args, const int8_t* yOffsets)
     {
         return Impl::drawStringYOffsets(rt, loc, colour, args, yOffsets);
     }
 
-    void SoftwareDrawingContext::drawStringTicker(Gfx::RenderTarget& rt, Ui::Point& origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width)
+    void SoftwareDrawingContext::drawStringTicker(Gfx::RenderTarget& rt, Ui::Point origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width)
     {
         Impl::drawStringTicker(rt, origin, stringId, colour, numLinesToDisplay, numCharactersToDisplay, width);
     }

--- a/src/OpenLoco/src/Drawing/SoftwareDrawingContext.h
+++ b/src/OpenLoco/src/Drawing/SoftwareDrawingContext.h
@@ -35,7 +35,7 @@ namespace OpenLoco::Drawing
         void drawStringLeftClipped(
             Gfx::RenderTarget& rt,
             Ui::Point& origin,
-            int16_t width,
+            uint16_t width,
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr) override;
@@ -73,7 +73,7 @@ namespace OpenLoco::Drawing
         void drawStringCentredRaw(
             Gfx::RenderTarget& rt,
             Ui::Point& origin,
-            int16_t linebreakCount,
+            uint16_t linebreakCount,
             AdvancedColour colour,
             const char* wrappedStr) override;
 
@@ -100,7 +100,7 @@ namespace OpenLoco::Drawing
             const void* args) override;
 
         void drawStringYOffsets(Gfx::RenderTarget& rt, const Ui::Point& loc, AdvancedColour colour, const void* args, const int8_t* yOffsets) override;
-        void drawStringTicker(Gfx::RenderTarget& rt, const Ui::Point& origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width) override;
+        void drawStringTicker(Gfx::RenderTarget& rt, Ui::Point& origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width) override;
         uint16_t getStringWidthNewLined(const char* buffer) override;
         std::pair<uint16_t, uint16_t> wrapString(char* buffer, uint16_t stringWidth) override;
 

--- a/src/OpenLoco/src/Drawing/SoftwareDrawingContext.h
+++ b/src/OpenLoco/src/Drawing/SoftwareDrawingContext.h
@@ -21,20 +21,20 @@ namespace OpenLoco::Drawing
 
         Ui::Point drawString(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             AdvancedColour colour,
             const char* str) override;
 
         void drawStringLeft(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr) override;
 
         void drawStringLeftClipped(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
@@ -42,14 +42,14 @@ namespace OpenLoco::Drawing
 
         void drawStringLeftUnderline(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr) override;
 
         int16_t drawStringLeftWrapped(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
@@ -57,14 +57,14 @@ namespace OpenLoco::Drawing
 
         void drawStringCentred(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr) override;
 
         void drawStringCentredClipped(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
@@ -72,14 +72,14 @@ namespace OpenLoco::Drawing
 
         void drawStringCentredRaw(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             uint16_t linebreakCount,
             AdvancedColour colour,
             const char* wrappedStr) override;
 
         uint16_t drawStringCentredWrapped(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
@@ -87,20 +87,20 @@ namespace OpenLoco::Drawing
 
         void drawStringRight(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr) override;
 
         void drawStringRightUnderline(
             Gfx::RenderTarget& rt,
-            Ui::Point& origin,
+            Ui::Point origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args) override;
 
-        void drawStringYOffsets(Gfx::RenderTarget& rt, const Ui::Point& loc, AdvancedColour colour, const void* args, const int8_t* yOffsets) override;
-        void drawStringTicker(Gfx::RenderTarget& rt, Ui::Point& origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width) override;
+        void drawStringYOffsets(Gfx::RenderTarget& rt, Ui::Point loc, AdvancedColour colour, const void* args, const int8_t* yOffsets) override;
+        void drawStringTicker(Gfx::RenderTarget& rt, Ui::Point origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width) override;
         uint16_t getStringWidthNewLined(const char* buffer) override;
         std::pair<uint16_t, uint16_t> wrapString(char* buffer, uint16_t stringWidth) override;
 

--- a/src/OpenLoco/src/Drawing/SoftwareDrawingContext.h
+++ b/src/OpenLoco/src/Drawing/SoftwareDrawingContext.h
@@ -19,7 +19,7 @@ namespace OpenLoco::Drawing
         uint16_t getStringWidth(const char* buffer) override;
         uint16_t getMaxStringWidth(const char* buffer) override;
 
-        Ui::Point drawString(
+        void drawString(
             Gfx::RenderTarget& rt,
             Ui::Point origin,
             AdvancedColour colour,

--- a/src/OpenLoco/src/Drawing/SoftwareDrawingContext.h
+++ b/src/OpenLoco/src/Drawing/SoftwareDrawingContext.h
@@ -19,73 +19,64 @@ namespace OpenLoco::Drawing
         uint16_t getStringWidth(const char* buffer) override;
         uint16_t getMaxStringWidth(const char* buffer) override;
 
-        Ui::Point drawString(Gfx::RenderTarget& rt, int16_t x, int16_t y, AdvancedColour colour, const char* str) override;
+        Ui::Point drawString(
+            Gfx::RenderTarget& rt,
+            Ui::Point& origin,
+            AdvancedColour colour,
+            const char* str) override;
+
+        void drawStringLeft(
+            Gfx::RenderTarget& rt,
+            Ui::Point& origin,
+            AdvancedColour colour,
+            StringId stringId,
+            const void* args = nullptr) override;
+
+        void drawStringLeftClipped(
+            Gfx::RenderTarget& rt,
+            Ui::Point& origin,
+            int16_t width,
+            AdvancedColour colour,
+            StringId stringId,
+            const void* args = nullptr) override;
+
+        void drawStringLeftUnderline(
+            Gfx::RenderTarget& rt,
+            Ui::Point& origin,
+            AdvancedColour colour,
+            StringId stringId,
+            const void* args = nullptr) override;
 
         int16_t drawStringLeftWrapped(
             Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
-            int16_t width,
+            Ui::Point& origin,
+            uint16_t width,
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr) override;
-        void drawStringLeft(
-            Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
-            AdvancedColour colour,
-            StringId stringId,
-            const void* args = nullptr) override;
-        void drawStringLeft(
-            Gfx::RenderTarget& rt,
-            Ui::Point* origin,
-            AdvancedColour colour,
-            StringId stringId,
-            const void* args = nullptr) override;
-        void drawStringLeftClipped(
-            Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
-            int16_t width,
-            AdvancedColour colour,
-            StringId stringId,
-            const void* args = nullptr) override;
-        void drawStringRight(
-            Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
-            AdvancedColour colour,
-            StringId stringId,
-            const void* args = nullptr) override;
-        void drawStringRightUnderline(
-            Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
-            AdvancedColour colour,
-            StringId stringId,
-            const void* args) override;
-        void drawStringLeftUnderline(
-            Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
-            AdvancedColour colour,
-            StringId stringId,
-            const void* args = nullptr) override;
+
         void drawStringCentred(
             Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
+            Ui::Point& origin,
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr) override;
+
         void drawStringCentredClipped(
             Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
-            int16_t width,
+            Ui::Point& origin,
+            uint16_t width,
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr) override;
+
+        void drawStringCentredRaw(
+            Gfx::RenderTarget& rt,
+            Ui::Point& origin,
+            int16_t linebreakCount,
+            AdvancedColour colour,
+            const char* wrappedStr) override;
+
         uint16_t drawStringCentredWrapped(
             Gfx::RenderTarget& rt,
             Ui::Point& origin,
@@ -93,13 +84,21 @@ namespace OpenLoco::Drawing
             AdvancedColour colour,
             StringId stringId,
             const void* args = nullptr) override;
-        void drawStringCentredRaw(
+
+        void drawStringRight(
             Gfx::RenderTarget& rt,
-            int16_t x,
-            int16_t y,
-            int16_t linebreakCount,
+            Ui::Point& origin,
             AdvancedColour colour,
-            const char* wrappedStr) override;
+            StringId stringId,
+            const void* args = nullptr) override;
+
+        void drawStringRightUnderline(
+            Gfx::RenderTarget& rt,
+            Ui::Point& origin,
+            AdvancedColour colour,
+            StringId stringId,
+            const void* args) override;
+
         void drawStringYOffsets(Gfx::RenderTarget& rt, const Ui::Point& loc, AdvancedColour colour, const void* args, const int8_t* yOffsets) override;
         void drawStringTicker(Gfx::RenderTarget& rt, const Ui::Point& origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width) override;
         uint16_t getStringWidthNewLined(const char* buffer) override;

--- a/src/OpenLoco/src/Interop/Hooks.cpp
+++ b/src/OpenLoco/src/Interop/Hooks.cpp
@@ -705,7 +705,8 @@ void OpenLoco::Interop::registerHooks()
         [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
             registers backup = regs;
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-            auto pos = drawingCtx.drawString(*X86Pointer<Gfx::RenderTarget>(regs.edi), regs.cx, regs.dx, static_cast<Colour>(regs.al), X86Pointer<const char>(regs.esi));
+            auto point = Ui::Point(regs.cx, regs.dx);
+            auto pos = drawingCtx.drawString(*X86Pointer<Gfx::RenderTarget>(regs.edi), point, static_cast<Colour>(regs.al), X86Pointer<const char>(regs.esi));
             regs = backup;
             regs.cx = pos.x;
             regs.dx = pos.y;

--- a/src/OpenLoco/src/Interop/Hooks.cpp
+++ b/src/OpenLoco/src/Interop/Hooks.cpp
@@ -706,10 +706,8 @@ void OpenLoco::Interop::registerHooks()
             registers backup = regs;
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
             auto point = Ui::Point(regs.cx, regs.dx);
-            auto pos = drawingCtx.drawString(*X86Pointer<Gfx::RenderTarget>(regs.edi), point, static_cast<Colour>(regs.al), X86Pointer<const char>(regs.esi));
+            drawingCtx.drawString(*X86Pointer<Gfx::RenderTarget>(regs.edi), point, static_cast<Colour>(regs.al), X86Pointer<const char>(regs.esi));
             regs = backup;
-            regs.cx = pos.x;
-            regs.dx = pos.y;
 
             return 0;
         });

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1652,7 +1652,7 @@ namespace OpenLoco::StringIds
     constexpr StringId position_13th = 2035;
     constexpr StringId position_14th = 2036;
     constexpr StringId position_15th = 2037;
-
+    constexpr StringId buffer_2038 = 2038;
     constexpr StringId buffer_2039 = 2039;
     constexpr StringId buffer_2040 = 2040;
 

--- a/src/OpenLoco/src/Objects/CompetitorObject.cpp
+++ b/src/OpenLoco/src/Objects/CompetitorObject.cpp
@@ -39,7 +39,7 @@ namespace OpenLoco
             args.push<uint16_t>(intelligence);
             args.push(aiRatingToLevel(intelligence));
 
-            drawingCtx.drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::company_details_intelligence, &args);
+            drawingCtx.drawStringLeft(rt, rowPosition, Colour::black, StringIds::company_details_intelligence, &args);
             rowPosition.y += kDescriptionRowHeight;
         }
         {
@@ -47,7 +47,7 @@ namespace OpenLoco
             args.push<uint16_t>(aggressiveness);
             args.push(aiRatingToLevel(aggressiveness));
 
-            drawingCtx.drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::company_details_aggressiveness, &args);
+            drawingCtx.drawStringLeft(rt, rowPosition, Colour::black, StringIds::company_details_aggressiveness, &args);
             rowPosition.y += kDescriptionRowHeight;
         }
         {
@@ -55,7 +55,7 @@ namespace OpenLoco
             args.push<uint16_t>(competitiveness);
             args.push(aiRatingToLevel(competitiveness));
 
-            drawingCtx.drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::company_details_competitiveness, &args);
+            drawingCtx.drawStringLeft(rt, rowPosition, Colour::black, StringIds::company_details_competitiveness, &args);
         }
     }
 

--- a/src/OpenLoco/src/Objects/CurrencyObject.cpp
+++ b/src/OpenLoco/src/Objects/CurrencyObject.cpp
@@ -79,9 +79,7 @@ namespace OpenLoco
         _characterWidths[Font::large + 131] = currencyElement->width + 1;
 
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        auto point = Ui::Point(x, y - 9);
-
-        drawingCtx.drawStringCentred(rt, point, Colour::black, StringIds::object_currency_big_font);
+        drawingCtx.drawStringCentred(rt, Ui::Point(x, y - 9), Colour::black, StringIds::object_currency_big_font);
 
         _characterWidths[Font::large + 131] = defaultWidth;
         *defaultElement = backupElement;

--- a/src/OpenLoco/src/Objects/CurrencyObject.cpp
+++ b/src/OpenLoco/src/Objects/CurrencyObject.cpp
@@ -79,7 +79,9 @@ namespace OpenLoco
         _characterWidths[Font::large + 131] = currencyElement->width + 1;
 
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        drawingCtx.drawStringCentred(rt, x, y - 9, Colour::black, StringIds::object_currency_big_font);
+        auto point = Ui::Point(x, y - 9);
+
+        drawingCtx.drawStringCentred(rt, point, Colour::black, StringIds::object_currency_big_font);
 
         _characterWidths[Font::large + 131] = defaultWidth;
         *defaultElement = backupElement;

--- a/src/OpenLoco/src/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/src/Objects/ObjectManager.cpp
@@ -918,7 +918,7 @@ namespace OpenLoco::ObjectManager
         {
             FormatArguments args{};
             args.push(designed);
-            drawingCtx.drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_designed, &args);
+            drawingCtx.drawStringLeft(rt, rowPosition, Colour::black, StringIds::object_selection_designed, &args);
             rowPosition.y += kDescriptionRowHeight;
         }
 
@@ -926,7 +926,7 @@ namespace OpenLoco::ObjectManager
         {
             FormatArguments args{};
             args.push(obsolete);
-            drawingCtx.drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_obsolete, &args);
+            drawingCtx.drawStringLeft(rt, rowPosition, Colour::black, StringIds::object_selection_obsolete, &args);
             rowPosition.y += kDescriptionRowHeight;
         }
     }

--- a/src/OpenLoco/src/Objects/VehicleObject.cpp
+++ b/src/OpenLoco/src/Objects/VehicleObject.cpp
@@ -57,25 +57,25 @@ namespace OpenLoco
         {
             FormatArguments args{};
             args.push(power);
-            drawingCtx.drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_power, &args);
+            drawingCtx.drawStringLeft(rt, rowPosition, Colour::black, StringIds::object_selection_power, &args);
             rowPosition.y += kDescriptionRowHeight;
         }
         {
             FormatArguments args{};
             args.push<uint32_t>(StringManager::internalLengthToComma1DP(getLength()));
-            drawingCtx.drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_length, &args);
+            drawingCtx.drawStringLeft(rt, rowPosition, Colour::black, StringIds::object_selection_length, &args);
             rowPosition.y += kDescriptionRowHeight;
         }
         {
             FormatArguments args{};
             args.push(weight);
-            drawingCtx.drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_weight, &args);
+            drawingCtx.drawStringLeft(rt, rowPosition, Colour::black, StringIds::object_selection_weight, &args);
             rowPosition.y += kDescriptionRowHeight;
         }
         {
             FormatArguments args{};
             args.push(speed);
-            drawingCtx.drawStringLeft(rt, rowPosition.x, rowPosition.y, Colour::black, StringIds::object_selection_max_speed, &args);
+            drawingCtx.drawStringLeft(rt, rowPosition, Colour::black, StringIds::object_selection_max_speed, &args);
         }
         auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
         // Clear buffer
@@ -85,7 +85,7 @@ namespace OpenLoco
 
         if (StringManager::locoStrlen(buffer) != 0)
         {
-            drawingCtx.drawStringLeftWrapped(rt, rowPosition.x, rowPosition.y, width - 4, Colour::black, StringIds::buffer_1250);
+            drawingCtx.drawStringLeftWrapped(rt, rowPosition, width - 4, Colour::black, StringIds::buffer_1250);
         }
     }
 

--- a/src/OpenLoco/src/Ui/Dropdown.cpp
+++ b/src/OpenLoco/src/Ui/Dropdown.cpp
@@ -196,7 +196,8 @@ namespace OpenLoco::Ui::Dropdown
 
             drawingCtx.setCurrentFontSpriteBase(Font::m1);
 
-            drawingCtx.drawString(*rt, x, y, colour, _byte_112CC04);
+            auto point = Point(x, y);
+            drawingCtx.drawString(*rt, point, colour, _byte_112CC04);
         }
 
         // 0x004CD00E

--- a/src/OpenLoco/src/Ui/Dropdown.cpp
+++ b/src/OpenLoco/src/Ui/Dropdown.cpp
@@ -196,8 +196,7 @@ namespace OpenLoco::Ui::Dropdown
 
             drawingCtx.setCurrentFontSpriteBase(Font::m1);
 
-            auto point = Point(x, y);
-            drawingCtx.drawString(*rt, point, colour, _byte_112CC04);
+            drawingCtx.drawString(*rt, Point(x, y), colour, _byte_112CC04);
         }
 
         // 0x004CD00E

--- a/src/OpenLoco/src/Viewport.cpp
+++ b/src/OpenLoco/src/Viewport.cpp
@@ -136,7 +136,8 @@ namespace OpenLoco::Ui
         StringManager::formatString(str, getTransportIconsFromStationFlags(station.flags));
 
         drawingCtx.setCurrentFontSpriteBase(kZoomToStationFonts[zoom]);
-        drawingCtx.drawString(unZoomedRt, topLeft.x + borderImages.width, topLeft.y, Colour::black, buffer);
+        auto point = topLeft + Point(borderImages.width, 0);
+        drawingCtx.drawString(unZoomedRt, point, Colour::black, buffer);
     }
 
     // 0x0048DE97
@@ -192,7 +193,9 @@ namespace OpenLoco::Ui
 
             StringManager::formatString(buffer, town.name);
             drawingCtx.setCurrentFontSpriteBase(kZoomToTownFonts[rt.zoomLevel]);
-            drawingCtx.drawString(unZoomedRt, town.labelFrame.left[rt.zoomLevel] + 1, town.labelFrame.top[rt.zoomLevel] + 1, AdvancedColour(Colour::white).outline(), buffer);
+
+            auto point = Point(town.labelFrame.left[rt.zoomLevel] + 1, town.labelFrame.top[rt.zoomLevel] + 1);
+            drawingCtx.drawString(unZoomedRt, point, AdvancedColour(Colour::white).outline(), buffer);
         }
     }
 
@@ -235,7 +238,9 @@ namespace OpenLoco::Ui
             }
 
             drawingCtx.setCurrentFontSpriteBase(Font::medium_normal);
-            drawingCtx.drawString(unZoomedRt, orderFrame.frame.left[rt.zoomLevel] + 1, orderFrame.frame.top[rt.zoomLevel], AdvancedColour(Colour::white).outline(), const_cast<char*>(orderString.c_str()));
+
+            auto point = Point(orderFrame.frame.left[rt.zoomLevel] + 1, orderFrame.frame.top[rt.zoomLevel]);
+            drawingCtx.drawString(unZoomedRt, point, AdvancedColour(Colour::white).outline(), const_cast<char*>(orderString.c_str()));
         }
     }
 

--- a/src/OpenLoco/src/Widget.cpp
+++ b/src/OpenLoco/src/Widget.cpp
@@ -917,8 +917,10 @@ namespace OpenLoco::Ui
         if (activated)
         {
             static constexpr char strCheckmark[] = "\xAC";
+            auto point = Point(window->x + left, window->y + top);
+
             drawingCtx.setCurrentFontSpriteBase(Font::medium_bold);
-            drawingCtx.drawString(*rt, window->x + left, window->y + top, colour.opaque(), strCheckmark);
+            drawingCtx.drawString(*rt, point, colour.opaque(), strCheckmark);
         }
     }
 
@@ -938,7 +940,8 @@ namespace OpenLoco::Ui
         }
 
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        drawingCtx.drawStringLeft(*rt, window->x + left + 14, window->y + top, colour, text, &FormatArguments::common());
+        auto point = Point(window->x + left + 14, window->y + top);
+        drawingCtx.drawStringLeft(*rt, point, colour, text, &FormatArguments::common());
     }
 
     // 0x004CA679
@@ -968,7 +971,8 @@ namespace OpenLoco::Ui
             char buffer[512] = { 0 };
             StringManager::formatString(buffer, sizeof(buffer), text);
 
-            drawingCtx.drawString(*rt, l, t, colour, buffer);
+            auto point = Point(l, t);
+            drawingCtx.drawString(*rt, point, colour, buffer);
             textEndPos = l + drawingCtx.getStringWidth(buffer) + 1;
         }
 

--- a/src/OpenLoco/src/Widget.cpp
+++ b/src/OpenLoco/src/Widget.cpp
@@ -538,11 +538,10 @@ namespace OpenLoco::Ui
         }
 
         int16_t centreX = window->x + (widget->left + widget->right + 1) / 2 - 1;
-        auto point = Point(centreX, y);
         int16_t width = widget->right - widget->left - 2;
 
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        drawingCtx.drawStringCentredClipped(*rt, point, width, colour, string, &FormatArguments::common());
+        drawingCtx.drawStringCentredClipped(*rt, Point(centreX, y), width, colour, string, &FormatArguments::common());
     }
 
     // 0x004CB263
@@ -556,10 +555,9 @@ namespace OpenLoco::Ui
             colour = colour.inset();
         }
 
-        auto point = Point(x, y);
         int width = widget->right - widget->left - 2;
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        drawingCtx.drawStringLeftClipped(*rt, point, width, colour, string, &FormatArguments::common());
+        drawingCtx.drawStringLeftClipped(*rt, Point(x, y), width, colour, string, &FormatArguments::common());
     }
 
     // 0x4CB2D6
@@ -630,8 +628,7 @@ namespace OpenLoco::Ui
 
         drawStationNameBackground(rt, window, this, x, y, colour, width);
 
-        auto point = Point(x, y);
-        drawingCtx.drawString(*rt, point, Colour::black, stringBuffer);
+        drawingCtx.drawString(*rt, Point(x, y), Colour::black, stringBuffer);
     }
 
     // 0x004CA7F6
@@ -703,9 +700,8 @@ namespace OpenLoco::Ui
 
         // pusha
         {
-            auto point = Point(ax + 2, cx);
             const char* hLeftStr = "\x90\xBE";
-            drawingCtx.drawString(*rt, point, Colour::black, hLeftStr);
+            drawingCtx.drawString(*rt, Point(ax + 2, cx), Colour::black, hLeftStr);
         }
         // popa
 
@@ -720,9 +716,8 @@ namespace OpenLoco::Ui
 
         // pusha
         {
-            auto point = Point(bx - 7, cx);
             const char* hRightStr = "\x90\xAF";
-            drawingCtx.drawString(*rt, point, Colour::black, hRightStr);
+            drawingCtx.drawString(*rt, Point(bx - 7, cx), Colour::black, hRightStr);
         }
         // popa
 
@@ -776,9 +771,8 @@ namespace OpenLoco::Ui
 
         // pusha
         {
-            auto point = Point(ax + 1, cx - 1);
             const char* vTopStr = "\x90\xA0";
-            drawingCtx.drawString(*rt, point, Colour::black, vTopStr);
+            drawingCtx.drawString(*rt, Point(ax + 1, cx - 1), Colour::black, vTopStr);
         }
         // popa
 
@@ -793,9 +787,8 @@ namespace OpenLoco::Ui
 
         // pusha
         {
-            auto point = Point(ax + 1, dx - 9);
             const char* vBottomStr = "\x90\xAA";
-            drawingCtx.drawString(*rt, point, Colour::black, vBottomStr);
+            drawingCtx.drawString(*rt, Point(ax + 1, dx - 9), Colour::black, vBottomStr);
         }
         // popa
 

--- a/src/OpenLoco/src/Widget.cpp
+++ b/src/OpenLoco/src/Widget.cpp
@@ -538,9 +538,11 @@ namespace OpenLoco::Ui
         }
 
         int16_t centreX = window->x + (widget->left + widget->right + 1) / 2 - 1;
+        auto point = Point(centreX, y);
         int16_t width = widget->right - widget->left - 2;
+
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        drawingCtx.drawStringCentredClipped(*rt, centreX, y, width, colour, string, &FormatArguments::common());
+        drawingCtx.drawStringCentredClipped(*rt, point, width, colour, string, &FormatArguments::common());
     }
 
     // 0x004CB263
@@ -554,9 +556,10 @@ namespace OpenLoco::Ui
             colour = colour.inset();
         }
 
+        auto point = Point(x, y);
         int width = widget->right - widget->left - 2;
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        drawingCtx.drawStringLeftClipped(*rt, x, y, width, colour, string, &FormatArguments::common());
+        drawingCtx.drawStringLeftClipped(*rt, point, width, colour, string, &FormatArguments::common());
     }
 
     // 0x4CB2D6
@@ -576,9 +579,10 @@ namespace OpenLoco::Ui
             colour = colour.FD();
         }
 
+        auto point = Point(window->x + left + 1, window->y + top);
         int width = this->right - this->left - 2;
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        drawingCtx.drawStringLeftClipped(*rt, window->x + left + 1, window->y + top, width, colour, text, &FormatArguments::common());
+        drawingCtx.drawStringLeftClipped(*rt, point, width, colour, text, &FormatArguments::common());
     }
 
     // 0x4CB29C
@@ -602,10 +606,9 @@ namespace OpenLoco::Ui
         drawingCtx.fillRect(*rt, l + 1, t + 1, r - 1, b - 1, enumValue(ExtColour::unk2E), Drawing::RectFlags::transparent);
 
         int16_t width = r - l - 4 - 10;
-        int16_t y = t + 1;
-        int16_t x = l + 2 + (width / 2);
+        auto point = Point(l + 2 + (width / 2), t + 1);
 
-        drawingCtx.drawStringCentredClipped(*rt, x, y, width, AdvancedColour(Colour::white).outline(), text, &FormatArguments::common());
+        drawingCtx.drawStringCentredClipped(*rt, point, width, AdvancedColour(Colour::white).outline(), text, &FormatArguments::common());
     }
 
     // 0x004CA750
@@ -627,7 +630,8 @@ namespace OpenLoco::Ui
 
         drawStationNameBackground(rt, window, this, x, y, colour, width);
 
-        drawingCtx.drawString(*rt, x, y, Colour::black, stringBuffer);
+        auto point = Point(x, y);
+        drawingCtx.drawString(*rt, point, Colour::black, stringBuffer);
     }
 
     // 0x004CA7F6
@@ -646,7 +650,8 @@ namespace OpenLoco::Ui
         int16_t stringWidth = drawingCtx.clipString(width - 8, stringBuffer);
         x -= (stringWidth - 1) / 2;
 
-        drawingCtx.drawString(*rt, x, window->y + top + 1, AdvancedColour(Colour::black).outline(), stringBuffer);
+        auto point = Point(x, window->y + top + 1);
+        drawingCtx.drawString(*rt, point, AdvancedColour(Colour::black).outline(), stringBuffer);
     }
 
     // 0x004CA88B
@@ -665,7 +670,8 @@ namespace OpenLoco::Ui
         int16_t stringWidth = drawingCtx.clipString(width - 8, stringBuffer);
         x -= (stringWidth - 1) / 2;
 
-        drawingCtx.drawString(*rt, x, window->y + top + 1, AdvancedColour(Colour::black).outline(), stringBuffer);
+        auto point = Point(x, window->y + top + 1);
+        drawingCtx.drawString(*rt, point, AdvancedColour(Colour::black).outline(), stringBuffer);
     }
 
     static void draw_hscroll(Gfx::RenderTarget* rt, const Window* window, Widget* widget, Drawing::RectInsetFlags flags, AdvancedColour colour, [[maybe_unused]] bool enabled, [[maybe_unused]] bool disabled, [[maybe_unused]] bool activated, [[maybe_unused]] bool hovered, int16_t scrollview_index)
@@ -696,7 +702,11 @@ namespace OpenLoco::Ui
         // popa
 
         // pusha
-        drawingCtx.drawString(*rt, ax + 2, cx, Colour::black, (char*)0x005045F2);
+        {
+            auto point = Point(ax + 2, cx);
+            const char* hLeftStr = "\x90\xBE";
+            drawingCtx.drawString(*rt, point, Colour::black, hLeftStr);
+        }
         // popa
 
         // pusha
@@ -709,7 +719,11 @@ namespace OpenLoco::Ui
         // popa
 
         // pusha
-        drawingCtx.drawString(*rt, bx - 6 - 1, cx, Colour::black, (char*)0x005045F5);
+        {
+            auto point = Point(bx - 7, cx);
+            const char* hRightStr = "\x90\xAF";
+            drawingCtx.drawString(*rt, point, Colour::black, hRightStr);
+        }
         // popa
 
         // pusha
@@ -761,7 +775,11 @@ namespace OpenLoco::Ui
         // popa
 
         // pusha
-        drawingCtx.drawString(*rt, ax + 1, cx - 1, Colour::black, (char*)0x005045EC);
+        {
+            auto point = Point(ax + 1, cx - 1);
+            const char* vTopStr = "\x90\xA0";
+            drawingCtx.drawString(*rt, point, Colour::black, vTopStr);
+        }
         // popa
 
         // pusha
@@ -774,7 +792,11 @@ namespace OpenLoco::Ui
         // popa
 
         // pusha
-        drawingCtx.drawString(*rt, ax + 1, dx - 8 - 1, Colour::black, (char*)0x005045EF);
+        {
+            auto point = Point(ax + 1, dx - 9);
+            const char* vBottomStr = "\x90\xAA";
+            drawingCtx.drawString(*rt, point, Colour::black, vBottomStr);
+        }
         // popa
 
         // pusha

--- a/src/OpenLoco/src/Windows/About.cpp
+++ b/src/OpenLoco/src/Windows/About.cpp
@@ -77,42 +77,41 @@ namespace OpenLoco::Ui::Windows::About
         // Draw widgets.
         window.draw(rt);
 
-        const int16_t x = window.x + kWindowSize.width / 2;
-        int16_t y = window.y + 25;
+        auto point = Point(window.x + kWindowSize.width / 2, window.y + 25);
 
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_69, nullptr);
+        drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::about_locomotion_69, nullptr);
 
-        y += 10;
-        drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_70, nullptr);
+        point.y += 10;
+        drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::about_locomotion_70, nullptr);
 
         // Chris Sawyer logo
         drawingCtx.drawImage(rt, window.x + 92, window.y + 52, ImageIds::chris_sawyer_logo_small);
 
-        y += 79;
-        drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_71, nullptr);
+        point.y += 79;
+        drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::about_locomotion_71, nullptr);
 
-        y += 10;
-        drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_72, nullptr);
+        point.y += 10;
+        drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::about_locomotion_72, nullptr);
 
-        y += 10;
-        drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_73, nullptr);
+        point.y += 10;
+        drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::about_locomotion_73, nullptr);
 
-        y += 10;
-        drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_74, nullptr);
+        point.y += 10;
+        drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::about_locomotion_74, nullptr);
 
-        y += 13;
-        drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_75, nullptr);
+        point.y += 13;
+        drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::about_locomotion_75, nullptr);
 
-        y += 25;
-        drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_76, nullptr);
+        point.y += 25;
+        drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::about_locomotion_76, nullptr);
 
-        y += 10;
-        drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::about_locomotion_77, nullptr);
+        point.y += 10;
+        drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::about_locomotion_77, nullptr);
 
         // Licenced to Atari
-        y += 25;
-        drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::licenced_to_atari_inc, nullptr);
+        point.y += 25;
+        drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::licenced_to_atari_inc, nullptr);
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Windows/AboutMusic.cpp
+++ b/src/OpenLoco/src/Windows/AboutMusic.cpp
@@ -132,33 +132,32 @@ namespace OpenLoco::Ui::Windows::AboutMusic
             { StringIds::sandy_track_blues, StringIds::sandy_track_blues_credit },
         };
 
-        const int16_t x = 240;
-        uint16_t y = 2;
+        auto point = Point(240, 2);
 
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
         for (const auto& songStrings : stringsToDraw)
         {
-            if (y + (kRowHeight * 3 + 4) < rt.y)
+            if (point.y + (kRowHeight * 3 + 4) < rt.y)
             {
-                y += kRowHeight * 3 + 4;
+                point.y += kRowHeight * 3 + 4;
                 continue;
             }
-            else if (y > rt.y + rt.height)
+            else if (point.y > rt.y + rt.height)
             {
                 break;
             }
 
             // Song name
-            drawingCtx.drawStringCentred(rt, x, y, Colour::black, songStrings.first);
-            y += kRowHeight;
+            drawingCtx.drawStringCentred(rt, point, Colour::black, songStrings.first);
+            point.y += kRowHeight;
 
             // Credit line
-            drawingCtx.drawStringCentred(rt, x, y, Colour::black, songStrings.second);
-            y += kRowHeight;
+            drawingCtx.drawStringCentred(rt, point, Colour::black, songStrings.second);
+            point.y += kRowHeight;
 
             // Show CS' copyright after every two lines.
-            drawingCtx.drawStringCentred(rt, x, y, Colour::black, StringIds::music_copyright);
-            y += kRowHeight + 4;
+            drawingCtx.drawStringCentred(rt, point, Colour::black, StringIds::music_copyright);
+            point.y += kRowHeight + 4;
         }
     }
 

--- a/src/OpenLoco/src/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Windows/BuildVehicle.cpp
@@ -1222,7 +1222,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         args.push(StringIds::buffer_2039);
 
         Ui::Point position = { inputSession.xOffset, 1 };
-        drawingCtx.drawStringLeft(*clipped, &position, Colour::black, StringIds::black_stringid, &args);
+        drawingCtx.drawStringLeft(*clipped, position, Colour::black, StringIds::black_stringid, &args);
 
         // Draw search box cursor, blinking
         if ((inputSession.cursorFrame % 32) < 16)
@@ -1230,7 +1230,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
             // We draw the string again to figure out where the cursor should go; position.x will be adjusted
             textBuffer[inputSession.cursorPosition] = '\0';
             position = { inputSession.xOffset, 1 };
-            drawingCtx.drawStringLeft(*clipped, &position, Colour::black, StringIds::black_stringid, &args);
+            drawingCtx.drawStringLeft(*clipped, position, Colour::black, StringIds::black_stringid, &args);
             drawingCtx.fillRect(*clipped, position.x, position.y, position.x, position.y + 9, Colours::getShade(self.getColour(WindowColour::secondary).c(), 9), Drawing::RectFlags::none);
         }
     }
@@ -1246,8 +1246,6 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         drawSearchBox(window, rt);
 
         {
-            auto x = window.x + 2;
-            auto y = window.y + window.height - 13;
             auto bottomLeftMessage = StringIds::select_new_vehicle;
             FormatArguments args{};
             if (_buildTargetVehicle != -1)
@@ -1261,7 +1259,8 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 }
             }
 
-            drawingCtx.drawStringLeftClipped(*rt, x, y, window.width - 186, Colour::black, bottomLeftMessage, &args);
+            auto point = Point(window.x + 2, window.y + window.height - 13);
+            drawingCtx.drawStringLeftClipped(*rt, point, window.width - 186, Colour::black, bottomLeftMessage, &args);
         }
 
         if (_cargoSupportedFilter != 0xFF && _cargoSupportedFilter != 0xFE)
@@ -1274,7 +1273,8 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
             args.push(cargoObj->unitInlineSprite);
 
             auto& widget = window.widgets[widx::cargoLabel];
-            drawingCtx.drawStringLeftClipped(*rt, window.x + widget.left + 2, window.y + widget.top, widget.width() - 15, Colour::black, StringIds::wcolour2_stringid, &args);
+            auto point = Point(window.x + widget.left + 2, window.y + widget.top);
+            drawingCtx.drawStringLeftClipped(*rt, point, widget.width() - 15, Colour::black, StringIds::wcolour2_stringid, &args);
         }
 
         if (window.rowHover == -1)
@@ -1400,7 +1400,8 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
 
         auto x = window.widgets[widx::scrollview_vehicle_selection].right + window.x + 2;
         auto y = window.widgets[widx::scrollview_vehicle_preview].bottom + window.y + 2;
-        drawingCtx.drawStringLeftWrapped(*rt, x, y, 180, Colour::black, StringIds::buffer_1250);
+        auto point = Point(x, y);
+        drawingCtx.drawStringLeftWrapped(*rt, point, 180, Colour::black, StringIds::buffer_1250);
     }
 
     // 0x4C3307
@@ -1431,8 +1432,8 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
 
                     auto widget = window.widgets[widx::scrollview_vehicle_selection];
                     auto width = widget.right - widget.left - 17;
-                    auto y = (window.rowHeight - 10) / 2;
-                    drawingCtx.drawStringLeftWrapped(rt, 3, y, width, Colour::black, defaultMessage, &args);
+                    auto point = Point(3, (window.rowHeight - 10) / 2);
+                    drawingCtx.drawStringLeftWrapped(rt, point, width, Colour::black, defaultMessage, &args);
                 }
                 else
                 {
@@ -1492,7 +1493,9 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                         FormatArguments args{};
                         args.push(vehicleObj->name);
                         half = (window.rowHeight - 10) / 2;
-                        drawingCtx.drawStringLeft(rt, x + 3, y + half, Colour::black, colouredString, &args);
+
+                        auto point = Point(x + 3, y + half);
+                        drawingCtx.drawStringLeft(rt, point, Colour::black, colouredString, &args);
                     }
                 }
                 break;
@@ -1531,7 +1534,9 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 *buffer++ = '\0';
                 FormatArguments args{};
                 args.push(StringIds::buffer_1250);
-                drawingCtx.drawStringCentredClipped(rt, 89, 52, 177, Colour::darkOrange, StringIds::wcolour2_stringid, &args);
+
+                auto point = Point(89, 52);
+                drawingCtx.drawStringCentredClipped(rt, point, 177, Colour::darkOrange, StringIds::wcolour2_stringid, &args);
                 break;
             }
         }

--- a/src/OpenLoco/src/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Windows/BuildVehicle.cpp
@@ -1400,8 +1400,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
 
         auto x = window.widgets[widx::scrollview_vehicle_selection].right + window.x + 2;
         auto y = window.widgets[widx::scrollview_vehicle_preview].bottom + window.y + 2;
-        auto point = Point(x, y);
-        drawingCtx.drawStringLeftWrapped(*rt, point, 180, Colour::black, StringIds::buffer_1250);
+        drawingCtx.drawStringLeftWrapped(*rt, Point(x, y), 180, Colour::black, StringIds::buffer_1250);
     }
 
     // 0x4C3307
@@ -1535,8 +1534,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 FormatArguments args{};
                 args.push(StringIds::buffer_1250);
 
-                auto point = Point(89, 52);
-                drawingCtx.drawStringCentredClipped(rt, point, 177, Colour::darkOrange, StringIds::wcolour2_stringid, &args);
+                drawingCtx.drawStringCentredClipped(rt, Point(89, 52), 177, Colour::darkOrange, StringIds::wcolour2_stringid, &args);
                 break;
             }
         }

--- a/src/OpenLoco/src/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Windows/Cheats.cpp
@@ -224,19 +224,21 @@ namespace OpenLoco::Ui::Windows::Cheats
             // Add cash step label and value
             {
                 auto& widget = self.widgets[Widx::cash_step_value];
+                auto point = Point(self.x + 10, self.y + widget.top);
+
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + 10,
-                    self.y + widget.top,
+                    point,
                     Colour::black,
                     StringIds::cheat_amount);
 
                 FormatArguments args{};
                 args.push(_cashIncreaseStep);
+
+                point = Point(self.x + widget.left + 1, self.y + widget.top);
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + widget.left + 1,
-                    self.y + widget.top,
+                    point,
                     Colour::black,
                     StringIds::cheat_loan_value,
                     &args);
@@ -245,10 +247,11 @@ namespace OpenLoco::Ui::Windows::Cheats
             // Loan label and value
             {
                 auto& widget = self.widgets[Widx::loan_value];
+                auto point = Point(self.x + 10, self.y + widget.top);
+
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + 10,
-                    self.y + widget.top,
+                    point,
                     Colour::black,
                     StringIds::company_current_loan);
 
@@ -257,10 +260,10 @@ namespace OpenLoco::Ui::Windows::Cheats
                 FormatArguments args{};
                 args.push(company->currentLoan);
 
+                point = Point(self.x + widget.left + 1, self.y + widget.top);
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + widget.left + 1,
-                    self.y + widget.top,
+                    point,
                     Colour::black,
                     StringIds::cheat_loan_value,
                     &args);
@@ -269,20 +272,21 @@ namespace OpenLoco::Ui::Windows::Cheats
             // Add year label and value
             {
                 auto& widget = self.widgets[Widx::year_step_value];
+                auto point = Point(self.x + 10, self.y + widget.top);
+
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + 10,
-                    self.y + widget.top,
+                    point,
                     Colour::black,
                     StringIds::cheat_year);
 
                 FormatArguments args{};
                 args.push(_date.year);
 
+                point = Point(self.x + widget.left + 1, self.y + widget.top);
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + widget.left + 1,
-                    self.y + widget.top,
+                    point,
                     Colour::black,
                     StringIds::cheat_year_value,
                     &args);
@@ -291,20 +295,21 @@ namespace OpenLoco::Ui::Windows::Cheats
             // Add month label and value
             {
                 auto& widget = self.widgets[Widx::month_step_value];
+                auto point = Point(self.x + 10, self.y + widget.top);
+
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + 10,
-                    self.y + widget.top,
+                    point,
                     Colour::black,
                     StringIds::cheat_month);
 
                 FormatArguments args{};
                 args.push((StringId)StringManager::monthToString(_date.month).second);
 
+                point = Point(self.x + widget.left + 1, self.y + widget.top);
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + widget.left + 1,
-                    self.y + widget.top,
+                    point,
                     Colour::black,
                     StringIds::black_stringid,
                     &args);
@@ -313,20 +318,21 @@ namespace OpenLoco::Ui::Windows::Cheats
             // Add day label and value
             {
                 auto& widget = self.widgets[Widx::day_step_value];
+                auto point = Point(self.x + 10, self.y + widget.top);
+
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + 10,
-                    self.y + widget.top,
+                    point,
                     Colour::black,
                     StringIds::cheat_day);
 
                 FormatArguments args{};
                 args.push(_date.day + 1); // +1 since days in game are 0-based, but IRL they are 1-based
 
+                point = Point(self.x + widget.left + 1, self.y + widget.top);
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + widget.left + 1,
-                    self.y + widget.top,
+                    point,
                     Colour::black,
                     StringIds::cheat_day_value,
                     &args);
@@ -554,10 +560,10 @@ namespace OpenLoco::Ui::Windows::Cheats
             // Draw current company name
             auto company = CompanyManager::get(_targetCompanyId);
             auto& widget = self.widgets[Widx::target_company_dropdown];
+            auto point = Point(self.x + widget.left, self.y + widget.top);
             drawingCtx.drawStringLeft(
                 *rt,
-                self.x + widget.left,
-                self.y + widget.top,
+                point,
                 Colour::black,
                 StringIds::black_stringid,
                 &company->name);

--- a/src/OpenLoco/src/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Windows/CompanyFaceSelection.cpp
@@ -280,8 +280,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
             auto objectPtr = self.object;
             strcpy(str, ObjectManager::ObjectIndexEntry::read(&objectPtr)._name);
 
-            auto point = Point(x, y);
-            drawingCtx.drawStringCentredClipped(*rt, point, width, Colour::black, StringIds::buffer_2039);
+            drawingCtx.drawStringCentredClipped(*rt, Point(x, y), width, Colour::black, StringIds::buffer_2039);
         }
 
         // There was code for displaying competitor stats if window opened with none
@@ -327,8 +326,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
                 stringColour = self.getColour(WindowColour::secondary).opaque().inset();
             }
 
-            auto point = Point(0, y - 1);
-            drawingCtx.drawString(rt, point, stringColour, const_cast<char*>(name.c_str()));
+            drawingCtx.drawString(rt, Point(0, y - 1), stringColour, const_cast<char*>(name.c_str()));
 
             index++;
         }

--- a/src/OpenLoco/src/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Windows/CompanyFaceSelection.cpp
@@ -279,7 +279,9 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
             *str++ = ControlCodes::windowColour2;
             auto objectPtr = self.object;
             strcpy(str, ObjectManager::ObjectIndexEntry::read(&objectPtr)._name);
-            drawingCtx.drawStringCentredClipped(*rt, x, y, width, Colour::black, StringIds::buffer_2039);
+
+            auto point = Point(x, y);
+            drawingCtx.drawStringCentredClipped(*rt, point, width, Colour::black, StringIds::buffer_2039);
         }
 
         // There was code for displaying competitor stats if window opened with none
@@ -324,7 +326,9 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
                 drawingCtx.setCurrentFontSpriteBase(Font::m1);
                 stringColour = self.getColour(WindowColour::secondary).opaque().inset();
             }
-            drawingCtx.drawString(rt, 0, y - 1, stringColour, const_cast<char*>(name.c_str()));
+
+            auto point = Point(0, y - 1);
+            drawingCtx.drawString(rt, point, stringColour, const_cast<char*>(name.c_str()));
 
             index++;
         }

--- a/src/OpenLoco/src/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Windows/CompanyList.cpp
@@ -443,9 +443,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             args.push(self.var_83C);
 
-            auto xPos = self.x + 3;
-            auto yPos = self.y + self.height - 13;
-            drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::black_stringid, &args);
+            auto point = Point(self.x + 3, self.y + self.height - 13);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x00435EA7
@@ -490,7 +489,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     args.push(imageId);
                     args.push(company->name);
 
-                    drawingCtx.drawStringLeftClipped(rt, 0, yBottom - 1, 173, Colour::black, stringId, &args);
+                    auto point = Point(0, yBottom - 1);
+                    drawingCtx.drawStringLeftClipped(rt, point, 173, Colour::black, stringId, &args);
                 }
 
                 {
@@ -500,7 +500,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     args.rewind();
                     args.push(ownerStatus);
 
-                    drawingCtx.drawStringLeftClipped(rt, 175, yBottom + 7, 208, Colour::black, stringId, &args);
+                    auto point = Point(175, yBottom + 7);
+                    drawingCtx.drawStringLeftClipped(rt, point, 208, Colour::black, stringId, &args);
                 }
 
                 auto performanceStringId = StringIds::performance_index;
@@ -521,7 +522,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     args.push(performanceStringId);
                     formatPerformanceIndex(company->performanceIndex, args);
 
-                    drawingCtx.drawStringLeftClipped(rt, 385, yBottom - 1, 143, Colour::black, stringId, &args);
+                    auto point = Point(385, yBottom - 1);
+                    drawingCtx.drawStringLeftClipped(rt, point, 143, Colour::black, stringId, &args);
                 }
 
                 {
@@ -530,7 +532,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     args.push(StringIds::company_value_currency);
                     args.push(company->companyValueHistory[0]);
 
-                    drawingCtx.drawStringLeftClipped(rt, 530, yBottom - 1, 98, Colour::black, stringId, &args);
+                    auto point = Point(530, yBottom - 1);
+                    drawingCtx.drawStringLeftClipped(rt, point, 98, Colour::black, stringId, &args);
                 }
             }
         }
@@ -1050,7 +1053,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 auto args = FormatArguments();
                 args.push(cargo->name);
 
-                drawingCtx.drawStringLeftClipped(*rt, x + 6, y, 94, Colour::black, stringId, &args);
+                auto point = Point(x + 6, y);
+                drawingCtx.drawStringLeftClipped(*rt, point, 94, Colour::black, stringId, &args);
 
                 y += 10;
                 cargoCount++;
@@ -1125,24 +1129,28 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 Common::drawGraph(&self, rt);
             }
 
-            auto x = self.width + self.x - 104;
-            auto y = self.y + 52;
+            {
+                auto x = self.width + self.x - 104;
+                auto y = self.y + 52;
 
-            drawGraphLegend(&self, rt, x, y);
+                drawGraphLegend(&self, rt, x, y);
+            }
 
-            x = self.x + 8;
-            y = self.widgets[Common::widx::panel].top + self.y + 1;
+            {
+                auto point = Point(self.x + 8, self.widgets[Common::widx::panel].top + self.y + 1);
 
-            FormatArguments args{};
-            args.push<uint16_t>(100);
-            args.push<uint16_t>(10);
+                FormatArguments args{};
+                args.push<uint16_t>(100);
+                args.push<uint16_t>(10);
 
-            drawingCtx.drawStringLeft(*rt, x, y, Colour::black, StringIds::cargo_deliver_graph_title, &args);
+                drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::cargo_deliver_graph_title, &args);
+            }
 
-            x = self.x + 160;
-            y = self.height + self.y - 13;
+            {
+                auto point = Point(self.x + 160, self.height + self.y - 13);
 
-            drawingCtx.drawStringLeft(*rt, x, y, Colour::black, StringIds::cargo_transit_time);
+                drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::cargo_transit_time);
+            }
         }
 
         // 0x004379F2
@@ -1255,8 +1263,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
                         StringIds::water_speed_record,
                     };
 
-                    auto x = self.x + 4;
-                    drawingCtx.drawStringLeft(*rt, x, y, Colour::black, string[i], &args);
+                    auto point = Point(self.x + 4, y);
+                    drawingCtx.drawStringLeft(*rt, point, Colour::black, string[i], &args);
                 }
                 y += 11;
 
@@ -1273,15 +1281,15 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     auto x = self.x + 4;
                     drawingCtx.drawImage(rt, x, y, imageId);
 
-                    x = self.x + 33;
                     y += 7;
+                    auto point = Point(self.x + 33, y);
 
                     FormatArguments args{};
                     args.push(company->name);
                     args.push<uint16_t>(0);
                     args.push(CompanyManager::getRecords().date[i]);
 
-                    drawingCtx.drawStringLeft(*rt, x, y, Colour::black, StringIds::record_date_achieved, &args);
+                    drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::record_date_achieved, &args);
                     y += 17;
                 }
 
@@ -1603,9 +1611,9 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 if (!(self->isDisabled(widx::tab_values)))
                 {
-                    auto x = self->widgets[widx::tab_values].left + self->x + 28;
-                    auto y = self->widgets[widx::tab_values].top + self->y + 14 + 1;
-                    drawingCtx.drawStringRight(*rt, x, y, Colour::black, StringIds::currency_symbol);
+                    auto& widget = self->widgets[widx::tab_values];
+                    auto point = Point(widget.left + self->x + 28, widget.top + self->y + 14 + 1);
+                    drawingCtx.drawStringRight(*rt, point, Colour::black, StringIds::currency_symbol);
                 }
             }
 
@@ -1619,9 +1627,9 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
                 if (!(self->isDisabled(widx::tab_payment_rates)))
                 {
-                    auto x = self->widgets[widx::tab_payment_rates].left + self->x + 28;
-                    auto y = self->widgets[widx::tab_payment_rates].top + self->y + 14 + 1;
-                    drawingCtx.drawStringRight(*rt, x, y, Colour::black, StringIds::currency_symbol);
+                    auto& widget = self->widgets[widx::tab_payment_rates];
+                    auto point = Point(widget.left + self->x + 28, widget.top + self->y + 14 + 1);
+                    drawingCtx.drawStringRight(*rt, point, Colour::black, StringIds::currency_symbol);
                 }
             }
 
@@ -1681,7 +1689,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 FormatArguments args{};
                 args.push(company.name);
 
-                drawingCtx.drawStringLeftClipped(*rt, x + 6, y, 94, Colour::black, stringId, &args);
+                auto point = Point(x + 6, y);
+                drawingCtx.drawStringLeftClipped(*rt, point, 94, Colour::black, stringId, &args);
 
                 y += 10;
                 companyCount++;

--- a/src/OpenLoco/src/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Windows/CompanyWindow.cpp
@@ -206,10 +206,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             // Draw 'owner' label
             {
                 auto& widget = self.widgets[widx::face];
+                auto point = Point(self.x + (widget.left + widget.right) / 2, self.y + widget.top - 12);
                 drawingCtx.drawStringCentred(
                     *rt,
-                    self.x + (widget.left + widget.right) / 2,
-                    self.y + widget.top - 12,
+                    point,
                     Colour::black,
                     StringIds::window_owner,
                     nullptr);
@@ -260,10 +260,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 CompanyManager::getOwnerStatus(CompanyId(self.number), args);
 
                 auto& widget = self.widgets[widx::unk_11];
+                auto point = Point(self.x + widget.left - 1, self.y + widget.top - 1);
                 drawingCtx.drawStringLeftClipped(
                     *rt,
-                    self.x + widget.left - 1,
-                    self.y + widget.top - 1,
+                    point,
                     widget.right - widget.left,
                     Colour::black,
                     StringIds::black_stringid,
@@ -751,21 +751,27 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 FormatArguments args{};
                 args.push<uint16_t>(competitor->intelligence);
                 args.push(aiRatingToLevel(competitor->intelligence));
-                drawingCtx.drawStringLeft(rt, x, y, Colour::black, StringIds::company_details_intelligence, &args);
+
+                auto point = Point(x, y);
+                drawingCtx.drawStringLeft(rt, point, Colour::black, StringIds::company_details_intelligence, &args);
                 y += 10;
             }
             {
                 FormatArguments args{};
                 args.push<uint16_t>(competitor->aggressiveness);
                 args.push(aiRatingToLevel(competitor->aggressiveness));
-                drawingCtx.drawStringLeft(rt, x, y, Colour::black, StringIds::company_details_aggressiveness, &args);
+
+                auto point = Point(x, y);
+                drawingCtx.drawStringLeft(rt, point, Colour::black, StringIds::company_details_aggressiveness, &args);
                 y += 10;
             }
             {
                 FormatArguments args{};
                 args.push<uint16_t>(competitor->competitiveness);
                 args.push(aiRatingToLevel(competitor->competitiveness));
-                drawingCtx.drawStringLeft(rt, x, y, Colour::black, StringIds::company_details_competitiveness, &args);
+
+                auto point = Point(x, y);
+                drawingCtx.drawStringLeft(rt, point, Colour::black, StringIds::company_details_competitiveness, &args);
                 y += 10;
             }
         }
@@ -796,7 +802,9 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             {
                 FormatArguments args{};
                 args.push(company->startedDate);
-                drawingCtx.drawStringLeft(*rt, x, y, Colour::black, StringIds::company_details_started, &args);
+
+                auto point = Point(x, y);
+                drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::company_details_started, &args);
                 y += 10;
             }
 
@@ -813,14 +821,18 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 {
                     formatId = StringIds::company_details_performance_increasing;
                 }
-                drawingCtx.drawStringLeft(*rt, x, y, Colour::black, formatId, &args);
+
+                auto point = Point(x, y);
+                drawingCtx.drawStringLeft(*rt, point, Colour::black, formatId, &args);
                 y += 25;
             }
 
             {
                 FormatArguments args{};
                 args.push(company->ownerName);
-                drawingCtx.drawStringLeftClipped(*rt, x, y, 213, Colour::black, StringIds::owner_label, &args);
+
+                auto point = Point(x, y);
+                drawingCtx.drawStringLeftClipped(*rt, point, 213, Colour::black, StringIds::owner_label, &args);
                 y += 10;
             }
 
@@ -838,26 +850,25 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     {
                         FormatArguments args{};
                         args.push(count);
-                        drawingCtx.drawStringLeft(*rt, x, y, Colour::black, transportTypeCountString[i], &args);
+
+                        auto point = Point(x, y);
+                        drawingCtx.drawStringLeft(*rt, point, Colour::black, transportTypeCountString[i], &args);
                         y += 10;
                     }
                 }
             }
 
             {
-                x = self.x + (self.widgets[widx::viewport].left + self.widgets[widx::viewport].right) / 2;
-                y = self.y + self.widgets[widx::viewport].top - 12;
-                drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::wcolour2_headquarters);
+                auto& widget = self.widgets[widx::viewport];
+                auto point = Point(self.x + widget.midX(), self.y + widget.top - 12);
+                drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::wcolour2_headquarters);
             }
 
             if (company->headquartersX == -1)
             {
-                auto width = self.widgets[widx::viewport].width();
-                Ui::Point loc = {
-                    static_cast<int16_t>(self.x + self.widgets[widx::viewport].left + width / 2),
-                    static_cast<int16_t>(self.y + self.widgets[widx::viewport].top + self.widgets[widx::viewport].height() / 2 - 5)
-                };
-                width -= 2;
+                auto& widget = self.widgets[widx::viewport];
+                auto loc = Point(self.x + widget.midX(), self.y + widget.midY() - 5);
+                auto width = widget.width() - 2;
                 drawingCtx.drawStringCentredWrapped(*rt, loc, width, Colour::black, StringIds::not_yet_constructed);
             }
 
@@ -1417,23 +1428,20 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             Common::drawCompanySelect(&self, rt);
 
             const auto& widget = self.widgets[widx::main_colour_scheme];
-            const uint16_t x = self.x + 6;
-            uint16_t y = self.y + widget.top + 3;
+            auto point = Point(self.x + 6, self.y + widget.top + 3);
 
             // 'Main colour scheme'
             drawingCtx.drawStringLeft(
                 *rt,
-                x,
-                y,
+                point,
                 Colour::black,
                 StringIds::main_colour_scheme);
 
             // 'Special colour schemes used for'
-            y += 17;
+            point.y += 17;
             drawingCtx.drawStringLeft(
                 *rt,
-                x,
-                y,
+                point,
                 Colour::black,
                 StringIds::special_colour_schemes_used_for);
         }
@@ -1767,10 +1775,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // Draw 'expenditure/income' label
             {
+                auto point = Point(self.x + 5, self.y + 47);
                 drawingCtx.drawStringLeftUnderline(
                     *rt,
-                    self.x + 5,
-                    self.y + 47,
+                    point,
                     Colour::black,
                     StringIds::expenditure_income,
                     nullptr);
@@ -1809,10 +1817,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 FormatArguments args{};
                 args.push(ExpenditureLabels[i]);
 
+                auto point = Point(self.x + 5, y - 1);
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + 5,
-                    y - 1,
+                    point,
                     Colour::black,
                     StringIds::wcolour2_stringid,
                     &args);
@@ -1822,23 +1830,24 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // 'Current loan' label
             {
+                auto point = Point(self.x + 7, self.y + self.widgets[widx::currentLoan].top);
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + 7,
-                    self.y + self.widgets[widx::currentLoan].top,
+                    point,
                     Colour::black,
                     StringIds::company_current_loan);
             }
 
             // '@ X% interest per' label
             {
-                loco_global<uint8_t, 0x00525FC6> _loanInterestRate;
                 FormatArguments args{};
-                args.push<uint16_t>(_loanInterestRate);
+                args.push<uint16_t>(getGameState().loanInterestRate);
+
+                auto& widget = self.widgets[widx::currentLoan];
+                auto point = Point(self.x + widget.right + 3, self.y + widget.top + 1);
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + self.widgets[widx::currentLoan].right + 3,
-                    self.y + self.widgets[widx::currentLoan].top + 1,
+                    point,
                     Colour::black,
                     StringIds::interest_per_year,
                     &args);
@@ -1856,10 +1865,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 if (company->cash.var_04 < 0)
                     cashFormat = StringIds::cash_negative;
 
+                auto point = Point(self.x + 7, self.y + self.widgets[widx::currentLoan].top + 13);
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + 7,
-                    self.y + self.widgets[widx::currentLoan].top + 13,
+                    point,
                     Colour::black,
                     cashFormat,
                     &args);
@@ -1871,10 +1880,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 FormatArguments args{};
                 args.push(company->companyValueHistory[0]);
 
+                auto point = Point(self.x + 7, self.y + self.widgets[widx::currentLoan].top + 26);
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + 7,
-                    self.y + self.widgets[widx::currentLoan].top + 26,
+                    point,
                     Colour::black,
                     StringIds::company_value,
                     &args);
@@ -1886,10 +1895,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 FormatArguments args{};
                 args.push(company->vehicleProfit);
 
+                auto point = Point(self.x + 7, self.y + self.widgets[widx::currentLoan].top + 39);
                 drawingCtx.drawStringLeft(
                     *rt,
-                    self.x + 7,
-                    self.y + self.widgets[widx::currentLoan].top + 39,
+                    point,
                     Colour::black,
                     StringIds::profit_from_vehicles,
                     &args);
@@ -1909,13 +1918,14 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             }
 
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
+            auto point = Point(x, y);
             drawingCtx.drawStringRightUnderline(
                 *rt,
-                x,
-                y,
+                point,
                 Colour::black,
                 format,
                 &args);
+
             y += 14;
         }
 
@@ -1935,10 +1945,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     args.push(StringIds::currency48);
                     args.push(expenditures);
 
+                    auto point = Point(x, y);
                     drawingCtx.drawStringRight(
                         *rt,
-                        x,
-                        y,
+                        point,
                         Colour::black,
                         StringIds::black_stringid,
                         &args);
@@ -1966,7 +1976,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             y += 4;
 
-            drawingCtx.drawStringRight(*rt, x, y, Colour::black, mainFormat, &args);
+            auto point = Point(x, y);
+            drawingCtx.drawStringRight(*rt, point, Colour::black, mainFormat, &args);
 
             drawingCtx.fillRect(*rt, x - expenditureColumnWidth + 10, y - 2, x, y - 2, PaletteIndex::index_0A, Drawing::RectFlags::none);
         }
@@ -2260,12 +2271,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             uint16_t y = self.y + 47;
 
             // 'Cargo delivered'
-            drawingCtx.drawStringLeft(
-                *rt,
-                self.x + 5,
-                y,
-                Colour::black,
-                StringIds::cargo_delivered);
+            {
+                auto point = Point(self.x + 5, y);
+                drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::cargo_delivered);
+            }
 
             y += 10;
 
@@ -2285,13 +2294,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
                 args.push(company->cargoDelivered[i]);
 
-                drawingCtx.drawStringLeft(
-                    *rt,
-                    self.x + 10,
-                    y,
-                    Colour::black,
-                    StringIds::black_stringid,
-                    &args);
+                auto point = Point(self.x + 10, y);
+                drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::black_stringid, &args);
 
                 numPrinted++;
                 y += 10;
@@ -2300,12 +2304,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             // No cargo delivered yet?
             if (numPrinted == 0)
             {
-                drawingCtx.drawStringLeft(
-                    *rt,
-                    self.x + 10,
-                    y,
-                    Colour::black,
-                    StringIds::cargo_delivered_none);
+                auto point = Point(self.x + 10, y);
+                drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::cargo_delivered_none);
             }
         }
 
@@ -2454,19 +2454,21 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             char* scenarioDetailsString = getGameState().scenarioDetails;
             StringManager::locoStrcpy(buffer_2039, scenarioDetailsString);
 
-            int16_t y = self.y + 47;
+            auto point = Point(self.x + 5, self.y + 47);
+
             // for example: "Provide the transport services on this little island" for "Boulder Breakers" scenario
-            y = drawingCtx.drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::buffer_2039);
-            y += 5;
-            drawingCtx.drawStringLeft(*rt, self.x + 5, y, Colour::black, StringIds::challenge_label);
-            y += 10;
+            point.y = drawingCtx.drawStringLeftWrapped(*rt, point, self.width - 10, Colour::black, StringIds::buffer_2039);
+            point.y += 5;
+
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::challenge_label);
+            point.y += 10;
 
             {
                 FormatArguments args{};
                 Scenario::formatChallengeArguments(Scenario::getObjective(), Scenario::getObjectiveProgress(), args);
 
-                y = drawingCtx.drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::challenge_value, &args);
-                y += 5;
+                point.y = drawingCtx.drawStringLeftWrapped(*rt, point, self.width - 10, Colour::black, StringIds::challenge_value, &args);
+                point.y += 5;
             }
 
             Company* playerCompany = CompanyManager::getPlayerCompany();
@@ -2480,13 +2482,13 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 args.push(years);
                 args.push(months);
 
-                drawingCtx.drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::success_you_completed_the_challenge_in_years_months, &args);
+                drawingCtx.drawStringLeftWrapped(*rt, point, self.width - 10, Colour::black, StringIds::success_you_completed_the_challenge_in_years_months, &args);
                 return;
             }
 
             if ((playerCompany->challengeFlags & CompanyFlags::challengeFailed) != CompanyFlags::none)
             {
-                drawingCtx.drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::failed_you_failed_to_complete_the_challenge);
+                drawingCtx.drawStringLeftWrapped(*rt, point, self.width - 10, Colour::black, StringIds::failed_you_failed_to_complete_the_challenge);
                 return;
             }
 
@@ -2500,14 +2502,14 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 args.skip(2);
                 args.push(years);
                 args.push(months);
-                drawingCtx.drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::beaten_by_other_player_completed_in_years_months, &args);
+                drawingCtx.drawStringLeftWrapped(*rt, point, self.width - 10, Colour::black, StringIds::beaten_by_other_player_completed_in_years_months, &args);
                 return;
             }
 
             {
                 FormatArguments args{};
                 args.push<uint16_t>(playerCompany->challengeProgress);
-                y = drawingCtx.drawStringLeftWrapped(*rt, self.x + 5, y, self.width - 10, Colour::black, StringIds::progress_towards_completing_challenge_percent, &args);
+                point.y = drawingCtx.drawStringLeftWrapped(*rt, point, self.width - 10, Colour::black, StringIds::progress_towards_completing_challenge_percent, &args);
             }
 
             if ((Scenario::getObjective().flags & Scenario::ObjectiveFlags::withinTimeLimit) != Scenario::ObjectiveFlags::none)
@@ -2521,7 +2523,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 args.push(years);
                 args.push(months);
 
-                drawingCtx.drawStringLeftWrapped(*rt, self.x + 5, y, self.width + 10, Colour::black, StringIds::time_remaining_years_months, &args);
+                drawingCtx.drawStringLeftWrapped(*rt, point, self.width + 10, Colour::black, StringIds::time_remaining_years_months, &args);
                 return;
             }
         }

--- a/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
@@ -2648,7 +2648,10 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
         if (_constructionHover != 1)
-            drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::build_this);
+        {
+            auto point = Point(x, y);
+            drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::build_this);
+        }
 
         y += 11;
 
@@ -2658,7 +2661,8 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             {
                 FormatArguments args{};
                 args.push<uint32_t>(_trackCost);
-                drawingCtx.drawStringCentred(*rt, x, y, Colour::black, StringIds::build_cost, &args);
+                auto point = Point(x, y);
+                drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::build_cost, &args);
             }
         }
     }

--- a/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
@@ -2649,8 +2649,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
         if (_constructionHover != 1)
         {
-            auto point = Point(x, y);
-            drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::build_this);
+            drawingCtx.drawStringCentred(*rt, Point(x, y), Colour::black, StringIds::build_this);
         }
 
         y += 11;
@@ -2661,8 +2660,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             {
                 FormatArguments args{};
                 args.push<uint32_t>(_trackCost);
-                auto point = Point(x, y);
-                drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::build_cost, &args);
+                drawingCtx.drawStringCentred(*rt, Point(x, y), Colour::black, StringIds::build_cost, &args);
             }
         }
     }

--- a/src/OpenLoco/src/Windows/Construction/OverheadTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/OverheadTab.cpp
@@ -517,16 +517,14 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
             }
         }
 
-        auto xPos = self.x + 69;
-        auto yPos = self.widgets[widx::image].bottom + self.y + 4;
-
         if (_modCost != 0x80000000 && _modCost != 0)
         {
             FormatArguments args{};
             args.push<uint32_t>(_modCost);
 
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-            drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::build_cost, &args);
+            auto point = Point(self.x + 69, self.widgets[widx::image].bottom + self.y + 4);
+            drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::build_cost, &args);
         }
     }
 

--- a/src/OpenLoco/src/Windows/Construction/SignalTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/SignalTab.cpp
@@ -316,7 +316,8 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
             FormatArguments args{};
             args.push(trainSignalObject->description);
 
-            drawingCtx.drawStringLeftWrapped(*rt, xPos, yPos, width, Colour::black, StringIds::signal_black, &args);
+            auto point = Point(xPos, yPos);
+            drawingCtx.drawStringLeftWrapped(*rt, point, width, Colour::black, StringIds::signal_black, &args);
         }
 
         auto imageId = trainSignalObject->image;
@@ -338,10 +339,8 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
             FormatArguments args{};
             args.push<uint32_t>(_signalCost);
 
-            xPos = self.x + 69;
-            yPos = self.widgets[widx::single_direction].bottom + self.y + 5;
-
-            drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::build_cost, &args);
+            auto point = Point(self.x + 69, self.widgets[widx::single_direction].bottom + self.y + 5);
+            drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::build_cost, &args);
         }
     }
 

--- a/src/OpenLoco/src/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/StationTab.cpp
@@ -979,13 +979,13 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
         if (_stationCost != 0x80000000 && _stationCost != 0)
         {
-            xPos = self.x + 69;
-            yPos = self.widgets[widx::image].bottom + self.y + 4;
+            auto& widget = self.widgets[widx::image];
+            auto point = Point(self.x + 69, widget.bottom + self.y + 4);
 
             FormatArguments args{};
             args.push<uint32_t>(_stationCost);
 
-            drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::build_cost, &args);
+            drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::build_cost, &args);
         }
 
         xPos = self.x + 3;
@@ -1012,18 +1012,20 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
         xPos = self.x + 69;
         yPos = self.widgets[widx::image].bottom + self.y + 18;
+
+        auto origin = Point(xPos, yPos);
         width = self.width - 4;
-        drawingCtx.drawStringCentredClipped(*rt, xPos, yPos, width, Colour::black, StringIds::new_station_buffer, &args);
+        drawingCtx.drawStringCentredClipped(*rt, origin, width, Colour::black, StringIds::new_station_buffer, &args);
 
         xPos = self.x + 2;
         yPos = self.widgets[widx::image].bottom + self.y + 29;
-        Ui::Point origin = { xPos, yPos };
 
-        drawingCtx.drawStringLeft(*rt, &origin, Colour::black, StringIds::catchment_area_accepts);
+        origin = Point(xPos, yPos);
+        drawingCtx.drawStringLeft(*rt, origin, Colour::black, StringIds::catchment_area_accepts);
 
         if (_constructingStationAcceptedCargoTypes == 0)
         {
-            drawingCtx.drawStringLeft(*rt, origin.x, origin.y, Colour::black, StringIds::catchment_area_nothing);
+            drawingCtx.drawStringLeft(*rt, origin, Colour::black, StringIds::catchment_area_nothing);
         }
         else
         {
@@ -1046,13 +1048,13 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
         xPos = self.x + 2;
         yPos = self.widgets[widx::image].bottom + self.y + 49;
-        origin = { xPos, yPos };
+        origin = Point(xPos, yPos);
 
-        drawingCtx.drawStringLeft(*rt, &origin, Colour::black, StringIds::catchment_area_produces);
+        drawingCtx.drawStringLeft(*rt, origin, Colour::black, StringIds::catchment_area_produces);
 
         if (_constructingStationProducedCargoTypes == 0)
         {
-            drawingCtx.drawStringLeft(*rt, origin.x, origin.y, Colour::black, StringIds::catchment_area_nothing);
+            drawingCtx.drawStringLeft(*rt, origin, Colour::black, StringIds::catchment_area_nothing);
         }
         else
         {

--- a/src/OpenLoco/src/Windows/Error.cpp
+++ b/src/OpenLoco/src/Windows/Error.cpp
@@ -241,7 +241,8 @@ namespace OpenLoco::Ui::Windows::Error
 
             if (_errorCompetitorId == CompanyId::null)
             {
-                drawingCtx.drawStringCentredRaw(*rt, ((width + 1) / 2) + x - 1, y + 1, _linebreakCount, Colour::black, &_errorText[0]);
+                auto point = Point(((width + 1) / 2) + x - 1, y + 1);
+                drawingCtx.drawStringCentredRaw(*rt, point, _linebreakCount, Colour::black, &_errorText[0]);
             }
             else
             {
@@ -262,7 +263,8 @@ namespace OpenLoco::Ui::Windows::Error
                     drawingCtx.drawImage(rt, xPos, yPos, ImageIds::owner_jailed);
                 }
 
-                drawingCtx.drawStringCentredRaw(*rt, self.x + 156, self.y + 20, _linebreakCount, Colour::black, &_errorText[0]);
+                auto point = Point(self.x + 156, self.y + 20);
+                drawingCtx.drawStringCentredRaw(*rt, point, _linebreakCount, Colour::black, &_errorText[0]);
             }
         }
 

--- a/src/OpenLoco/src/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Windows/IndustryList.cpp
@@ -141,9 +141,6 @@ namespace OpenLoco::Ui::Windows::IndustryList
             self.draw(rt);
             Common::drawTabs(&self, rt);
 
-            auto xPos = self.x + 4;
-            auto yPos = self.y + self.height - 12;
-
             FormatArguments args{};
             if (self.var_83C == 1)
                 args.push(StringIds::status_num_industries_singular);
@@ -151,7 +148,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 args.push(StringIds::status_num_industries_plural);
             args.push(self.var_83C);
 
-            drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::black_stringid, &args);
+            auto point = Point(self.x + 4, self.y + self.height - 12);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x00457EC4
@@ -421,7 +419,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     args.push(industry->name);
                     args.push(industry->town);
 
-                    drawingCtx.drawStringLeftClipped(rt, 0, yPos, 198, Colour::black, text_colour_id, &args);
+                    auto point = Point(0, yPos);
+                    drawingCtx.drawStringLeftClipped(rt, point, 198, Colour::black, text_colour_id, &args);
                 }
                 // Industry Status
                 {
@@ -431,7 +430,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     FormatArguments args{};
                     args.push(StringIds::buffer_1250);
 
-                    drawingCtx.drawStringLeftClipped(rt, 200, yPos, 238, Colour::black, text_colour_id, &args);
+                    auto point = Point(200, yPos);
+                    drawingCtx.drawStringLeftClipped(rt, point, 238, Colour::black, text_colour_id, &args);
                 }
                 // Industry Production Delivered
                 {
@@ -446,7 +446,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     FormatArguments args{};
                     args.push<uint16_t>(productionTransported);
 
-                    drawingCtx.drawStringLeftClipped(rt, 440, yPos, 138, Colour::black, StringIds::production_transported_percent, &args);
+                    auto point = Point(440, yPos);
+                    drawingCtx.drawStringLeftClipped(rt, point, 138, Colour::black, StringIds::production_transported_percent, &args);
                 }
                 yPos += kRowHeight;
             }
@@ -654,10 +655,9 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
             if (self.var_83C == 0)
             {
-                auto xPos = self.x + 3;
-                auto yPos = self.y + self.height - 13;
+                auto point = Point(self.x + 3, self.y + self.height - 13);
                 auto width = self.width - 19;
-                drawingCtx.drawStringLeftClipped(*rt, xPos, yPos, width, Colour::black, StringIds::no_industry_available);
+                drawingCtx.drawStringLeftClipped(*rt, point, width, Colour::black, StringIds::no_industry_available);
                 return;
             }
 
@@ -689,18 +689,18 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
             if (!isEditorMode() && !isSandboxMode())
             {
-                auto xPos = self.x + 3 + self.width - 19;
-                auto yPos = self.y + self.height - 13;
+                auto point = Point(self.x + 3 + self.width - 19, self.y + self.height - 13);
                 widthOffset = 138;
 
-                drawingCtx.drawStringRight(*rt, xPos, yPos, Colour::black, StringIds::build_cost, &args);
+                drawingCtx.drawStringRight(*rt, point, Colour::black, StringIds::build_cost, &args);
             }
 
-            auto xPos = self.x + 3;
-            auto yPos = self.y + self.height - 13;
-            auto width = self.width - 19 - widthOffset;
+            {
+                auto point = Point(self.x + 3, self.y + self.height - 13);
+                auto width = self.width - 19 - widthOffset;
 
-            drawingCtx.drawStringLeftClipped(*rt, xPos, yPos, width, Colour::black, StringIds::black_stringid, &industryObj->name);
+                drawingCtx.drawStringLeftClipped(*rt, point, width, Colour::black, StringIds::black_stringid, &industryObj->name);
+            }
         }
 
         // 0x0045843A

--- a/src/OpenLoco/src/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Windows/IndustryWindow.cpp
@@ -147,10 +147,9 @@ namespace OpenLoco::Ui::Windows::Industry
             args.push(StringIds::buffer_1250);
 
             auto widget = &self.widgets[widx::status_bar];
-            auto x = self.x + widget->left - 1;
-            auto y = self.y + widget->top - 1;
+            auto point = Point(self.x + widget->left - 1, self.y + widget->top - 1);
             auto width = widget->width();
-            drawingCtx.drawStringLeftClipped(*rt, x, y, width, Colour::black, StringIds::black_stringid, &args);
+            drawingCtx.drawStringLeftClipped(*rt, point, width, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x00455C86
@@ -455,16 +454,14 @@ namespace OpenLoco::Ui::Windows::Industry
 
             auto industry = IndustryManager::get(IndustryId(self.number));
             const auto* industryObj = industry->getObject();
-            int16_t xPos = self.x + 3;
-            int16_t yPos = self.y + 45;
-            Ui::Point origin = { xPos, yPos };
+            auto origin = Point(self.x + 3, self.y + 45);
 
             // Draw Last Months received cargo stats
             if (industry->canReceiveCargo())
             {
+                drawingCtx.drawStringLeft(*rt, origin, Colour::black, StringIds::received_cargo);
                 origin.x += 4;
                 origin.y += 10;
-                drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::received_cargo);
 
                 auto cargoNumber = 0;
                 for (const auto& receivedCargoType : industryObj->requiredCargoType)
@@ -484,7 +481,7 @@ namespace OpenLoco::Ui::Windows::Industry
                         }
                         args.push<uint32_t>(industry->receivedCargoQuantityPreviousMonth[cargoNumber]);
 
-                        origin.y = drawingCtx.drawStringLeftWrapped(*rt, origin.x, origin.y, 290, Colour::black, StringIds::black_stringid, &args);
+                        origin.y = drawingCtx.drawStringLeftWrapped(*rt, origin, 290, Colour::black, StringIds::black_stringid, &args);
                     }
                     cargoNumber++;
                 }
@@ -495,7 +492,7 @@ namespace OpenLoco::Ui::Windows::Industry
             // Draw Last Months produced cargo stats
             if (industry->canProduceCargo())
             {
-                drawingCtx.drawStringLeft(*rt, origin.x, origin.y, Colour::black, StringIds::produced_cargo);
+                drawingCtx.drawStringLeft(*rt, origin, Colour::black, StringIds::produced_cargo);
                 origin.y += 10;
                 origin.x += 4;
 
@@ -518,7 +515,7 @@ namespace OpenLoco::Ui::Windows::Industry
                         args.push<uint32_t>(industry->producedCargoQuantityPreviousMonth[cargoNumber]);
                         args.push<uint16_t>(industry->producedCargoPercentTransportedPreviousMonth[cargoNumber]);
 
-                        origin.y = drawingCtx.drawStringLeftWrapped(*rt, origin.x, origin.y, 290, Colour::black, StringIds::transported_cargo, &args);
+                        origin.y = drawingCtx.drawStringLeftWrapped(*rt, origin, 290, Colour::black, StringIds::transported_cargo, &args);
                     }
                     cargoNumber++;
                 }
@@ -596,10 +593,8 @@ namespace OpenLoco::Ui::Windows::Industry
                 FormatArguments args{};
                 args.push(cargoObj->unitsAndCargoName);
 
-                int16_t x = self.x + 2;
-                int16_t y = self.y - 24 + 68;
-
-                drawingCtx.drawStringLeft(*rt, x, y, Colour::black, StringIds::production_graph_label, &args);
+                auto point = Point(self.x + 2, self.y - 24 + 68);
+                drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::production_graph_label, &args);
             }
 
             // Draw Y label and grid lines.
@@ -612,7 +607,8 @@ namespace OpenLoco::Ui::Windows::Industry
 
                 drawingCtx.drawRect(*rt, self.x + 41, yPos, 239, 1, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4), Drawing::RectFlags::none);
 
-                drawingCtx.drawStringRight(*rt, self.x + 39, yPos - 6, Colour::black, StringIds::population_graph_people, &args);
+                auto point = Point(self.x + 39, yPos - 6);
+                drawingCtx.drawStringRight(*rt, point, Colour::black, StringIds::population_graph_people, &args);
 
                 yTick += 1000;
             }
@@ -637,7 +633,8 @@ namespace OpenLoco::Ui::Windows::Industry
                         FormatArguments args{};
                         args.push(year);
 
-                        drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::population_graph_year, &args);
+                        auto point = Point(xPos, yPos);
+                        drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::population_graph_year, &args);
                     }
 
                     drawingCtx.drawRect(*rt, xPos, yPos + 11, 1, self.height - 74, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4), Drawing::RectFlags::none);

--- a/src/OpenLoco/src/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Windows/KeyboardShortcuts.cpp
@@ -187,7 +187,8 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
             formatter.push(baseStringId);
             formatter.push(buffer);
 
-            drawingCtx.drawStringLeft(rt, 0, yPos - 1, Colour::black, format, &formatter);
+            auto point = Point(0, yPos - 1);
+            drawingCtx.drawStringLeft(rt, point, Colour::black, format, &formatter);
             yPos += kRowHeight;
         }
     }

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -275,7 +275,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     args.push(obj->name);
 
                     auto pos = Point(window.x + 10, window.y + window.widgets[widx::change_heightmap_btn].top);
-                    drawingCtx.drawStringLeft(*rt, &pos, Colour::black, StringIds::landscapeOptionsCurrentHillObject, &args);
+                    drawingCtx.drawStringLeft(*rt, pos, Colour::black, StringIds::landscapeOptionsCurrentHillObject, &args);
                     break;
                 }
 
@@ -283,12 +283,8 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                 {
                     // Draw label
                     auto& widget = window.widgets[widx::terrainSmoothingNum];
-                    drawingCtx.drawStringLeft(
-                        *rt,
-                        window.x + 10,
-                        window.y + widget.top,
-                        Colour::black,
-                        StringIds::landscapeOptionsSmoothingPasses);
+                    auto pos = Point(window.x + 10, window.y + widget.top);
+                    drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::landscapeOptionsSmoothingPasses);
 
                     // Prepare value
                     FormatArguments args{};
@@ -296,8 +292,8 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     args.push<uint16_t>(options.numTerrainSmoothingPasses);
 
                     // Draw value
-                    auto pos = Point(window.x + widget.left + 1, window.y + widget.top);
-                    drawingCtx.drawStringLeft(*rt, &pos, Colour::black, StringIds::black_stringid, &args);
+                    pos = Point(window.x + widget.left + 1, window.y + widget.top);
+                    drawingCtx.drawStringLeft(*rt, pos, Colour::black, StringIds::black_stringid, &args);
                     break;
                 }
 
@@ -315,7 +311,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                         args.push(StringManager::getString(StringIds::noneSelected));
 
                     auto pos = Point(window.x + 10, window.y + window.widgets[widx::browseHeightmapFile].top);
-                    drawingCtx.drawStringLeft(*rt, &pos, Colour::black, StringIds::currentHeightmapFile, &args);
+                    drawingCtx.drawStringLeft(*rt, pos, Colour::black, StringIds::currentHeightmapFile, &args);
                     break;
                 }
             }

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -684,7 +684,8 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                 {
                     FormatArguments args{};
                     args.push(landObject->name);
-                    drawingCtx.drawStringLeftClipped(rt, 24, yPos + 5, 121, Colour::black, StringIds::wcolour2_stringid, &args);
+                    auto point = Point(24, yPos + 5);
+                    drawingCtx.drawStringLeftClipped(rt, point, 121, Colour::black, StringIds::wcolour2_stringid, &args);
                 }
 
                 // Draw rectangle.
@@ -695,7 +696,8 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     FormatArguments args{};
                     const StringId distributionId = landDistributionLabelIds[enumValue(S5::getOptions().landDistributionPatterns[i])];
                     args.push(distributionId);
-                    drawingCtx.drawStringLeftClipped(rt, 151, yPos + 5, 177, Colour::black, StringIds::black_stringid, &args);
+                    auto point = Point(151, yPos + 5);
+                    drawingCtx.drawStringLeftClipped(rt, point, 177, Colour::black, StringIds::black_stringid, &args);
                 }
 
                 // Draw rectangle (knob).
@@ -703,7 +705,10 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                 drawingCtx.fillRectInset(rt, 329, yPos + 6, 339, yPos + 15, window.getColour(WindowColour::secondary), flags);
 
                 // Draw triangle (knob).
-                drawingCtx.drawStringLeft(rt, 330, yPos + 6, Colour::black, StringIds::dropdown, nullptr);
+                {
+                    auto point = Point(330, yPos + 6);
+                    drawingCtx.drawStringLeft(rt, point, Colour::black, StringIds::dropdown, nullptr);
+                }
 
                 yPos += kRowHeight;
             }
@@ -1046,59 +1051,59 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
             Common::draw(window, rt);
 
+            auto point = Point(window.x + 10, window.y + window.widgets[widx::number_of_forests].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::number_of_forests].top,
+                point,
                 Colour::black,
                 StringIds::number_of_forests);
 
+            point = Point(window.x + 10, window.y + window.widgets[widx::minForestRadius].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::minForestRadius].top,
+                point,
                 Colour::black,
                 StringIds::min_forest_radius);
 
+            point = Point(window.x + 10, window.y + window.widgets[widx::maxForestRadius].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::maxForestRadius].top,
+                point,
                 Colour::black,
                 StringIds::max_forest_radius);
 
+            point = Point(window.x + 10, window.y + window.widgets[widx::minForestDensity].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::minForestDensity].top,
+                point,
                 Colour::black,
                 StringIds::min_forest_density);
 
+            point = Point(window.x + 10, window.y + window.widgets[widx::maxForestDensity].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::maxForestDensity].top,
+                point,
                 Colour::black,
                 StringIds::max_forest_density);
 
+            point = Point(window.x + 10, window.y + window.widgets[widx::number_random_trees].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::number_random_trees].top,
+                point,
                 Colour::black,
                 StringIds::number_random_trees);
 
+            point = Point(window.x + 10, window.y + window.widgets[widx::min_altitude_for_trees].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::min_altitude_for_trees].top,
+                point,
                 Colour::black,
                 StringIds::min_altitude_for_trees);
 
+            point = Point(window.x + 10, window.y + window.widgets[widx::max_altitude_for_trees].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::max_altitude_for_trees].top,
+                point,
                 Colour::black,
                 StringIds::max_altitude_for_trees);
         }
@@ -1271,17 +1276,17 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
             Common::draw(window, rt);
 
+            auto point = Point(window.x + 10, window.y + window.widgets[widx::number_of_towns].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::number_of_towns].top,
+                point,
                 Colour::black,
                 StringIds::number_of_towns);
 
+            point = Point(window.x + 10, window.y + window.widgets[widx::max_town_size].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::max_town_size].top,
+                point,
                 Colour::black,
                 StringIds::max_town_size);
         }
@@ -1405,10 +1410,10 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
             Common::draw(window, rt);
 
+            auto point = Point(window.x + 10, window.y + window.widgets[widx::num_industries].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::num_industries].top,
+                point,
                 Colour::black,
                 StringIds::number_of_industries);
         }

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -251,17 +251,17 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
             Common::draw(window, rt);
 
+            auto point = Point(window.x + 10, window.y + window.widgets[widx::start_year].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::start_year].top,
+                point,
                 Colour::black,
                 StringIds::start_year);
 
+            point = Point(window.x + 10, window.y + window.widgets[widx::heightMapBox].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::heightMapBox].top,
+                point,
                 Colour::black,
                 StringIds::height_map_source);
 
@@ -620,24 +620,24 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
             Common::draw(window, rt);
 
+            auto point = Point(window.x + 10, window.y + window.widgets[widx::min_land_height].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::min_land_height].top,
+                point,
                 Colour::black,
                 StringIds::min_land_height);
 
+            point.y = window.y + window.widgets[widx::topography_style].top;
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::topography_style].top,
+                point,
                 Colour::black,
                 StringIds::topography_style);
 
+            point.y = window.y + window.widgets[widx::hill_density].top;
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::hill_density].top,
+                point,
                 Colour::black,
                 StringIds::hill_density);
         }
@@ -940,10 +940,10 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
             Common::draw(window, rt);
 
+            auto point = Point(window.x + 10, window.y + window.widgets[widx::sea_level].top);
             drawingCtx.drawStringLeft(
                 *rt,
-                window.x + 10,
-                window.y + window.widgets[widx::sea_level].top,
+                point,
                 Colour::black,
                 StringIds::sea_level);
         }

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -548,7 +548,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046D273
-    static void drawGraphKeyOverall(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t* y)
+    static void drawGraphKeyOverall(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t& y)
     {
         static const PaletteIndex_t overallColours[] = {
             PaletteIndex::index_41,
@@ -575,7 +575,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             auto colour = overallColours[i];
             if (!(self->var_854 & (1 << i)) || !(mapFrameNumber & (1 << 2)))
             {
-                drawingCtx.drawRect(*rt, x, *y + 3, 5, 5, colour, Drawing::RectFlags::none);
+                drawingCtx.drawRect(*rt, x, y + 3, 5, 5, colour, Drawing::RectFlags::none);
             }
 
             FormatArguments args{};
@@ -588,9 +588,10 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 stringId = StringIds::small_white_string;
             }
 
-            drawingCtx.drawStringLeftClipped(*rt, x + 6, *y, 94, Colour::black, stringId, &args);
+            auto point = Point(x + 6, y);
+            drawingCtx.drawStringLeftClipped(*rt, point, 94, Colour::black, stringId, &args);
 
-            *y += 10;
+            y += 10;
         }
     }
 
@@ -605,7 +606,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     };
 
     // 0x0046D379
-    static void drawGraphKeyVehicles(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t* y)
+    static void drawGraphKeyVehicles(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t& y)
     {
         static const StringId lineNames[] = {
             StringIds::forbid_trains,
@@ -624,7 +625,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             {
                 auto colour = vehicleTypeColours[i];
 
-                drawingCtx.drawRect(*rt, x, *y + 3, 5, 5, colour, Drawing::RectFlags::none);
+                drawingCtx.drawRect(*rt, x, y + 3, 5, 5, colour, Drawing::RectFlags::none);
             }
 
             FormatArguments args{};
@@ -637,9 +638,10 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 stringId = StringIds::small_white_string;
             }
 
-            drawingCtx.drawStringLeftClipped(*rt, x + 6, *y, 94, Colour::black, stringId, &args);
+            auto point = Point(x + 6, y);
+            drawingCtx.drawStringLeftClipped(*rt, point, 94, Colour::black, stringId, &args);
 
-            *y += 10;
+            y += 10;
         }
     }
 
@@ -658,7 +660,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     // clang-format on
 
     // 0x0046D47F
-    static void drawGraphKeyIndustries(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t* y)
+    static void drawGraphKeyIndustries(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t& y)
     {
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -673,7 +675,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             {
                 auto colour = industryColours[_assignedIndustryColours[i]];
 
-                drawingCtx.drawRect(*rt, x, *y + 3, 5, 5, colour, Drawing::RectFlags::none);
+                drawingCtx.drawRect(*rt, x, y + 3, 5, 5, colour, Drawing::RectFlags::none);
             }
 
             FormatArguments args{};
@@ -686,14 +688,15 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 stringId = StringIds::small_white_string;
             }
 
-            drawingCtx.drawStringLeftClipped(*rt, x + 6, *y, 94, Colour::black, stringId, &args);
+            auto point = Point(x + 6, y);
+            drawingCtx.drawStringLeftClipped(*rt, point, 94, Colour::black, stringId, &args);
 
-            *y += 10;
+            y += 10;
         }
     }
 
     // 0x0046D5A4
-    static void drawGraphKeyRoutes(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t* y)
+    static void drawGraphKeyRoutes(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t& y)
     {
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -704,7 +707,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
             if (!(self->var_854 & (1 << i)) || !(mapFrameNumber & (1 << 2)))
             {
-                drawingCtx.drawRect(*rt, x, *y + 3, 5, 5, colour, Drawing::RectFlags::none);
+                drawingCtx.drawRect(*rt, x, y + 3, 5, 5, colour, Drawing::RectFlags::none);
             }
 
             auto routeType = StringIds::map_routes_aircraft;
@@ -738,14 +741,15 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 stringId = StringIds::small_white_string;
             }
 
-            drawingCtx.drawStringLeftClipped(*rt, x + 6, *y, 94, Colour::black, stringId, &args);
+            auto point = Point(x + 6, y);
+            drawingCtx.drawStringLeftClipped(*rt, point, 94, Colour::black, stringId, &args);
 
-            *y += 10;
+            y += 10;
         }
     }
 
     // 0x0046D6E1
-    static void drawGraphKeyCompanies(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t* y)
+    static void drawGraphKeyCompanies(Window* self, Gfx::RenderTarget* rt, uint16_t x, uint16_t& y)
     {
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -756,7 +760,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
             if (!(self->var_854 & (1 << enumValue(index))) || !(mapFrameNumber & (1 << 2)))
             {
-                drawingCtx.drawRect(*rt, x, *y + 3, 5, 5, colour, Drawing::RectFlags::none);
+                drawingCtx.drawRect(*rt, x, y + 3, 5, 5, colour, Drawing::RectFlags::none);
             }
 
             FormatArguments args{};
@@ -769,9 +773,10 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 stringId = StringIds::small_white_string;
             }
 
-            drawingCtx.drawStringLeftClipped(*rt, x + 6, *y, 94, Colour::black, stringId, &args);
+            auto point = Point(x + 6, y);
+            drawingCtx.drawStringLeftClipped(*rt, point, 94, Colour::black, stringId, &args);
 
-            *y += 10;
+            y += 10;
         }
     }
 
@@ -917,23 +922,23 @@ namespace OpenLoco::Ui::Windows::MapWindow
             switch (self.currentTab + widx::tabOverall)
             {
                 case widx::tabOverall:
-                    drawGraphKeyOverall(&self, rt, x, &y);
+                    drawGraphKeyOverall(&self, rt, x, y);
                     break;
 
                 case widx::tabVehicles:
-                    drawGraphKeyVehicles(&self, rt, x, &y);
+                    drawGraphKeyVehicles(&self, rt, x, y);
                     break;
 
                 case widx::tabIndustries:
-                    drawGraphKeyIndustries(&self, rt, x, &y);
+                    drawGraphKeyIndustries(&self, rt, x, y);
                     break;
 
                 case widx::tabRoutes:
-                    drawGraphKeyRoutes(&self, rt, x, &y);
+                    drawGraphKeyRoutes(&self, rt, x, y);
                     break;
 
                 case widx::tabOwnership:
-                    drawGraphKeyCompanies(&self, rt, x, &y);
+                    drawGraphKeyCompanies(&self, rt, x, y);
                     break;
             }
 
@@ -963,11 +968,11 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 break;
         }
 
-        auto x = self.x + self.widgets[widx::statusBar].left - 1;
-        auto y = self.y + self.widgets[widx::statusBar].top - 1;
-        auto width = self.widgets[widx::statusBar].width();
+        auto& widget = self.widgets[widx::statusBar];
+        auto point = Point(self.x + widget.left - 1, self.y + widget.top - 1);
+        auto width = widget.width();
 
-        drawingCtx.drawStringLeftClipped(*rt, x, y, width, Colour::black, StringIds::black_stringid, &args);
+        drawingCtx.drawStringLeftClipped(*rt, point, width, Colour::black, StringIds::black_stringid, &args);
     }
 
     // 0x0046BF0F based on
@@ -1357,7 +1362,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             townPos.y -= 3;
 
             drawingCtx.setCurrentFontSpriteBase(Font::small);
-            drawingCtx.drawString(*rt, townPos.x, townPos.y, AdvancedColour(Colour::purple).outline(), _stringFormatBuffer);
+            drawingCtx.drawString(*rt, townPos, AdvancedColour(Colour::purple).outline(), _stringFormatBuffer);
         }
     }
 

--- a/src/OpenLoco/src/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Windows/MessageWindow.cpp
@@ -248,14 +248,16 @@ namespace OpenLoco::Ui::Windows::MessageWindow
                     args.push(StringIds::tiny_font_date);
                     args.push(message->date);
 
-                    drawingCtx.drawStringLeft(rt, 0, height, Colour::black, stringId, &args);
+                    auto point = Point(0, height);
+                    drawingCtx.drawStringLeft(rt, point, Colour::black, stringId, &args);
                 }
                 {
                     auto args = FormatArguments();
                     args.push(StringIds::buffer_2039);
 
                     auto width = self.widgets[widx::scrollview].width() - 14;
-                    drawingCtx.drawStringLeftWrapped(rt, 0, height + 6, width, Colour::black, stringId, &args);
+                    auto point = Point(0, height + 6);
+                    drawingCtx.drawStringLeftWrapped(rt, point, width, Colour::black, stringId, &args);
                     height += messageHeight;
                 }
             }
@@ -541,7 +543,8 @@ namespace OpenLoco::Ui::Windows::MessageWindow
                     auto args = FormatArguments();
                     args.push(newsStringIds[i]);
 
-                    drawingCtx.drawStringLeft(*rt, self.x + 4, yPos, Colour::black, StringIds::wcolour2_stringid, &args);
+                    auto point = Point(self.x + 4, yPos);
+                    drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::wcolour2_stringid, &args);
                 }
 
                 {
@@ -549,7 +552,8 @@ namespace OpenLoco::Ui::Windows::MessageWindow
                     auto args = FormatArguments();
                     args.push(newsDropdownStringIds[static_cast<uint8_t>(Config::get().old.newsSettings[i])]);
 
-                    drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::black_stringid, &args);
+                    auto point = Point(xPos, yPos);
+                    drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::black_stringid, &args);
                 }
                 yPos += 15;
             }

--- a/src/OpenLoco/src/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/src/Windows/MusicSelection.cpp
@@ -111,11 +111,17 @@ namespace OpenLoco::Ui::Windows::MusicSelection
 
             // Draw checkmark if track is enabled.
             if (config.enabledMusic[i])
-                drawingCtx.drawStringLeft(rt, 2, y, window.getColour(WindowColour::secondary), StringIds::wcolour2_stringid, (void*)&StringIds::checkmark);
+            {
+                auto point = Point(2, y);
+                drawingCtx.drawStringLeft(rt, point, window.getColour(WindowColour::secondary), StringIds::wcolour2_stringid, (void*)&StringIds::checkmark);
+            }
 
             // Draw track name.
-            StringId music_title_id = Audio::getMusicInfo(i)->titleId;
-            drawingCtx.drawStringLeft(rt, 15, y, window.getColour(WindowColour::secondary), text_colour_id, (void*)&music_title_id);
+            {
+                auto point = Point(15, y);
+                StringId music_title_id = Audio::getMusicInfo(i)->titleId;
+                drawingCtx.drawStringLeft(rt, point, window.getColour(WindowColour::secondary), text_colour_id, (void*)&music_title_id);
+            }
 
             y += kRowHeight;
         }

--- a/src/OpenLoco/src/Windows/NetworkStatus.cpp
+++ b/src/OpenLoco/src/Windows/NetworkStatus.cpp
@@ -105,10 +105,10 @@ namespace OpenLoco::Ui::Windows::NetworkStatus
 
         self.draw(rt);
 
-        uint16_t x = self.x + (self.width / 2);
-        uint16_t y = self.y + (self.height / 2);
-        uint16_t width = self.width;
-        drawingCtx.drawStringCentredClipped(*rt, x, y, width, Colour::black, StringIds::buffer_1250, nullptr);
+        auto origin = Point32(self.x + (self.width / 2), self.y + (self.height / 2));
+        auto width = self.width;
+
+        drawingCtx.drawStringCentredClipped(*rt, origin, width, Colour::black, StringIds::buffer_1250, nullptr);
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Windows/NetworkStatus.cpp
+++ b/src/OpenLoco/src/Windows/NetworkStatus.cpp
@@ -105,7 +105,7 @@ namespace OpenLoco::Ui::Windows::NetworkStatus
 
         self.draw(rt);
 
-        auto origin = Point32(self.x + (self.width / 2), self.y + (self.height / 2));
+        auto origin = Point(self.x + (self.width / 2), self.y + (self.height / 2));
         auto width = self.width;
 
         drawingCtx.drawStringCentredClipped(*rt, origin, width, Colour::black, StringIds::buffer_1250, nullptr);

--- a/src/OpenLoco/src/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Windows/News/News.cpp
@@ -505,7 +505,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
         }
 
         // 0x0042A036
-        static void drawViewportString(Gfx::RenderTarget* rt, uint16_t x, uint16_t y, uint16_t width, MessageItemArgumentType itemType, uint16_t itemIndex)
+        static void drawViewportString(Gfx::RenderTarget* rt, Point origin, uint16_t width, MessageItemArgumentType itemType, uint16_t itemIndex)
         {
             FormatArguments args{};
 
@@ -588,7 +588,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 case MessageItemArgumentType::vehicleTab:
                 {
                     auto drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-                    drawingCtx.drawStringCentredClipped(*rt, x, y, width, Colour::black, StringIds::black_tiny_font, &args);
+                    drawingCtx.drawStringCentredClipped(*rt, origin, width, Colour::black, StringIds::black_tiny_font, &args);
                     break;
                 }
 
@@ -635,7 +635,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             y = self->y + 1;
             origin = { x, y };
 
-            drawingCtx.drawStringLeft(*rt, &origin, Colour::black, StringIds::news_date, &news->date);
+            drawingCtx.drawStringLeft(*rt, origin, Colour::black, StringIds::news_date, &news->date);
 
             self->drawViewports(rt);
 
@@ -719,7 +719,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             origin.x = self->x + 4;
             origin.y = self->y + 5;
 
-            drawingCtx.drawStringLeft(*rt, &origin, Colour::black, StringIds::news_date, &news->date);
+            drawingCtx.drawStringLeft(*rt, origin, Colour::black, StringIds::news_date, &news->date);
 
             self->drawViewports(rt);
 
@@ -831,8 +831,9 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     x += self.x;
                     auto y = self.widgets[Common::widx::viewport1Button].bottom - 7 + self.y;
                     auto width = self.widgets[Common::widx::viewport1Button].width() - 1;
+                    auto point = Point(x, y);
 
-                    drawViewportString(rt, x, y, width, mtd.argumentTypes[0], news->itemSubjects[0]);
+                    drawViewportString(rt, point, width, mtd.argumentTypes[0], news->itemSubjects[0]);
                 }
             }
             if (mtd.hasFlag(MessageTypeFlags::hasSecondItem))
@@ -843,8 +844,9 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     x += self.x;
                     auto y = self.widgets[Common::widx::viewport2Button].bottom - 7 + self.y;
                     auto width = self.widgets[Common::widx::viewport2Button].width() - 1;
+                    auto point = Point(x, y);
 
-                    drawViewportString(rt, x, y, width, mtd.argumentTypes[1], news->itemSubjects[1]);
+                    drawViewportString(rt, point, width, mtd.argumentTypes[1], news->itemSubjects[1]);
                 }
             }
         }

--- a/src/OpenLoco/src/Windows/News/Ticker.cpp
+++ b/src/OpenLoco/src/Windows/News/Ticker.cpp
@@ -211,7 +211,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
             _word_525CE0 = _word_525CE0 | (1 << 15);
         }
 
-        drawingCtx.drawStringTicker(*clipped, { 55, 0 }, StringIds::buffer_2039, Colour::black, 4, ((_word_525CE0 & ~(1 << 15)) >> 2), 109);
+        auto point = Point(55, 0);
+        drawingCtx.drawStringTicker(*clipped, point, StringIds::buffer_2039, Colour::black, 4, ((_word_525CE0 & ~(1 << 15)) >> 2), 109);
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Windows/ObjectLoadError.cpp
+++ b/src/OpenLoco/src/Windows/ObjectLoadError.cpp
@@ -84,7 +84,8 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
 
         // Draw explanatory text
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
-        drawingCtx.drawStringLeftWrapped(*rt, self.x + 3, self.y + 19, self.width - 6, self.getColour(WindowColour::secondary), StringIds::objectErrorExplanation);
+        auto point = Point(self.x + 3, self.y + 19);
+        drawingCtx.drawStringLeftWrapped(*rt, point, self.width - 6, self.getColour(WindowColour::secondary), StringIds::objectErrorExplanation);
     }
 
     static StringId objectTypeToString(ObjectType type)
@@ -174,12 +175,11 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
         // Acquire string buffer
         auto* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
 
-        const auto namePos = 1;
-        const auto typePos = window.widgets[Widx::typeHeader].left - 4;
-        const auto typeWidth = window.widgets[Widx::typeHeader].width() - 6;
-        const auto checksumPos = window.widgets[Widx::checksumHeader].left - 4;
-
         uint16_t y = 0;
+        auto namePos = Point(1, y);
+        auto typePos = Point(window.widgets[Widx::typeHeader].left - 4, y);
+        auto typeWidth = window.widgets[Widx::typeHeader].width() - 6;
+        auto checksumPos = Point(window.widgets[Widx::checksumHeader].left - 4, y);
         for (uint16_t i = 0; i < window.rowCount; i++)
         {
             if (y + kRowHeight < rt.y)
@@ -211,7 +211,8 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
             buffer[8] = '\0';
 
             // Draw object name
-            drawingCtx.drawStringLeft(rt, namePos, y, window.getColour(WindowColour::secondary), textColourId, &args);
+            namePos.y = y;
+            drawingCtx.drawStringLeft(rt, namePos, window.getColour(WindowColour::secondary), textColourId, &args);
 
             // Copy object checksum to buffer
             const auto checksum = fmt::format("{:08X}", header.checksum);
@@ -219,14 +220,16 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
             buffer[8] = '\0';
 
             // Draw object checksum
-            drawingCtx.drawStringLeft(rt, checksumPos, y, window.getColour(WindowColour::secondary), textColourId, &args);
+            checksumPos.y = y;
+            drawingCtx.drawStringLeft(rt, checksumPos, window.getColour(WindowColour::secondary), textColourId, &args);
 
             // Prepare object type for drawing
             args.rewind();
             args.push(objectTypeToString(header.getType()));
 
             // Draw object type
-            drawingCtx.drawStringLeftWrapped(rt, typePos, y, typeWidth, window.getColour(WindowColour::secondary), textColourId, &args);
+            typePos.y = y;
+            drawingCtx.drawStringLeftWrapped(rt, typePos, typeWidth, window.getColour(WindowColour::secondary), textColourId, &args);
 
             y += kRowHeight;
         }

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -864,7 +864,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
             FormatArguments args{};
             args.push<StringId>(StringIds::buffer_1250);
-            drawingCtx.drawStringLeft(*clipped, 18, height - kDescriptionRowHeight * 3 - 4, Colour::black, StringIds::object_selection_filename, &args);
+
+            auto point = Point(18, height - kDescriptionRowHeight * 3 - 4);
+            drawingCtx.drawStringLeft(*clipped, point, Colour::black, StringIds::object_selection_filename, &args);
         }
     }
 
@@ -885,7 +887,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         // Draw search box input buffer
         Ui::Point position = { inputSession.xOffset, 1 };
-        drawingCtx.drawStringLeft(*clipped, &position, Colour::black, StringIds::black_stringid, &args);
+        drawingCtx.drawStringLeft(*clipped, position, Colour::black, StringIds::black_stringid, &args);
 
         // Draw search box cursor, blinking
         if ((inputSession.cursorFrame % 32) < 16)
@@ -893,7 +895,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             // We draw the string again to figure out where the cursor should go; position.x will be adjusted
             textBuffer[inputSession.cursorPosition] = '\0';
             position = { inputSession.xOffset, 1 };
-            drawingCtx.drawStringLeft(*clipped, &position, Colour::black, StringIds::black_stringid, &args);
+            drawingCtx.drawStringLeft(*clipped, position, Colour::black, StringIds::black_stringid, &args);
             drawingCtx.fillRect(*clipped, position.x, position.y, position.x, position.y + 9, Colours::getShade(self.getColour(WindowColour::secondary).c(), 9), Drawing::RectFlags::none);
         }
     }
@@ -921,11 +923,10 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             args.push(levelStringIds[self.var_856]);
 
             auto& widget = self.widgets[widx::filterLabel];
-            auto xPos = self.x + widget.left;
-            auto yPos = self.y + widget.top;
+            auto point = Point(self.x + widget.left, self.y + widget.top);
 
             // Draw current level on combobox
-            drawingCtx.drawStringLeftClipped(*rt, xPos, yPos, widget.width() - 15, Colour::black, StringIds::wcolour2_stringid, &args);
+            drawingCtx.drawStringLeftClipped(*rt, point, widget.width() - 15, Colour::black, StringIds::wcolour2_stringid, &args);
         }
 
         bool doDefault = true;
@@ -958,7 +959,10 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         args.push(_112C1C5[type]);
         args.push(ObjectManager::getMaxObjects(static_cast<ObjectType>(type)));
 
-        drawingCtx.drawStringLeft(*rt, self.x + 3, self.y + self.height - 12, Colour::black, 2038, &args);
+        {
+            auto point = Point(self.x + 3, self.y + self.height - 12);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::buffer_2038, &args);
+        }
 
         if (self.rowHover == -1)
             return;
@@ -991,7 +995,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
             strncpy(buffer, ObjectManager::ObjectIndexEntry::read(&objectPtr)._name, 510);
 
-            drawingCtx.drawStringCentredClipped(*rt, x, y, width, Colour::black, StringIds::buffer_2039);
+            auto point = Point(x, y);
+            drawingCtx.drawStringCentredClipped(*rt, point, width, Colour::black, StringIds::buffer_2039);
         }
 
         {
@@ -1081,7 +1086,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 }
 
                 static constexpr char strCheckmark[] = "\xAC";
-                drawingCtx.drawString(rt, x, y, checkColour, strCheckmark);
+                auto point = Point(x, y);
+                drawingCtx.drawString(rt, point, checkColour, strCheckmark);
             }
 
             char buffer[512]{};
@@ -1089,7 +1095,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             strncpy(&buffer[1], entry.object._name, 510);
             drawingCtx.setCurrentFontSpriteBase(Font::medium_bold);
 
-            drawingCtx.drawString(rt, 15, y, Colour::black, buffer);
+            auto point = Point(15, y);
+            drawingCtx.drawString(rt, point, Colour::black, buffer);
             y += kRowHeight;
         }
     }

--- a/src/OpenLoco/src/Windows/Options.cpp
+++ b/src/OpenLoco/src/Windows/Options.cpp
@@ -681,28 +681,30 @@ namespace OpenLoco::Ui::Windows::Options
 
             Common::drawTabs(&w, rt);
 
-            int16_t x = w.x + 10;
-            int16_t y = w.y + Display::_widgets[Display::Widx::screen_mode].top + 1;
-            drawingCtx.drawStringLeft(*rt, x, y, Colour::black, StringIds::options_screen_mode, nullptr);
+            auto point = Point(w.x + 10, w.y + Display::_widgets[Display::Widx::screen_mode].top + 1);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::options_screen_mode);
 
-            y = w.y + Display::_widgets[Display::Widx::display_resolution].top + 1;
-            drawingCtx.drawStringLeft(*rt, x, y, Colour::black, StringIds::display_resolution, nullptr);
+            point.y = w.y + Display::_widgets[Display::Widx::display_resolution].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::display_resolution);
 
-            y = w.y + Display::_widgets[Display::Widx::construction_marker].top + 1;
-            drawingCtx.drawStringLeft(*rt, x, y, Colour::black, StringIds::construction_marker, nullptr);
+            point.y = w.y + Display::_widgets[Display::Widx::construction_marker].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::construction_marker);
 
-            y = w.y + Display::_widgets[Display::Widx::vehicles_min_scale].top + 1;
-            drawingCtx.drawStringLeft(*rt, x, y, Colour::black, StringIds::vehicles_min_scale, nullptr);
+            point.y = w.y + Display::_widgets[Display::Widx::vehicles_min_scale].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::vehicles_min_scale);
 
-            y = w.y + Display::_widgets[Display::Widx::station_names_min_scale].top + 1;
-            drawingCtx.drawStringLeft(*rt, x, y, Colour::black, StringIds::station_names_min_scale, nullptr);
+            point.y = w.y + Display::_widgets[Display::Widx::station_names_min_scale].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::station_names_min_scale);
 
-            y = w.y + Display::_widgets[Display::Widx::display_scale].top + 1;
-            drawingCtx.drawStringLeft(*rt, x, y, Colour::black, StringIds::window_scale_factor, nullptr);
+            point.y = w.y + Display::_widgets[Display::Widx::display_scale].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::window_scale_factor);
 
-            int scale = (int)(Config::get().scaleFactor * 100);
+            FormatArguments args{};
+            args.push<int32_t>(Config::get().scaleFactor * 100);
+
             auto& scaleWidget = w.widgets[Widx::display_scale];
-            drawingCtx.drawStringLeft(*rt, w.x + scaleWidget.left + 1, w.y + scaleWidget.top + 1, Colour::black, StringIds::scale_formatted, &scale);
+            point = Point(w.x + scaleWidget.left + 1, w.y + scaleWidget.top + 1);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::scale_formatted, &args);
         }
 
         static void applyScreenModeRestrictions(Window* w)
@@ -1039,9 +1041,15 @@ namespace OpenLoco::Ui::Windows::Options
 
             Common::drawTabs(&w, rt);
 
-            drawingCtx.drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::currently_playing_btn].top, Colour::black, StringIds::currently_playing, nullptr);
+            {
+                auto point = Point(w.x + 10, w.y + w.widgets[Widx::currently_playing_btn].top);
+                drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::currently_playing);
+            }
 
-            drawingCtx.drawStringLeft(*rt, w.x + 183, w.y + w.widgets[Widx::volume].top + 7, Colour::black, StringIds::volume, nullptr);
+            {
+                auto point = Point(w.x + 183, w.y + w.widgets[Widx::volume].top + 7);
+                drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::volume);
+            }
 
             drawingCtx.drawImage(rt, w.x + w.widgets[Widx::volume].left, w.y + w.widgets[Widx::volume].top, Gfx::recolour(ImageIds::volume_slider_track, w.getColour(WindowColour::secondary).c()));
 
@@ -1450,11 +1458,20 @@ namespace OpenLoco::Ui::Windows::Options
             w.draw(rt);
             Common::drawTabs(&w, rt);
 
-            drawingCtx.drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::language].top + 1, Colour::black, StringIds::options_language, nullptr);
-            drawingCtx.drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::distance_speed].top + 1, Colour::black, StringIds::distance_and_speed, nullptr);
-            drawingCtx.drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::heights].top + 1, Colour::black, StringIds::heights, nullptr);
-            drawingCtx.drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::currency].top + 1, Colour::black, StringIds::current_game_currency, nullptr);
-            drawingCtx.drawStringLeft(*rt, w.x + 10, w.y + w.widgets[Widx::preferred_currency].top + 1, Colour::black, StringIds::new_game_currency, nullptr);
+            auto point = Point(w.x + 10, w.y + w.widgets[Widx::language].top + 1);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::options_language);
+
+            point.y = w.y + w.widgets[Widx::distance_speed].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::distance_and_speed);
+
+            point.y = w.y + w.widgets[Widx::heights].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::heights);
+
+            point.y = w.y + w.widgets[Widx::currency].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::current_game_currency);
+
+            point.y = w.y + w.widgets[Widx::preferred_currency].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::new_game_currency);
         }
 
         static void onMouseUp(Window& w, WidgetIndex_t wi)
@@ -2111,7 +2128,8 @@ namespace OpenLoco::Ui::Windows::Options
                 args.push(StringIds::buffer_2039);
 
                 auto width = w.widgets[Widx::changeOwnerNameBtn].left - 24;
-                drawingCtx.drawStringLeftClipped(*rt, w.x + 24, w.y + w.widgets[Widx::changeOwnerNameBtn].top + 1, width, Colour::black, StringIds::wcolour2_preferred_owner_name, &args);
+                auto point = Point(w.x + 24, w.y + w.widgets[Widx::changeOwnerNameBtn].top + 1);
+                drawingCtx.drawStringLeftClipped(*rt, point, width, Colour::black, StringIds::wcolour2_preferred_owner_name, &args);
             }
 
             // Draw competitor name and face
@@ -2122,7 +2140,8 @@ namespace OpenLoco::Ui::Windows::Options
                 FormatArguments args = {};
                 args.push(competitor->name);
                 const auto width = w.widgets[Widx::changeOwnerFaceBtn].left - 24;
-                drawingCtx.drawStringLeftClipped(*rt, w.x + 24, w.y + w.widgets[Widx::changeOwnerFaceBtn].top + 1, width, Colour::black, StringIds::currentPreferredFace, &args);
+                auto point = Point(w.x + 24, w.y + w.widgets[Widx::changeOwnerFaceBtn].top + 1);
+                drawingCtx.drawStringLeftClipped(*rt, point, width, Colour::black, StringIds::currentPreferredFace, &args);
 
                 const auto& widget = w.widgets[Widx::ownerFacePreview];
                 auto placeForImage = Ui::Point(w.x + widget.left + 1, w.y + widget.top + 1);
@@ -2414,7 +2433,9 @@ namespace OpenLoco::Ui::Windows::Options
             FormatArguments args{};
             args.push(stringId);
             args.push(value);
-            drawingCtx.drawStringLeft(*rt, w->x + widget.left + 1, w->y + widget.top + 1, Colour::black, StringIds::black_stringid, &args);
+
+            auto point = Point(w->x + widget.left + 1, w->y + widget.top + 1);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x004C1282
@@ -2426,8 +2447,8 @@ namespace OpenLoco::Ui::Windows::Options
             Common::drawTabs(&w, rt);
 
             // Label for autosave frequency
-            auto y = w.y + w.widgets[Widx::autosave_frequency].top;
-            drawingCtx.drawStringLeft(*rt, w.x + 10, y, Colour::black, StringIds::autosave_frequency, nullptr);
+            auto point = Point(w.x + 10, w.y + w.widgets[Widx::autosave_frequency].top);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::autosave_frequency, nullptr);
 
             // Value for autosave frequency
             auto freq = Config::get().autosaveFrequency;
@@ -2447,8 +2468,8 @@ namespace OpenLoco::Ui::Windows::Options
             drawDropdownContent(&w, rt, Widx::autosave_frequency, stringId, freq);
 
             // Label for autosave amount
-            y = w.y + w.widgets[Widx::autosave_amount].top;
-            drawingCtx.drawStringLeft(*rt, w.x + 10, y, Colour::black, StringIds::autosave_amount, nullptr);
+            point = Point(w.x + 10, w.y + w.widgets[Widx::autosave_amount].top);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::autosave_amount);
 
             // Value for autosave amount
             auto scale = Config::get().autosaveAmount;

--- a/src/OpenLoco/src/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/src/Windows/PlayerInfoPanel.cpp
@@ -222,7 +222,9 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
             auto args = FormatArguments();
             args.push(playerCompany->cash.var_00);
             args.push(playerCompany->cash.var_04);
-            drawingCtx.drawStringCentred(*rt, x, window.y + frame.top + 2, colour, companyValueString, &args);
+
+            auto point = Point(x, window.y + frame.top + 2);
+            drawingCtx.drawStringCentred(*rt, point, colour, companyValueString, &args);
         }
 
         {
@@ -245,7 +247,9 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
 
             auto args = FormatArguments();
             args.push(playerCompany->performanceIndex);
-            drawingCtx.drawStringCentred(*rt, x, window.y + frame.top + 14, colour, performanceString, &args);
+
+            auto point = Point(x, window.y + frame.top + 14);
+            drawingCtx.drawStringCentred(*rt, point, colour, performanceString, &args);
         }
     }
 

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -396,7 +396,8 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         {
             auto folder = &_displayFolderBuffer[0];
             auto args = getStringPtrFormatArgs(folder);
-            drawingCtx.drawStringLeft(*rt, window.x + 3, window.y + window.widgets[widx::parent_button].top + 6, Colour::black, StringIds::window_browse_folder, &args);
+            auto point = Point(window.x + 3, window.y + window.widgets[widx::parent_button].top + 6);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::window_browse_folder, &args);
         }
 
         auto selectedIndex = window.var_85A;
@@ -415,10 +416,10 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                 nameBuffer = Localisation::convertUnicodeToLoco(nameBuffer);
 
                 auto args = getStringPtrFormatArgs(nameBuffer.c_str());
+                auto point = Point(x + (width / 2), y);
                 drawingCtx.drawStringCentredClipped(
                     *rt,
-                    x + (width / 2),
-                    y,
+                    point,
                     width,
                     Colour::black,
                     StringIds::wcolour2_stringid,

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -485,17 +485,22 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         // Company
         {
             auto args = getStringPtrFormatArgs(saveInfo.company);
-            y = drawingCtx.drawStringLeftWrapped(rt, x, y, maxWidth, Colour::black, StringIds::window_browse_company, &args);
+            auto point = Point(x, y);
+            y = drawingCtx.drawStringLeftWrapped(rt, point, maxWidth, Colour::black, StringIds::window_browse_company, &args);
         }
 
         // Owner
         {
             auto args = getStringPtrFormatArgs(saveInfo.owner);
-            y = drawingCtx.drawStringLeftWrapped(rt, x, y, maxWidth, Colour::black, StringIds::owner_label, &args);
+            auto point = Point(x, y);
+            y = drawingCtx.drawStringLeftWrapped(rt, point, maxWidth, Colour::black, StringIds::owner_label, &args);
         }
 
         // Date
-        y = drawingCtx.drawStringLeftWrapped(rt, x, y, maxWidth, Colour::black, StringIds::window_browse_date, &saveInfo.date);
+        {
+            auto point = Point(x, y);
+            y = drawingCtx.drawStringLeftWrapped(rt, point, maxWidth, Colour::black, StringIds::window_browse_date, &saveInfo.date);
+        }
 
         // Challenge progress
         auto flags = saveInfo.challengeFlags;
@@ -560,7 +565,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         Ui::Point origin = { 0, 1 };
         {
             auto args = getStringPtrFormatArgs(text);
-            drawingCtx.drawStringLeft(rt, &origin, Colour::black, StringIds::black_stringid, &args);
+            drawingCtx.drawStringLeft(rt, origin, Colour::black, StringIds::black_stringid, &args);
         }
 
         if (showCaret)
@@ -568,7 +573,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             if (caret == -1)
             {
                 // Draw horizontal caret
-                drawingCtx.drawStringLeft(rt, &origin, Colour::black, StringIds::window_browse_input_caret, nullptr);
+                drawingCtx.drawStringLeft(rt, origin, Colour::black, StringIds::window_browse_input_caret, nullptr);
             }
             else
             {
@@ -577,7 +582,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                 const std::string gbuffer = std::string(text, caret);
                 auto args = getStringPtrFormatArgs(gbuffer.c_str());
                 origin = { 0, 1 };
-                drawingCtx.drawStringLeft(rt, &origin, Colour::black, StringIds::black_stringid, &args);
+                drawingCtx.drawStringLeft(rt, origin, Colour::black, StringIds::black_stringid, &args);
 
                 // Draw vertical caret
                 drawingCtx.drawRect(rt, origin.x, origin.y, 1, 9, Colours::getShade(window->getColour(WindowColour::secondary).c(), 9), Drawing::RectFlags::none);
@@ -637,7 +642,8 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
 
             // Draw the name
             auto args = getStringPtrFormatArgs(nameBuffer.c_str());
-            drawingCtx.drawStringLeft(rt, x, y, Colour::black, stringId, &args);
+            auto point = Point(x, y);
+            drawingCtx.drawStringLeft(rt, point, Colour::black, stringId, &args);
 
             y += lineHeight;
             i++;

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -448,7 +448,8 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         if (filenameBox.type != WidgetType::none)
         {
             // Draw filename label
-            drawingCtx.drawStringLeft(*rt, window.x + 3, window.y + filenameBox.top + 2, Colour::black, StringIds::window_browse_filename, nullptr);
+            auto point = Point(window.x + 3, window.y + filenameBox.top + 2);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::window_browse_filename);
 
             // Clip to text box
             auto context2 = Gfx::clipRenderTarget(*rt, Ui::Rect(window.x + filenameBox.left + 1, window.y + filenameBox.top + 1, filenameBox.right - filenameBox.left - 1, filenameBox.bottom - filenameBox.top - 1));
@@ -511,7 +512,9 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                     progress = saveInfo.challengeProgress;
                 }
             }
-            drawingCtx.drawStringLeftWrapped(rt, x, y, maxWidth, Colour::black, stringId, &progress);
+
+            auto point = Point(x, y);
+            drawingCtx.drawStringLeftWrapped(rt, point, maxWidth, Colour::black, stringId, &progress);
         }
     }
 

--- a/src/OpenLoco/src/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioOptions.cpp
@@ -194,15 +194,14 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
             Common::draw(window, rt);
 
-            const int16_t xPos = window.x + 5;
-            int16_t yPos = window.y + widgets[widx::check_time_limit].bottom + 10;
-            drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::challenge_label);
+            auto point = Point(window.x + 5, window.y + widgets[widx::check_time_limit].bottom + 10);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::challenge_label);
 
             FormatArguments args{};
             OpenLoco::Scenario::formatChallengeArguments(Scenario::getObjective(), Scenario::getObjectiveProgress(), args);
 
-            yPos += 10;
-            drawingCtx.drawStringLeftWrapped(*rt, xPos, yPos, window.width - 10, Colour::black, StringIds::challenge_value, &args);
+            point.y += 10;
+            drawingCtx.drawStringLeftWrapped(*rt, point, window.width - 10, Colour::black, StringIds::challenge_value, &args);
         }
 
         static const StringId objectiveTypeLabelIds[] = {
@@ -608,35 +607,20 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
             Common::draw(window, rt);
 
-            {
-                const int16_t xPos = window.x + 10;
-                int16_t yPos = window.y + widgets[widx::max_competing_companies].top + 1;
-                drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::max_competing_companies);
-            }
+            auto point = Point(window.x + 10, window.y + widgets[widx::max_competing_companies].top + 1);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::max_competing_companies);
 
-            {
-                const int16_t xPos = window.x + 10;
-                int16_t yPos = window.y + widgets[widx::delay_before_competing_companies_start].top + 1;
-                drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::delay_before_competing_companies_start);
-            }
+            point.y = window.y + widgets[widx::delay_before_competing_companies_start].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::delay_before_competing_companies_start);
 
-            {
-                const int16_t xPos = window.x + 10;
-                int16_t yPos = window.y + widgets[widx::preferred_intelligence].top + 1;
-                drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::preferred_intelligence);
-            }
+            point.y = window.y + widgets[widx::preferred_intelligence].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::preferred_intelligence);
 
-            {
-                const int16_t xPos = window.x + 10;
-                int16_t yPos = window.y + widgets[widx::preferred_aggressiveness].top + 1;
-                drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::preferred_aggressiveness);
-            }
+            point.y = window.y + widgets[widx::preferred_aggressiveness].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::preferred_aggressiveness);
 
-            {
-                const int16_t xPos = window.x + 10;
-                int16_t yPos = window.y + widgets[widx::preferred_competitiveness].top + 1;
-                drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::preferred_competitiveness);
-            }
+            point.y = window.y + widgets[widx::preferred_competitiveness].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::preferred_competitiveness);
         }
 
         static StringId preferenceLabelIds[] = {
@@ -874,23 +858,14 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
             Common::draw(window, rt);
 
-            {
-                const int16_t xPos = window.x + 10;
-                int16_t yPos = window.y + widgets[widx::starting_loan].top + 1;
-                drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::starting_loan);
-            }
+            auto point = Point(window.x + 10, window.y + widgets[widx::starting_loan].top + 1);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::starting_loan);
 
-            {
-                const int16_t xPos = window.x + 10;
-                int16_t yPos = window.y + widgets[widx::max_loan_size].top + 1;
-                drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::max_loan_size);
-            }
+            point.y = window.y + widgets[widx::max_loan_size].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::max_loan_size);
 
-            {
-                const int16_t xPos = window.x + 10;
-                int16_t yPos = window.y + widgets[widx::loan_interest_rate].top + 1;
-                drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::loan_interest_rate);
-            }
+            point.y = window.y + widgets[widx::loan_interest_rate].top + 1;
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::loan_interest_rate);
         }
 
         static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
@@ -1032,19 +1007,25 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::change_name_btn].top + 1;
                 int16_t width = widgets[widx::change_name_btn].left - 20;
-                drawingCtx.drawStringLeftClipped(*rt, xPos, yPos, width, Colour::black, StringIds::scenario_name_stringid, &args);
+
+                auto point = Point(xPos, yPos);
+                drawingCtx.drawStringLeftClipped(*rt, point, width, Colour::black, StringIds::scenario_name_stringid, &args);
             }
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::scenario_group].top + 1;
-                drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::scenario_group);
+
+                auto point = Point(xPos, yPos);
+                drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::scenario_group);
             }
 
             {
                 const int16_t xPos = window.x + 10;
                 int16_t yPos = window.y + widgets[widx::change_details_btn].top + 1;
-                drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::scenario_details);
+
+                auto point = Point(xPos, yPos);
+                drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::scenario_details);
             }
 
             {
@@ -1063,7 +1044,8 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                 }
 
                 auto& target = window.widgets[widx::change_details_btn];
-                drawingCtx.drawStringLeftWrapped(*rt, window.x + 16, window.y + 12 + target.top, target.left - 26, Colour::black, StringIds::black_stringid, &args);
+                auto point = Point(window.x + 16, window.y + 12 + target.top);
+                drawingCtx.drawStringLeftWrapped(*rt, point, target.left - 26, Colour::black, StringIds::black_stringid, &args);
             }
         }
 

--- a/src/OpenLoco/src/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioSelect.cpp
@@ -326,7 +326,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             args.push<uint16_t>(scenarioInfo->numCompetingCompanies);
             StringId competitionStringId = scenarioInfo->numCompetingCompanies == 0 ? StringIds::challenge_competing_companies_none : StringIds::challenge_competing_companies_up_to;
 
-            drawingCtx.drawStringLeftWrapped(*rt, Point(x, y), 170, Colour::black, competitionStringId, &args);
+            y = drawingCtx.drawStringLeftWrapped(*rt, Point(x, y), 170, Colour::black, competitionStringId, &args);
 
             if (scenarioInfo->numCompetingCompanies == 0 || scenarioInfo->competingCompanyDelay == 0)
                 return;

--- a/src/OpenLoco/src/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioSelect.cpp
@@ -316,7 +316,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             args.push(StringIds::buffer_1250);
 
             origin = Point(x, y);
-            y = drawingCtx.drawStringLeftWrapped(*rt, point, 170, Colour::black, StringIds::challenge_value, &args);
+            y = drawingCtx.drawStringLeftWrapped(*rt, origin, 170, Colour::black, StringIds::challenge_value, &args);
 
             // Start year
             y += 5;
@@ -324,7 +324,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             args.push(scenarioInfo->startYear);
 
             origin = Point(x, y);
-            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::challenge_start_date, &args);
+            drawingCtx.drawStringLeft(*rt, origin, Colour::black, StringIds::challenge_start_date, &args);
 
             // Competing companies
             y += 10;
@@ -333,7 +333,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             StringId competitionStringId = scenarioInfo->numCompetingCompanies == 0 ? StringIds::challenge_competing_companies_none : StringIds::challenge_competing_companies_up_to;
 
             origin = Point(x, y);
-            drawingCtx.drawStringLeftWrapped(*rt, point, 170, Colour::black, competitionStringId, &args);
+            drawingCtx.drawStringLeftWrapped(*rt, origin, 170, Colour::black, competitionStringId, &args);
 
             if (scenarioInfo->numCompetingCompanies == 0 || scenarioInfo->competingCompanyDelay == 0)
                 return;
@@ -342,7 +342,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             args = FormatArguments();
             args.push<uint16_t>(scenarioInfo->competingCompanyDelay);
             competitionStringId = scenarioInfo->numCompetingCompanies == 1 ? StringIds::competition_not_starting_for_month : StringIds::competition_not_starting_for_months;
-            drawingCtx.drawStringLeft(*rt, point, Colour::black, competitionStringId, &args);
+            drawingCtx.drawStringLeft(*rt, origin, Colour::black, competitionStringId, &args);
         }
     }
 

--- a/src/OpenLoco/src/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioSelect.cpp
@@ -231,8 +231,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 
             x += colWidth / 2;
 
-            auto point = Point(x, y);
-            drawingCtx.drawStringCentredClipped(*rt, point, 170, Colour::black, StringIds::wcolour2_stringid, &args);
+            drawingCtx.drawStringCentredClipped(*rt, Point(x, y), 170, Colour::black, StringIds::wcolour2_stringid, &args);
 
             y += 14;
         }
@@ -284,8 +283,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             args.push(StringIds::randomly_generated_landscape);
 
             // Overlay random map note.
-            auto origin = Ui::Point(x, y);
-            drawingCtx.drawStringCentredWrapped(*rt, origin, 128, Colour::black, StringIds::wcolour2_stringid, &args);
+            drawingCtx.drawStringCentredWrapped(*rt, Point(x, y), 128, Colour::black, StringIds::wcolour2_stringid, &args);
         }
 
         {
@@ -299,13 +297,11 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             FormatArguments args{};
             args.push(StringIds::buffer_2039);
 
-            auto origin = Ui::Point(x, y);
-            y = drawingCtx.drawStringLeftWrapped(*rt, origin, 170, Colour::black, StringIds::black_stringid, &args);
+            y = drawingCtx.drawStringLeftWrapped(*rt, Point(x, y), 170, Colour::black, StringIds::black_stringid, &args);
 
             // Challenge header
             y += 5;
-            origin = Point(x, y);
-            drawingCtx.drawStringLeft(*rt, origin, Colour::black, StringIds::challenge_label, nullptr);
+            drawingCtx.drawStringLeft(*rt, Point(x, y), Colour::black, StringIds::challenge_label, nullptr);
 
             // Challenge text
             str = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
@@ -315,16 +311,14 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             args = FormatArguments();
             args.push(StringIds::buffer_1250);
 
-            origin = Point(x, y);
-            y = drawingCtx.drawStringLeftWrapped(*rt, origin, 170, Colour::black, StringIds::challenge_value, &args);
+            y = drawingCtx.drawStringLeftWrapped(*rt, Point(x, y), 170, Colour::black, StringIds::challenge_value, &args);
 
             // Start year
             y += 5;
             args = FormatArguments();
             args.push(scenarioInfo->startYear);
 
-            origin = Point(x, y);
-            drawingCtx.drawStringLeft(*rt, origin, Colour::black, StringIds::challenge_start_date, &args);
+            drawingCtx.drawStringLeft(*rt, Point(x, y), Colour::black, StringIds::challenge_start_date, &args);
 
             // Competing companies
             y += 10;
@@ -332,8 +326,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             args.push<uint16_t>(scenarioInfo->numCompetingCompanies);
             StringId competitionStringId = scenarioInfo->numCompetingCompanies == 0 ? StringIds::challenge_competing_companies_none : StringIds::challenge_competing_companies_up_to;
 
-            origin = Point(x, y);
-            drawingCtx.drawStringLeftWrapped(*rt, origin, 170, Colour::black, competitionStringId, &args);
+            drawingCtx.drawStringLeftWrapped(*rt, Point(x, y), 170, Colour::black, competitionStringId, &args);
 
             if (scenarioInfo->numCompetingCompanies == 0 || scenarioInfo->competingCompanyDelay == 0)
                 return;
@@ -342,7 +335,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             args = FormatArguments();
             args.push<uint16_t>(scenarioInfo->competingCompanyDelay);
             competitionStringId = scenarioInfo->numCompetingCompanies == 1 ? StringIds::competition_not_starting_for_month : StringIds::competition_not_starting_for_months;
-            drawingCtx.drawStringLeft(*rt, origin, Colour::black, competitionStringId, &args);
+            drawingCtx.drawStringLeft(*rt, Point(x, y), Colour::black, competitionStringId, &args);
         }
     }
 

--- a/src/OpenLoco/src/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioSelect.cpp
@@ -231,7 +231,8 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 
             x += colWidth / 2;
 
-            drawingCtx.drawStringCentredClipped(*rt, Point32(x, y), 170, Colour::black, StringIds::wcolour2_stringid, &args);
+            auto point = Point(x, y);
+            drawingCtx.drawStringCentredClipped(*rt, point, 170, Colour::black, StringIds::wcolour2_stringid, &args);
 
             y += 14;
         }
@@ -297,12 +298,14 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 
             FormatArguments args{};
             args.push(StringIds::buffer_2039);
-            y = drawingCtx.drawStringLeftWrapped(*rt, x, y, 170, Colour::black, StringIds::black_stringid, &args);
+
+            auto origin = Ui::Point(x, y);
+            y = drawingCtx.drawStringLeftWrapped(*rt, origin, 170, Colour::black, StringIds::black_stringid, &args);
 
             // Challenge header
             y += 5;
-            auto origin = Ui::Point(x, y);
-            drawingCtx.drawStringLeft(*rt, &origin, Colour::black, StringIds::challenge_label, nullptr);
+            origin = Point(x, y);
+            drawingCtx.drawStringLeft(*rt, origin, Colour::black, StringIds::challenge_label, nullptr);
 
             // Challenge text
             str = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
@@ -311,20 +314,26 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             y += 10;
             args = FormatArguments();
             args.push(StringIds::buffer_1250);
-            y = drawingCtx.drawStringLeftWrapped(*rt, x, y, 170, Colour::black, StringIds::challenge_value, &args);
+
+            origin = Point(x, y);
+            y = drawingCtx.drawStringLeftWrapped(*rt, point, 170, Colour::black, StringIds::challenge_value, &args);
 
             // Start year
             y += 5;
             args = FormatArguments();
             args.push(scenarioInfo->startYear);
-            drawingCtx.drawStringLeft(*rt, x, y, Colour::black, StringIds::challenge_start_date, &args);
+
+            origin = Point(x, y);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::challenge_start_date, &args);
 
             // Competing companies
             y += 10;
             args = FormatArguments();
             args.push<uint16_t>(scenarioInfo->numCompetingCompanies);
             StringId competitionStringId = scenarioInfo->numCompetingCompanies == 0 ? StringIds::challenge_competing_companies_none : StringIds::challenge_competing_companies_up_to;
-            y = drawingCtx.drawStringLeftWrapped(*rt, x, y, 170, Colour::black, competitionStringId, &args);
+
+            origin = Point(x, y);
+            drawingCtx.drawStringLeftWrapped(*rt, point, 170, Colour::black, competitionStringId, &args);
 
             if (scenarioInfo->numCompetingCompanies == 0 || scenarioInfo->competingCompanyDelay == 0)
                 return;
@@ -333,7 +342,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             args = FormatArguments();
             args.push<uint16_t>(scenarioInfo->competingCompanyDelay);
             competitionStringId = scenarioInfo->numCompetingCompanies == 1 ? StringIds::competition_not_starting_for_month : StringIds::competition_not_starting_for_months;
-            drawingCtx.drawStringLeft(*rt, x, y, Colour::black, competitionStringId, &args);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, competitionStringId, &args);
         }
     }
 

--- a/src/OpenLoco/src/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioSelect.cpp
@@ -230,7 +230,8 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             args.push(StringIds::buffer_2039);
 
             x += colWidth / 2;
-            drawingCtx.drawStringCentredClipped(*rt, x, y, 170, Colour::black, StringIds::wcolour2_stringid, &args);
+
+            drawingCtx.drawStringCentredClipped(*rt, Point32(x, y), 170, Colour::black, StringIds::wcolour2_stringid, &args);
 
             y += 14;
         }

--- a/src/OpenLoco/src/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioSelect.cpp
@@ -390,8 +390,8 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
                 FormatArguments args{};
                 args.push(StringIds::buffer_2039);
 
-                const int16_t x = 210;
-                drawingCtx.drawStringCentred(rt, x, y + 1, Colour::black, formatStringId, &args);
+                auto point = Point(210, y + 1);
+                drawingCtx.drawStringCentred(rt, point, Colour::black, formatStringId, &args);
             }
 
             // Completed?
@@ -415,8 +415,8 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
                 args.push<uint16_t>(scenarioInfo->completedMonths / 12);
                 args.push<uint16_t>(scenarioInfo->completedMonths % 12);
 
-                const int16_t x = (self.widgets[widx::list].width() - ScrollView::barWidth) / 2;
-                drawingCtx.drawStringCentred(rt, x, y + 10, Colour::black, formatStringId, &args);
+                auto point = Point((self.widgets[widx::list].width() - ScrollView::barWidth) / 2, y + 10);
+                drawingCtx.drawStringCentred(rt, point, Colour::black, formatStringId, &args);
             }
 
             y += kRowHeight;

--- a/src/OpenLoco/src/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Windows/StationList.cpp
@@ -464,7 +464,9 @@ namespace OpenLoco::Ui::Windows::StationList
                 args.push<uint16_t>(enumValue(station->town));
                 args.push<uint16_t>(getTransportIconsFromStationFlags(station->flags));
 
-                drawingCtx.drawStringLeftClipped(rt, 0, yPos, 198, Colour::black, text_colour_id, &args);
+
+                auto point = Point(0, yPos);
+                drawingCtx.drawStringLeftClipped(rt, point, 198, Colour::black, text_colour_id, &args);
             }
 
             char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
@@ -474,7 +476,9 @@ namespace OpenLoco::Ui::Windows::StationList
             {
                 auto args = FormatArguments{};
                 args.push(StringIds::buffer_1250);
-                drawingCtx.drawStringLeftClipped(rt, 200, yPos, 198, Colour::black, text_colour_id, &args);
+
+                auto point = Point(200, yPos);
+                drawingCtx.drawStringLeftClipped(rt, point, 198, Colour::black, text_colour_id, &args);
             }
 
             // Total units waiting.
@@ -486,7 +490,9 @@ namespace OpenLoco::Ui::Windows::StationList
                 auto args = FormatArguments{};
                 args.push(StringIds::num_units);
                 args.push<uint32_t>(totalUnits);
-                drawingCtx.drawStringLeftClipped(rt, 400, yPos, 88, Colour::black, text_colour_id, &args);
+
+                auto point = Point(400, yPos);
+                drawingCtx.drawStringLeftClipped(rt, point, 88, Colour::black, text_colour_id, &args);
             }
 
             // And, finally, what goods the station accepts.
@@ -509,7 +515,9 @@ namespace OpenLoco::Ui::Windows::StationList
             {
                 auto args = FormatArguments{};
                 args.push(StringIds::buffer_1250);
-                drawingCtx.drawStringLeftClipped(rt, 490, yPos, 118, Colour::black, text_colour_id, &args);
+
+                auto point = Point(490, yPos);
+                drawingCtx.drawStringLeftClipped(rt, point, 118, Colour::black, text_colour_id, &args);
             }
 
             yPos += kRowHeight;
@@ -556,7 +564,7 @@ namespace OpenLoco::Ui::Windows::StationList
 
         // Draw number of stations.
         auto origin = Ui::Point(window.x + 4, window.y + window.height - 12);
-        drawingCtx.drawStringLeft(*rt, &origin, Colour::black, StringIds::black_stringid, &args);
+        drawingCtx.drawStringLeft(*rt, origin, Colour::black, StringIds::black_stringid, &args);
     }
 
     // 0x004917BB

--- a/src/OpenLoco/src/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Windows/StationList.cpp
@@ -464,7 +464,6 @@ namespace OpenLoco::Ui::Windows::StationList
                 args.push<uint16_t>(enumValue(station->town));
                 args.push<uint16_t>(getTransportIconsFromStationFlags(station->flags));
 
-
                 auto point = Point(0, yPos);
                 drawingCtx.drawStringLeftClipped(rt, point, 198, Colour::black, text_colour_id, &args);
             }

--- a/src/OpenLoco/src/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Windows/StationWindow.cpp
@@ -719,7 +719,7 @@ namespace OpenLoco::Ui::Windows::Station
                 }
 
                 uint8_t amount = (rating * 327) / 256;
-                drawRatingBar(&self, &rt, 100, y, amount, colour);
+                drawRatingBar(&self, &rt, 100, point.y, amount, colour);
 
                 uint16_t percent = rating / 2;
                 point.x = 201;

--- a/src/OpenLoco/src/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Windows/StationWindow.cpp
@@ -130,10 +130,9 @@ namespace OpenLoco::Ui::Windows::Station
             args.push(StringIds::buffer_1250);
 
             const auto& widget = self.widgets[widx::status_bar];
-            const auto x = self.x + widget.left - 1;
-            const auto y = self.y + widget.top - 1;
             const auto width = widget.width() - 1;
-            drawingCtx.drawStringLeftClipped(*rt, x, y, width, Colour::black, StringIds::black_stringid, &args);
+            auto point = Point(self.x + widget.left - 1, self.y + widget.top - 1);
+            drawingCtx.drawStringLeftClipped(*rt, point, width, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x0048E4D4
@@ -398,11 +397,10 @@ namespace OpenLoco::Ui::Windows::Station
             *buffer++ = '\0';
 
             const auto& widget = self.widgets[widx::status_bar];
-            const auto x = self.x + widget.left - 1;
-            const auto y = self.y + widget.top - 1;
             const auto width = widget.width();
+            auto point = Point(self.x + widget.left - 1, self.y + widget.top - 1);
 
-            drawingCtx.drawStringLeftClipped(*rt, x, y, width, Colour::black, StringIds::buffer_1250);
+            drawingCtx.drawStringLeftClipped(*rt, point, width, Colour::black, StringIds::buffer_1250);
         }
 
         // 0x0048EB0B
@@ -521,7 +519,8 @@ namespace OpenLoco::Ui::Windows::Station
                     if (cargo.origin != StationId(self.number))
                         cargoStr = StringIds::station_cargo_en_route_start;
 
-                    drawingCtx.drawStringRight(rt, xPos, y, AdvancedColour(Colour::black).outline(), cargoStr, &args);
+                    auto point = Point(xPos, y);
+                    drawingCtx.drawStringRight(rt, point, AdvancedColour(Colour::black).outline(), cargoStr, &args);
                     y += 10;
                 }
 
@@ -532,7 +531,8 @@ namespace OpenLoco::Ui::Windows::Station
                     args.push(originStation->name);
                     args.push(originStation->town);
 
-                    drawingCtx.drawStringRight(rt, xPos, y, AdvancedColour(Colour::black).outline(), StringIds::station_cargo_en_route_end, &args);
+                    auto point = Point(xPos, y);
+                    drawingCtx.drawStringRight(rt, point, AdvancedColour(Colour::black).outline(), StringIds::station_cargo_en_route_end, &args);
                     y += 10;
                 }
 
@@ -548,7 +548,9 @@ namespace OpenLoco::Ui::Windows::Station
             {
                 FormatArguments args{};
                 args.push(StringIds::nothing_waiting);
-                drawingCtx.drawStringLeft(rt, 1, 0, Colour::black, StringIds::black_stringid, &args);
+
+                auto point = Point(1, 0);
+                drawingCtx.drawStringLeft(rt, point, Colour::black, StringIds::black_stringid, &args);
             }
         }
 
@@ -690,7 +692,7 @@ namespace OpenLoco::Ui::Windows::Station
             drawingCtx.clearSingle(rt, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4));
 
             const auto station = StationManager::get(StationId(self.number));
-            int16_t y = 0;
+            auto point = Point(0, 0);
             auto cargoId = 0;
             for (const auto& cargoStats : station->cargoStats)
             {
@@ -702,7 +704,8 @@ namespace OpenLoco::Ui::Windows::Station
                 }
 
                 auto cargoObj = ObjectManager::get<CargoObject>(cargoId);
-                drawingCtx.drawStringLeftClipped(rt, 1, y, 98, Colour::black, StringIds::wcolour2_stringid, &cargoObj->name);
+                point.x = 1;
+                drawingCtx.drawStringLeftClipped(rt, point, 98, Colour::black, StringIds::wcolour2_stringid, &cargoObj->name);
 
                 auto rating = cargo.rating;
                 auto colour = Colour::green;
@@ -719,8 +722,10 @@ namespace OpenLoco::Ui::Windows::Station
                 drawRatingBar(&self, &rt, 100, y, amount, colour);
 
                 uint16_t percent = rating / 2;
-                drawingCtx.drawStringLeft(rt, 201, y, Colour::black, StringIds::station_cargo_rating_percent, &percent);
-                y += 10;
+                point.x = 201;
+                drawingCtx.drawStringLeft(rt, point, Colour::black, StringIds::station_cargo_rating_percent, &percent);
+
+                point.y += 10;
                 cargoId++;
             }
         }

--- a/src/OpenLoco/src/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Windows/TerraForm.cpp
@@ -734,19 +734,23 @@ namespace OpenLoco::Ui::Windows::Terraform
                 treeCost = Economy::getInflationAdjustedCost(treeObj->buildCostFactor, treeObj->costIndex, 12);
             }
 
-            FormatArguments args{};
-            args.push<uint32_t>(treeCost);
-
             if (!isEditorMode())
             {
-                auto xPos = self.x + 3 + self.width - 17;
-                auto yPos = self.y + self.height - 13;
-                drawingCtx.drawStringRight(*rt, xPos, yPos, Colour::black, StringIds::build_cost, &args);
+                FormatArguments args{};
+                args.push<uint32_t>(treeCost);
+
+                auto point = Point(self.x + 3 + self.width - 17, self.y + self.height - 13);
+                drawingCtx.drawStringRight(*rt, point, Colour::black, StringIds::build_cost, &args);
             }
-            auto xPos = self.x + 3;
-            auto yPos = self.y + self.height - 13;
-            auto width = self.width - 19 - xPos;
-            drawingCtx.drawStringLeftClipped(*rt, xPos, yPos, width, Colour::black, StringIds::black_stringid, &treeObj->name);
+
+            {
+                FormatArguments args{};
+                args.push(treeObj->name);
+
+                auto point = Point(self.x + 3, self.y + self.height - 13);
+                auto width = self.width - 19 - point.x;
+                drawingCtx.drawStringLeftClipped(*rt, point, width, Colour::black, StringIds::black_stringid, &args);
+            }
         }
 
         static void drawTreeThumb(TreeObject* treeObj, Gfx::RenderTarget* clipped)
@@ -1084,13 +1088,13 @@ namespace OpenLoco::Ui::Windows::Terraform
             // Draw as a number if we can't fit a sprite
             if (_adjustToolSize > 10)
             {
-
                 auto xPos = toolArea.midX() + self.x;
                 auto yPos = toolArea.midY() + self.y - 5;
+                auto point = Point(xPos, yPos);
 
                 FormatArguments args{};
                 args.push<uint16_t>(_adjustToolSize);
-                drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::tile_inspector_coord, &args);
+                drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::tile_inspector_coord, &args);
             }
 
             if (_raiseLandCost == 0x80000000)
@@ -1099,13 +1103,16 @@ namespace OpenLoco::Ui::Windows::Terraform
             if (_raiseLandCost == 0)
                 return;
 
-            auto xPos = toolArea.midX() + self.x;
-            auto yPos = toolArea.bottom + self.y + 5;
+            {
+                auto xPos = toolArea.midX() + self.x;
+                auto yPos = toolArea.bottom + self.y + 5;
+                auto point = Point(xPos, yPos);
 
-            FormatArguments args{};
-            args.push<uint32_t>(_raiseLandCost);
+                FormatArguments args{};
+                args.push<uint32_t>(_raiseLandCost);
 
-            drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::clear_land_cost, &args);
+                drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::clear_land_cost, &args);
+            }
         }
 
         static constexpr WindowEventList kEvents = {
@@ -1702,10 +1709,11 @@ namespace OpenLoco::Ui::Windows::Terraform
             {
                 auto xPos = toolArea.midX() + self.x;
                 auto yPos = toolArea.midY() + self.y - 5;
+                auto point = Point(xPos, yPos);
 
                 FormatArguments args{};
                 args.push<uint16_t>(_adjustToolSize);
-                drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::tile_inspector_coord, &args);
+                drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::tile_inspector_coord, &args);
             }
 
             auto xPos = toolArea.midX() + self.x;
@@ -1717,7 +1725,9 @@ namespace OpenLoco::Ui::Windows::Terraform
                 {
                     FormatArguments args{};
                     args.push<uint32_t>(_raiseLandCost);
-                    drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::increase_height_cost, &args);
+
+                    auto point = Point(xPos, yPos);
+                    drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::increase_height_cost, &args);
                 }
             }
 
@@ -1729,7 +1739,9 @@ namespace OpenLoco::Ui::Windows::Terraform
                 {
                     FormatArguments args{};
                     args.push<uint32_t>(_lowerLandCost);
-                    drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::decrease_height_cost, &args);
+
+                    auto point = Point(xPos, yPos);
+                    drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::decrease_height_cost, &args);
                 }
             }
         }
@@ -2012,10 +2024,11 @@ namespace OpenLoco::Ui::Windows::Terraform
             {
                 auto xPos = toolArea.midX() + self.x;
                 auto yPos = toolArea.midY() + self.y - 5;
+                auto point = Point(xPos, yPos);
 
                 FormatArguments args{};
                 args.push<uint16_t>(_adjustToolSize);
-                drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::tile_inspector_coord, &args);
+                drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::tile_inspector_coord, &args);
             }
 
             auto xPos = toolArea.midX() + self.x;
@@ -2028,7 +2041,8 @@ namespace OpenLoco::Ui::Windows::Terraform
                     FormatArguments args{};
                     args.push<uint32_t>(_raiseWaterCost);
 
-                    drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::increase_height_cost, &args);
+                    auto point = Point(xPos, yPos);
+                    drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::increase_height_cost, &args);
                 }
             }
 
@@ -2041,7 +2055,8 @@ namespace OpenLoco::Ui::Windows::Terraform
                     FormatArguments args{};
                     args.push<uint32_t>(_lowerWaterCost);
 
-                    drawingCtx.drawStringCentred(*rt, xPos, yPos, Colour::black, StringIds::decrease_height_cost, &args);
+                    auto point = Point(xPos, yPos);
+                    drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::decrease_height_cost, &args);
                 }
             }
         }
@@ -2471,8 +2486,12 @@ namespace OpenLoco::Ui::Windows::Terraform
             auto xPos = self.x + 3;
             auto yPos = self.y + self.height - 13;
             auto width = self.width - 19;
+            auto point = Point(xPos, yPos);
 
-            drawingCtx.drawStringLeftClipped(*rt, xPos, yPos, width, Colour::black, StringIds::black_stringid, &wallObj->name);
+            FormatArguments args{};
+            args.push(wallObj->name);
+
+            drawingCtx.drawStringLeftClipped(*rt, point, width, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x004BC11C

--- a/src/OpenLoco/src/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Windows/TextInputWindow.cpp
@@ -250,7 +250,8 @@ namespace OpenLoco::Ui::Windows::TextInput
             args.push<uint16_t>(maxNumCharacters);
 
             widget = &_widgets[Widx::ok];
-            drawingCtx.drawStringRight(*rt, window.x + widget->left - 5, window.y + widget->top + 1, Colour::black, StringIds::num_characters_left_int_int, &args);
+            auto point = Point(window.x + widget->left - 5, window.y + widget->top + 1);
+            drawingCtx.drawStringRight(*rt, point, Colour::black, StringIds::num_characters_left_int_int, &args);
         }
 
         if ((inputSession.cursorFrame % 32) >= 16)
@@ -266,7 +267,7 @@ namespace OpenLoco::Ui::Windows::TextInput
             args.push(StringIds::buffer_2039);
 
             position = { inputSession.xOffset, 1 };
-            drawingCtx.drawStringLeft(*clipped, &position, Colour::black, StringIds::black_stringid, &args);
+            drawingCtx.drawStringLeft(*clipped, position, Colour::black, StringIds::black_stringid, &args);
             drawingCtx.fillRect(*clipped, position.x, position.y, position.x, position.y + 9, Colours::getShade(window.getColour(WindowColour::secondary).c(), 9), Drawing::RectFlags::none);
         }
     }

--- a/src/OpenLoco/src/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Windows/TextInputWindow.cpp
@@ -220,7 +220,7 @@ namespace OpenLoco::Ui::Windows::TextInput
         *((StringId*)(&_commonFormatArgs[0])) = _message;
         memcpy(&_commonFormatArgs[2], _formatArgs + 8, 8);
 
-        Ui::Point position = { (int16_t)(window.x + window.width / 2), (int16_t)(window.y + 30) };
+        Ui::Point position = Point(window.x + window.width / 2, window.y + 30);
         drawingCtx.drawStringCentredWrapped(*rt, position, window.width - 8, Colour::black, StringIds::wcolour2_stringid, &_commonFormatArgs[0]);
 
         auto widget = &_widgets[Widx::input];
@@ -233,20 +233,25 @@ namespace OpenLoco::Ui::Windows::TextInput
         char* drawnBuffer = (char*)StringManager::getString(StringIds::buffer_2039);
         strcpy(drawnBuffer, inputSession.buffer.c_str());
 
-        *((StringId*)(&_commonFormatArgs[0])) = StringIds::buffer_2039;
+        {
+            FormatArguments args{};
+            args.push(StringIds::buffer_2039);
 
-        position = { inputSession.xOffset, 1 };
-        drawingCtx.drawStringLeft(*clipped, &position, Colour::black, StringIds::black_stringid, _commonFormatArgs);
+            position = { inputSession.xOffset, 1 };
+            drawingCtx.drawStringLeft(*clipped, position, Colour::black, StringIds::black_stringid, &args);
+        }
 
         const uint16_t numCharacters = static_cast<uint16_t>(inputSession.cursorPosition);
         const uint16_t maxNumCharacters = inputSession.inputLenLimit;
 
-        FormatArguments args{};
-        args.push<uint16_t>(numCharacters);
-        args.push<uint16_t>(maxNumCharacters);
+        {
+            FormatArguments args{};
+            args.push<uint16_t>(numCharacters);
+            args.push<uint16_t>(maxNumCharacters);
 
-        widget = &_widgets[Widx::ok];
-        drawingCtx.drawStringRight(*rt, window.x + widget->left - 5, window.y + widget->top + 1, Colour::black, StringIds::num_characters_left_int_int, &args);
+            widget = &_widgets[Widx::ok];
+            drawingCtx.drawStringRight(*rt, window.x + widget->left - 5, window.y + widget->top + 1, Colour::black, StringIds::num_characters_left_int_int, &args);
+        }
 
         if ((inputSession.cursorFrame % 32) >= 16)
         {
@@ -256,10 +261,14 @@ namespace OpenLoco::Ui::Windows::TextInput
         strncpy(drawnBuffer, inputSession.buffer.c_str(), inputSession.cursorPosition);
         drawnBuffer[inputSession.cursorPosition] = '\0';
 
-        *((StringId*)(&_commonFormatArgs[0])) = StringIds::buffer_2039;
-        position = { inputSession.xOffset, 1 };
-        drawingCtx.drawStringLeft(*clipped, &position, Colour::black, StringIds::black_stringid, _commonFormatArgs);
-        drawingCtx.fillRect(*clipped, position.x, position.y, position.x, position.y + 9, Colours::getShade(window.getColour(WindowColour::secondary).c(), 9), Drawing::RectFlags::none);
+        {
+            FormatArguments args{};
+            args.push(StringIds::buffer_2039);
+
+            position = { inputSession.xOffset, 1 };
+            drawingCtx.drawStringLeft(*clipped, &position, Colour::black, StringIds::black_stringid, &args);
+            drawingCtx.fillRect(*clipped, position.x, position.y, position.x, position.y + 9, Colours::getShade(window.getColour(WindowColour::secondary).c(), 9), Drawing::RectFlags::none);
+        }
     }
 
     // 0x004CE8B6

--- a/src/OpenLoco/src/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Windows/TileInspector.cpp
@@ -149,13 +149,15 @@ namespace OpenLoco::Ui::Windows::TileInspector
             FormatArguments args{};
             args.push(StringIds::tile_inspector_x_coord);
             auto& widget = self.widgets[widx::xPos];
-            drawingCtx.drawStringLeft(*rt, self.x + widget.left - 15, self.y + widget.top + 1, Colour::black, StringIds::wcolour2_stringid, &args);
+            auto point = Point(self.x + widget.left - 15, self.y + widget.top + 1);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::wcolour2_stringid, &args);
         }
         {
             FormatArguments args{};
             args.push(StringIds::tile_inspector_y_coord);
             auto& widget = self.widgets[widx::yPos];
-            drawingCtx.drawStringLeft(*rt, self.x + widget.left - 15, self.y + widget.top + 1, Colour::black, StringIds::wcolour2_stringid, &args);
+            auto point = Point(self.x + widget.left - 15, self.y + widget.top + 1);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::wcolour2_stringid, &args);
         }
 
         // Coord X/Y values
@@ -163,13 +165,15 @@ namespace OpenLoco::Ui::Windows::TileInspector
             FormatArguments args{};
             args.push<int16_t>(_currentPosition.x);
             auto& widget = self.widgets[widx::xPos];
-            drawingCtx.drawStringLeft(*rt, self.x + widget.left + 2, self.y + widget.top + 1, Colour::black, StringIds::tile_inspector_coord, &args);
+            auto point = Point(self.x + widget.left + 2, self.y + widget.top + 1);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::tile_inspector_coord, &args);
         }
         {
             FormatArguments args{};
             args.push<int16_t>(_currentPosition.y);
             auto& widget = self.widgets[widx::yPos];
-            drawingCtx.drawStringLeft(*rt, self.x + widget.left + 2, self.y + widget.top + 1, Colour::black, StringIds::tile_inspector_coord, &args);
+            auto point = Point(self.x + widget.left + 2, self.y + widget.top + 1);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::tile_inspector_coord, &args);
         }
 
         // Selected element details
@@ -183,7 +187,8 @@ namespace OpenLoco::Ui::Windows::TileInspector
             snprintf(&buffer[1], std::size(buffer) - 1, "Data: %02x %02x %02x %02x %02x %02x %02x %02x", data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
 
             auto widget = self.widgets[widx::detailsGroup];
-            drawingCtx.drawString(*rt, self.x + widget.left + 7, self.y + widget.top + 14, Colour::black, buffer);
+            auto point = Point(self.x + widget.left + 7, self.y + widget.top + 14);
+            drawingCtx.drawString(*rt, point, Colour::black, buffer);
         }
     }
 
@@ -379,35 +384,40 @@ namespace OpenLoco::Ui::Windows::TileInspector
 
             // Draw name and type
             auto* widget = &self.widgets[widx::nameTypeHeader];
-            drawingCtx.drawStringLeftClipped(rt, 0, yPos, widget->width(), Colour::black, formatString, &args);
+            auto point = Point(0, yPos);
+            drawingCtx.drawStringLeftClipped(rt, point, widget->width(), Colour::black, formatString, &args);
 
             // Draw base height
             widget = &self.widgets[widx::baseHeightHeader];
             args.rewind();
             args.push(StringIds::uint16_raw);
             args.push<uint16_t>(element.baseZ());
-            drawingCtx.drawStringLeftClipped(rt, widget->left - 4, yPos, widget->width(), Colour::black, formatString, &args);
+            point = Point(widget->left - 4, yPos);
+            drawingCtx.drawStringLeftClipped(rt, point, widget->width(), Colour::black, formatString, &args);
 
             // Draw clear height
             widget = &self.widgets[widx::clearHeightHeader];
             args.rewind();
             args.push(StringIds::uint16_raw);
             args.push<uint16_t>(element.clearZ());
-            drawingCtx.drawStringLeftClipped(rt, widget->left - 4, yPos, widget->width(), Colour::black, formatString, &args);
+            point = Point(widget->left - 4, yPos);
+            drawingCtx.drawStringLeftClipped(rt, point, widget->width(), Colour::black, formatString, &args);
 
             // Draw direction
             widget = &self.widgets[widx::directionHeader];
             args.rewind();
             args.push(StringIds::uint16_raw);
             args.push<uint16_t>(element.data()[0] & 0x03);
-            drawingCtx.drawStringLeftClipped(rt, widget->left - 4, yPos, widget->width(), Colour::black, formatString, &args);
+            point = Point(widget->left - 4, yPos);
+            drawingCtx.drawStringLeftClipped(rt, point, widget->width(), Colour::black, formatString, &args);
 
             // Draw ghost flag
             widget = &self.widgets[widx::ghostHeader];
             if (element.isGhost())
             {
                 static constexpr char strCheckmark[] = "\xAC";
-                drawingCtx.drawString(rt, widget->left - 4, yPos, Colour::white, strCheckmark);
+                point = Point(widget->left - 4, yPos);
+                drawingCtx.drawString(rt, point, Colour::white, strCheckmark);
             }
 
             rowNum++;

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -177,7 +177,12 @@ namespace OpenLoco::Ui::Windows::TimePanel
         {
             c = Colour::white;
         }
-        drawingCtx.drawStringCentred(*rt, self.x + _widgets[Widx::date_btn].midX(), self.y + _widgets[Widx::date_btn].top + 1, c, format, &args);
+
+        {
+            auto& widget = _widgets[Widx::date_btn];
+            auto point = Point(self.x + widget.midX(), self.y + widget.top + 1);
+            drawingCtx.drawStringCentred(*rt, point, c, format, &args);
+        }
 
         auto skin = ObjectManager::get<InterfaceSkinObject>();
         drawingCtx.drawImage(rt, self.x + _widgets[Widx::map_chat_menu].left - 2, self.y + _widgets[Widx::map_chat_menu].top - 1, skin->img + map_sprites_by_rotation[WindowManager::getCurrentRotation()]);

--- a/src/OpenLoco/src/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Windows/TitleMenu.cpp
@@ -272,25 +272,26 @@ namespace OpenLoco::Ui::Windows::TitleMenu
 
         if (window.widgets[Widx::multiplayer_toggle_btn].type != Ui::WidgetType::none)
         {
-            int16_t y = window.widgets[Widx::multiplayer_toggle_btn].top + 3 + window.y;
-            int16_t x = window.width / 2 + window.x;
+            auto& widget = window.widgets[Widx::multiplayer_toggle_btn];
+            auto point = Point(widget.top + 3 + window.y, window.width / 2 + window.x);
 
             StringId string = StringIds::single_player_mode;
+            FormatArguments args{};
 
             if (OpenLoco::isNetworked())
             {
                 // char[512+1]
                 auto buffer = StringManager::getString(StringIds::buffer_2039);
 
+                // TODO: ?? replace this
                 char* playerName = (char*)0xF254D0;
-
                 strcpy((char*)buffer, playerName);
 
-                addr<0x112C826, StringId>() = StringIds::buffer_2039;
+                args.push(StringIds::buffer_2039);
                 string = StringIds::two_player_mode_connected;
             }
 
-            drawingCtx.drawStringCentredClipped(*rt, x, y, kWW - 4, Colour::black, string, (char*)0x112c826);
+            drawingCtx.drawStringCentredClipped(*rt, point, kWW - 4, Colour::black, string, &args);
         }
     }
 

--- a/src/OpenLoco/src/Windows/TitleVersion.cpp
+++ b/src/OpenLoco/src/Windows/TitleVersion.cpp
@@ -38,7 +38,8 @@ namespace OpenLoco::Ui::Windows::TitleVersion
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
         auto versionInfo = getVersionInfo();
-        drawingCtx.drawString(*rt, window.x, window.y, AdvancedColour(Colour::white).outline(), versionInfo.c_str());
+        auto point = Point(window.x, window.y);
+        drawingCtx.drawString(*rt, point, AdvancedColour(Colour::white).outline(), versionInfo.c_str());
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Windows/ToolTip.cpp
+++ b/src/OpenLoco/src/Windows/ToolTip.cpp
@@ -191,7 +191,8 @@ namespace OpenLoco::Ui::Windows::ToolTip
         drawingCtx.drawRect(*rt, x + 1, y + height - 1 - 1, 1, 1, enumValue(ExtColour::unk2E), Drawing::RectFlags::transparent);
         drawingCtx.drawRect(*rt, x + width - 1 - 1, y + height - 1 - 1, 1, 1, enumValue(ExtColour::unk2E), Drawing::RectFlags::transparent);
 
-        drawingCtx.drawStringCentredRaw(*rt, ((width + 1) / 2) + x - 1, y + 1, _lineBreakCount, Colour::black, _text);
+        auto point = Point(((width + 1) / 2) + x - 1, y + 1);
+        drawingCtx.drawStringCentredRaw(*rt, point, _lineBreakCount, Colour::black, _text);
     }
 
     // 0x004C94F7

--- a/src/OpenLoco/src/Windows/ToolbarBottomEditor.cpp
+++ b/src/OpenLoco/src/Windows/ToolbarBottomEditor.cpp
@@ -81,7 +81,7 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
         drawingCtx.drawRectInset(*rt, next.left + self.x + 1, next.top + self.y + 1, next.width() - 2, next.height() - 2, self.getColour(WindowColour::secondary), Drawing::RectInsetFlags::borderInset | Drawing::RectInsetFlags::fillNone);
 
         auto point = Point((previous.right + next.left) / 2 + self.x, self.y + self.height - 12);
-        drawingCtx.drawStringCentred(*rt, point self.getColour(WindowColour::tertiary).opaque().outline(), _stepNames[EditorController::getCurrentStep()]);
+        drawingCtx.drawStringCentred(*rt, point, self.getColour(WindowColour::tertiary).opaque().outline(), _stepNames[EditorController::getCurrentStep()]);
 
         if (EditorController::canGoBack())
         {

--- a/src/OpenLoco/src/Windows/ToolbarBottomEditor.cpp
+++ b/src/OpenLoco/src/Windows/ToolbarBottomEditor.cpp
@@ -80,7 +80,8 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
         }
         drawingCtx.drawRectInset(*rt, next.left + self.x + 1, next.top + self.y + 1, next.width() - 2, next.height() - 2, self.getColour(WindowColour::secondary), Drawing::RectInsetFlags::borderInset | Drawing::RectInsetFlags::fillNone);
 
-        drawingCtx.drawStringCentred(*rt, (previous.right + next.left) / 2 + self.x, self.y + self.height - 12, self.getColour(WindowColour::tertiary).opaque().outline(), _stepNames[EditorController::getCurrentStep()]);
+        auto point = Point((previous.right + next.left) / 2 + self.x, self.y + self.height - 12);
+        drawingCtx.drawStringCentred(*rt, point self.getColour(WindowColour::tertiary).opaque().outline(), _stepNames[EditorController::getCurrentStep()]);
 
         if (EditorController::canGoBack())
         {
@@ -92,8 +93,12 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
             {
                 textColour = Colour::white;
             }
-            drawingCtx.drawStringCentred(*rt, self.x + x, self.y + y, textColour, StringIds::editor_previous_step);
-            drawingCtx.drawStringCentred(*rt, self.x + x, self.y + y + 10, textColour, _stepNames[EditorController::getPreviousStep()]);
+
+            point = Point(self.x + x, self.y + y);
+            drawingCtx.drawStringCentred(*rt, point, textColour, StringIds::editor_previous_step);
+
+            point = Point(self.x + x, self.y + y + 10);
+            drawingCtx.drawStringCentred(*rt, point, textColour, _stepNames[EditorController::getPreviousStep()]);
         }
         drawingCtx.drawImage(rt, self.x + next.right - 29, self.y + next.top + 4, ImageIds::step_forward);
         int x = next.left + (next.width() - 31) / 2;
@@ -103,8 +108,12 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
         {
             textColour = Colour::white;
         }
-        drawingCtx.drawStringCentred(*rt, self.x + x, self.y + y, textColour, StringIds::editor_next_step);
-        drawingCtx.drawStringCentred(*rt, self.x + x, self.y + y + 10, textColour, _stepNames[EditorController::getNextStep()]);
+
+        point = Point(self.x + x, self.y + y);
+        drawingCtx.drawStringCentred(*rt, point, textColour, StringIds::editor_next_step);
+
+        point = Point(self.x + x, self.y + y + 10);
+        drawingCtx.drawStringCentred(*rt, point, textColour, _stepNames[EditorController::getNextStep()]);
     }
 
     // 0x0043D0ED

--- a/src/OpenLoco/src/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Windows/TownList.cpp
@@ -180,14 +180,16 @@ namespace OpenLoco::Ui::Windows::TownList
                     FormatArguments args{};
                     args.push(town->name);
 
-                    drawingCtx.drawStringLeftClipped(rt, 0, yPos, 198, Colour::black, text_colour_id, &args);
+                    auto point = Point(0, yPos);
+                    drawingCtx.drawStringLeftClipped(rt, point, 198, Colour::black, text_colour_id, &args);
                 }
                 // Town Type
                 {
                     FormatArguments args{};
                     args.push(town->getTownSizeString());
 
-                    drawingCtx.drawStringLeftClipped(rt, 200, yPos, 278, Colour::black, text_colour_id, &args);
+                    auto point = Point(200, yPos);
+                    drawingCtx.drawStringLeftClipped(rt, point, 278, Colour::black, text_colour_id, &args);
                 }
                 // Town Population
                 {
@@ -195,7 +197,8 @@ namespace OpenLoco::Ui::Windows::TownList
                     args.push(StringIds::int_32);
                     args.push(town->population);
 
-                    drawingCtx.drawStringLeftClipped(rt, 280, yPos, 68, Colour::black, text_colour_id, &args);
+                    auto point = Point(280, yPos);
+                    drawingCtx.drawStringLeftClipped(rt, point, 68, Colour::black, text_colour_id, &args);
                 }
                 // Town Stations
                 {
@@ -203,7 +206,8 @@ namespace OpenLoco::Ui::Windows::TownList
                     args.push(StringIds::int_32);
                     args.push<int32_t>(town->numStations);
 
-                    drawingCtx.drawStringLeftClipped(rt, 350, yPos, 68, Colour::black, text_colour_id, &args);
+                    auto point = Point(350, yPos);
+                    drawingCtx.drawStringLeftClipped(rt, point, 68, Colour::black, text_colour_id, &args);
                 }
                 yPos += kRowHeight;
             }
@@ -217,9 +221,6 @@ namespace OpenLoco::Ui::Windows::TownList
             self.draw(rt);
             Common::drawTabs(&self, rt);
 
-            auto xPos = self.x + 4;
-            auto yPos = self.y + self.height - 12;
-
             FormatArguments args{};
             if (self.var_83C == 1)
                 args.push(StringIds::status_towns_singular);
@@ -227,7 +228,8 @@ namespace OpenLoco::Ui::Windows::TownList
                 args.push(StringIds::status_towns_plural);
             args.push(self.var_83C);
 
-            drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::black_stringid, &args);
+            auto point = Point(self.x + 4, self.y + self.height - 12);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x0049A27F
@@ -656,9 +658,11 @@ namespace OpenLoco::Ui::Windows::TownList
             self.draw(rt);
             Common::drawTabs(&self, rt);
 
-            drawingCtx.drawStringLeft(*rt, self.x + 3, self.y + self.widgets[widx::current_size].top + 1, Colour::black, StringIds::town_size_label);
+            auto point = Point(self.x + 3, self.y + self.widgets[widx::current_size].top + 1);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::town_size_label);
 
-            drawingCtx.drawStringLeft(*rt, self.x + 3, self.y + self.height - 13, Colour::black, StringIds::select_town_size);
+            point = Point(self.x + 3, self.y + self.height - 13);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::select_town_size);
         }
 
         // 0x0049A675
@@ -886,8 +890,11 @@ namespace OpenLoco::Ui::Windows::TownList
             }
 
             auto buildingObj = ObjectManager::get<BuildingObject>(buildingId);
+            FormatArguments args{};
+            args.push(buildingObj->name);
 
-            drawingCtx.drawStringLeftClipped(*rt, self.x + 3, self.y + self.height - 13, self.width - 19, Colour::black, StringIds::black_stringid, &buildingObj->name);
+            auto point = Point(self.x + 3, self.y + self.height - 13);
+            drawingCtx.drawStringLeftClipped(*rt, point, self.width - 19, Colour::black, StringIds::black_stringid, &args);
         }
 
         // 0x0049AB31

--- a/src/OpenLoco/src/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Windows/TownWindow.cpp
@@ -143,10 +143,9 @@ namespace OpenLoco::Ui::Windows::Town
             args.push(town->population);
 
             const auto& widget = self.widgets[widx::status_bar];
-            const auto x = self.x + widget.left - 1;
-            const auto y = self.y + widget.top - 1;
             const auto width = widget.width() - 1;
-            drawingCtx.drawStringLeftClipped(*rt, x, y, width, Colour::black, StringIds::status_town_population, &args);
+            auto point = Point(self.x + widget.left - 1, self.y + widget.top - 1);
+            drawingCtx.drawStringLeftClipped(*rt, point, width, Colour::black, StringIds::status_town_population, &args);
         }
 
         // 0x00499079
@@ -417,7 +416,8 @@ namespace OpenLoco::Ui::Windows::Town
                 const uint16_t xPos = 39;
                 drawingCtx.drawRect(*clipped, xPos, yPos, 241, 1, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4), Drawing::RectFlags::none);
 
-                drawingCtx.drawStringRight(*clipped, xPos, yPos - 6, Colour::black, StringIds::population_graph_people, &args);
+                auto point = Point(xPos, yPos - 6);
+                drawingCtx.drawStringRight(*clipped, point, Colour::black, StringIds::population_graph_people, &args);
 
                 yTick += 1000;
             }
@@ -439,7 +439,8 @@ namespace OpenLoco::Ui::Windows::Town
                         FormatArguments args{};
                         args.push(year);
 
-                        drawingCtx.drawStringCentred(*clipped, xPos, yPos, Colour::black, StringIds::population_graph_year, &args);
+                        auto point = Point(xPos, yPos);
+                        drawingCtx.drawStringCentred(*clipped, point, Colour::black, StringIds::population_graph_year, &args);
                     }
 
                     drawingCtx.drawRect(*clipped, xPos, 11, 1, self.height - 66, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4), Drawing::RectFlags::none);
@@ -531,12 +532,11 @@ namespace OpenLoco::Ui::Windows::Town
             self.draw(rt);
             Common::drawTabs(&self, rt);
 
-            uint16_t xPos = self.x + 4;
-            uint16_t yPos = self.y + 46;
-            drawingCtx.drawStringLeft(*rt, xPos, yPos, Colour::black, StringIds::local_authority_ratings_transport_companies);
+            auto point = Point(self.x + 4, self.y + 46);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::local_authority_ratings_transport_companies);
 
-            xPos += 4;
-            yPos += 14;
+            point.x += 4;
+            point.y += 14;
             auto town = TownManager::get(TownId(self.number));
             for (uint8_t i = 0; i < std::size(town->companyRatings); i++)
             {
@@ -562,9 +562,9 @@ namespace OpenLoco::Ui::Windows::Town
                 args.push(rating);
                 args.push(rank);
 
-                drawingCtx.drawStringLeftClipped(*rt, xPos, yPos, self.width - 12, Colour::black, StringIds::town_rating_company_percentage_rank, &args);
+                drawingCtx.drawStringLeftClipped(*rt, point, self.width - 12, Colour::black, StringIds::town_rating_company_percentage_rank, &args);
 
-                yPos += 10;
+                point.y += 10;
             }
         }
 

--- a/src/OpenLoco/src/Windows/Tutorial.cpp
+++ b/src/OpenLoco/src/Windows/Tutorial.cpp
@@ -73,11 +73,11 @@ namespace OpenLoco::Ui::Windows::Tutorial
         args.push(titleStringIds[tutorialNumber]);
 
         auto& widget = self.widgets[Widx::frame];
-        auto yPos = self.y + widget.top + 4;
-        drawingCtx.drawStringCentred(*rt, self.x + widget.midX(), yPos, Colour::black, StringIds::tutorial_text, &args);
+        auto point = Point(self.x + widget.midX(), self.y + widget.top + 4);
+        drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::tutorial_text, &args);
 
-        yPos += 10;
-        drawingCtx.drawStringCentred(*rt, self.x + widget.midX(), yPos, Colour::black, StringIds::tutorial_control, nullptr);
+        point.y += 10;
+        drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::tutorial_control);
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Windows/Vehicle.cpp
@@ -3302,15 +3302,19 @@ namespace OpenLoco::Ui::Windows::Vehicle
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
-            auto loc = Point(8, y - 1);
-            drawingCtx.drawStringLeft(rt, loc, Colour::black, strFormat, &args);
+            char buffer[512];
+            StringManager::formatString(buffer, std::size(buffer), strFormat, &args);
+
+            drawingCtx.setCurrentFontSpriteBase(Font::medium_bold);
+            drawingCtx.drawString(rt, Point(8, y - 1), Colour::black, buffer);
+            auto labelWidth = drawingCtx.getStringWidth(buffer);
 
             if (order.hasFlags(Vehicles::OrderFlags::HasNumber))
             {
                 if (ToolManager::isToolActive(self.type, self.number))
                 {
                     auto imageId = kNumberCircle[orderNumber - 1];
-                    drawingCtx.drawImage(&rt, loc.x + 3, loc.y + 1, Gfx::recolour(imageId, Colour::white));
+                    drawingCtx.drawImage(&rt, labelWidth + 8 + 3, y, Gfx::recolour(imageId, Colour::white));
                 }
                 orderNumber++;
             }

--- a/src/OpenLoco/src/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Windows/Vehicle.cpp
@@ -1639,7 +1639,11 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 args.push(vehicleObj->name);
                 x += 2;
                 y = pos.y + (self.rowHeight / 2) - 6;
-                drawingCtx.drawStringLeft(rt, x, y, Colour::black, carStr, &args);
+
+                {
+                    auto point = Point(x, y);
+                    drawingCtx.drawStringLeft(rt, point, Colour::black, carStr, &args);
+                }
 
                 pos.y += self.rowHeight;
             }
@@ -1886,16 +1890,26 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 return;
             }
             head->generateCargoTotalString(buffer);
-            FormatArguments args = {};
-            args.push<StringId>(StringIds::buffer_1250);
-            drawingCtx.drawStringLeftClipped(*rt, self.x + 3, self.y + self.height - 25, self.width - 15, Colour::black, StringIds::total_stringid, &args);
+
+            {
+                FormatArguments args = {};
+                args.push<StringId>(StringIds::buffer_1250);
+
+                auto point = Point(self.x + 3, self.y + self.height - 25);
+                drawingCtx.drawStringLeftClipped(*rt, point, self.width - 15, Colour::black, StringIds::total_stringid, &args);
+            }
 
             // draw cargo capacity
-            buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
-            head->generateCargoCapacityString(buffer);
-            args = {};
-            args.push<StringId>(StringIds::buffer_1250);
-            drawingCtx.drawStringLeftClipped(*rt, self.x + 3, self.y + self.height - 13, self.width - 15, Colour::black, StringIds::vehicle_capacity_stringid, &args);
+            {
+                buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
+                head->generateCargoCapacityString(buffer);
+
+                FormatArguments args = {};
+                args.push<StringId>(StringIds::buffer_1250);
+
+                auto point = Point(self.x + 3, self.y + self.height - 13);
+                drawingCtx.drawStringLeftClipped(*rt, point, self.width - 15, Colour::black, StringIds::vehicle_capacity_stringid, &args);
+            }
         }
 
         // based on 0x004B40C7
@@ -1911,13 +1925,16 @@ namespace OpenLoco::Ui::Windows::Vehicle
             auto cargoObj = ObjectManager::get<CargoObject>(cargoType);
             auto unitNameFormat = cargoQty == 1 ? cargoObj->unitNameSingular : cargoObj->unitNamePlural;
             auto station = StationManager::get(stationId);
+
             FormatArguments args{};
             args.push(StringIds::cargo_from);
             args.push(unitNameFormat);
             args.push<uint32_t>(cargoQty);
             args.push(station->name);
             args.push(station->town);
-            drawingCtx.drawStringLeft(rt, x, y, Colour::black, strFormat, &args);
+
+            auto point = Point(x, y);
+            drawingCtx.drawStringLeft(rt, point, Colour::black, strFormat, &args);
             y += 10;
         }
 
@@ -1966,7 +1983,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     {
                         FormatArguments args{};
                         args.push<StringId>(StringIds::cargo_empty);
-                        drawingCtx.drawStringLeft(rt, width, cargoTextHeight + 5, Colour::black, strFormat, &args);
+
+                        auto point = Point(width, cargoTextHeight + 5);
+                        drawingCtx.drawStringLeft(rt, point, Colour::black, strFormat, &args);
                     }
                 }
 
@@ -2285,7 +2304,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     FormatArguments args{};
                     args.push<uint32_t>(veh1->lastIncome.day);
                     // Last income on: {DATE DMY}
-                    drawingCtx.drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::last_income_on_date, &args);
+                    drawingCtx.drawStringLeft(*rt, pos, Colour::black, StringIds::last_income_on_date, &args);
                 }
 
                 pos.y += 10;
@@ -2305,8 +2324,11 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     args.push(veh1->lastIncome.cargoDistances[i]);
                     args.push<uint16_t>(veh1->lastIncome.cargoAges[i]);
                     args.push<currency32_t>(veh1->lastIncome.cargoProfits[i]);
+
                     // {STRINGID} transported {INT16} blocks in {INT16} days = {CURRENCY32}
-                    drawingCtx.drawStringLeftWrapped(*rt, pos.x + 4, pos.y, self.width - 12, Colour::black, StringIds::transported_blocks_in_days, &args);
+                    pos.x += 4;
+                    drawingCtx.drawStringLeftWrapped(*rt, pos, self.width - 12, Colour::black, StringIds::transported_blocks_in_days, &args);
+                    pos.x -= 4;
 
                     // TODO: fix function to take pointer to offset
                     pos.y += 12;
@@ -2315,7 +2337,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             else
             {
                 // Last income: N/A"
-                drawingCtx.drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::last_income_na);
+                drawingCtx.drawStringLeft(*rt, pos, Colour::black, StringIds::last_income_na);
                 pos.y += 10;
             }
 
@@ -2326,7 +2348,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 // Last journey average speed: {VELOCITY}
                 FormatArguments args{};
                 args.push(head->lastAverageSpeed);
-                drawingCtx.drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::last_journey_average_speed, &args);
+                drawingCtx.drawStringLeft(*rt, pos, Colour::black, StringIds::last_journey_average_speed, &args);
                 pos.y += 10 + 5;
             }
 
@@ -2334,7 +2356,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 // Monthly Running Cost: {CURRENCY32}
                 FormatArguments args{};
                 args.push(head->calculateRunningCost());
-                drawingCtx.drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::vehicle_monthly_running_cost, &args);
+                drawingCtx.drawStringLeft(*rt, pos, Colour::black, StringIds::vehicle_monthly_running_cost, &args);
                 pos.y += 10;
             }
 
@@ -2343,7 +2365,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 FormatArguments args{};
                 auto monthlyProfit = (train.veh2->totalRecentProfit()) / 4;
                 args.push(monthlyProfit);
-                drawingCtx.drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::vehicle_monthly_profit, &args);
+                drawingCtx.drawStringLeft(*rt, pos, Colour::black, StringIds::vehicle_monthly_profit, &args);
                 pos.y += 10 + 5;
             }
 
@@ -2352,7 +2374,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 FormatArguments args{};
                 args.push(train.head->totalRefundCost);
                 pos.y = self.y + self.height - 14;
-                drawingCtx.drawStringLeft(*rt, pos.x, pos.y, Colour::black, StringIds::sale_value_of_vehicle, &args);
+                drawingCtx.drawStringLeft(*rt, pos, Colour::black, StringIds::sale_value_of_vehicle, &args);
             }
         }
 
@@ -3193,9 +3215,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             if (ToolManager::isToolActive(WindowType::vehicle, self.number))
             {
                 // Location at bottom left edge of window
-                Ui::Point loc{ static_cast<int16_t>(self.x + 3), static_cast<int16_t>(self.y + self.height - 13) };
-
-                drawingCtx.drawStringLeftClipped(*rt, loc.x, loc.y, self.width - 14, Colour::black, StringIds::route_click_on_waypoint);
+                auto loc = Point(self.x + 3, self.y + self.height - 13);
+                drawingCtx.drawStringLeftClipped(*rt, loc, self.width - 14, Colour::black, StringIds::route_click_on_waypoint);
             }
         }
 
@@ -3283,8 +3304,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
-            Ui::Point loc = { 8, static_cast<int16_t>(y - 1) };
-            drawingCtx.drawStringLeft(rt, &loc, Colour::black, strFormat, &args);
+            auto loc = Point(8, y - 1);
+            drawingCtx.drawStringLeft(rt, loc, Colour::black, strFormat, &args);
+
             if (order.hasFlags(Vehicles::OrderFlags::HasNumber))
             {
                 if (ToolManager::isToolActive(self.type, self.number))
@@ -3313,7 +3335,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             auto rowNum = 0;
             if (head->sizeOfOrderTable == 1)
             {
-                drawingCtx.drawStringLeft(rt, 8, 0, Colour::black, StringIds::no_route_defined);
+                auto point = Point(8, 0);
+                drawingCtx.drawStringLeft(rt, point, Colour::black, StringIds::no_route_defined);
                 rowNum++; // Used to move down the text
             }
 
@@ -3361,7 +3384,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 sub_4B4A58(self, rt, strFormat, args, order, y);
                 if (head->currentOrder + head->orderTableOffset == order.getOffset())
                 {
-                    drawingCtx.drawStringLeft(rt, 1, y - 1, Colour::black, StringIds::orders_current_order);
+                    auto point = Point(1, y - 1);
+                    drawingCtx.drawStringLeft(rt, point, Colour::black, StringIds::orders_current_order);
                 }
 
                 rowNum++;
@@ -3383,7 +3407,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             loc.y -= 1;
             auto args = FormatArguments::common(orderString[0]);
-            drawingCtx.drawStringLeft(rt, &loc, Colour::black, strFormat, &args);
+            drawingCtx.drawStringLeft(rt, loc, Colour::black, strFormat, &args);
         }
 
         static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Windows/Vehicle.cpp
@@ -2446,8 +2446,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
     namespace Route
     {
-        static loco_global<uint8_t, 0x00113646A> _113646A;
-
         static Vehicles::OrderRingView getOrderTable(const Vehicles::VehicleHead* const head)
         {
             return Vehicles::OrderRingView(head->orderTableOffset);
@@ -3300,7 +3298,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         };
 
         // 0x004B4A58 based on
-        static void sub_4B4A58(Window& self, Gfx::RenderTarget& rt, const StringId strFormat, FormatArguments& args, Vehicles::Order& order, int16_t& y)
+        static void drawOrderLabel(Window& self, Gfx::RenderTarget& rt, const StringId strFormat, FormatArguments& args, Vehicles::Order& order, int16_t& y, int16_t& orderNumber)
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
 
@@ -3311,10 +3309,10 @@ namespace OpenLoco::Ui::Windows::Vehicle
             {
                 if (ToolManager::isToolActive(self.type, self.number))
                 {
-                    auto imageId = kNumberCircle[_113646A - 1];
+                    auto imageId = kNumberCircle[orderNumber - 1];
                     drawingCtx.drawImage(&rt, loc.x + 3, loc.y + 1, Gfx::recolour(imageId, Colour::white));
                 }
-                _113646A++;
+                orderNumber++;
             }
         }
 
@@ -3340,7 +3338,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 rowNum++; // Used to move down the text
             }
 
-            _113646A = 1; // Number ?symbol? TODO: make not a global
+            int16_t orderNumber = 1;
             for (auto& order : getOrderTable(head))
             {
                 int16_t y = rowNum * lineHeight;
@@ -3381,7 +3379,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     }
                 }
 
-                sub_4B4A58(self, rt, strFormat, args, order, y);
+                drawOrderLabel(self, rt, strFormat, args, order, y, orderNumber);
                 if (head->currentOrder + head->orderTableOffset == order.getOffset())
                 {
                     auto point = Point(1, y - 1);

--- a/src/OpenLoco/src/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Windows/Vehicle.cpp
@@ -982,14 +982,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     strFormat = StringIds::black_stringid;
                 }
 
-                drawingCtx.drawStringLeftClipped(
-                    *rt,
-                    self.x + self.widgets[widx::status].left - 1,
-                    self.y + self.widgets[widx::status].top - 1,
-                    self.widgets[widx::status].width() - 1,
-                    Colour::black,
-                    strFormat,
-                    &args);
+                auto& widget = self.widgets[widx::status];
+                auto point = Point(self.x + widget.left - 1, self.y + widget.top - 1);
+                drawingCtx.drawStringLeftClipped(*rt, point, widget.width() - 1, Colour::black, strFormat, &args);
             }
 
             Widget& speedWidget = self.widgets[widx::speedControl];
@@ -1001,19 +996,11 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     self.y + speedWidget.top + 10,
                     Gfx::recolour(ImageIds::speed_control_track, self.getColour(WindowColour::secondary).c()));
 
-                drawingCtx.drawStringCentred(
-                    *rt,
-                    self.x + speedWidget.midX(),
-                    self.y + speedWidget.top + 4,
-                    Colour::black,
-                    StringIds::tiny_power);
+                auto point = Point(self.x + speedWidget.midX(), self.y + speedWidget.top + 4);
+                drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::tiny_power);
 
-                drawingCtx.drawStringCentred(
-                    *rt,
-                    self.x + speedWidget.midX(),
-                    self.y + speedWidget.bottom - 10,
-                    Colour::black,
-                    StringIds::tiny_brake);
+                point = Point(self.x + speedWidget.midX(), self.y + speedWidget.bottom - 10);
+                drawingCtx.drawStringCentred(*rt, point, Colour::black, StringIds::tiny_brake);
 
                 drawingCtx.drawImage(
                     rt,
@@ -1031,17 +1018,10 @@ namespace OpenLoco::Ui::Windows::Vehicle
             {
                 FormatArguments args = {};
                 args.push(StringIds::getVehicleType(veh->vehicleType));
-                Ui::Point origin;
-                Widget& button = self.widgets[widx::viewport];
-                origin.x = self.x + button.midX();
-                origin.y = self.y + button.midY();
-                drawingCtx.drawStringCentredWrapped(
-                    *rt,
-                    origin,
-                    button.width() - 6,
-                    Colour::black,
-                    StringIds::click_on_view_select_string_id_start,
-                    &args);
+
+                auto& button = self.widgets[widx::viewport];
+                auto origin = Point(self.x + button.midX(), self.y + button.midY());
+                drawingCtx.drawStringCentredWrapped(*rt, origin, button.width() - 6, Colour::black, StringIds::click_on_view_select_string_id_start, &args);
             }
         }
 
@@ -1581,7 +1561,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 {
                     str = StringIds::vehicle_details_total_power_and_weight;
                 }
-                drawingCtx.drawStringLeftClipped(*rt, pos.x, pos.y, self.width - 6, Colour::black, str, &args);
+                drawingCtx.drawStringLeftClipped(*rt, pos, self.width - 6, Colour::black, str, &args);
             }
 
             {
@@ -1595,7 +1575,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 {
                     str = StringIds::vehicle_details_max_speed_and_rack_rail_and_reliability;
                 }
-                drawingCtx.drawStringLeftClipped(*rt, pos.x, pos.y, self.width - 16, Colour::black, str, &args);
+                drawingCtx.drawStringLeftClipped(*rt, pos, self.width - 16, Colour::black, str, &args);
             }
 
             {
@@ -1609,7 +1589,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     str = StringIds::vehicle_car_count_and_length;
                     args.push<uint32_t>(head->getCarCount());
                 }
-                drawingCtx.drawStringLeftClipped(*rt, pos.x, pos.y, self.width - 16, Colour::black, str, &args);
+                drawingCtx.drawStringLeftClipped(*rt, pos, self.width - 16, Colour::black, str, &args);
             }
         }
 

--- a/src/OpenLoco/src/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Windows/VehicleList.cpp
@@ -700,7 +700,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
         if (filterActive)
         {
             // Draw filter text as prepared
-            drawingCtx.drawStringLeftClipped(*rt, xPos, self.y + widget->top, widget->width() - 15, Colour::black, StringIds::wcolour2_stringid, &args);
+            auto point = Point(xPos, self.y + widget->top);
+            drawingCtx.drawStringLeftClipped(*rt, point, widget->width() - 15, Colour::black, StringIds::wcolour2_stringid, &args);
         }
     }
 
@@ -769,7 +770,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
                 // Draw status
                 yPos += 2;
-                drawingCtx.drawStringLeftClipped(rt, 1, yPos, 308, AdvancedColour(Colour::black).outline(), format, &args);
+                auto point = Point(1, yPos);
+                drawingCtx.drawStringLeftClipped(rt, point, 308, AdvancedColour(Colour::black).outline(), format, &args);
             }
 
             auto vehicle = Vehicles::Vehicle(*head);
@@ -785,7 +787,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
                 }
 
                 auto args = FormatArguments::common(profit);
-                drawingCtx.drawStringLeftClipped(rt, 310, yPos, 98, AdvancedColour(Colour::black).outline(), format, &args);
+                auto point = Point(310, yPos);
+                drawingCtx.drawStringLeftClipped(rt, point, 98, AdvancedColour(Colour::black).outline(), format, &args);
             }
 
             // Vehicle age
@@ -796,14 +799,16 @@ namespace OpenLoco::Ui::Windows::VehicleList
                     format = StringIds::vehicle_list_age_year;
 
                 auto args = FormatArguments::common(age);
-                drawingCtx.drawStringLeftClipped(rt, 410, yPos, 63, AdvancedColour(Colour::black).outline(), format, &args);
+                auto point = Point(410, yPos);
+                drawingCtx.drawStringLeftClipped(rt, point, 63, AdvancedColour(Colour::black).outline(), format, &args);
             }
 
             // Vehicle reliability
             {
                 int16_t reliability = vehicle.veh2->reliability;
                 auto args = FormatArguments::common(reliability);
-                drawingCtx.drawStringLeftClipped(rt, 475, yPos, 65, AdvancedColour(Colour::black).outline(), StringIds::vehicle_list_reliability, &args);
+                auto point = Point(475, yPos);
+                drawingCtx.drawStringLeftClipped(rt, point, 65, AdvancedColour(Colour::black).outline(), StringIds::vehicle_list_reliability, &args);
             }
 
             yPos += self.rowHeight - 2;

--- a/src/OpenLoco/src/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Windows/VehicleList.cpp
@@ -636,7 +636,9 @@ namespace OpenLoco::Ui::Windows::VehicleList
             FormatArguments args{};
             args.push(footerStringId);
             args.push(self.var_83C);
-            drawingCtx.drawStringLeft(*rt, self.x + 3, self.y + self.height - 13, Colour::black, StringIds::black_stringid, &args);
+
+            auto point = Point(self.x + 3, self.y + self.height - 13);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::black_stringid, &args);
         }
 
         static constexpr std::array<StringId, 3> typeToFilterStringIds{
@@ -650,7 +652,9 @@ namespace OpenLoco::Ui::Windows::VehicleList
             FormatArguments args{};
             args.push(typeToFilterStringIds[self.var_88A]);
             auto* widget = &self.widgets[Widx::filter_type];
-            drawingCtx.drawStringLeftClipped(*rt, self.x + widget->left + 1, self.y + widget->top, widget->width() - 15, Colour::black, StringIds::wcolour2_stringid, &args);
+
+            auto point = Point(self.x + widget->left + 1, self.y + widget->top);
+            drawingCtx.drawStringLeftClipped(*rt, point, widget->width() - 15, Colour::black, StringIds::wcolour2_stringid, &args);
         }
 
         auto* widget = &self.widgets[Widx::cargo_type];


### PR DESCRIPTION
On master, the various `drawString` functions use a variety of signatures. Some use separate parameters for x and y coordinates, while some use the `Ui::Point` type. This PR changes all the signatures for all `drawString` variants to use `Ui::Point`, and adjusts all callers accordingly.

A similar cleanup should be done for the other drawing functions, but that is outside the scope for this PR.

Other changes:
- The origin point is no longer passed by reference, but by value. The Point type fits snugly into a 32-bit register.
- The `drawString` function no longer returns anything (was Ui::Point, now void). The return type was unused, or no longer used, anywhere.
- The `drawStringLeftWrapped` now returns line width rather than y-pos, as advertised.