### PR TITLE
Fix hook for station name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Feature: [#2331] Allow setting a preferred owner face to be used for new games.
 - Fix: [#2312] Object selection allowing deselection of in-use objects, leading to crashes.
 - Fix: [#2316, #2321] Vehicles do not rotate in announcement for their invention.
+- Fix: [#2352] Height-related station names generated incorrectly.
 - Change: [#2324] Loading and saving landscapes now defaults to the OpenLoco user folder.
 - Change: [#2328] In the landscape generation window, water options are now presented in a separate tab.
 

--- a/src/OpenLoco/src/World/StationManager.cpp
+++ b/src/OpenLoco/src/World/StationManager.cpp
@@ -644,7 +644,7 @@ namespace OpenLoco::StationManager
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 registers backup = regs;
                 auto stationId = (reinterpret_cast<Station*>(regs.esi))->id();
-                const auto newName = generateNewStationName(stationId, TownId(regs.ebx), World::Pos3(regs.ax, regs.cx, regs.dh * 4), regs.dl);
+                const auto newName = generateNewStationName(stationId, TownId(regs.ebx), World::Pos3(regs.ax, regs.cx, regs.dh * World::kSmallZStep), regs.dl);
                 regs = backup;
                 regs.bx = newName;
                 return 0;

--- a/src/OpenLoco/src/World/StationManager.cpp
+++ b/src/OpenLoco/src/World/StationManager.cpp
@@ -644,7 +644,7 @@ namespace OpenLoco::StationManager
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 registers backup = regs;
                 auto stationId = (reinterpret_cast<Station*>(regs.esi))->id();
-                const auto newName = generateNewStationName(stationId, TownId(regs.ebx), World::Pos3(regs.ax, regs.cx, regs.dh), regs.dl);
+                const auto newName = generateNewStationName(stationId, TownId(regs.ebx), World::Pos3(regs.ax, regs.cx, regs.dh * 4), regs.dl);
                 regs = backup;
                 regs.bx = newName;
                 return 0;


### PR DESCRIPTION
#2315 implemented allocate station which use the correct value for z but i didn't notice we had the hook wrong all this time... This modifies replays unfortunately.