### PR TITLE
Rework generator options in landscape generation window

### DIFF
--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2391,3 +2391,4 @@ strings:
   2336: General
   2337: Generator
   2338: "{COLOUR WINDOW_2}Current hill object: {COLOUR BLACK}{STRINGID}"
+  2339: "{COLOUR WINDOW_2}Number of terrain smoothing passes:"

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2388,3 +2388,6 @@ strings:
   2333: "{SMALLFONT}{COLOUR BLACK}When enabled, the maximum length for railroad stations is no longer constrained to 16 tiles. Note that stations can still not occupy more than 80 tiles overall."
   2334: Landscape Generation - Water
   2335: "{SMALLFONT}{COLOUR BLACK}Water generation options"
+  2336: General
+  2336: Generator
+  2337: "{COLOUR WINDOW_2}Current hill object: {COLOUR BLACK}{STRINGID}"

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2200,9 +2200,9 @@ strings:
   2145: "Never"
   2146: "Every month"
   2147: "Every {INT32} months"
-  2148: "{COLOUR WINDOW_2}Generator:"
-  2149: Original
-  2150: Simplex
+  2148: "{COLOUR WINDOW_2}Height map source:"
+  2149: Original generator
+  2150: Simplex generator
   2151: "Modify vehicle"
   2152: "Clone vehicle"
   2153: "Can't clone vehicle..."
@@ -2389,5 +2389,5 @@ strings:
   2334: Landscape Generation - Water
   2335: "{SMALLFONT}{COLOUR BLACK}Water generation options"
   2336: General
-  2336: Generator
-  2337: "{COLOUR WINDOW_2}Current hill object: {COLOUR BLACK}{STRINGID}"
+  2337: Generator
+  2338: "{COLOUR WINDOW_2}Current hill object: {COLOUR BLACK}{STRINGID}"

--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -52,7 +52,8 @@ namespace OpenLoco::EditorController
     // 0x0043D7DC
     void init()
     {
-        setAllScreenFlags(ScreenFlags::editor);
+        clearScreenFlag(ScreenFlags::title);
+        setScreenFlag(ScreenFlags::editor);
         setGameSpeed(GameSpeed::Normal);
 
         auto& options = S5::getOptions();

--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -129,6 +129,10 @@ namespace OpenLoco::EditorController
         Gfx::loadPalette();
         Gfx::invalidateScreen();
 
+        // New in OpenLoco
+        options.generator = S5::LandGeneratorType::Original;
+        options.numTerrainSmoothingPasses = 2;
+
         resetScreenAge();
         throw GameException::Interrupt;
     }

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1951,6 +1951,9 @@ namespace OpenLoco::StringIds
     constexpr StringId disableStationSizeLimitTooltip = 2333;
     constexpr StringId title_landscape_generation_water = 2334;
     constexpr StringId tooltip_landscape_generation_water = 2335;
+    constexpr StringId landscapeOptionsGroupGeneral = 2336;
+    constexpr StringId landscapeOptionsGroupGenerator = 2336;
+    constexpr StringId landscapeOptionsCurrentHillObject = 2337;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1954,6 +1954,7 @@ namespace OpenLoco::StringIds
     constexpr StringId landscapeOptionsGroupGeneral = 2336;
     constexpr StringId landscapeOptionsGroupGenerator = 2337;
     constexpr StringId landscapeOptionsCurrentHillObject = 2338;
+    constexpr StringId landscapeOptionsSmoothingPasses = 2339;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1763,7 +1763,7 @@ namespace OpenLoco::StringIds
     constexpr StringId autosave_never = 2145;
     constexpr StringId autosave_every_month = 2146;
     constexpr StringId autosave_every_x_months = 2147;
-    constexpr StringId generator = 2148;
+    constexpr StringId height_map_source = 2148;
     constexpr StringId generator_original = 2149;
     constexpr StringId generator_simplex = 2150;
     constexpr StringId dropdown_modify_vehicle = 2151;
@@ -1952,8 +1952,8 @@ namespace OpenLoco::StringIds
     constexpr StringId title_landscape_generation_water = 2334;
     constexpr StringId tooltip_landscape_generation_water = 2335;
     constexpr StringId landscapeOptionsGroupGeneral = 2336;
-    constexpr StringId landscapeOptionsGroupGenerator = 2336;
-    constexpr StringId landscapeOptionsCurrentHillObject = 2337;
+    constexpr StringId landscapeOptionsGroupGenerator = 2337;
+    constexpr StringId landscapeOptionsCurrentHillObject = 2338;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Map/MapGenerator/SimplexTerrainGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/SimplexTerrainGenerator.cpp
@@ -11,9 +11,11 @@ namespace OpenLoco::World::MapGenerator
         initialiseRng(seed);
 
         auto hillDensity = std::clamp<uint8_t>(options.hillDensity, 0, 100) / 100.0f;
+        auto smoothingPasses = std::clamp<uint8_t>(options.numTerrainSmoothingPasses, 1, 5);
 
         SimplexSettings settings;
         settings.low = options.minLandHeight;
+        settings.smooth = smoothingPasses;
 
         switch (options.topographyStyle)
         {
@@ -21,35 +23,30 @@ namespace OpenLoco::World::MapGenerator
                 settings.high = options.minLandHeight + 8;
                 settings.baseFreq = 4.0f * hillDensity;
                 settings.octaves = 5;
-                settings.smooth = 2;
                 generate(settings, heightMap);
                 break;
             case TopographyStyle::smallHills:
                 settings.high = options.minLandHeight + 14;
                 settings.baseFreq = 6.0f * hillDensity;
                 settings.octaves = 6;
-                settings.smooth = 1;
                 generate(settings, heightMap);
                 break;
             case TopographyStyle::mountains:
                 settings.high = 32;
                 settings.baseFreq = 4.0f * hillDensity;
                 settings.octaves = 6;
-                settings.smooth = 1;
                 generate(settings, heightMap);
                 break;
             case TopographyStyle::halfMountainsHills:
                 settings.high = 32;
                 settings.baseFreq = 8.0f * hillDensity;
                 settings.octaves = 6;
-                settings.smooth = 2;
                 generate(settings, heightMap);
                 break;
             case TopographyStyle::halfMountainsFlat:
                 settings.high = 32;
                 settings.baseFreq = 6.0f * hillDensity;
                 settings.octaves = 5;
-                settings.smooth = 5;
                 generate(settings, heightMap);
                 break;
         }

--- a/src/OpenLoco/src/S5/S5.h
+++ b/src/OpenLoco/src/S5/S5.h
@@ -119,8 +119,9 @@ namespace OpenLoco::S5
 
         // new fields:
         LandGeneratorType generator;
+        uint8_t numTerrainSmoothingPasses;
 
-        std::byte pad_41BD[348];
+        std::byte pad_41BD[347];
     };
 #pragma pack(pop)
 

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -10,6 +10,7 @@
 namespace OpenLoco
 {
     enum class LoadOrQuitMode : uint16_t;
+    enum class ObjectType : uint8_t;
 }
 
 namespace OpenLoco::Gfx
@@ -273,6 +274,7 @@ namespace OpenLoco::Ui::Windows
     namespace ObjectSelectionWindow
     {
         Window* open();
+        Window& openInTab(ObjectType objectType);
         bool tryCloseWindow();
     }
 

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -160,12 +160,14 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
     {
         enum widx
         {
-            start_year = Common::widx::tab_industries + 1,
+            groupGeneral = Common::widx::tab_industries + 1,
+            start_year,
             start_year_down,
             start_year_up,
             generator,
             generator_btn,
 
+            groupGenerator,
             change_heightmap_btn,
             generate_when_game_starts,
 
@@ -188,12 +190,14 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             common_options_widgets(217, StringIds::title_landscape_generation_options),
 
             // General options
-            makeStepperWidgets({ 256, 52 }, { 100, 12 }, WidgetType::combobox, WindowColour::secondary, StringIds::start_year_value),
-            makeDropdownWidgets({ 176, 68 }, { 180, 12 }, WidgetType::combobox, WindowColour::secondary),
+            makeWidget({ 4, 50 }, { 358, 50 }, WidgetType::groupbox, WindowColour::secondary, StringIds::landscapeOptionsGroupGeneral),
+            makeStepperWidgets({ 256, 65 }, { 100, 12 }, WidgetType::combobox, WindowColour::secondary, StringIds::start_year_value),
+            makeDropdownWidgets({ 176, 81 }, { 180, 12 }, WidgetType::combobox, WindowColour::secondary),
 
             // Generator options
-            makeWidget({ 205, 112 }, { 75, 12 }, WidgetType::button, WindowColour::secondary, StringIds::change),
-            makeWidget({ 10, 84 }, { 346, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::label_generate_random_landscape_when_game_starts, StringIds::tooltip_generate_random_landscape_when_game_starts),
+            makeWidget({ 4, 105 }, { 358, 50 }, WidgetType::groupbox, WindowColour::secondary, StringIds::landscapeOptionsGroupGenerator),
+            makeWidget({ 280, 120 }, { 75, 12 }, WidgetType::button, WindowColour::secondary, StringIds::change),
+            makeWidget({ 10, 136 }, { 346, 12 }, WidgetType::checkbox, WindowColour::secondary, StringIds::label_generate_random_landscape_when_game_starts, StringIds::tooltip_generate_random_landscape_when_game_starts),
 
             // Generate button
             makeWidget({ 196, 200 }, { 160, 12 }, WidgetType::button, WindowColour::secondary, StringIds::button_generate_landscape, StringIds::tooltip_generate_random_landscape),
@@ -225,8 +229,11 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             if (options.generator == S5::LandGeneratorType::Original)
             {
                 auto* obj = ObjectManager::get<HillShapesObject>();
+                FormatArguments args{};
+                args.push(obj->name);
+
                 auto pos = Point(window.x + 10, window.y + window.widgets[widx::change_heightmap_btn].top);
-                drawingCtx.drawStringLeft(*rt, &pos, Colour::black, obj->name);
+                drawingCtx.drawStringLeft(*rt, &pos, Colour::black, StringIds::landscapeOptionsCurrentHillObject, &args);
             }
         }
 

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -316,6 +316,17 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     break;
                 }
             }
+
+            if ((options.scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) == Scenario::ScenarioFlags::none)
+            {
+                self.activatedWidgets |= (1 << widx::generate_when_game_starts);
+                self.disabledWidgets |= (1 << widx::generate_now);
+            }
+            else
+            {
+                self.activatedWidgets &= ~(1 << widx::generate_when_game_starts);
+                self.disabledWidgets &= ~(1 << widx::generate_now);
+            }
         }
 
         static void confirmResetLandscape(int32_t promptType)

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -164,8 +164,8 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             start_year,
             start_year_down,
             start_year_up,
-            generator,
-            generator_btn,
+            heightMapBox,
+            heightMapDropdown,
 
             groupGenerator,
             change_heightmap_btn,
@@ -179,8 +179,8 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         const uint64_t enabled_widgets = Common::enabled_widgets |
              (1 << widx::start_year_up) |
              (1 << widx::start_year_down) |
-             (1 << widx::generator) |
-             (1 << widx::generator_btn) |
+             (1 << widx::heightMapBox) |
+             (1 << widx::heightMapDropdown) |
              (1 << widx::change_heightmap_btn) |
              (1 << widx::generate_when_game_starts) |
              (1 << widx::generate_now);
@@ -221,9 +221,9 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             drawingCtx.drawStringLeft(
                 *rt,
                 window.x + 10,
-                window.y + window.widgets[widx::generator].top,
+                window.y + window.widgets[widx::heightMapBox].top,
                 Colour::black,
-                StringIds::generator);
+                StringIds::height_map_source);
 
             auto& options = S5::getOptions();
             if (options.generator == S5::LandGeneratorType::Original)
@@ -251,7 +251,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             args.push<uint16_t>(S5::getOptions().scenarioStartYear);
 
             auto& options = S5::getOptions();
-            window.widgets[widx::generator].text = generatorIds[enumValue(options.generator)];
+            window.widgets[widx::heightMapBox].text = generatorIds[enumValue(options.generator)];
 
             if ((S5::getOptions().scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) == Scenario::ScenarioFlags::none)
             {
@@ -287,7 +287,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         {
             switch (widgetIndex)
             {
-                case widx::generator_btn:
+                case widx::heightMapDropdown:
                     if (itemIndex != -1)
                     {
                         S5::getOptions().generator = static_cast<S5::LandGeneratorType>(itemIndex);
@@ -316,9 +316,9 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     window.invalidate();
                     break;
 
-                case widx::generator_btn:
+                case widx::heightMapDropdown:
                 {
-                    Widget& target = window.widgets[widx::generator];
+                    Widget& target = window.widgets[widx::heightMapBox];
                     Dropdown::show(window.x + target.left, window.y + target.top, target.width() - 4, target.height(), window.getColour(WindowColour::secondary), std::size(generatorIds), 0x80);
 
                     for (size_t i = 0; i < std::size(generatorIds); i++)

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -506,6 +506,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             window.var_856 = enumValue(FilterLevel::advanced);
         }
 
+        assignTabPositions(&window);
         switchTab(window, objectType);
         return window;
     }

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -490,6 +490,26 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         return window;
     }
 
+    static void switchTab(Window& self, ObjectType newTab);
+
+    Window& openInTab(ObjectType objectType)
+    {
+        auto& window = *open();
+        auto& info = _tabDisplayInfo[enumValue(objectType)];
+
+        if ((info.flags & ObjectTabFlags::alwaysHidden) != ObjectTabFlags::none)
+        {
+            window.var_856 = enumValue(FilterLevel::expert);
+        }
+        else
+        {
+            window.var_856 = enumValue(FilterLevel::advanced);
+        }
+
+        switchTab(window, objectType);
+        return window;
+    }
+
     // 0x004733AC
     static void prepareDraw(Ui::Window& self)
     {
@@ -1119,6 +1139,35 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         }
     }
 
+    static void switchTab(Window& self, ObjectType newTab)
+    {
+        repositionTargetTab(&self, newTab);
+
+        const auto& tabFlags = _tabDisplayInfo[self.currentTab].flags;
+        _filterByVehicleType = (tabFlags & ObjectTabFlags::filterByVehicleType) != ObjectTabFlags::none;
+        _currentVehicleType = VehicleType::train;
+
+        populateTabObjectList(newTab, FilterFlags(self.var_858));
+
+        self.rowHover = -1;
+        self.object = nullptr;
+        self.scrollAreas[0].contentWidth = 0;
+        ObjectManager::freeTemporaryObject();
+        auto objIndex = getFirstAvailableSelectedObject(&self);
+
+        if (objIndex.index != -1)
+        {
+            self.rowHover = objIndex.index;
+            self.object = reinterpret_cast<std::byte*>(objIndex.object._header);
+
+            ObjectManager::loadTemporaryObject(*objIndex.object._header);
+        }
+
+        applyFilterToObjectList(FilterFlags(self.var_858));
+        self.initScrollWidgets();
+        self.invalidate();
+    }
+
     // 0x004737BA
     static void onMouseUp(Window& self, WidgetIndex_t w)
     {
@@ -1159,31 +1208,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
                 if (clickedTab != -1 && self.currentTab != clickedTab)
                 {
-                    repositionTargetTab(&self, static_cast<ObjectType>(clickedTab));
-
-                    const auto& tabFlags = _tabDisplayInfo[self.currentTab].flags;
-                    _filterByVehicleType = (tabFlags & ObjectTabFlags::filterByVehicleType) != ObjectTabFlags::none;
-                    _currentVehicleType = VehicleType::train;
-
-                    populateTabObjectList(static_cast<ObjectType>(clickedTab), FilterFlags(self.var_858));
-
-                    self.rowHover = -1;
-                    self.object = nullptr;
-                    self.scrollAreas[0].contentWidth = 0;
-                    ObjectManager::freeTemporaryObject();
-                    auto objIndex = getFirstAvailableSelectedObject(&self);
-
-                    if (objIndex.index != -1)
-                    {
-                        self.rowHover = objIndex.index;
-                        self.object = reinterpret_cast<std::byte*>(objIndex.object._header);
-
-                        ObjectManager::loadTemporaryObject(*objIndex.object._header);
-                    }
-
-                    applyFilterToObjectList(FilterFlags(self.var_858));
-                    self.initScrollWidgets();
-                    self.invalidate();
+                    switchTab(self, ObjectType(clickedTab));
                 }
 
                 break;


### PR DESCRIPTION
This PR rework the height map generator options in the landscape generation window.

If the original generator is selected, the hill shape object in use will now be shown. Next to this, a 'change' button is shown leading back to the object selection window.

If the simplex generator is selected, the user can specify the number of terrain smoothing passes to apply instead.

This area may be reused by #1941, e.g. to allow showing what PNG file is being used for the height map, along with a browse button.

The PR currently builds on a few unrelated changes which are probably best reviewed separately. These have been spun off to #2354 and #2355.

Before:
![Unnamed (3)](https://github.com/OpenLoco/OpenLoco/assets/604665/c8fc7c9b-696d-4b52-871e-83ca34646d93)

After:
![Unnamed (1)](https://github.com/OpenLoco/OpenLoco/assets/604665/66a87559-7688-4030-8609-6fed703f6583) ![Unnamed (2)](https://github.com/OpenLoco/OpenLoco/assets/604665/4beca865-d8a5-401a-85e3-fb5140c4e902)
