### PR TITLE
Fix scenario editor (regression from #2354)

### DIFF
--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -52,12 +52,7 @@ namespace OpenLoco::EditorController
     // 0x0043D7DC
     void init()
     {
-        // TODO: not sure why title flag is preserved?
-        bool wasTitleMode = isTitleMode();
         setAllScreenFlags(ScreenFlags::editor);
-        if (wasTitleMode)
-            setScreenFlag(ScreenFlags::title);
-
         setGameSpeed(GameSpeed::Normal);
 
         auto& options = S5::getOptions();


### PR DESCRIPTION
In #2354, we implemented the initialisation function for the scenario editor. Confusingly, we noticed the title screen flag was retained while resetting the other screen flags.

Well, we must have skipped something, because retaining it was inhibiting the editor's viewport functionality, e.g. scrolling, rotating, panning...

The fix is simple: remove the title screen flag as well. This makes the most sense to do as well, to me.