### PR TITLE
Update SoftwareDrawingContext.h

### DIFF
--- a/src/OpenLoco/src/Drawing/SoftwareDrawingContext.h
+++ b/src/OpenLoco/src/Drawing/SoftwareDrawingContext.h
@@ -28,20 +28,20 @@ namespace OpenLoco::Drawing
             int16_t width,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) override;
+            const FormatArguments& args = {}) override;
         void drawStringLeft(
             Gfx::RenderTarget& rt,
             int16_t x,
             int16_t y,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) override;
+            const FormatArguments& args = {}) override;
         void drawStringLeft(
             Gfx::RenderTarget& rt,
             Ui::Point* origin,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) override;
+            const FormatArguments& args = {}) override;
         void drawStringLeftClipped(
             Gfx::RenderTarget& rt,
             int16_t x,
@@ -49,35 +49,35 @@ namespace OpenLoco::Drawing
             int16_t width,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) override;
+            const FormatArguments& args = {}) override;
         void drawStringRight(
             Gfx::RenderTarget& rt,
             int16_t x,
             int16_t y,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) override;
+            const FormatArguments& args = {}) override;
         void drawStringRightUnderline(
             Gfx::RenderTarget& rt,
             int16_t x,
             int16_t y,
             AdvancedColour colour,
             StringId stringId,
-            const void* args) override;
+            const FormatArguments& args) override;
         void drawStringLeftUnderline(
             Gfx::RenderTarget& rt,
             int16_t x,
             int16_t y,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) override;
+            const FormatArguments& args = {}) override;
         void drawStringCentred(
             Gfx::RenderTarget& rt,
             int16_t x,
             int16_t y,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) override;
+            const FormatArguments& args = {}) override;
         void drawStringCentredClipped(
             Gfx::RenderTarget& rt,
             int16_t x,
@@ -85,14 +85,14 @@ namespace OpenLoco::Drawing
             int16_t width,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) override;
+            const FormatArguments& args = {}) override;
         uint16_t drawStringCentredWrapped(
             Gfx::RenderTarget& rt,
             Ui::Point& origin,
             uint16_t width,
             AdvancedColour colour,
             StringId stringId,
-            const void* args = nullptr) override;
+            const FormatArguments& args = {}) override;
         void drawStringCentredRaw(
             Gfx::RenderTarget& rt,
             int16_t x,
@@ -100,7 +100,7 @@ namespace OpenLoco::Drawing
             int16_t linebreakCount,
             AdvancedColour colour,
             const char* wrappedStr) override;
-        void drawStringYOffsets(Gfx::RenderTarget& rt, const Ui::Point& loc, AdvancedColour colour, const void* args, const int8_t* yOffsets) override;
+        void drawStringYOffsets(Gfx::RenderTarget& rt, const Ui::Point& loc, AdvancedColour colour, const FormatArguments& args, const int8_t* yOffsets) override;
         void drawStringTicker(Gfx::RenderTarget& rt, const Ui::Point& origin, StringId stringId, Colour colour, uint8_t numLinesToDisplay, uint16_t numCharactersToDisplay, uint16_t width) override;
         uint16_t getStringWidthNewLined(const char* buffer) override;
         std::pair<uint16_t, uint16_t> wrapString(char* buffer, uint16_t stringWidth) override;
@@ -121,3 +121,4 @@ namespace OpenLoco::Drawing
         void setCurrentFontSpriteBase(int16_t base) override;
     };
 }
+


### PR DESCRIPTION
Updated function signatures in the SoftwareDrawingContext class to replace const void* args with const FormatArguments& args where necessary. Updated the overridden virtual functions to match the new function signatures. These changes ensure that the functions now accept a const FormatArguments& instead of a const void* for the args parameter, as suggested in the fix.