### PR TITLE
Fix music stop when loading saved game in title screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Change: [#2473] Progress bars no longer pop up for autosaves.
 - Change: [#2509] The options window can now be opened with a keyboard shortcut (unassigned by default).
+- Fix: [#2341] Title music stops when clicking Load Game on title screen.
 - Fix: [#2463] Allow removing protected structures (e.g. electricity pylons) when sandbox mode is enabled.
 
 24.05.1 (2024-05-09)

--- a/src/OpenLoco/src/Game.cpp
+++ b/src/OpenLoco/src/Game.cpp
@@ -47,7 +47,10 @@ namespace OpenLoco::Game
 
     static bool openBrowsePrompt(StringId titleId, browse_type type, const char* filter)
     {
-        Audio::pauseSound();
+        if (!isTitleMode())
+        {
+            Audio::pauseSound();
+        }
         setPauseFlag(1 << 2);
         Gfx::invalidateScreen();
         Gfx::renderAndUpdate();
@@ -130,11 +133,6 @@ namespace OpenLoco::Game
     // 0x0043BFF8
     void loadGame()
     {
-        if (isTitleMode())
-        {
-            Title::stop();
-        }
-
         GameCommands::LoadSaveQuitGameArgs args{};
         args.option1 = GameCommands::LoadSaveQuitGameArgs::Options::closeSavePrompt;
         args.option2 = LoadOrQuitMode::loadGamePrompt;

--- a/src/OpenLoco/src/Windows/PromptSaveWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptSaveWindow.cpp
@@ -66,7 +66,10 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
             window->flags |= Ui::WindowFlags::transparent;
 
             setPauseFlag(1 << 1);
-            Audio::pauseSound();
+            if (!isTitleMode())
+            {
+                Audio::pauseSound();
+            }
             WindowManager::invalidate(WindowType::timeToolbar);
         }
 


### PR DESCRIPTION
This fixes #2341.

However something is not clear to me:
1. Why `loadGame()` had `Title::stop();`? Maybe it was added thinking that the function was for loading the selected game and not for opening load game window.
2. It seems that the _Load saved game_ button is opening a `PromptSaveWindow` and closing it immediately. In fact the code calls `Ui::WindowManager::close(Ui::WindowType::saveGamePrompt);` and then `0x0043C577 onClose()`. Why is that?

