### PR TITLE
Implement terrain generation

### DIFF
--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -162,6 +162,7 @@ set(OLOCO_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/AnimationManager.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/BuildingElement.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/IndustryElement.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/MapGenerator/HeightMap.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/MapGenerator/MapGenerator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/MapGenerator/OriginalTerrainGenerator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Map/MapGenerator/PngImage.cpp"

--- a/src/OpenLoco/src/Map/MapGenerator/HeightMap.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/HeightMap.cpp
@@ -1,0 +1,32 @@
+#include "HeightMap.h"
+#include <algorithm>
+
+namespace OpenLoco::World::MapGenerator
+{
+    constexpr uint8_t kHeightmapMarkedFlag = (1 << 7);
+
+    void HeightMap::resetMarkerFlags()
+    {
+        std::for_each_n(data(), size(), [](uint8_t& value) { value &= ~kHeightmapMarkedFlag; });
+    }
+
+    uint8_t HeightMap::getHeight(Point pos) const
+    {
+        return (*this)[pos] & ~kHeightmapMarkedFlag;
+    }
+
+    bool HeightMap::isMarkerSet(Point pos) const
+    {
+        return (*this)[pos] & kHeightmapMarkedFlag;
+    }
+
+    void HeightMap::setMarker(Point pos)
+    {
+        (*this)[pos] |= kHeightmapMarkedFlag;
+    }
+
+    void HeightMap::unsetMarker(Point pos)
+    {
+        (*this)[pos] &= ~kHeightmapMarkedFlag;
+    }
+}

--- a/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
+++ b/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
@@ -14,8 +14,6 @@ namespace OpenLoco::World::MapGenerator
         int32_t y{};
     };
 
-    constexpr uint8_t kHeightmapMarkedFlag = (1 << 7);
-
     class HeightMap
     {
     private:
@@ -69,9 +67,10 @@ namespace OpenLoco::World::MapGenerator
             return _height.size();
         }
 
-        void resetMarkerFlags()
-        {
-            std::for_each_n(data(), size(), [](uint8_t& value) { value &= ~kHeightmapMarkedFlag; });
-        }
+        uint8_t getHeight(Point pos) const;
+        void resetMarkerFlags();
+        bool isMarkerSet(Point pos) const;
+        void setMarker(Point pos);
+        void unsetMarker(Point pos);
     };
 }

--- a/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
+++ b/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
@@ -13,6 +13,8 @@ namespace OpenLoco::World::MapGenerator
         int32_t y{};
     };
 
+    constexpr uint8_t kHeightmapMarkedFlag = (1 << 7);
+
     class HeightMap
     {
     private:

--- a/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
+++ b/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -66,6 +67,11 @@ namespace OpenLoco::World::MapGenerator
         size_t size() const
         {
             return _height.size();
+        }
+
+        void resetMarkerFlags()
+        {
+            std::for_each_n(data(), size(), [](uint8_t& value) { value &= ~kHeightmapMarkedFlag; });
         }
     };
 }

--- a/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
+++ b/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -276,7 +276,7 @@ namespace OpenLoco::World::MapGenerator
     {
         heightMap.resetMarkerFlags();
 
-        // Mark tiles below mountain level
+        // Mark tiles above mountain level
         for (auto pos : getWorldRange())
         {
             auto height = heightMap.getHeight({ pos.x, pos.y });

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -208,7 +208,7 @@ namespace OpenLoco::World::MapGenerator
             surface->setTerrain(surfaceStyle);
             auto res = getRandomTerrainVariation(*surface);
             if (res)
-                surface->setVar7(*res);
+                surface->setVariation(*res);
         }
     }
 

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -227,7 +227,7 @@ namespace OpenLoco::World::MapGenerator
         }
 
         // Apply surface style to tiles that have *not* been marked
-        applySurfaceStyleToMarkedTiles(HeightMap, surfaceStyle, false);
+        applySurfaceStyleToMarkedTiles(heightMap, surfaceStyle, false);
     }
 
     // 0x0046A439
@@ -248,7 +248,7 @@ namespace OpenLoco::World::MapGenerator
         }
 
         // Apply surface style to tiles that have been marked
-        applySurfaceStyleToMarkedTiles(HeightMap, surfaceStyle, true);
+        applySurfaceStyleToMarkedTiles(heightMap, surfaceStyle, true);
     }
 
     // 0x0046A5B3
@@ -268,7 +268,7 @@ namespace OpenLoco::World::MapGenerator
         }
 
         // Apply surface style to tiles that have been marked
-        applySurfaceStyleToMarkedTiles(HeightMap, surfaceStyle, true);
+        applySurfaceStyleToMarkedTiles(heightMap, surfaceStyle, true);
     }
 
     // 0x0046A4F9
@@ -288,7 +288,7 @@ namespace OpenLoco::World::MapGenerator
         }
 
         // Apply surface style to tiles that have *not* been marked
-        applySurfaceStyleToMarkedTiles(HeightMap, surfaceStyle, false);
+        applySurfaceStyleToMarkedTiles(heightMap, surfaceStyle, false);
     }
 
     // 0x0046A0D8

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -197,27 +197,14 @@ namespace OpenLoco::World::MapGenerator
 
         // Set visited flag for tiles far from water
         auto seaLevel = getGameState().seaLevel;
-        auto hmIndex = 0;
-        for (auto yPos = 384; yPos > 0; yPos--)
+        for (auto pos : getWorldRange())
         {
-            for (auto xPos = 384; xPos > 0; xPos--)
-            {
-                auto height = heightMap.data()[hmIndex] & ~kHeightmapMarkedFlag;
-                if (height > seaLevel)
-                    continue;
+            auto height = heightMap[{ pos.x, pos.y }] & ~kHeightmapMarkedFlag;
+            if (height > seaLevel)
+                continue;
 
-                auto lookaheadIndex = hmIndex;
-                for (auto attemptsLow = 50; attemptsLow > 0; attemptsLow--)
-                {
-                    for (auto attemptsHigh = 50; attemptsHigh > 0; attemptsHigh--)
-                    {
-                        lookaheadIndex &= 0x3FFFF;
-                        heightMap.data()[lookaheadIndex] |= kHeightmapMarkedFlag;
-                        lookaheadIndex++;
-                    }
-                    lookaheadIndex += 512 - 50;
-                }
-            }
+            for (auto lookaheadPos : getClampedRange(pos, pos + TilePos2(50, 50)))
+                heightMap[{ lookaheadPos.x, lookaheadPos.y }] |= kHeightmapMarkedFlag;
         }
 
         // Apply surface style to marked tiles

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -319,14 +319,14 @@ namespace OpenLoco::World::MapGenerator
         // Mark tiles with sudden height changes in the next row
         for (auto pos : getWorldRange())
         {
-            auto heightA = heightMap.getHeight({ pos.x + 0, pos.y }) & 0x7F;
-            auto heightB = heightMap.getHeight({ pos.x + 1, pos.y }) & 0x7F;
+            auto heightA = heightMap.getHeight({ pos.x + 0, pos.y });
+            auto heightB = heightMap.getHeight({ pos.x + 1, pos.y });
 
             // Find no cliff between A and B?
             if (std::abs(heightB - heightA) < 4)
             {
-                auto heightC = heightMap.getHeight({ pos.x + 0, pos.y + 1 }) & 0x7F;
-                auto heightD = heightMap.getHeight({ pos.x + 1, pos.y + 1 }) & 0x7F;
+                auto heightC = heightMap.getHeight({ pos.x + 0, pos.y + 1 });
+                auto heightD = heightMap.getHeight({ pos.x + 1, pos.y + 1 });
 
                 // Find no cliff between C and D?
                 if (std::abs(heightD - heightC) < 4)

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -197,7 +197,7 @@ namespace OpenLoco::World::MapGenerator
         for (auto& pos : World::getDrawableTileRange())
         {
             const bool tileIsMarked = heightMap.isMarkerSet({ pos.x, pos.y });
-            if ((requireMark && !tileIsMarked) || (!requireMark && tileIsMarked))
+            if (requireMark != tileIsMarked)
                 continue;
 
             auto tile = TileManager::get(pos);

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -262,6 +262,7 @@ namespace OpenLoco::World::MapGenerator
         // Mark tiles above mountain level
         for (auto pos : getWorldRange())
         {
+            // NB: this is an inclusive check to match vanilla
             auto height = heightMap.getHeight({ pos.x, pos.y });
             if (height <= kMountainTerrainHeight)
                 continue;
@@ -282,6 +283,7 @@ namespace OpenLoco::World::MapGenerator
         // Mark tiles above mountain level
         for (auto pos : getWorldRange())
         {
+            // NB: this is an exclusive check to match vanilla
             auto height = heightMap.getHeight({ pos.x, pos.y });
             if (height < kMountainTerrainHeight)
                 continue;

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -69,7 +69,7 @@ namespace OpenLoco::World::MapGenerator
     // 0x004625D0
     static void generateLand(HeightMap& heightMap)
     {
-        for (auto pos : World::getDrawableTileRange())
+        for (auto& pos : World::getDrawableTileRange())
         {
             const MicroZ q00 = heightMap[{ pos.x - 1, pos.y - 1 }];
             const MicroZ q01 = heightMap[{ pos.x + 0, pos.y - 1 }];
@@ -129,7 +129,7 @@ namespace OpenLoco::World::MapGenerator
     {
         auto seaLevel = getGameState().seaLevel;
 
-        for (auto pos : World::getDrawableTileRange())
+        for (auto& pos : World::getDrawableTileRange())
         {
             auto tile = TileManager::get(pos);
             auto* surface = tile.surface();
@@ -194,7 +194,7 @@ namespace OpenLoco::World::MapGenerator
 
     static void applySurfaceStyleToMarkedTiles(HeightMap& heightMap, uint8_t surfaceStyle, bool requireMark)
     {
-        for (auto pos : World::getDrawableTileRange())
+        for (auto& pos : World::getDrawableTileRange())
         {
             const bool tileIsMarked = heightMap.isMarkerSet({ pos.x, pos.y });
             if ((requireMark && !tileIsMarked) || (!requireMark && tileIsMarked))
@@ -417,7 +417,7 @@ namespace OpenLoco::World::MapGenerator
     // 0x004611DF
     static void generateSurfaceVariation()
     {
-        for (auto pos : World::getDrawableTileRange())
+        for (auto& pos : World::getDrawableTileRange())
         {
             auto tile = TileManager::get(pos);
             auto* surface = tile.surface();
@@ -466,7 +466,7 @@ namespace OpenLoco::World::MapGenerator
     {
         auto currentSeason = getGameState().currentSeason;
 
-        for (auto pos : World::getDrawableTileRange())
+        for (auto& pos : World::getDrawableTileRange())
         {
             auto tile = TileManager::get(pos);
             for (auto el : tile)

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -192,8 +192,7 @@ namespace OpenLoco::World::MapGenerator
     // 0x0046A379
     static void generateTerrainFarFromWater(HeightMap& heightMap, uint8_t surfaceStyle)
     {
-        // Reset visited flag
-        std::for_each_n(heightMap.data(), heightMap.size(), [](uint8_t& data) { data &= ~kHeightmapMarkedFlag; });
+        heightMap.resetMarkerFlags();
 
         // Set visited flag for tiles far from water
         auto seaLevel = getGameState().seaLevel;

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -39,6 +39,9 @@ using namespace OpenLoco::World::MapGenerator;
 
 namespace OpenLoco::World::MapGenerator
 {
+    static constexpr auto kCliffTerrainHeightDiff = 4;
+    static constexpr auto kMountainTerrainHeight = 26;
+
     static loco_global<uint8_t*, 0x00F00160> _heightMap;
 
     static fs::path _pngHeightmapPath{};
@@ -260,7 +263,7 @@ namespace OpenLoco::World::MapGenerator
         for (auto pos : getWorldRange())
         {
             auto height = heightMap.getHeight({ pos.x, pos.y });
-            if (height < 27)
+            if (height <= kMountainTerrainHeight)
                 continue;
 
             for (auto lookaheadPos : getClampedRange(pos, pos + TilePos2(24, 24)))
@@ -280,7 +283,7 @@ namespace OpenLoco::World::MapGenerator
         for (auto pos : getWorldRange())
         {
             auto height = heightMap.getHeight({ pos.x, pos.y });
-            if (height < 26)
+            if (height < kMountainTerrainHeight)
                 continue;
 
             for (auto lookaheadPos : getClampedRange(pos, pos + TilePos2(50, 50)))
@@ -323,13 +326,13 @@ namespace OpenLoco::World::MapGenerator
             auto heightB = heightMap.getHeight({ pos.x + 1, pos.y });
 
             // Find no cliff between A and B?
-            if (std::abs(heightB - heightA) < 4)
+            if (std::abs(heightB - heightA) < kCliffTerrainHeightDiff)
             {
                 auto heightC = heightMap.getHeight({ pos.x + 0, pos.y + 1 });
                 auto heightD = heightMap.getHeight({ pos.x + 1, pos.y + 1 });
 
                 // Find no cliff between C and D?
-                if (std::abs(heightD - heightC) < 4)
+                if (std::abs(heightD - heightC) < kCliffTerrainHeightDiff)
                     continue;
             }
 

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -325,8 +325,8 @@ namespace OpenLoco::World::MapGenerator
             // Find no cliff between A and B?
             if (std::abs(heightB - heightA) < 4)
             {
-                auto heightC = heightMap.getHeight({ pos.x + heightMap.pitch + 0, pos.y }) & 0x7F;
-                auto heightD = heightMap.getHeight({ pos.x + heightMap.pitch + 1, pos.y }) & 0x7F;
+                auto heightC = heightMap.getHeight({ pos.x + 0, pos.y + 1 }) & 0x7F;
+                auto heightD = heightMap.getHeight({ pos.x + 1, pos.y + 1 }) & 0x7F;
 
                 // Find no cliff between C and D?
                 if (std::abs(heightD - heightC) < 4)

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -193,7 +193,7 @@ namespace OpenLoco::World::MapGenerator
     {
         for (auto pos : World::getDrawableTileRange())
         {
-            const bool tileIsMarked = heightMap[{ pos.x, pos.y }] & kHeightmapMarkedFlag;
+            const bool tileIsMarked = heightMap.isMarkerSet({ pos.x, pos.y });
             if ((requireMark && !tileIsMarked) || (!requireMark && tileIsMarked))
                 continue;
 
@@ -218,12 +218,12 @@ namespace OpenLoco::World::MapGenerator
         auto seaLevel = getGameState().seaLevel;
         for (auto pos : getWorldRange())
         {
-            auto height = heightMap[{ pos.x, pos.y }] & ~kHeightmapMarkedFlag;
+            auto height = heightMap.getHeight({ pos.x, pos.y });
             if (height > seaLevel)
                 continue;
 
             for (auto lookaheadPos : getClampedRange(pos, pos + TilePos2(50, 50)))
-                heightMap[{ lookaheadPos.x, lookaheadPos.y }] |= kHeightmapMarkedFlag;
+                heightMap.setMarker({ lookaheadPos.x, lookaheadPos.y });
         }
 
         // Apply surface style to tiles that have *not* been marked
@@ -239,12 +239,12 @@ namespace OpenLoco::World::MapGenerator
         auto seaLevel = getGameState().seaLevel;
         for (auto pos : getWorldRange())
         {
-            auto height = heightMap[{ pos.x, pos.y }] & ~kHeightmapMarkedFlag;
+            auto height = heightMap.getHeight({ pos.x, pos.y });
             if (height < seaLevel)
                 continue;
 
             for (auto lookaheadPos : getClampedRange(pos, pos + TilePos2(50, 50)))
-                heightMap[{ lookaheadPos.x, lookaheadPos.y }] |= kHeightmapMarkedFlag;
+                heightMap.setMarker({ lookaheadPos.x, lookaheadPos.y });
         }
 
         // Apply surface style to tiles that have been marked
@@ -259,12 +259,12 @@ namespace OpenLoco::World::MapGenerator
         // Mark tiles above mountain level
         for (auto pos : getWorldRange())
         {
-            auto height = heightMap[{ pos.x, pos.y }] & ~kHeightmapMarkedFlag;
+            auto height = heightMap.getHeight({ pos.x, pos.y });
             if (height < 27)
                 continue;
 
             for (auto lookaheadPos : getClampedRange(pos, pos + TilePos2(24, 24)))
-                heightMap[{ lookaheadPos.x, lookaheadPos.y }] |= kHeightmapMarkedFlag;
+                heightMap.setMarker({ lookaheadPos.x, lookaheadPos.y });
         }
 
         // Apply surface style to tiles that have been marked
@@ -279,12 +279,12 @@ namespace OpenLoco::World::MapGenerator
         // Mark tiles below mountain level
         for (auto pos : getWorldRange())
         {
-            auto height = heightMap[{ pos.x, pos.y }] & ~kHeightmapMarkedFlag;
+            auto height = heightMap.getHeight({ pos.x, pos.y });
             if (height < 26)
                 continue;
 
             for (auto lookaheadPos : getClampedRange(pos, pos + TilePos2(50, 50)))
-                heightMap[{ lookaheadPos.x, lookaheadPos.y }] |= kHeightmapMarkedFlag;
+                heightMap.setMarker({ lookaheadPos.x, lookaheadPos.y });
         }
 
         // Apply surface style to tiles that have *not* been marked

--- a/src/OpenLoco/src/Map/SurfaceElement.h
+++ b/src/OpenLoco/src/Map/SurfaceElement.h
@@ -119,8 +119,6 @@ namespace OpenLoco::World
             _type |= state ? 0x80 : 0;
         }
         void removeIndustry(const World::Pos2& pos);
-
-        void setVar7(uint8_t value) { _7 = value; }
     };
 #pragma pack(pop)
     static_assert(sizeof(SurfaceElement) == kTileElementSize);

--- a/src/OpenLoco/src/Map/TileManager.cpp
+++ b/src/OpenLoco/src/Map/TileManager.cpp
@@ -1269,7 +1269,7 @@ namespace OpenLoco::World::TileManager
                 surface->setWater(targetHeight / kMicroToSmallZStep);
             }
             surface->setType6Flag(false);
-            surface->setVar7(0);
+            surface->setVariation(0);
 
             mapInvalidateTileFull(pos);
         }


### PR DESCRIPTION
This implements the first four terrain generation functions, near/far water, near/far mountains, as well as the 'around cliffs' terrain. They share common patterns, which I've extracted into separate functions.

I am leaving the other two methods, small/large random areas, for a future PR, as they do not share these common patterns.