### PR TITLE
Fix crash when creating too big a station

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#2379] Text cursor is not rendering in the right position.
 - Fix: [#2380] 'Number of smoothing passes' label is displayed incorrectly.
+- Fix: [#2396] Crash when creating a station of greater than 80 tiles.
 
 24.03 (2024-03-30)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/GameCommands/Road/CreateRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/CreateRoadStation.cpp
@@ -64,7 +64,7 @@ namespace OpenLoco::GameCommands
 
         // _lastPlacedTrackStationId = nearbyStation.id; set in callers
         auto* station = StationManager::get(nearbyStation.id);
-        if (station->stationTileSize > 80)
+        if (station->stationTileSize >= std::size(station->stationTiles))
         {
             if (nearbyStation.isPhysicallyAttached)
             {

--- a/src/OpenLoco/src/GameCommands/Track/CreateTrainStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Track/CreateTrainStation.cpp
@@ -78,7 +78,7 @@ namespace OpenLoco::GameCommands
 
         // _lastPlacedTrackStationId = nearbyStation.id; set in callers
         auto* station = StationManager::get(nearbyStation.id);
-        if (station->stationTileSize > 80)
+        if (station->stationTileSize >= std::size(station->stationTiles))
         {
             if (nearbyStation.isPhysicallyAttached)
             {


### PR DESCRIPTION
I thought that this would solve #2357 but I'm not sure if it would as that save only has 64 station tiles (which is a curious number anyway)