### PR TITLE
Fix crash when owner status still points to deleted vehicle (#2388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#2379] Text cursor is not rendering in the right position.
 - Fix: [#2380] 'Number of smoothing passes' label is displayed incorrectly.
+- Fix: [#2388] Occasional crash after deleting a vehicle.
 - Fix: [#2396] Crash when creating a station of greater than 80 tiles.
 
 24.03 (2024-03-30)

--- a/src/OpenLoco/src/Vehicles/VehicleManager.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleManager.cpp
@@ -249,6 +249,7 @@ namespace OpenLoco::VehicleManager
         Vehicles::OrderManager::freeOrders(&head);
         MessageManager::removeAllSubjectRefs(enumValue(head.id), MessageItemArgumentType::vehicle);
         const auto companyId = head.owner;
+        CompanyManager::get(companyId)->clearOwnerStatusForDeletedVehicle(head.id);
         EntityManager::freeEntity(train.tail);
         EntityManager::freeEntity(train.veh2);
         EntityManager::freeEntity(train.veh1);

--- a/src/OpenLoco/src/World/Company.cpp
+++ b/src/OpenLoco/src/World/Company.cpp
@@ -63,6 +63,16 @@ namespace OpenLoco
         Ui::WindowManager::invalidate(Ui::WindowType::company, enumValue(companyId));
     }
 
+    void Company::clearOwnerStatusForDeletedVehicle(EntityId vehicleId)
+    {
+        // Prevent any possible owner status with a dangling reference to a deleted vehicle
+
+        if (ownerStatus.isEntity() && ownerStatus.getEntity() == vehicleId)
+        {
+            ownerStatus = OwnerStatus();
+        }
+    }
+
     // 0x00437FC5
     void Company::updateDaily()
     {
@@ -109,6 +119,12 @@ namespace OpenLoco
             }
             if (ownerStatus.isEntity())
             {
+                if (EntityManager::get<Vehicles::VehicleBase>(ownerStatus.getEntity()) == nullptr)
+                {
+                    assert(EntityManager::get<Vehicles::VehicleBase>(ownerStatus.getEntity()) != nullptr);
+                    return;
+                }
+
                 Vehicles::Vehicle train(ownerStatus.getEntity());
                 if (train.veh2->position.x != Location::null)
                 {

--- a/src/OpenLoco/src/World/Company.h
+++ b/src/OpenLoco/src/World/Company.h
@@ -221,6 +221,7 @@ namespace OpenLoco
         bool empty() const;
         bool isVehicleIndexUnlocked(const uint8_t vehicleIndex) const;
         void recalculateTransportCounts();
+        void clearOwnerStatusForDeletedVehicle(EntityId vehicleId);
         void updateDaily();
         void updateDailyLogic();
         void updateDailyPlayer();


### PR DESCRIPTION
* When a vehicle is sold/deleted a company may still have its owner status pointed to the vehicle. This change makes sure that we have a valid owner status by making sure it is updated to a new sane value.

* Added changelog

This solves #2388 and implements defensive measures so something similar might not happen again. 