### PR TITLE
Bump vcpkg to 2024.03.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: lukka/run-vcpkg@v11.4
         with:
           vcpkgDirectory: '${{ github.workspace }}/vcpkg'
-          vcpkgGitCommitId: 1be4527b3f30ab4fd01b621a3fc355b49b995ad0 
+          vcpkgGitCommitId: a34c873a9717a888f58dc05268dea15592c2f0ff
       - name: Build OpenLoco
         shell: cmd
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (WIN32)
         endif ()
         FetchContent_Declare(vcpkg
             GIT_REPOSITORY https://github.com/microsoft/vcpkg.git
-            GIT_TAG 1be4527b3f30ab4fd01b621a3fc355b49b995ad0)
+            GIT_TAG a34c873a9717a888f58dc05268dea15592c2f0ff)
         FetchContent_MakeAvailable(vcpkg)
 
         set(CMAKE_TOOLCHAIN_FILE "${vcpkg_SOURCE_DIR}/scripts/buildsystems/vcpkg.cmake"


### PR DESCRIPTION
This bumps vcpkg from [2023.06.20](https://github.com/microsoft/vcpkg/releases/tag/2023.06.20) to [2024.03.25](https://github.com/microsoft/vcpkg/releases/tag/2024.03.25).

This includes newer versions of SDL2, which might help with #2401 