### PR TITLE
Make focus optional for text input widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 24.04+ (???)
 ------------------------------------------------------------------------
 - Fix: [#2413] Gridlines are hidden when closing construction windows.
+- Fix: [#2416] Cursors in embedded text fiels are not rendering in the right position.
+- Change: [#2416] Most text input fields are no longer focused by default, allowing shortcuts to be used.
 
 24.04 (2024-04-07)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Input.h
+++ b/src/OpenLoco/src/Input.h
@@ -41,6 +41,7 @@ namespace OpenLoco::Input
         rightMousePressed = 1U << 5,
         flag6 = 1U << 6,
         viewportScrolling = 1U << 7,
+        widgetFocused = 1U << 8,
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(Flags);
 
@@ -76,6 +77,11 @@ namespace OpenLoco::Input
     bool isPressed(Ui::WindowType type, Ui::WindowNumber_t number, Ui::WidgetIndex_t index);
     Ui::WidgetIndex_t getPressedWidgetIndex();
     void setPressedWidgetIndex(Ui::WidgetIndex_t index);
+
+    bool isFocused(Ui::WindowType type, Ui::WindowNumber_t number);
+    bool isFocused(Ui::WindowType type, Ui::WindowNumber_t number, Ui::WidgetIndex_t index);
+    void setFocus(Ui::WindowType type, Ui::WindowNumber_t number, Ui::WidgetIndex_t index);
+    void resetFocus();
 
     void updateCursorPosition();
 

--- a/src/OpenLoco/src/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Windows/BuildVehicle.cpp
@@ -1230,7 +1230,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
             // We draw the string again to figure out where the cursor should go; position.x will be adjusted
             textBuffer[inputSession.cursorPosition] = '\0';
             position = { inputSession.xOffset, 1 };
-            drawingCtx.drawStringLeft(*clipped, position, Colour::black, StringIds::black_stringid, &args);
+            position = drawingCtx.drawStringLeft(*clipped, position, Colour::black, StringIds::black_stringid, &args);
             drawingCtx.fillRect(*clipped, position.x, position.y, position.x, position.y + 9, Colours::getShade(self.getColour(WindowColour::secondary).c(), 9), Gfx::RectFlags::none);
         }
     }

--- a/src/OpenLoco/src/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Windows/BuildVehicle.cpp
@@ -1225,7 +1225,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         drawingCtx.drawStringLeft(*clipped, position, Colour::black, StringIds::black_stringid, &args);
 
         // Draw search box cursor, blinking
-        if ((inputSession.cursorFrame % 32) < 16)
+        if (Input::isFocused(self.type, self.number, widx::searchBox) && (inputSession.cursorFrame % 32) < 16)
         {
             // We draw the string again to figure out where the cursor should go; position.x will be adjusted
             textBuffer[inputSession.cursorPosition] = '\0';
@@ -1809,6 +1809,9 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
 
     static bool keyUp(Window& w, uint32_t charCode, uint32_t keyCode)
     {
+        if (!Input::isFocused(w.type, w.number, widx::searchBox))
+            return false;
+
         if (!inputSession.handleInput(charCode, keyCode))
             return false;
 

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -890,7 +890,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         drawingCtx.drawStringLeft(*clipped, position, Colour::black, StringIds::black_stringid, &args);
 
         // Draw search box cursor, blinking
-        if ((inputSession.cursorFrame % 32) < 16)
+        if (Input::isFocused(self.type, self.number, widx::textInput) && (inputSession.cursorFrame % 32) < 16)
         {
             // We draw the string again to figure out where the cursor should go; position.x will be adjusted
             textBuffer[inputSession.cursorPosition] = '\0';
@@ -1466,6 +1466,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     static bool keyUp(Window& w, uint32_t charCode, uint32_t keyCode)
     {
+        if (!Input::isFocused(w.type, w.number, widx::textInput))
+            return false;
+
         if (!inputSession.handleInput(charCode, keyCode))
             return false;
 

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -895,7 +895,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             // We draw the string again to figure out where the cursor should go; position.x will be adjusted
             textBuffer[inputSession.cursorPosition] = '\0';
             position = { inputSession.xOffset, 1 };
-            drawingCtx.drawStringLeft(*clipped, position, Colour::black, StringIds::black_stringid, &args);
+            position = drawingCtx.drawStringLeft(*clipped, position, Colour::black, StringIds::black_stringid, &args);
             drawingCtx.fillRect(*clipped, position.x, position.y, position.x, position.y + 9, Colours::getShade(self.getColour(WindowColour::secondary).c(), 9), Gfx::RectFlags::none);
         }
     }

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -148,6 +148,9 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             auto& widget = window->widgets[widx::text_filename];
             inputSession.calculateTextOffset(widget.width());
 
+            // Focus the textbox element
+            Input::setFocus(window->type, window->number, widx::text_filename);
+
             window->setColour(WindowColour::primary, Colour::black);
             window->setColour(WindowColour::secondary, Colour::mutedSeaGreen);
 
@@ -455,7 +458,8 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             auto context2 = Gfx::clipRenderTarget(*rt, Ui::Rect(window.x + filenameBox.left + 1, window.y + filenameBox.top + 1, filenameBox.right - filenameBox.left - 1, filenameBox.bottom - filenameBox.top - 1));
             if (context2)
             {
-                drawTextInput(&window, *context2, inputSession.buffer.c_str(), inputSession.cursorPosition, (inputSession.cursorFrame & 0x10) == 0);
+                bool showCaret = Input::isFocused(window.type, window.number, widx::text_filename) && (inputSession.cursorFrame & 0x10) == 0;
+                drawTextInput(&window, *context2, inputSession.buffer.c_str(), inputSession.cursorPosition, showCaret);
             }
         }
     }
@@ -660,7 +664,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             w.callOnMouseUp(widx::close_button);
             return true;
         }
-        else if (!inputSession.handleInput(charCode, keyCode))
+        else if (Input::isFocused(w.type, w.number, widx::text_filename) && !inputSession.handleInput(charCode, keyCode))
         {
             return false;
         }

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -583,7 +583,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                 const std::string gbuffer = std::string(text, caret);
                 auto args = getStringPtrFormatArgs(gbuffer.c_str());
                 origin = { 0, 1 };
-                drawingCtx.drawStringLeft(rt, origin, Colour::black, StringIds::black_stringid, &args);
+                origin = drawingCtx.drawStringLeft(rt, origin, Colour::black, StringIds::black_stringid, &args);
 
                 // Draw vertical caret
                 drawingCtx.drawRect(rt, origin.x, origin.y, 1, 9, Colours::getShade(window->getColour(WindowColour::secondary).c(), 9), Gfx::RectFlags::none);

--- a/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptBrowseWindow.cpp
@@ -664,7 +664,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             w.callOnMouseUp(widx::close_button);
             return true;
         }
-        else if (Input::isFocused(w.type, w.number, widx::text_filename) && !inputSession.handleInput(charCode, keyCode))
+        else if (!Input::isFocused(w.type, w.number, widx::text_filename) || !inputSession.handleInput(charCode, keyCode))
         {
             return false;
         }

--- a/src/OpenLoco/src/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Windows/TextInputWindow.cpp
@@ -1,6 +1,7 @@
 #include "Graphics/Colour.h"
 #include "Graphics/ImageIds.h"
 #include "Graphics/SoftwareDrawingEngine.h"
+#include "Input.h"
 #include "Localisation/FormatArguments.hpp"
 #include "Localisation/Formatting.h"
 #include "Localisation/StringIds.h"
@@ -150,6 +151,9 @@ namespace OpenLoco::Ui::Windows::TextInput
             window->flags |= WindowFlags::flag_11;
             _widgets[Widx::title].type = WidgetType::caption_24;
         }
+
+        // Focus the textbox element
+        Input::setFocus(window->type, window->number, Widx::input);
     }
 
     /**
@@ -262,6 +266,7 @@ namespace OpenLoco::Ui::Windows::TextInput
         strncpy(drawnBuffer, inputSession.buffer.c_str(), inputSession.cursorPosition);
         drawnBuffer[inputSession.cursorPosition] = '\0';
 
+        if (Input::isFocused(window.type, window.number, Widx::input))
         {
             auto width = drawingCtx.getStringWidth(drawnBuffer);
             auto cursorPos = Point(inputSession.xOffset + width, 1);
@@ -312,7 +317,7 @@ namespace OpenLoco::Ui::Windows::TextInput
             w.callOnMouseUp(Widx::close);
             return true;
         }
-        else if (!inputSession.handleInput(charCode, keyCode))
+        else if (Input::isFocused(w.type, w.number, Widx::input) && !inputSession.handleInput(charCode, keyCode))
         {
             return false;
         }

--- a/src/OpenLoco/src/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Windows/TextInputWindow.cpp
@@ -317,7 +317,7 @@ namespace OpenLoco::Ui::Windows::TextInput
             w.callOnMouseUp(Widx::close);
             return true;
         }
-        else if (Input::isFocused(w.type, w.number, Widx::input) && !inputSession.handleInput(charCode, keyCode))
+        else if (!Input::isFocused(w.type, w.number, Widx::input) || !inputSession.handleInput(charCode, keyCode))
         {
             return false;
         }


### PR DESCRIPTION
Since their introduction, text input widgets have been focused while their window is open. This meant they would always override shortcut behaviour, which is not always what is expected. This PR changes this behaviour, with focus now being optional.

The new behaviour should be more straightforward. Text boxes can be focused by clicking them. Clicking anywhere else will unfocus them immediately.

Two windows set focus automatically: the main text input window, and the load/save prompt window. Other uses require clicking.

Currently, the focus properties reside in MouseInput.cpp, along with a bunch of widged-related state. Ideally, these would be moved to the WindowManager namespace, along with most of the MouseInput.cpp file. However, as overdue that is, this is matter for a future PR.

Also found three more small regressions from #2348 that were not yet covered by #2399. All three have to do with the cursor not being positioned correctly.