### PR TITLE
Implement removeRoadStation game command

### DIFF
--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -95,6 +95,7 @@ set(OLOCO_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Industries/RemoveIndustry.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Industries/RenameIndustry.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Road/CreateRoadStation.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Road/RemoveRoadStation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Terraform/ChangeLandMaterial.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Terraform/ClearLand.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Terraform/CreateTree.cpp"

--- a/src/OpenLoco/src/GameCommands/GameCommands.cpp
+++ b/src/OpenLoco/src/GameCommands/GameCommands.cpp
@@ -164,7 +164,7 @@ namespace OpenLoco::GameCommands
         { GameCommand::createRoadMod,                nullptr,                   0x0047A21E, true  },
         { GameCommand::removeRoadMod,                nullptr,                   0x0047A42F, true  },
         { GameCommand::createRoadStation,            createRoadStation,         0x0048C708, true  },
-        { GameCommand::removeRoadStation,            nullptr,                   0x0048D2AC, true  },
+        { GameCommand::removeRoadStation,            removeRoadStation,         0x0048D2AC, true  },
         { GameCommand::createBuilding,               createBuilding,            0x0042D133, true  },
         { GameCommand::removeBuilding,               removeBuilding,            0x0042D74E, true  },
         { GameCommand::renameTown,                   renameTown,                0x0049B11E, false },

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
@@ -114,7 +114,7 @@ namespace OpenLoco::GameCommands
                 if (stationEl == nullptr)
                     return FAILURE;
 
-                if (stationEl->isAiAllocated())
+                if (stationEl->isGhost())
                     updateStationTileRegistration = false;
 
                 foundStationId = stationEl->stationId();

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
@@ -70,26 +70,28 @@ namespace OpenLoco::GameCommands
             return FAILURE;
         }
 
-        // Try to find the station element, if actually present
-        World::StationElement* stationEl = nullptr;
-        while (auto* nextElement = initialElRoad->next())
+        // Find the station element for an ownership check
         {
-            stationEl = nextElement->as<World::StationElement>();
-            if (stationEl != nullptr)
+            World::StationElement* stationEl = nullptr;
+            while (auto* nextElement = initialElRoad->next())
             {
-                break;
+                stationEl = nextElement->as<World::StationElement>();
+                if (stationEl != nullptr)
+                {
+                    break;
+                }
+
+                if (nextElement->isLast())
+                {
+                    return FAILURE;
+                }
             }
 
-            if (nextElement->isLast())
+            // NB: vanilla would query owner from station object, not the station element
+            if (!sub_431E6A(stationEl->owner(), reinterpret_cast<const World::TileElement*>(stationEl)))
             {
                 return FAILURE;
             }
-        }
-
-        // NB: vanilla would query owner from station object, not the station element
-        if (!sub_431E6A(stationEl->owner(), reinterpret_cast<const World::TileElement*>(stationEl)))
-        {
-            return FAILURE;
         }
 
         const auto& roadPieces = World::TrackData::getRoadPiece(args.roadId);

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
@@ -72,19 +72,25 @@ namespace OpenLoco::GameCommands
 
         // Find the station element for an ownership check
         {
+            // Station element must be the next element after the last consecutive road element
             World::StationElement* stationEl = nullptr;
-            while (auto* nextElement = initialElRoad->next())
+            auto* elRoad = initialElRoad;
+            while (!elRoad->isLast())
             {
-                stationEl = nextElement->as<World::StationElement>();
-                if (stationEl != nullptr)
+                auto* nextEl = elRoad->next();
+                elRoad = nextEl->as<World::RoadElement>();
+                if (elRoad != nullptr && elRoad->baseHeight() == args.pos.z)
                 {
-                    break;
+                    continue;
                 }
 
-                if (nextElement->isLast())
-                {
-                    return FAILURE;
-                }
+                stationEl = nextEl->as<World::StationElement>();
+                break;
+            }
+
+            if (stationEl == nullptr)
+            {
+                return FAILURE;
             }
 
             // NB: vanilla would query owner from station struct, not the station element

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
@@ -106,7 +106,6 @@ namespace OpenLoco::GameCommands
             const auto roadLoc = roadStart + World::Pos3{ Math::Vector::rotate(World::Pos2{ piece.x, piece.y }, args.rotation), piece.z };
 
             auto* elRoad = getElRoad(roadLoc, args.rotation, args.type, args.roadId, piece.index);
-
             if (elRoad == nullptr)
                 return FAILURE;
 
@@ -119,11 +118,13 @@ namespace OpenLoco::GameCommands
                 updateStationTileRegistration = false;
 
             foundStationId = stationEl->stationId();
-
             auto* stationObj = ObjectManager::get<RoadStationObject>(stationEl->objectId());
-            auto removeCostBase = Economy::getInflationAdjustedCost(stationObj->sellCostFactor, stationObj->costIndex, 8);
-            const auto cost = (removeCostBase * World::TrackData::getRoadMiscData(args.roadId).costFactor) / 256;
-            totalCost += cost;
+
+            if (piece.index == 0)
+            {
+                auto removeCostBase = Economy::getInflationAdjustedCost(stationObj->sellCostFactor, stationObj->costIndex, 8);
+                totalCost += (removeCostBase * World::TrackData::getRoadMiscData(args.roadId).costFactor) / 256;
+            }
 
             if ((flags & Flags::apply) != 0)
             {

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
@@ -87,7 +87,7 @@ namespace OpenLoco::GameCommands
                 }
             }
 
-            // NB: vanilla would query owner from station object, not the station element
+            // NB: vanilla would query owner from station struct, not the station element
             if (!sub_431E6A(stationEl->owner(), reinterpret_cast<const World::TileElement*>(stationEl)))
             {
                 return FAILURE;

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
@@ -1,0 +1,154 @@
+#include "RemoveRoadStation.h"
+#include "Economy/Economy.h"
+#include "Map/RoadElement.h"
+#include "Map/StationElement.h"
+#include "Map/TileElement.h"
+#include "Map/TileManager.h"
+#include "Map/Track/TrackData.h"
+#include "Objects/ObjectManager.h"
+#include "Objects/RoadStationObject.h"
+#include "ViewportManager.h"
+#include "World/Station.h"
+#include "World/StationManager.h"
+
+namespace OpenLoco::GameCommands
+{
+    // TODO: based on CreateRoadStation.cpp
+    static World::RoadElement* getElRoad(World::Pos3 pos, uint8_t rotation, uint8_t roadObjectId, uint8_t roadId, uint8_t index)
+    {
+        auto tile = World::TileManager::get(pos);
+        for (auto& el : tile)
+        {
+            auto* elRoad = el.as<World::RoadElement>();
+            if (elRoad == nullptr)
+            {
+                continue;
+            }
+            if (elRoad->baseHeight() != pos.z)
+            {
+                continue;
+            }
+            if (elRoad->unkDirection() != rotation)
+            {
+                continue;
+            }
+            if (elRoad->roadId() != roadId)
+            {
+                continue;
+            }
+            // TODO: not seeing this check in disasm
+            if (elRoad->roadObjectId() != roadObjectId)
+            {
+                continue;
+            }
+            if (elRoad->sequenceIndex() != index)
+            {
+                continue;
+            }
+            return elRoad;
+        }
+        return nullptr;
+    }
+
+    // 0x0048D2AC
+    static currency32_t removeRoadStation(const RoadStationRemovalArgs& args, const uint8_t flags)
+    {
+        setExpenditureType(ExpenditureType::Construction);
+        setPosition(args.pos + World::Pos3(16, 16, 0));
+        bool updateStationTileRegistration = true;
+
+        // Get road at position
+        auto* initialElRoad = getElRoad(args.pos, args.rotation, args.type, args.roadId, args.index);
+        if (initialElRoad == nullptr)
+        {
+            return FAILURE;
+        }
+
+        // No station element on this road?
+        if (!initialElRoad->hasStationElement())
+        {
+            return FAILURE;
+        }
+
+        // Try to find the station element, if actually present
+        World::StationElement* stationEl = nullptr;
+        while (auto* nextElement = initialElRoad->next())
+        {
+            stationEl = nextElement->as<World::StationElement>();
+            if (stationEl != nullptr)
+            {
+                break;
+            }
+
+            if (nextElement->isLast())
+            {
+                return FAILURE;
+            }
+        }
+
+        // NB: vanilla would query owner from station object, not the station element
+        if (!sub_431E6A(stationEl->owner(), reinterpret_cast<const World::TileElement*>(stationEl)))
+        {
+            return FAILURE;
+        }
+
+        const auto& roadPieces = World::TrackData::getRoadPiece(args.roadId);
+        const auto& argPiece = roadPieces[args.index];
+        const auto roadStart = args.pos - World::Pos3(Math::Vector::rotate(World::Pos2(argPiece.x, argPiece.y), args.rotation), argPiece.z);
+
+        StationId foundStationId = StationId::null;
+        currency32_t totalCost = 0;
+
+        for (auto& piece : roadPieces)
+        {
+            const auto roadLoc = roadStart + World::Pos3{ Math::Vector::rotate(World::Pos2{ piece.x, piece.y }, args.rotation), piece.z };
+
+            auto* elRoad = getElRoad(roadLoc, args.rotation, args.type, args.roadId, piece.index);
+
+            if (elRoad != nullptr)
+            {
+                auto* nextEl = elRoad->next();
+                auto* stationEl = nextEl->as<World::StationElement>();
+                if (stationEl == nullptr)
+                    return FAILURE;
+
+                if (stationEl->isAiAllocated())
+                    updateStationTileRegistration = false;
+
+                foundStationId = stationEl->stationId();
+
+                auto* stationObj = ObjectManager::get<RoadStationObject>(stationEl->objectId());
+                auto removeCostBase = Economy::getInflationAdjustedCost(stationObj->sellCostFactor, stationObj->costIndex, 8);
+                const auto cost = (removeCostBase * World::TrackData::getRoadMiscData(args.roadId).costFactor) / 256;
+                totalCost += cost;
+
+                if ((flags & Flags::apply) != 0)
+                {
+                    elRoad->setClearZ(elRoad->clearZ() - stationObj->height);
+                    Ui::ViewportManager::invalidate(World::Pos2(roadLoc), stationEl->baseHeight(), stationEl->clearHeight(), ZoomLevel::eighth);
+                    elRoad->setHasStationElement(false);
+                    World::TileManager::removeElement(*nextEl);
+                }
+            }
+        }
+
+        if (updateStationTileRegistration && (flags & Flags::apply) != 0)
+        {
+            auto* station = StationManager::get(foundStationId);
+            removeTileFromStation(foundStationId, roadStart, args.rotation);
+            station->invalidate();
+
+            recalculateStationModes(foundStationId);
+            recalculateStationCenter(foundStationId);
+            station->updateLabel();
+            station->invalidate();
+        }
+
+        return totalCost;
+    }
+
+    void removeRoadStation(registers& regs)
+    {
+        regs.ebx = removeRoadStation(RoadStationRemovalArgs(regs), regs.bl);
+    }
+}

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
@@ -96,7 +96,7 @@ namespace OpenLoco::GameCommands
         bool updateStationTileRegistration = true;
 
         // Get road at position
-        auto* initialElRoad = getElRoad(args.pos, args.rotation, args.type, args.roadId, args.index);
+        auto* initialElRoad = getElRoad(args.pos, args.rotation, args.roadObjectId, args.roadId, args.index);
         if (initialElRoad == nullptr)
         {
             return FAILURE;

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
@@ -142,6 +142,10 @@ namespace OpenLoco::GameCommands
             const auto roadLoc = roadStart + World::Pos3{ Math::Vector::rotate(World::Pos2{ piece.x, piece.y }, args.rotation), piece.z };
 
             const auto roadRange = getRoadElementsRange(args.pos);
+            if (roadRange.begin == nullptr || roadRange.end == nullptr)
+            {
+                return FAILURE;
+            }
             World::StationElement* stationEl = roadRange.end->as<World::StationElement>();
 
             if (stationEl->isGhost())

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.cpp
@@ -147,6 +147,10 @@ namespace OpenLoco::GameCommands
                 return FAILURE;
             }
             World::StationElement* stationEl = roadRange.end->as<World::StationElement>();
+            if (stationEl == nullptr)
+            {
+                return FAILURE;
+            }
 
             if (stationEl->isGhost())
                 updateStationTileRegistration = false;

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.h
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.h
@@ -37,4 +37,6 @@ namespace OpenLoco::GameCommands
             return regs;
         }
     };
+
+    void removeRoadStation(registers& regs);
 }

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.h
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoadStation.h
@@ -14,7 +14,7 @@ namespace OpenLoco::GameCommands
             , rotation(regs.bh & 0x3)
             , roadId(regs.dl & 0xF)
             , index(regs.dh & 0x3)
-            , type(regs.bp & 0xF)
+            , roadObjectId(regs.bp & 0xF)
         {
         }
 
@@ -22,7 +22,7 @@ namespace OpenLoco::GameCommands
         uint8_t rotation;
         uint8_t roadId;
         uint8_t index;
-        uint8_t type;
+        uint8_t roadObjectId;
 
         explicit operator registers() const
         {
@@ -33,7 +33,7 @@ namespace OpenLoco::GameCommands
             regs.bh = rotation;
             regs.dl = roadId;
             regs.dh = index;
-            regs.bp = type;
+            regs.bp = roadObjectId;
             return regs;
         }
     };

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -1091,7 +1091,7 @@ namespace OpenLoco::Ui::ViewportInteraction
         args.rotation = road->unkDirection();
         args.roadId = road->roadId();
         args.index = road->sequenceIndex();
-        args.type = road->roadObjectId();
+        args.roadObjectId = road->roadObjectId();
         if (GameCommands::doCommand(args, GameCommands::Flags::apply) != GameCommands::FAILURE)
         {
             Audio::playSound(Audio::SoundId::demolish, GameCommands::getPosition());

--- a/src/OpenLoco/src/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/StationTab.cpp
@@ -210,7 +210,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                 args.rotation = _stationGhostRotation;
                 args.roadId = _stationGhostTrackId;
                 args.index = _stationGhostTileIndex;
-                args.type = _stationGhostType & ~(1 << 7);
+                args.roadObjectId = _stationGhostType & ~(1 << 7);
                 GameCommands::doCommand(args, GameCommands::Flags::apply | GameCommands::Flags::noErrorWindow | GameCommands::Flags::noPayment | GameCommands::Flags::ghost);
             }
             else


### PR DESCRIPTION
This implements the removeRoadStation game command. It's very similar to removeTrainStation, so let's merge this after #2410.