### PR TITLE
Add progress bars to gamestate import/export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix: [#2411] Progress bar windows are not actually rendered.
 - Fix: [#2413] Gridlines are hidden when closing construction windows.
 - Fix: [#2416] Cursors in embedded text fiels are not rendering in the right position.
+- Change: [#1014] Loading and saving save files and scenarios uses progress bars again.
 - Change: [#2411] Internal progress bars can now be used during the object and scenario indexing processes.
 - Change: [#2416] Most text input fields are no longer focused by default, allowing shortcuts to be used.
 

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -808,7 +808,8 @@ namespace OpenLoco::StringIds
     constexpr StringId error_file_contains_invalid_data = 1083;
     constexpr StringId error_file_is_not_single_player_save = 1084;
     constexpr StringId error_file_is_not_two_player_save = 1085;
-
+    constexpr StringId please_wait = 1086;
+    constexpr StringId initialising = 1087;
     constexpr StringId loading = 1088;
     constexpr StringId installing_new_data = 1089;
     constexpr StringId white = 1090;

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -20,6 +20,7 @@
 #include "SawyerStream.h"
 #include "ScenarioManager.h"
 #include "SceneManager.h"
+#include "Ui/ProgressBar.h"
 #include "Ui/WindowManager.h"
 #include "Vehicles/OrderManager.h"
 #include "ViewportManager.h"
@@ -549,7 +550,12 @@ namespace OpenLoco::S5
 
         try
         {
+            Ui::ProgressBar::begin(StringIds::loading);
+            Ui::ProgressBar::setProgress(10);
+
             auto file = importSave(stream);
+
+            Ui::ProgressBar::setProgress(90);
 
             if (file->header.version != kCurrentVersion)
             {
@@ -578,6 +584,7 @@ namespace OpenLoco::S5
                 {
                     _loadErrorCode = 255;
                     _loadErrorMessage = StringIds::error_file_contains_invalid_data;
+                    Ui::ProgressBar::end();
                     return false;
                 }
                 if (file->landscapeOptions->editorStep == EditorController::Step::null)
@@ -585,29 +592,45 @@ namespace OpenLoco::S5
                     file->landscapeOptions->editorStep = EditorController::Step::landscapeEditor;
                 }
             }
+
+            Ui::ProgressBar::setProgress(100);
+
+            // Any packed objects to install?
             if (!file->packedObjects.empty())
             {
+                const auto progressStep = 50 / file->packedObjects.size();
+                auto currentProgress = 100;
                 bool objectInstalled = false;
+
                 for (auto [object, data] : file->packedObjects)
                 {
                     if (ObjectManager::tryInstallObject(object, data))
                     {
                         objectInstalled = true;
                     }
+
+                    currentProgress += progressStep;
+                    Ui::ProgressBar::setProgress(currentProgress);
                 }
+
                 if (objectInstalled)
                 {
                     ObjectManager::loadIndex();
                 }
             }
+
+            Ui::ProgressBar::setProgress(150);
+
             if (file->header.type == S5Type::objects)
             {
                 addr<0x00525F62, uint16_t>() = 0;
                 _loadErrorCode = 254;
                 _loadErrorMessage = StringIds::new_objects_installed_successfully;
+                Ui::ProgressBar::end();
                 // Throws!
                 Game::returnToTitle();
             }
+
             if (!hasLoadFlags(flags, LoadFlags::scenario | LoadFlags::landscape))
             {
                 if (file->header.type == S5Type::scenario)
@@ -636,6 +659,7 @@ namespace OpenLoco::S5
                 }
             }
 
+            // Load required objects
             auto loadObjectResult = ObjectManager::loadAll(file->requiredObjects);
             if (!loadObjectResult.success)
             {
@@ -645,16 +669,19 @@ namespace OpenLoco::S5
                 {
                     CompanyManager::reset();
                     addr<0x00525F62, uint16_t>() = 0;
+                    Ui::ProgressBar::end();
                     return false;
                 }
                 else
                 {
+                    Ui::ProgressBar::end();
                     Game::returnToTitle();
                     return false;
                 }
             }
 
             ObjectManager::reloadAll();
+            Ui::ProgressBar::setProgress(200);
 
             _gameState = file->gameState;
             if (hasLoadFlags(flags, LoadFlags::scenario | LoadFlags::landscape))
@@ -685,6 +712,9 @@ namespace OpenLoco::S5
             ObjectManager::sub_4748FA();
             TileManager::resetSurfaceClearance();
             IndustryManager::createAllMapAnimations();
+
+            Ui::ProgressBar::setProgress(225);
+
             if (hasLoadFlags(flags, LoadFlags::landscape))
             {
                 Scenario::initialiseSnowLine();
@@ -710,6 +740,7 @@ namespace OpenLoco::S5
             if (hasLoadFlags(flags, LoadFlags::scenario))
             {
                 _gameState->var_014A = 0;
+                Ui::ProgressBar::end();
                 return true;
             }
             if (!hasLoadFlags(flags, LoadFlags::titleSequence))
@@ -727,6 +758,8 @@ namespace OpenLoco::S5
                     Gui::init();
                 }
             }
+
+            Ui::ProgressBar::setProgress(245);
 
             auto mainWindow = WindowManager::getMainWindow();
             if (mainWindow != nullptr)
@@ -760,6 +793,8 @@ namespace OpenLoco::S5
                 addr<0x0050BF6C, uint8_t>() = 1;
             }
 
+            Ui::ProgressBar::end();
+
             if (!hasLoadFlags(flags, LoadFlags::titleSequence) && !hasLoadFlags(flags, LoadFlags::twoPlayer) && !hasLoadFlags(flags, LoadFlags::landscape))
             {
                 resetScreenAge();
@@ -773,6 +808,7 @@ namespace OpenLoco::S5
             Logging::error("Unable to load S5: {}", e.what());
             _loadErrorCode = 255;
             _loadErrorMessage = e.getLocalisedMessage();
+            Ui::ProgressBar::end();
             return false;
         }
         catch (const std::exception& e)
@@ -780,6 +816,7 @@ namespace OpenLoco::S5
             Logging::error("Unable to load S5: {}", e.what());
             _loadErrorCode = 255;
             _loadErrorMessage = StringIds::null;
+            Ui::ProgressBar::end();
             return false;
         }
     }

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -263,6 +263,9 @@ namespace OpenLoco::S5
 
     bool exportGameStateToFile(Stream& stream, SaveFlags flags)
     {
+        Ui::ProgressBar::begin(StringIds::please_wait);
+        Ui::ProgressBar::setProgress(20);
+
         if ((flags & SaveFlags::noWindowClose) == SaveFlags::none
             && (flags & SaveFlags::raw) == SaveFlags::none
             && (flags & SaveFlags::dump) == SaveFlags::none)
@@ -279,6 +282,8 @@ namespace OpenLoco::S5
             Vehicles::OrderManager::zeroUnusedOrderTable();
         }
 
+        Ui::ProgressBar::setProgress(40);
+
         bool saveResult;
         {
             auto requiredObjects = ObjectManager::getHeaders();
@@ -294,11 +299,15 @@ namespace OpenLoco::S5
             saveResult = exportGameState(stream, *file, packedObjects);
         }
 
+        Ui::ProgressBar::setProgress(230);
+
         if ((flags & SaveFlags::raw) == SaveFlags::none
             && (flags & SaveFlags::dump) == SaveFlags::none)
         {
             ObjectManager::reloadAll();
         }
+
+        Ui::ProgressBar::end();
 
         if (saveResult)
         {


### PR DESCRIPTION
Closes #1014.

Adding these makes it apparent that the title screen is loaded twice when opening the game, somehow? Worth looking into for a potential speed-up.