### PR TITLE
Add last month production column to the industries list (#1652)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 24.04+ (???)
 ------------------------------------------------------------------------
 - Feature: [#2] The window limit has been increased from 12 to 64.
-- Feature: [#1652] Display the production of each industry from the previous month in the industry list
+- Feature: [#1652] Display the production of each industry from the previous month in the industry list.
 - Fix: [#2411] Progress bar windows are not actually rendered.
 - Fix: [#2413] Gridlines are hidden when closing construction windows.
 - Fix: [#2416] Cursors in embedded text fiels are not rendering in the right position.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 24.04+ (???)
 ------------------------------------------------------------------------
 - Feature: [#2] The window limit has been increased from 12 to 64.
+- Feature: [#1652] Display the production of each industry from the previous month in the industry list
 - Fix: [#2411] Progress bar windows are not actually rendered.
 - Fix: [#2413] Gridlines are hidden when closing construction windows.
 - Fix: [#2416] Cursors in embedded text fiels are not rendering in the right position.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2398,3 +2398,6 @@ strings:
   2343: "{COLOUR WINDOW_2}Current heightmap file: {COLOUR BLACK}{STRING}"
   2344: "(none selected)"
   2345: "Checking scenario files..."
+  2346: "{COLOUR BLACK}Production Last Month"
+  2347: "{COLOUR BLACK}Production Last Month ▼"
+  2348: "{SMALLFONT}{COLOUR BLACK}Sort list by production last month"

--- a/data/language/nl-NL.yml
+++ b/data/language/nl-NL.yml
@@ -2398,3 +2398,6 @@ strings:
   2343: "{COLOUR WINDOW_2}Huidig hoogtekaart-bestand: {COLOUR BLACK}{STRING}"
   2344: "(geen selectie)"
   2345: "Bezig met checken van scenario's..."
+  2346: "{COLOUR BLACK}Productie afgelopen maand"
+  2347: "{COLOUR BLACK}Productie afgelopen maand ▼"
+  2348: "{SMALLFONT}{COLOUR BLACK}Sorteer lijst op productie afgelopen maand"

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1979,6 +1979,9 @@ namespace OpenLoco::StringIds
     constexpr StringId currentHeightmapFile = 2343;
     constexpr StringId noneSelected = 2344;
     constexpr StringId checkingScenarioFiles = 2345;
+    constexpr StringId industry_table_header_production_last_month = 2346;
+    constexpr StringId industry_table_header_production_last_month_desc = 2347;
+    constexpr StringId sort_industry_production_last_month = 2348;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Objects/IndustryObject.cpp
+++ b/src/OpenLoco/src/Objects/IndustryObject.cpp
@@ -21,7 +21,7 @@ namespace OpenLoco
         auto requiredCargoState = false;
         for (const auto& requiredCargo : requiredCargoType)
         {
-            if (requiredCargo != 0xff)
+            if (requiredCargo != kCargoTypeNull)
             {
                 requiredCargoState = true;
                 break;
@@ -35,7 +35,7 @@ namespace OpenLoco
         auto produceCargoState = false;
         for (const auto& producedCargo : producedCargoType)
         {
-            if (producedCargo != 0xff)
+            if (producedCargo != kCargoTypeNull)
             {
                 produceCargoState = true;
                 break;
@@ -51,7 +51,7 @@ namespace OpenLoco
 
         for (const auto& producedCargo : producedCargoType)
         {
-            if (producedCargo != 0xFF)
+            if (producedCargo != kCargoTypeNull)
             {
                 producedCargoCount++;
 
@@ -72,7 +72,7 @@ namespace OpenLoco
 
         for (const auto& requiredCargo : requiredCargoType)
         {
-            if (requiredCargo != 0xFF)
+            if (requiredCargo != kCargoTypeNull)
             {
                 requiredCargoCount++;
 

--- a/src/OpenLoco/src/Objects/Object.h
+++ b/src/OpenLoco/src/Objects/Object.h
@@ -46,6 +46,8 @@ namespace OpenLoco
     };
 
     constexpr size_t kMaxObjectTypes = 34;
+    constexpr uint8_t kCargoTypeNull = 0xFF;
+
 #pragma pack(push, 1)
     struct ObjectHeader
     {

--- a/src/OpenLoco/src/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Windows/IndustryList.cpp
@@ -73,8 +73,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
     namespace IndustryList
     {
-        static constexpr Ui::Size kWindowSize = { 600, 197 };
-        static constexpr Ui::Size kMaxDimensions = { 600, 900 };
+        static constexpr Ui::Size kWindowSize = { 759, 197 };
+        static constexpr Ui::Size kMaxDimensions = { 759, 900 };
         static constexpr Ui::Size kMinDimensions = { 192, 100 };
 
         static constexpr uint8_t kRowHeight = 10;
@@ -84,16 +84,18 @@ namespace OpenLoco::Ui::Windows::IndustryList
             sort_industry_name = 6,
             sort_industry_status,
             sort_industry_production_transported,
+            sort_industry_production_last_month,
             scrollview,
         };
 
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << sort_industry_name) | (1 << sort_industry_status) | (1 << sort_industry_production_transported) | (1 << scrollview);
+        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << sort_industry_name) | (1 << sort_industry_status) | (1 << sort_industry_production_transported) | (1 << sort_industry_production_last_month) | (1 << scrollview);
 
         static constexpr Widget widgets[] = {
             commonWidgets(600, 197, StringIds::title_industries),
             makeWidget({ 4, 44 }, { 199, 11 }, WidgetType::buttonTableHeader, WindowColour::secondary, Widget::kContentNull, StringIds::sort_industry_name),
             makeWidget({ 204, 44 }, { 204, 11 }, WidgetType::buttonTableHeader, WindowColour::secondary, Widget::kContentNull, StringIds::sort_industry_status),
             makeWidget({ 444, 44 }, { 159, 11 }, WidgetType::buttonTableHeader, WindowColour::secondary, Widget::kContentNull, StringIds::sort_industry_production_transported),
+            makeWidget({ 603, 44 }, { 159, 11 }, WidgetType::buttonTableHeader, WindowColour::secondary, Widget::kContentNull, StringIds::sort_industry_production_last_month),
             makeWidget({ 3, 56 }, { 593, 125 }, WidgetType::scrollview, WindowColour::secondary, Scrollbars::vertical),
             widgetEnd(),
         };
@@ -103,6 +105,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
             Name,
             Status,
             ProductionTransported,
+            ProductionLastMonth,
         };
 
         // 0x00457B94
@@ -122,10 +125,14 @@ namespace OpenLoco::Ui::Windows::IndustryList
             self.widgets[widx::sort_industry_production_transported].left = std::min(self.width - 4, 444);
             self.widgets[widx::sort_industry_production_transported].right = std::min(self.width - 4, 603);
 
+            self.widgets[widx::sort_industry_production_last_month].left = std::min(self.width - 4, 603);
+            self.widgets[widx::sort_industry_production_last_month].right = std::min(self.width - 4, 762);
+
             // Set header button captions.
             self.widgets[widx::sort_industry_name].text = self.sortMode == SortMode::Name ? StringIds::industry_table_header_desc : StringIds::industry_table_header;
             self.widgets[widx::sort_industry_status].text = self.sortMode == SortMode::Status ? StringIds::industry_table_header_status_desc : StringIds::industry_table_header_status;
             self.widgets[widx::sort_industry_production_transported].text = self.sortMode == SortMode::ProductionTransported ? StringIds::industry_table_header_production_desc : StringIds::industry_table_header_production;
+            self.widgets[widx::sort_industry_production_last_month].text = self.sortMode == SortMode::ProductionLastMonth ? StringIds::industry_table_header_production_last_month_desc : StringIds::industry_table_header_production_last_month;
 
             if (isEditorMode() || isSandboxMode())
                 self.widgets[Common::widx::tab_new_industry].tooltip = StringIds::tooltip_build_new_industries;
@@ -169,6 +176,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 case widx::sort_industry_name:
                 case widx::sort_industry_status:
                 case widx::sort_industry_production_transported:
+                case widx::sort_industry_production_last_month:
                 {
                     auto sortMode = widgetIndex - widx::sort_industry_name;
                     if (self.sortMode == sortMode)
@@ -275,6 +283,38 @@ namespace OpenLoco::Ui::Windows::IndustryList
             return rhsVar < lhsVar;
         }
 
+        static std::pair<uint32_t, StringId> getProductionLastMonth(const OpenLoco::Industry& industry)
+        {
+            auto industryObj = ObjectManager::get<IndustryObject>(industry.objectId);
+            auto cargoProduction = std::numeric_limits<uint32_t>::max();
+            StringId unitType = StringIds::empty;
+
+            if (industryObj->producesCargo())
+            {
+                auto cargoNumber = 0;
+                for (const auto& producedCargoType : industryObj->producedCargoType)
+                {
+                    if (producedCargoType != kCargoTypeNull)
+                    {
+                        cargoProduction = industry.producedCargoQuantityPreviousMonth[cargoNumber];
+
+                        auto cargoObj = ObjectManager::get<CargoObject>(producedCargoType);
+                        unitType = cargoProduction > 1 ? cargoObj->unitNamePlural : cargoObj->unitNameSingular;
+                        break; // Only support one cargo type for now - it seems most (all?) industries only have a single cargo type
+                    }
+
+                    cargoNumber++;
+                }
+            }
+
+            return std::make_pair(cargoProduction, unitType);
+        }
+
+        static bool orderByProductionLastMonth(const OpenLoco::Industry& lhs, const OpenLoco::Industry& rhs)
+        {
+            return getProductionLastMonth(rhs).first < getProductionLastMonth(lhs).first;
+        }
+
         // 0x00457A52, 0x00457A9F, 0x00457AF3
         static bool getOrder(const SortMode mode, OpenLoco::Industry& lhs, OpenLoco::Industry& rhs)
         {
@@ -288,6 +328,9 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
                 case SortMode::ProductionTransported:
                     return orderByProductionTransported(lhs, rhs);
+
+                case SortMode::ProductionLastMonth:
+                    return orderByProductionLastMonth(lhs, rhs);
             }
 
             return false;
@@ -433,22 +476,31 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     auto point = Point(200, yPos);
                     drawingCtx.drawStringLeftClipped(rt, point, 238, Colour::black, text_colour_id, &args);
                 }
-                // Industry Production Delivered
+                if (industry->canProduceCargo())
                 {
-                    if (!industry->canProduceCargo())
+                    // Industry Production Delivered
                     {
-                        yPos += kRowHeight;
-                        continue;
+                        auto productionTransported = getAverageTransportedCargo(*industry);
+
+                        FormatArguments args{};
+                        args.push<uint16_t>(productionTransported);
+
+                        auto point = Point(440, yPos);
+                        drawingCtx.drawStringLeftClipped(rt, point, 138, Colour::black, StringIds::production_transported_percent, &args);
                     }
+                    // Industry Production Last Month
+                    {
+                        auto productionTransported = getProductionLastMonth(*industry);
 
-                    auto productionTransported = getAverageTransportedCargo(*industry);
+                        FormatArguments args{};
+                        args.push(productionTransported.second);
+                        args.push<uint32_t>(productionTransported.first);
 
-                    FormatArguments args{};
-                    args.push<uint16_t>(productionTransported);
-
-                    auto point = Point(440, yPos);
-                    drawingCtx.drawStringLeftClipped(rt, point, 138, Colour::black, StringIds::production_transported_percent, &args);
+                        auto point = Point(600, yPos);
+                        drawingCtx.drawStringLeftClipped(rt, point, 138, Colour::black, StringIds::black_stringid, &args);
+                    }
                 }
+
                 yPos += kRowHeight;
             }
         }

--- a/src/OpenLoco/src/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Windows/IndustryList.cpp
@@ -540,10 +540,13 @@ namespace OpenLoco::Ui::Windows::IndustryList
         // 0x00457FCA
         static void tabReset(Window* self)
         {
+            self->invalidate();
             self->minWidth = kMinDimensions.width;
             self->minHeight = kMinDimensions.height;
             self->maxWidth = kMaxDimensions.width;
             self->maxHeight = kMaxDimensions.height;
+            self->width = kWindowSize.width;
+            self->height = kWindowSize.height;
             self->var_83C = 0;
             self->rowHover = -1;
             Common::refreshIndustryList(self);

--- a/src/OpenLoco/src/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Windows/IndustryWindow.cpp
@@ -464,7 +464,7 @@ namespace OpenLoco::Ui::Windows::Industry
                 auto cargoNumber = 0;
                 for (const auto& receivedCargoType : industryObj->requiredCargoType)
                 {
-                    if (receivedCargoType != 0xFF)
+                    if (receivedCargoType != kCargoTypeNull)
                     {
                         auto cargoObj = ObjectManager::get<CargoObject>(receivedCargoType);
                         FormatArguments args{};
@@ -497,7 +497,7 @@ namespace OpenLoco::Ui::Windows::Industry
                 auto cargoNumber = 0;
                 for (const auto& producedCargoType : industryObj->producedCargoType)
                 {
-                    if (producedCargoType != 0xFF)
+                    if (producedCargoType != kCargoTypeNull)
                     {
                         auto cargoObj = ObjectManager::get<CargoObject>(producedCargoType);
                         FormatArguments args{};
@@ -565,10 +565,10 @@ namespace OpenLoco::Ui::Windows::Industry
             auto industryObj = ObjectManager::get<IndustryObject>(IndustryManager::get(IndustryId(self->number))->objectId);
             auto disabledWidgets = 0;
 
-            if (industryObj->producedCargoType[0] == 0xFF)
+            if (industryObj->producedCargoType[0] == kCargoTypeNull)
                 disabledWidgets |= (1 << Common::widx::tab_production);
 
-            if (industryObj->producedCargoType[1] == 0xFF)
+            if (industryObj->producedCargoType[1] == kCargoTypeNull)
                 disabledWidgets |= (1 << Common::widx::tab_production_2);
 
             self->disabledWidgets = disabledWidgets;
@@ -836,7 +836,7 @@ namespace OpenLoco::Ui::Windows::Industry
             uint32_t imageId = 0xFFFFFFFF;
             auto widget = self->widgets[tab];
 
-            if (industryObj->producedCargoType[productionTabNumber] != 0xFF)
+            if (industryObj->producedCargoType[productionTabNumber] != kCargoTypeNull)
             {
                 imageId = Gfx::recolour(skin->img, self->getColour(WindowColour::secondary).c());
 


### PR DESCRIPTION
Implements #1652

* Add column to industry list w/ sorting support
* Industry cargo type checks: Figured it was best now to extract the 0xFF to constant for re-use - there are several other places where this magic constant is used, so let me know if you'd like to revert this or are open for a follow-up PR to replace other occurrences 
* Updated changelog

![image](https://github.com/OpenLoco/OpenLoco/assets/1426097/f03478ba-bea2-4f21-96f6-9e68a72ae5ce)
