### PR TITLE
Remove setjmp/longjmp interop support

### DIFF
--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -501,26 +501,6 @@ namespace OpenLoco
     {
         static bool isInitialised = false;
 
-        // Locomotion has several routines that will prematurely end the current tick.
-        // This usually happens when switching game mode. It does this by jumping to
-        // the end of the original routine and resetting esp back to an initial value
-        // stored at the beginning of tick. Until those routines are re-written, we
-        // must simulate it using 'setjmp'.
-        static jmp_buf tickJump;
-
-        // When Locomotion wants to jump to the end of a tick, it sets ESP
-        // to some static memory that we define
-        static loco_global<void*, 0x0050C1A6> _tickJumpESP;
-        static uint8_t spareStackMemory[2048];
-        _tickJumpESP = spareStackMemory + sizeof(spareStackMemory);
-
-        if (setjmp(tickJump))
-        {
-            // Premature end of current tick
-            tickInterrupted();
-            return;
-        }
-
         try
         {
             auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
@@ -530,14 +510,6 @@ namespace OpenLoco
             if (!isInitialised)
             {
                 isInitialised = true;
-
-                // This address is where those routines jump back to end the tick prematurely
-                registerHook(
-                    0x0046AD71,
-                    [](registers&) FORCE_ALIGN_ARG_POINTER -> uint8_t {
-                        longjmp(tickJump, 1);
-                    });
-
                 initialise();
                 _last_tick_time = Platform::getTime();
             }
@@ -602,7 +574,7 @@ namespace OpenLoco
                 }
 
                 call(0x00452D1A); // nop redrawPeepAndRain
-                call(0x00440DEC);
+                call(0x00440DEC); // install scenario from 0x0050C18C ptr??
 
                 if (addr<0x00525340, int32_t>() == 1)
                 {


### PR DESCRIPTION
This removes the setjmp/longjmp interop support, which is no longer needed. All its users have since been replaced with `throw GameException`. This means we now have more freedom to refactor the tick loop.

I believe the last bit of code that still relied on this was reimplemented in #2307.