### PR TITLE
Remove redundant calls to Title::start

### DIFF
--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -341,7 +341,7 @@ namespace OpenLoco
         loadFile(fs::u8path(path));
     }
 
-    static void launchGame()
+    static void launchGameFromCmdLineOptions()
     {
         const auto& cmdLineOptions = getCommandLineOptions();
         if (cmdLineOptions.action == CommandLineAction::host)
@@ -351,7 +351,6 @@ namespace OpenLoco
         }
         else if (cmdLineOptions.action == CommandLineAction::join)
         {
-            Title::start();
             if (cmdLineOptions.port)
             {
                 Network::joinServer(cmdLineOptions.address, *cmdLineOptions.port);
@@ -364,10 +363,6 @@ namespace OpenLoco
         else if (!cmdLineOptions.path.empty())
         {
             loadFile(cmdLineOptions.path);
-        }
-        else
-        {
-            Title::start();
         }
     }
 
@@ -621,7 +616,7 @@ namespace OpenLoco
                     Intro::update();
                     if (!Intro::isActive())
                     {
-                        launchGame();
+                        launchGameFromCmdLineOptions();
                     }
                 }
                 else


### PR DESCRIPTION
The new progress bars (#2423) revealed we were loading the title screen twice. Means a very modest speedup in starting the game.