### PR TITLE
Increase window limit from 12 to 64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 24.04+ (???)
 ------------------------------------------------------------------------
+- Feature: [#2] The window limit has been increased from 12 to 50.
 - Fix: [#2411] Progress bar windows are not actually rendered.
 - Fix: [#2413] Gridlines are hidden when closing construction windows.
 - Fix: [#2416] Cursors in embedded text fiels are not rendering in the right position.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 24.04+ (???)
 ------------------------------------------------------------------------
-- Feature: [#2] The window limit has been increased from 12 to 50.
+- Feature: [#2] The window limit has been increased from 12 to 64.
 - Fix: [#2411] Progress bar windows are not actually rendered.
 - Fix: [#2413] Gridlines are hidden when closing construction windows.
 - Fix: [#2416] Cursors in embedded text fiels are not rendering in the right position.

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -40,7 +40,7 @@ namespace OpenLoco::Ui::WindowManager
         constexpr uint16_t byType = 1 << 7;
     }
 
-    static constexpr size_t kMaxWindows = 50;
+    static constexpr size_t kMaxWindows = 64;
 
     static loco_global<uint16_t, 0x0050C19C> _timeSinceLastTick;
     static loco_global<uint16_t, 0x0052334E> _thousandthTickCounter;

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -40,7 +40,7 @@ namespace OpenLoco::Ui::WindowManager
         constexpr uint16_t byType = 1 << 7;
     }
 
-    static constexpr size_t kMaxWindows = 12;
+    static constexpr size_t kMaxWindows = 50;
 
     static loco_global<uint16_t, 0x0050C19C> _timeSinceLastTick;
     static loco_global<uint16_t, 0x0052334E> _thousandthTickCounter;


### PR DESCRIPTION
With #2436 in, we can finally close #2.

The screenshot below uses 17 windows (13 floating windows, 3 panels, and 1 main window).

![Screenshot 2024-04-12 at 14 21 43](https://github.com/OpenLoco/OpenLoco/assets/604665/6b97c1ab-467b-4c5b-a779-bb11c76707d4)