### PR TITLE
Speed up ScenarioManager::loadScenarioProgress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Change: [#1014] Loading and saving save files and scenarios uses progress bars again.
 - Change: [#2411] Internal progress bars can now be used during the object and scenario indexing processes.
 - Change: [#2416] Most text input fields are no longer focused by default, allowing shortcuts to be used.
+- Technical: [#2456] Changing the in-game language has been sped up considerably.
 
 24.04 (2024-04-07)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/ScenarioManager.cpp
+++ b/src/OpenLoco/src/ScenarioManager.cpp
@@ -238,7 +238,6 @@ namespace OpenLoco::ScenarioManager
             ObjectManager::unload(*previousCurrency);
         }
         ObjectManager::load(options.currency);
-        ObjectManager::reloadAll();
         Gfx::loadCurrency();
 
         FormatArguments args{};
@@ -252,7 +251,6 @@ namespace OpenLoco::ScenarioManager
         {
             ObjectManager::unload(options.currency);
             ObjectManager::load(*previousCurrency);
-            ObjectManager::reloadAll();
             Gfx::loadCurrency();
         }
     }

--- a/src/OpenLoco/src/ScenarioManager.cpp
+++ b/src/OpenLoco/src/ScenarioManager.cpp
@@ -389,8 +389,10 @@ namespace OpenLoco::ScenarioManager
             return strcmp(lhs.scenarioName, rhs.scenarioName) < 0;
         });
 
-        Ui::ProgressBar::setProgress(240);
+        Ui::ProgressBar::setProgress(230);
         saveIndex();
+        Ui::ProgressBar::setProgress(240);
+        ObjectManager::reloadAll();
         Ui::ProgressBar::end();
     }
 


### PR DESCRIPTION
Changing the in-game language currently forces a rebuild of the scenario index to translate the scenario descriptions and progress strings. I noticed this progress is quite slow – much slower than the initial scenario index creation process. After some investigation, I narrowed it down to `ScenarioManager::loadScenarioProgress`.

More specifically, `loadScenarioProgress` temporarily swaps out the currency object, and then calls `ObjectManager::reloadAll()`. While likely better for completeness, it seems to me a superfluous step, what with there always being one currency object loaded anyway. Removing these calls makes the process considerably faster. (I want to say 10x faster, but I haven't actually benchmarked it.)

Hopefully, this does indeed work as I think it does. I imagine @duncanspumpkin to have thoughts on the matter 😄 