### PR TITLE
Correct naming and use of ViewportVisibility::heightMarksOnTrack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#2] The window limit has been increased from 12 to 64.
 - Feature: [#1652] Display the production of each industry from the previous month in the industry list.
+- Fix: [#2374] Height markers re-appear when building sloped track in construction window.
 - Fix: [#2411] Progress bar windows are not actually rendered.
 - Fix: [#2413] Gridlines are hidden when closing construction windows.
 - Fix: [#2416] Cursors in embedded text fiels are not rendering in the right position.

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -1941,11 +1941,11 @@ namespace OpenLoco::Ui::WindowManager
                 break;
             }
 
-            case ViewportVisibility::heightMarksOnLand:
+            case ViewportVisibility::heightMarksOnTrack:
             {
-                if (!viewport->hasFlags(ViewportFlags::height_marks_on_land))
+                if (!viewport->hasFlags(ViewportFlags::height_marks_on_tracks_roads))
                 {
-                    viewport->flags |= (ViewportFlags::height_marks_on_land);
+                    viewport->flags |= (ViewportFlags::height_marks_on_tracks_roads);
                     flagsChanged = true;
                 }
                 break;

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -35,7 +35,7 @@ namespace OpenLoco::Ui::WindowManager
     {
         reset,
         undergroundView,
-        heightMarksOnLand,
+        heightMarksOnTrack,
         overgroundView,
     };
 

--- a/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
@@ -2165,7 +2165,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             WindowManager::viewportSetVisibility(newViewState);
             if (_lastSelectedTrackGradient != 0)
             {
-                WindowManager::viewportSetVisibility(WindowManager::ViewportVisibility::heightMarksOnLand);
+                WindowManager::viewportSetVisibility(WindowManager::ViewportVisibility::heightMarksOnTrack);
             }
         }
         _byte_113603A = 0;
@@ -2218,7 +2218,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             WindowManager::viewportSetVisibility(newViewState);
             if (_lastSelectedTrackGradient != 0)
             {
-                WindowManager::viewportSetVisibility(WindowManager::ViewportVisibility::heightMarksOnLand);
+                WindowManager::viewportSetVisibility(WindowManager::ViewportVisibility::heightMarksOnTrack);
             }
         }
         _byte_113603A = 0;


### PR DESCRIPTION
In https://github.com/OpenLoco/OpenLoco/pull/2231/commits/9d772bb8fd73cbbb75994f1950df641469ef2ada, we revealed the `height_marks_on_land` and `height_marks_on_tracks_roads` flags were swapped in our implementation. As it turns out, we forgot this has implications for what we called `ViewportVisibility::heightMarksOnLand`, which should really have been `ViewportVisibility::heightMarksOnTrack` instead.

Should fix #2374.