### PR TITLE
Rename StringIds::buffer_2038 to StringIds::num_selected_num_max

### DIFF
--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1670,7 +1670,7 @@ namespace OpenLoco::StringIds
     constexpr StringId position_13th = 2035;
     constexpr StringId position_14th = 2036;
     constexpr StringId position_15th = 2037;
-    constexpr StringId buffer_2038 = 2038;
+    constexpr StringId num_selected_num_max = 2038;
     constexpr StringId buffer_2039 = 2039;
     constexpr StringId buffer_2040 = 2040;
 

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -962,7 +962,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         {
             auto point = Point(self.x + 3, self.y + self.height - 12);
-            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::buffer_2038, args);
+            drawingCtx.drawStringLeft(*rt, point, Colour::black, StringIds::num_selected_num_max, args);
         }
 
         if (self.rowHover == -1)


### PR DESCRIPTION
Not actually a buffer! The string reads `{COLOUR BLACK}{INT16} selected (maximum {INT16})`.
