### PR TITLE
Move options window centring to Gui::resize

### DIFF
--- a/src/OpenLoco/src/Gui.cpp
+++ b/src/OpenLoco/src/Gui.cpp
@@ -133,5 +133,9 @@ namespace OpenLoco::Gui
                 WindowManager::close(window);
             }
         }
+
+        window = WindowManager::find(WindowType::options);
+        if (window != nullptr)
+            window->moveToCentre();
     }
 }

--- a/src/OpenLoco/src/Ui.cpp
+++ b/src/OpenLoco/src/Ui.cpp
@@ -379,10 +379,6 @@ namespace OpenLoco::Ui
             cfg.windowResolution = { width, height };
             Config::write();
         }
-
-        auto optionsWindow = WindowManager::find(WindowType::options);
-        if (optionsWindow != nullptr)
-            optionsWindow->moveToCentre();
     }
 
     void triggerResize()


### PR DESCRIPTION
This bit of code was hacked into Ui::resize at some point (#421). Gui::resize deals with repositioning many windows already; it's the better place for it.