### PR TITLE
Remove unused function

### DIFF
--- a/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.cpp
@@ -247,13 +247,6 @@ namespace OpenLoco::Gfx
         auto max = Rect(0, 0, Ui::width(), Ui::height());
         auto rect = _rect.intersection(max);
 
-        registers regs;
-        regs.ax = rect.left();
-        regs.bx = rect.top();
-        regs.cx = rect.right() - 1;
-        regs.dx = rect.bottom() - 1;
-        call(0x00451D98, regs);
-
         RenderTarget rt;
         rt.width = rect.width();
         rt.height = rect.height();

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -557,7 +557,8 @@ namespace OpenLoco
 
                     Audio::playBackgroundMusic();
 
-                    if (Tutorial::state() != Tutorial::State::none && addr<0x0052532C, int32_t>() != 0 && addr<0x0113E2E4, int32_t>() < 0x40)
+                    // 0x0052532C != 0 isMinimized
+                    if (Tutorial::state() != Tutorial::State::none && addr<0x0052532C, int32_t>() != 0 && Ui::width() < 64)
                     {
                         Tutorial::stop();
 


### PR DESCRIPTION
This function hasn't done anything since probably OpenLoco began. To work it needed the window size be set in a global that we weren't setting. It looks to be some sort of debug thing or maybe some sort of indication to the render engine of where has changed.