### PR TITLE
Remove interop for window colours, refactor code

### DIFF
--- a/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
@@ -28,9 +28,6 @@ namespace OpenLoco::Gfx
 
     namespace Impl
     {
-        // TODO: Move them into RenderContext once everything is implemented.
-        static loco_global<AdvancedColour[4], 0x1136594> _windowColours;
-
         // 0x009DA3E0
         // Originally 0x009DA3E0 was an array of the image data pointers setup within 0x00452336
         // We have removed that step and instead work directly on the images.

--- a/src/OpenLoco/src/Graphics/TextRenderer.cpp
+++ b/src/OpenLoco/src/Graphics/TextRenderer.cpp
@@ -4,13 +4,13 @@
 #include "Graphics/ImageIds.h"
 #include "Localisation/Formatting.h"
 #include "RenderTarget.h"
+#include "Ui/WindowManager.h"
 
 namespace OpenLoco::Gfx
 {
     // TODO: Move them into RenderContext once everything is implemented.
     static loco_global<TextDrawFlags, 0x112C824> _currentFontFlags;
     static loco_global<Font, 0x0112C876> _currentFontSpriteBase;
-    static loco_global<AdvancedColour[4], 0x1136594> _windowColours;
 
     namespace Impl
     {
@@ -159,25 +159,25 @@ namespace OpenLoco::Gfx
                         break;
                     case ControlCodes::windowColour1:
                     {
-                        auto hue = _windowColours[0].c();
+                        auto hue = Ui::WindowManager::getWindowColour(Ui::WindowColour::primary).c();
                         setTextColours(Colours::getShade(hue, 7), PaletteIndex::index_0A, PaletteIndex::index_0A);
                         break;
                     }
                     case ControlCodes::windowColour2:
                     {
-                        auto hue = _windowColours[1].c();
+                        auto hue = Ui::WindowManager::getWindowColour(Ui::WindowColour::secondary).c();
                         setTextColours(Colours::getShade(hue, 9), PaletteIndex::index_0A, PaletteIndex::index_0A);
                         break;
                     }
                     case ControlCodes::windowColour3:
                     {
-                        auto hue = _windowColours[2].c();
+                        auto hue = Ui::WindowManager::getWindowColour(Ui::WindowColour::tertiary).c();
                         setTextColours(Colours::getShade(hue, 9), PaletteIndex::index_0A, PaletteIndex::index_0A);
                         break;
                     }
                     case ControlCodes::windowColour4:
                     {
-                        auto hue = _windowColours[3].c();
+                        auto hue = Ui::WindowManager::getWindowColour(Ui::WindowColour::quaternary).c();
                         setTextColours(Colours::getShade(hue, 9), PaletteIndex::index_0A, PaletteIndex::index_0A);
                         break;
                     }
@@ -902,25 +902,25 @@ namespace OpenLoco::Gfx
                         break;
                     case ControlCodes::windowColour1:
                     {
-                        auto hue = _windowColours[0].c();
+                        auto hue = Ui::WindowManager::getWindowColour(Ui::WindowColour::primary).c();
                         setTextColours(Colours::getShade(hue, 7), PaletteIndex::index_0A, PaletteIndex::index_0A);
                         break;
                     }
                     case ControlCodes::windowColour2:
                     {
-                        auto hue = _windowColours[1].c();
+                        auto hue = Ui::WindowManager::getWindowColour(Ui::WindowColour::secondary).c();
                         setTextColours(Colours::getShade(hue, 9), PaletteIndex::index_0A, PaletteIndex::index_0A);
                         break;
                     }
                     case ControlCodes::windowColour3:
                     {
-                        auto hue = _windowColours[2].c();
+                        auto hue = Ui::WindowManager::getWindowColour(Ui::WindowColour::tertiary).c();
                         setTextColours(Colours::getShade(hue, 9), PaletteIndex::index_0A, PaletteIndex::index_0A);
                         break;
                     }
                     case ControlCodes::windowColour4:
                     {
-                        auto hue = _windowColours[3].c();
+                        auto hue = Ui::WindowManager::getWindowColour(Ui::WindowColour::quaternary).c();
                         setTextColours(Colours::getShade(hue, 9), PaletteIndex::index_0A, PaletteIndex::index_0A);
                         break;
                     }
@@ -1144,25 +1144,25 @@ namespace OpenLoco::Gfx
                         break;
                     case ControlCodes::windowColour1:
                     {
-                        auto hue = _windowColours[0].c();
+                        auto hue = Ui::WindowManager::getWindowColour(Ui::WindowColour::primary).c();
                         setTextColours(Colours::getShade(hue, 7), PaletteIndex::index_0A, PaletteIndex::index_0A);
                         break;
                     }
                     case ControlCodes::windowColour2:
                     {
-                        auto hue = _windowColours[1].c();
+                        auto hue = Ui::WindowManager::getWindowColour(Ui::WindowColour::secondary).c();
                         setTextColours(Colours::getShade(hue, 9), PaletteIndex::index_0A, PaletteIndex::index_0A);
                         break;
                     }
                     case ControlCodes::windowColour3:
                     {
-                        auto hue = _windowColours[2].c();
+                        auto hue = Ui::WindowManager::getWindowColour(Ui::WindowColour::tertiary).c();
                         setTextColours(Colours::getShade(hue, 9), PaletteIndex::index_0A, PaletteIndex::index_0A);
                         break;
                     }
                     case ControlCodes::windowColour4:
                     {
-                        auto hue = _windowColours[3].c();
+                        auto hue = Ui::WindowManager::getWindowColour(Ui::WindowColour::quaternary).c();
                         setTextColours(Colours::getShade(hue, 9), PaletteIndex::index_0A, PaletteIndex::index_0A);
                         break;
                     }

--- a/src/OpenLoco/src/Paint/Paint.cpp
+++ b/src/OpenLoco/src/Paint/Paint.cpp
@@ -1238,8 +1238,8 @@ namespace OpenLoco::Paint
             Ui::Point loc(psString->vpPos.x >> zoom, psString->vpPos.y >> zoom);
             StringManager::formatString(buffer, psString->stringId, args);
 
-            Ui::WindowManager::setWindowColours(0, AdvancedColour(static_cast<Colour>(psString->colour)));
-            Ui::WindowManager::setWindowColours(1, AdvancedColour(static_cast<Colour>(psString->colour)));
+            Ui::WindowManager::setWindowColours(Ui::WindowColour::primary, AdvancedColour(static_cast<Colour>(psString->colour)));
+            Ui::WindowManager::setWindowColours(Ui::WindowColour::secondary, AdvancedColour(static_cast<Colour>(psString->colour)));
 
             tr.drawStringYOffsets(loc, Colour::black, buffer, psString->yOffsets);
         }

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -28,6 +28,7 @@
 #include "World/TownManager.h"
 #include <OpenLoco/Interop/Interop.hpp>
 #include <algorithm>
+#include <array>
 #include <cinttypes>
 #include <memory>
 #include <sfl/static_vector.hpp>
@@ -55,7 +56,7 @@ namespace OpenLoco::Ui::WindowManager
 
     static sfl::static_vector<Window, kMaxWindows> _windows;
 
-    loco_global<AdvancedColour[4], 0x1136594> _windowColours;
+    static std::array<AdvancedColour, enumValue(WindowColour::count)> _windowColours;
 
     static void viewportRedrawAfterShift(Window* window, Viewport* viewport, int16_t x, int16_t y);
 
@@ -500,10 +501,18 @@ namespace OpenLoco::Ui::WindowManager
         return _windows.size();
     }
 
-    void setWindowColours(uint8_t i, AdvancedColour colour)
+    void setWindowColours(WindowColour slot, AdvancedColour colour)
     {
-        assert(i < 4);
-        _windowColours[i] = colour;
+        const auto index = static_cast<size_t>(slot);
+        assert(index < _windowColours.size());
+        _windowColours[index] = colour;
+    }
+
+    AdvancedColour getWindowColour(WindowColour slot)
+    {
+        const auto index = static_cast<size_t>(slot);
+        assert(index < _windowColours.size());
+        return _windowColours[index];
     }
 
     WindowType getCurrentModalType()
@@ -1200,10 +1209,10 @@ namespace OpenLoco::Ui::WindowManager
         addr<0x1136F9E, int16_t>() = w->y;
 
         // Text colouring
-        setWindowColours(0, w->getColour(WindowColour::primary).opaque());
-        setWindowColours(1, w->getColour(WindowColour::secondary).opaque());
-        setWindowColours(2, w->getColour(WindowColour::tertiary).opaque());
-        setWindowColours(3, w->getColour(WindowColour::quaternary).opaque());
+        setWindowColours(WindowColour::primary, w->getColour(WindowColour::primary).opaque());
+        setWindowColours(WindowColour::secondary, w->getColour(WindowColour::secondary).opaque());
+        setWindowColours(WindowColour::tertiary, w->getColour(WindowColour::tertiary).opaque());
+        setWindowColours(WindowColour::quaternary, w->getColour(WindowColour::quaternary).opaque());
 
         drawingCtx.pushRenderTarget(rt);
 

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -41,7 +41,10 @@ namespace OpenLoco::Ui::WindowManager
 
     void init();
     void registerHooks();
-    void setWindowColours(uint8_t i, AdvancedColour colour);
+
+    void setWindowColours(WindowColour slot, AdvancedColour colour);
+    AdvancedColour getWindowColour(WindowColour slot);
+
     WindowType getCurrentModalType();
     void setCurrentModalType(WindowType type);
     Window* get(size_t index);


### PR DESCRIPTION
The way this works is a bit odd, before each window is rendered it copies the colors from what the window holds into the global, ideally when rendering the text it inherits the colors from the window so we avoid the need to set it in the window manager. For now this at least removes all the interop variables.