### PR TITLE
Fix bug with autosave frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+24.06+ (???)
+------------------------------------------------------------------------
+- Fix: [#2523] Autosaves are generated monthly regardless of frequency setting.
+
 24.06 (2024-06-28)
 ------------------------------------------------------------------------
 - Change: [#2473] Progress bars no longer pop up for autosaves.

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -748,9 +748,9 @@ namespace OpenLoco
             auto freq = Config::get().autosaveFrequency;
             if (freq > 0 && _monthsSinceLastAutosave >= freq)
             {
-                _monthsSinceLastAutosave = 0;
                 autosave();
                 autosaveClean();
+                autosaveReset();
             }
         }
     }

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -748,6 +748,7 @@ namespace OpenLoco
             auto freq = Config::get().autosaveFrequency;
             if (freq > 0 && _monthsSinceLastAutosave >= freq)
             {
+                _monthsSinceLastAutosave = 0;
                 autosave();
                 autosaveClean();
             }


### PR DESCRIPTION
 _monthsSinceLastAutosave was not being reset after it reached the autosave frequency so following the first time it was autosaved every subsequent autosave was done at a monthly frequency