### PR TITLE
More constexpr

### DIFF
--- a/src/Diagnostics/src/LogTerminal.cpp
+++ b/src/Diagnostics/src/LogTerminal.cpp
@@ -6,10 +6,10 @@
 
 namespace OpenLoco::Diagnostics::Logging
 {
-    static const auto kColourInfo = fmt::fg(fmt::color::light_gray);
-    static const auto kColourWarning = fmt::fg(fmt::color::yellow);
-    static const auto kColourError = fmt::fg(fmt::color::red);
-    static const auto kColourVerbose = fmt::fg(fmt::color::gray);
+    static constexpr auto kColourInfo = fmt::fg(fmt::color::light_gray);
+    static constexpr auto kColourWarning = fmt::fg(fmt::color::yellow);
+    static constexpr auto kColourError = fmt::fg(fmt::color::red);
+    static constexpr auto kColourVerbose = fmt::fg(fmt::color::gray);
 
     LogTerminal::LogTerminal()
     {

--- a/src/OpenLoco/src/Map/Track/SubpositionData.cpp
+++ b/src/OpenLoco/src/Map/Track/SubpositionData.cpp
@@ -18504,7 +18504,7 @@ namespace OpenLoco::World::TrackData
     };
 
     // 0x004D9DE4
-    static const std::array<std::array<std::array<std::span<const MoveInfo>, 10 * 8>, 2>, 2> _rightHand4D9DE4 = {
+    static constexpr std::array<std::array<std::array<std::span<const MoveInfo>, 10 * 8>, 2>, 2> _rightHand4D9DE4 = {
         std::array<std::array<std::span<const MoveInfo>, 10 * 8>, 2>{
             std::array<std::span<const MoveInfo>, 10 * 8>{
                 moveInfoTA0L1T0R0D0,

--- a/src/OpenLoco/src/Paint/PaintEffectEntity.cpp
+++ b/src/OpenLoco/src/Paint/PaintEffectEntity.cpp
@@ -179,7 +179,7 @@ namespace OpenLoco::Paint
             return;
         }
 
-        static const std::array<uint32_t, 28> kSplashImageIds = {
+        static constexpr std::array<uint32_t, 28> kSplashImageIds = {
             ImageIds::splash_00,
             ImageIds::splash_01,
             ImageIds::splash_02,
@@ -224,7 +224,7 @@ namespace OpenLoco::Paint
             return;
         }
 
-        static const std::array<uint32_t, 31> kFireballImageIds = {
+        static constexpr std::array<uint32_t, 31> kFireballImageIds = {
             ImageIds::fireball_00,
             ImageIds::fireball_01,
             ImageIds::fireball_02,
@@ -272,7 +272,7 @@ namespace OpenLoco::Paint
             return;
         }
 
-        static const std::array<uint32_t, 10> kExplosionSmokeImageIds = {
+        static constexpr std::array<uint32_t, 10> kExplosionSmokeImageIds = {
             ImageIds::explosion_smoke_00,
             ImageIds::explosion_smoke_01,
             ImageIds::explosion_smoke_02,
@@ -299,7 +299,7 @@ namespace OpenLoco::Paint
             return;
         }
 
-        static const std::array<uint32_t, 12> kSmokeImageIds = {
+        static constexpr std::array<uint32_t, 12> kSmokeImageIds = {
             ImageIds::smoke_00,
             ImageIds::smoke_01,
             ImageIds::smoke_02,

--- a/src/OpenLoco/src/Paint/PaintEffectEntity.cpp
+++ b/src/OpenLoco/src/Paint/PaintEffectEntity.cpp
@@ -27,7 +27,7 @@ namespace OpenLoco::Paint
     // 004FAAC8
     // This is an array of 22 signed int8 elements which are repeating 20 times, can be optimized after C++ implementation of 0x004FD120 - addToStringPlotList
     // clang-format off
-    static const int8_t kWiggleYOffsets[440] = {
+    static constexpr int8_t kWiggleYOffsets[440] = {
         0, 1, 2, 2, 3, 3, 3, 3, 2, 2, 1, 0, -1, -2, -2, -3, -3, -2, -2, -1,
         0, 1, 2, 2, 3, 3, 3, 3, 2, 2, 1, 0, -1, -2, -2, -3, -3, -2, -2, -1,
         0, 1, 2, 2, 3, 3, 3, 3, 2, 2, 1, 0, -1, -2, -2, -3, -3, -2, -2, -1,
@@ -144,7 +144,7 @@ namespace OpenLoco::Paint
             return;
         }
 
-        static const std::array<uint32_t, 18> kExplosionCloudImageIds = {
+        static constexpr std::array<uint32_t, 18> kExplosionCloudImageIds = {
             ImageIds::explosion_cloud_00,
             ImageIds::explosion_cloud_01,
             ImageIds::explosion_cloud_02,

--- a/src/OpenLoco/src/Title.cpp
+++ b/src/OpenLoco/src/Title.cpp
@@ -51,7 +51,7 @@ namespace OpenLoco::Title
     using TitleStep = std::variant<WaitStep, ReloadStep, MoveStep, RotateStep, ResetStep>;
     using TitleSequence = std::vector<TitleStep>;
 
-    static constexpr TitleSequence _titleSequence = {
+    static const TitleSequence _titleSequence = {
         MoveStep{ 231, 160 },
         WaitStep{ 368 },
         MoveStep{ 93, 59 },

--- a/src/OpenLoco/src/Title.cpp
+++ b/src/OpenLoco/src/Title.cpp
@@ -51,7 +51,7 @@ namespace OpenLoco::Title
     using TitleStep = std::variant<WaitStep, ReloadStep, MoveStep, RotateStep, ResetStep>;
     using TitleSequence = std::vector<TitleStep>;
 
-    static const TitleSequence _titleSequence = {
+    static constexpr TitleSequence _titleSequence = {
         MoveStep{ 231, 160 },
         WaitStep{ 368 },
         MoveStep{ 93, 59 },

--- a/src/OpenLoco/src/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Windows/Cheats.cpp
@@ -62,7 +62,7 @@ namespace OpenLoco::Ui::Windows::Cheats
 
             // Finances tab
             {
-                static const uint32_t financesTabImageIds[] = {
+                static constexpr uint32_t financesTabImageIds[] = {
                     InterfaceSkin::ImageIds::tab_finances_frame0,
                     InterfaceSkin::ImageIds::tab_finances_frame1,
                     InterfaceSkin::ImageIds::tab_finances_frame2,

--- a/src/OpenLoco/src/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Windows/Cheats.cpp
@@ -98,7 +98,7 @@ namespace OpenLoco::Ui::Windows::Cheats
 
             // Vehicles tab
             {
-                static const uint32_t vehiclesTabImageIds[] = {
+                static constexpr uint32_t vehiclesTabImageIds[] = {
                     InterfaceSkin::ImageIds::vehicle_train_frame_0,
                     InterfaceSkin::ImageIds::vehicle_train_frame_1,
                     InterfaceSkin::ImageIds::vehicle_train_frame_2,

--- a/src/OpenLoco/src/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Windows/CompanyList.cpp
@@ -1510,7 +1510,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             // Performance Index Tab
             {
-                static const uint32_t performanceImageIds[] = {
+                static constexpr uint32_t performanceImageIds[] = {
                     InterfaceSkin::ImageIds::tab_performance_index_frame0,
                     InterfaceSkin::ImageIds::tab_performance_index_frame1,
                     InterfaceSkin::ImageIds::tab_performance_index_frame2,
@@ -1534,7 +1534,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             // Cargo Unit Tab
             {
-                static const uint32_t cargoUnitsImageIds[] = {
+                static constexpr uint32_t cargoUnitsImageIds[] = {
                     InterfaceSkin::ImageIds::tab_cargo_units_frame0,
                     InterfaceSkin::ImageIds::tab_cargo_units_frame1,
                     InterfaceSkin::ImageIds::tab_cargo_units_frame2,
@@ -1558,7 +1558,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             // Cargo Distance Tab
             {
-                static const uint32_t cargoDistanceImageIds[] = {
+                static constexpr uint32_t cargoDistanceImageIds[] = {
                     InterfaceSkin::ImageIds::tab_cargo_distance_frame0,
                     InterfaceSkin::ImageIds::tab_cargo_distance_frame1,
                     InterfaceSkin::ImageIds::tab_cargo_distance_frame2,
@@ -1582,7 +1582,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             // Company Values Tab
             {
-                static const uint32_t companyValuesImageIds[] = {
+                static constexpr uint32_t companyValuesImageIds[] = {
                     InterfaceSkin::ImageIds::tab_production_frame0,
                     InterfaceSkin::ImageIds::tab_production_frame1,
                     InterfaceSkin::ImageIds::tab_production_frame2,

--- a/src/OpenLoco/src/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Windows/CompanyWindow.cpp
@@ -1360,7 +1360,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             };
 
             // clang-format off
-            static const ColourSchemeTuple tuples[] =
+            static constexpr ColourSchemeTuple tuples[] =
             {
                 { widx::check_steam_locomotives,     widx::main_colour_steam_locomotives,     widx::secondary_colour_steam_locomotives },
                 { widx::check_diesel_locomotives,    widx::main_colour_diesel_locomotives,    widx::secondary_colour_diesel_locomotives },
@@ -2666,7 +2666,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self->setWidgets(newWidgets);
             // self->initScrollWidgets();
 
-            static const widx tabWidgetIdxByTabId[] = {
+            static constexpr widx tabWidgetIdxByTabId[] = {
                 tab_status,
                 tab_details,
                 tab_colour_scheme,
@@ -2784,7 +2784,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // Colour scheme tab
             {
-                static const uint32_t colourSchemeTabImageIds[] = {
+                static constexpr uint32_t colourSchemeTabImageIds[] = {
                     InterfaceSkin::ImageIds::tab_colour_scheme_frame0,
                     InterfaceSkin::ImageIds::tab_colour_scheme_frame1,
                     InterfaceSkin::ImageIds::tab_colour_scheme_frame2,
@@ -2806,7 +2806,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // Finances tab
             {
-                static const uint32_t financesTabImageIds[] = {
+                static constexpr uint32_t financesTabImageIds[] = {
                     InterfaceSkin::ImageIds::tab_finances_frame0,
                     InterfaceSkin::ImageIds::tab_finances_frame1,
                     InterfaceSkin::ImageIds::tab_finances_frame2,
@@ -2836,7 +2836,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // Cargo delivered tab
             {
-                static const uint32_t cargoDeliveredTabImageIds[] = {
+                static constexpr uint32_t cargoDeliveredTabImageIds[] = {
                     InterfaceSkin::ImageIds::tab_cargo_delivered_frame0,
                     InterfaceSkin::ImageIds::tab_cargo_delivered_frame1,
                     InterfaceSkin::ImageIds::tab_cargo_delivered_frame2,
@@ -2854,7 +2854,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // Challenge tab
             {
-                static const uint32_t challengeTabImageIds[] = {
+                static constexpr uint32_t challengeTabImageIds[] = {
                     InterfaceSkin::ImageIds::tab_cup_frame0,
                     InterfaceSkin::ImageIds::tab_cup_frame1,
                     InterfaceSkin::ImageIds::tab_cup_frame2,

--- a/src/OpenLoco/src/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Windows/IndustryList.cpp
@@ -1386,7 +1386,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
             // Fund New Industries Tab
             {
-                static const uint32_t fundNewIndustriesImageIds[] = {
+                static constexpr uint32_t fundNewIndustriesImageIds[] = {
                     InterfaceSkin::ImageIds::build_industry_frame_0,
                     InterfaceSkin::ImageIds::build_industry_frame_1,
                     InterfaceSkin::ImageIds::build_industry_frame_2,

--- a/src/OpenLoco/src/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Windows/IndustryWindow.cpp
@@ -812,7 +812,7 @@ namespace OpenLoco::Ui::Windows::Industry
 
         static void drawProductionTab(Window* self, Gfx::DrawingContext& drawingCtx, uint8_t productionTabNumber)
         {
-            static const uint32_t productionTabImageIds[] = {
+            static constexpr uint32_t productionTabImageIds[] = {
                 InterfaceSkin::ImageIds::tab_production_frame0,
                 InterfaceSkin::ImageIds::tab_production_frame1,
                 InterfaceSkin::ImageIds::tab_production_frame2,
@@ -827,7 +827,7 @@ namespace OpenLoco::Ui::Windows::Industry
             auto industryObj = ObjectManager::get<IndustryObject>(industry->objectId);
             auto skin = ObjectManager::get<InterfaceSkinObject>();
 
-            static const uint32_t productionTabIds[] = {
+            static constexpr uint32_t productionTabIds[] = {
                 widx::tab_production,
                 widx::tab_production_2,
             };
@@ -881,7 +881,7 @@ namespace OpenLoco::Ui::Windows::Industry
 
             // Transported Tab
             {
-                static const uint32_t transportedTabImageIds[] = {
+                static constexpr uint32_t transportedTabImageIds[] = {
                     InterfaceSkin::ImageIds::tab_transported_frame0,
                     InterfaceSkin::ImageIds::tab_transported_frame1,
                     InterfaceSkin::ImageIds::tab_transported_frame2,

--- a/src/OpenLoco/src/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Windows/KeyboardShortcuts.cpp
@@ -20,7 +20,7 @@ using namespace OpenLoco::Input;
 
 namespace OpenLoco::Ui::Windows::KeyboardShortcuts
 {
-    static const int kRowHeight = 10; // CJK: 13
+    static constexpr int kRowHeight = 10; // CJK: 13
 
     static constexpr Widget _widgets[] = {
         makeWidget({ 0, 0 }, { 360, 238 }, WidgetType::frame, WindowColour::primary),

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -99,7 +99,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
             // Options tab
             {
-                static const uint32_t optionTabImageIds[] = {
+                static constexpr uint32_t optionTabImageIds[] = {
                     InterfaceSkin::ImageIds::tab_cogs_frame0,
                     InterfaceSkin::ImageIds::tab_cogs_frame1,
                     InterfaceSkin::ImageIds::tab_cogs_frame2,
@@ -316,7 +316,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             }
         }
 
-        static const StringId generatorIds[] = {
+        static constexpr StringId generatorIds[] = {
             StringIds::generator_original,
             StringIds::generator_simplex,
             StringIds::generator_png_heightmap,
@@ -634,7 +634,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                 StringIds::hill_density);
         }
 
-        static const StringId landDistributionLabelIds[] = {
+        static constexpr StringId landDistributionLabelIds[] = {
             StringIds::land_distribution_everywhere,
             StringIds::land_distribution_nowhere,
             StringIds::land_distribution_far_from_water,
@@ -722,7 +722,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             }
         }
 
-        static const StringId topographyStyleIds[] = {
+        static constexpr StringId topographyStyleIds[] = {
             StringIds::flat_land,
             StringIds::small_hills,
             StringIds::mountains,
@@ -1318,7 +1318,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                 StringIds::max_town_size);
         }
 
-        static const StringId townSizeLabels[] = {
+        static constexpr StringId townSizeLabels[] = {
             StringIds::town_size_1,
             StringIds::town_size_2,
             StringIds::town_size_3,
@@ -1444,7 +1444,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                 StringIds::number_of_industries);
         }
 
-        static const StringId numIndustriesLabels[] = {
+        static constexpr StringId numIndustriesLabels[] = {
             StringIds::industry_size_low,
             StringIds::industry_size_medium,
             StringIds::industry_size_high,
@@ -1537,7 +1537,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             window->setWidgets(newWidgets);
             window->initScrollWidgets();
 
-            static const widx tabWidgetIdxByTabId[] = {
+            static constexpr widx tabWidgetIdxByTabId[] = {
                 tab_options,
                 tab_land,
                 tab_water,

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -1145,7 +1145,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
         {
             if (!(self->disabledWidgets & (1 << widx::tabVehicles)))
             {
-                static const uint32_t vehicleImageIds[] = {
+                static constexpr uint32_t vehicleImageIds[] = {
                     InterfaceSkin::ImageIds::vehicle_train_frame_0,
                     InterfaceSkin::ImageIds::vehicle_train_frame_1,
                     InterfaceSkin::ImageIds::vehicle_train_frame_2,
@@ -1188,7 +1188,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
         {
             if (!(self->disabledWidgets & (1 << widx::tabRoutes)))
             {
-                static const uint32_t routeImageIds[] = {
+                static constexpr uint32_t routeImageIds[] = {
                     InterfaceSkin::ImageIds::tab_routes_frame_0,
                     InterfaceSkin::ImageIds::tab_routes_frame_1,
                     InterfaceSkin::ImageIds::tab_routes_frame_2,
@@ -1220,7 +1220,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     // 0x0046D273
     static void drawGraphKeyOverall(Window* self, Gfx::DrawingContext& drawingCtx, uint16_t x, uint16_t& y)
     {
-        static const PaletteIndex_t overallColours[] = {
+        static constexpr PaletteIndex_t overallColours[] = {
             PaletteIndex::index_41,
             PaletteIndex::index_7D,
             PaletteIndex::index_0C,
@@ -1229,7 +1229,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             PaletteIndex::index_64,
         };
 
-        static const StringId lineNames[] = {
+        static constexpr StringId lineNames[] = {
             StringIds::map_key_towns,
             StringIds::map_key_industries,
             StringIds::map_key_roads,
@@ -1266,7 +1266,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x004FDD62
-    static const PaletteIndex_t vehicleTypeColours[] = {
+    static constexpr PaletteIndex_t vehicleTypeColours[] = {
         PaletteIndex::index_AD,
         PaletteIndex::index_67,
         PaletteIndex::index_A2,
@@ -1278,7 +1278,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     // 0x0046D379
     static void drawGraphKeyVehicles(Window* self, Gfx::DrawingContext& drawingCtx, uint16_t x, uint16_t& y)
     {
-        static const StringId lineNames[] = {
+        static constexpr StringId lineNames[] = {
             StringIds::forbid_trains,
             StringIds::forbid_buses,
             StringIds::forbid_trucks,
@@ -1439,7 +1439,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     // 0x0046D81F
     static void formatVehicleString(Window* self, FormatArguments& args)
     {
-        static const StringId vehicleStringSingular[] = {
+        static constexpr StringId vehicleStringSingular[] = {
             StringIds::num_trains_singular,
             StringIds::num_buses_singular,
             StringIds::num_trucks_singular,
@@ -1448,7 +1448,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             StringIds::num_ships_singular,
         };
 
-        static const StringId vehicleStringPlural[] = {
+        static constexpr StringId vehicleStringPlural[] = {
             StringIds::num_trains_plural,
             StringIds::num_buses_plural,
             StringIds::num_trucks_plural,

--- a/src/OpenLoco/src/Windows/Options.cpp
+++ b/src/OpenLoco/src/Windows/Options.cpp
@@ -1002,7 +1002,7 @@ namespace OpenLoco::Ui::Windows::Options
             }
 
             {
-                static const StringId playlist_string_ids[] = {
+                static constexpr StringId playlist_string_ids[] = {
                     StringIds::play_only_music_from_current_era,
                     StringIds::play_all_music,
                     StringIds::play_custom_music_selection,

--- a/src/OpenLoco/src/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioOptions.cpp
@@ -71,7 +71,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
             // Challenge tab
             {
-                static const uint32_t challengeTabImageIds[] = {
+                static constexpr uint32_t challengeTabImageIds[] = {
                     InterfaceSkin::ImageIds::tab_cup_frame0,
                     InterfaceSkin::ImageIds::tab_cup_frame1,
                     InterfaceSkin::ImageIds::tab_cup_frame2,
@@ -107,7 +107,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
             // Finances tab
             {
-                static const uint32_t financesTabImageIds[] = {
+                static constexpr uint32_t financesTabImageIds[] = {
                     InterfaceSkin::ImageIds::tab_finances_frame0,
                     InterfaceSkin::ImageIds::tab_finances_frame1,
                     InterfaceSkin::ImageIds::tab_finances_frame2,
@@ -205,7 +205,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             tr.drawStringLeftWrapped(point, window.width - 10, Colour::black, StringIds::challenge_value, args);
         }
 
-        static const StringId objectiveTypeLabelIds[] = {
+        static constexpr StringId objectiveTypeLabelIds[] = {
             StringIds::objective_achieve_a_certain_company_value,
             StringIds::objective_achieve_a_certain_monthly_profit_from_vehicles,
             StringIds::objective_achieve_a_certain_performance_index,

--- a/src/OpenLoco/src/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Windows/StationWindow.cpp
@@ -960,7 +960,7 @@ namespace OpenLoco::Ui::Windows::Station
 
             // Cargo tab
             {
-                static const uint32_t cargoTabImageIds[] = {
+                static constexpr uint32_t cargoTabImageIds[] = {
                     InterfaceSkin::ImageIds::tab_cargo_delivered_frame0,
                     InterfaceSkin::ImageIds::tab_cargo_delivered_frame1,
                     InterfaceSkin::ImageIds::tab_cargo_delivered_frame2,

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -141,7 +141,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // TODO: use same list as top toolbar
-    static const uint32_t map_sprites_by_rotation[] = {
+    static constexpr uint32_t map_sprites_by_rotation[] = {
         InterfaceSkin::ImageIds::toolbar_menu_map_north,
         InterfaceSkin::ImageIds::toolbar_menu_map_west,
         InterfaceSkin::ImageIds::toolbar_menu_map_south,

--- a/src/OpenLoco/src/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Windows/ToolbarTop.cpp
@@ -795,7 +795,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             uint32_t x = window.widgets[Common::Widx::vehicles_menu].left + window.x;
             uint32_t y = window.widgets[Common::Widx::vehicles_menu].top + window.y;
 
-            static const uint32_t button_face_image_ids[] = {
+            static constexpr uint32_t button_face_image_ids[] = {
                 InterfaceSkin::ImageIds::vehicle_train_frame_0,
                 InterfaceSkin::ImageIds::vehicle_buses_frame_0,
                 InterfaceSkin::ImageIds::vehicle_trucks_frame_0,
@@ -825,7 +825,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             uint32_t x = window.widgets[Common::Widx::build_vehicles_menu].left + window.x;
             uint32_t y = window.widgets[Common::Widx::build_vehicles_menu].top + window.y;
 
-            static const uint32_t build_vehicle_images[] = {
+            static constexpr uint32_t build_vehicle_images[] = {
                 InterfaceSkin::ImageIds::toolbar_build_vehicle_train,
                 InterfaceSkin::ImageIds::toolbar_build_vehicle_bus,
                 InterfaceSkin::ImageIds::toolbar_build_vehicle_truck,

--- a/src/OpenLoco/src/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Windows/TownList.cpp
@@ -1550,7 +1550,7 @@ namespace OpenLoco::Ui::Windows::TownList
 
             // Build New Towns Tab
             {
-                static const uint32_t buildNewTownsImageIds[] = {
+                static constexpr uint32_t buildNewTownsImageIds[] = {
                     InterfaceSkin::ImageIds::build_town_frame_0,
                     InterfaceSkin::ImageIds::build_town_frame_1,
                     InterfaceSkin::ImageIds::build_town_frame_2,
@@ -1579,7 +1579,7 @@ namespace OpenLoco::Ui::Windows::TownList
 
             // Build New Buildings Tab
             {
-                static const uint32_t buildBuildingsImageIds[] = {
+                static constexpr uint32_t buildBuildingsImageIds[] = {
                     InterfaceSkin::ImageIds::build_buildings_frame_0,
                     InterfaceSkin::ImageIds::build_buildings_frame_1,
                     InterfaceSkin::ImageIds::build_buildings_frame_2,
@@ -1608,7 +1608,7 @@ namespace OpenLoco::Ui::Windows::TownList
 
             // Build New Misc Buildings Tab
             {
-                static const uint32_t buildMiscBuildingsImageIds[] = {
+                static constexpr uint32_t buildMiscBuildingsImageIds[] = {
                     InterfaceSkin::ImageIds::build_misc_buildings_frame_0,
                     InterfaceSkin::ImageIds::build_misc_buildings_frame_1,
                     InterfaceSkin::ImageIds::build_misc_buildings_frame_2,

--- a/src/OpenLoco/src/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Windows/TownWindow.cpp
@@ -753,7 +753,7 @@ namespace OpenLoco::Ui::Windows::Town
 
             // Population tab
             {
-                static const uint32_t populationTabImageIds[] = {
+                static constexpr uint32_t populationTabImageIds[] = {
                     InterfaceSkin::ImageIds::tab_population_frame0,
                     InterfaceSkin::ImageIds::tab_population_frame1,
                     InterfaceSkin::ImageIds::tab_population_frame2,
@@ -775,7 +775,7 @@ namespace OpenLoco::Ui::Windows::Town
 
             // Company ratings tab
             {
-                static const uint32_t ratingsTabImageIds[] = {
+                static constexpr uint32_t ratingsTabImageIds[] = {
                     InterfaceSkin::ImageIds::tab_ratings_frame0,
                     InterfaceSkin::ImageIds::tab_ratings_frame1,
                     InterfaceSkin::ImageIds::tab_ratings_frame2,

--- a/src/OpenLoco/src/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Windows/Vehicle.cpp
@@ -371,7 +371,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
         }
 
-        static const uint16_t rowHeights[vehicleTypeCount] = {
+        static constexpr uint16_t rowHeights[vehicleTypeCount] = {
             22,
             22,
             22,
@@ -677,7 +677,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 return;
             }
 
-            static const std::pair<StringId, VehicleChangeRunningModeArgs::Mode> itemToGameCommandInfo[3] = {
+            static constexpr std::pair<StringId, VehicleChangeRunningModeArgs::Mode> itemToGameCommandInfo[3] = {
                 { StringIds::cant_stop_string_id, VehicleChangeRunningModeArgs::Mode::stopVehicle },
                 { StringIds::cant_start_string_id, VehicleChangeRunningModeArgs::Mode::startVehicle },
                 { StringIds::cant_select_manual_mode_string_id, VehicleChangeRunningModeArgs::Mode::driveManually },

--- a/src/OpenLoco/src/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Windows/VehicleList.cpp
@@ -105,7 +105,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         transportingCargo,
     };
 
-    static const uint8_t row_heights[] = {
+    static constexpr uint8_t row_heights[] = {
         28,
         28,
         28,

--- a/src/OpenLoco/src/World/StationManager.cpp
+++ b/src/OpenLoco/src/World/StationManager.cpp
@@ -346,7 +346,7 @@ namespace OpenLoco::StationManager
         }
 
         // Additional names to try
-        static const std::pair<const StationName, const StringId> additionalNamePairs[] = {
+        static constexpr std::pair<const StationName, const StringId> additionalNamePairs[] = {
             { StationName::townTransfer, StringIds::station_town_transfer },
             { StationName::townHalt, StringIds::station_town_halt },
             { StationName::townAnnexe, StringIds::station_town_annexe },
@@ -364,7 +364,7 @@ namespace OpenLoco::StationManager
         }
 
         // Ordinal names to try
-        static const std::pair<const StationName, const StringId> ordinalNamePairs[] = {
+        static constexpr std::pair<const StationName, const StringId> ordinalNamePairs[] = {
             { StationName::townOrd1, StringIds::station_town_ord_1 },
             { StationName::townOrd2, StringIds::station_town_ord_2 },
             { StationName::townOrd3, StringIds::station_town_ord_3 },


### PR DESCRIPTION
While this doesn't matter that much for release builds it has some impact for debug builds as the compiler will be forced to evaluate the expression where without constexpr we would have static initializers. Also its generally good practice to have things like in this PR being constexpr.