### PR TITLE
Implement mark only loaded

### DIFF
--- a/src/OpenLoco/src/Objects/ObjectIndex.cpp
+++ b/src/OpenLoco/src/Objects/ObjectIndex.cpp
@@ -954,6 +954,8 @@ namespace OpenLoco::ObjectManager
         auto ptr = (std::byte*)_installedObjectList;
         for (ObjectIndexId i = 0; i < _installedObjectCount; i++)
         {
+            objectFlags[i] &= ~(SelectedObjectsFlags::inUse | SelectedObjectsFlags::selected);
+
             auto entry = ObjectIndexEntry::read(&ptr);
 
             auto objHandle = findObjectHandle(*entry._header);

--- a/src/OpenLoco/src/Objects/ObjectIndex.cpp
+++ b/src/OpenLoco/src/Objects/ObjectIndex.cpp
@@ -949,6 +949,30 @@ namespace OpenLoco::ObjectManager
         });
     }
 
+    static void applyLoadedObjectMarkToIndex(std::span<SelectedObjectsFlags> objectFlags, const std::array<std::span<uint8_t>, kMaxObjectTypes>& loadedObjectFlags)
+    {
+        auto ptr = (std::byte*)_installedObjectList;
+        for (ObjectIndexId i = 0; i < _installedObjectCount; i++)
+        {
+            auto entry = ObjectIndexEntry::read(&ptr);
+
+            auto objHandle = findObjectHandle(*entry._header);
+            if (!objHandle.has_value())
+            {
+                continue;
+            }
+            const auto loadedFlags = loadedObjectFlags[enumValue(objHandle->type)][objHandle->id];
+            if (loadedFlags & (1 << 0))
+            {
+                objectFlags[i] |= SelectedObjectsFlags::selected | SelectedObjectsFlags::inUse;
+            }
+            if (loadedFlags & (1 << 1))
+            {
+                objectFlags[i] |= SelectedObjectsFlags::selected;
+            }
+        }
+    }
+
     // 0x00472D3F
     static void markInUseObjects(std::span<SelectedObjectsFlags> objectFlags)
     {
@@ -975,26 +999,7 @@ namespace OpenLoco::ObjectManager
         markInUseCompetitorObjects(loadedObjectFlags[enumValue(ObjectType::competitor)]);
 
         // Copy results over to objectFlags
-        auto ptr = (std::byte*)_installedObjectList;
-        for (ObjectIndexId i = 0; i < _installedObjectCount; i++)
-        {
-            auto entry = ObjectIndexEntry::read(&ptr);
-
-            auto objHandle = findObjectHandle(*entry._header);
-            if (!objHandle.has_value())
-            {
-                continue;
-            }
-            const auto loadedFlags = loadedObjectFlags[enumValue(objHandle->type)][objHandle->id];
-            if (loadedFlags & (1 << 0))
-            {
-                objectFlags[i] |= SelectedObjectsFlags::selected | SelectedObjectsFlags::inUse;
-            }
-            if (loadedFlags & (1 << 1))
-            {
-                objectFlags[i] |= SelectedObjectsFlags::selected;
-            }
-        }
+        applyLoadedObjectMarkToIndex(objectFlags, loadedObjectFlags);
     }
 
     // 0x00472CFD
@@ -1062,6 +1067,25 @@ namespace OpenLoco::ObjectManager
             delete[] _50D144;
             _50D144 = nullptr;
         }
+    }
+
+    // 0x004BF935
+    void markOnlyLoadedObjects(std::span<SelectedObjectsFlags> objectFlags)
+    {
+        std::array<uint8_t, kMaxObjects> allLoadedObjectFlags{};
+        std::array<std::span<uint8_t>, kMaxObjectTypes> loadedObjectFlags;
+        auto count = 0;
+        for (uint8_t i = 0; i < kMaxObjectTypes; ++i)
+        {
+            const auto type = static_cast<ObjectType>(i);
+            loadedObjectFlags[i] = std::span<uint8_t>(allLoadedObjectFlags.begin() + count, getMaxObjects(type));
+            count += getMaxObjects(type);
+        }
+
+        markLoadedObjects(loadedObjectFlags);
+
+        // Copy results over to objectFlags
+        applyLoadedObjectMarkToIndex(objectFlags, loadedObjectFlags);
     }
 
     // 0x00474874

--- a/src/OpenLoco/src/Objects/ObjectIndex.h
+++ b/src/OpenLoco/src/Objects/ObjectIndex.h
@@ -76,6 +76,7 @@ namespace OpenLoco::ObjectManager
     bool selectObjectFromIndex(SelectObjectModes mode, const ObjectHeader& objHeader, std::span<SelectedObjectsFlags> objectFlags, ObjectSelectionMeta& selectionMetaData);
     void prepareSelectionList(bool markInUse);
     void freeSelectionList();
+    void markOnlyLoadedObjects(std::span<SelectedObjectsFlags> objectFlags);
     void loadSelectionListObjects(std::span<SelectedObjectsFlags> objectFlags);
     void unloadUnselectedSelectionListObjects(std::span<SelectedObjectsFlags> objectFlags);
     std::optional<ObjectType> validateObjectSelection(std::span<SelectedObjectsFlags> objectFlags);

--- a/src/OpenLoco/src/Windows/Options.cpp
+++ b/src/OpenLoco/src/Windows/Options.cpp
@@ -35,7 +35,6 @@ namespace OpenLoco::Ui::Windows::Options
     static void tabOnMouseUp(Window* w, WidgetIndex_t wi);
     static void sub_4C13BE(Window* w);
     static void setPreferredCurrencyNameBuffer();
-    static void sub_4BF935();
 
     static loco_global<uint32_t, 0x0050D430> _songProgress;
     static loco_global<int8_t, 0x0050D434> _currentSong;
@@ -1656,7 +1655,7 @@ namespace OpenLoco::Ui::Windows::Options
                     ObjectManager::load(*object.second._header);
                     ObjectManager::reloadAll();
                     Gfx::loadCurrency();
-                    sub_4BF935();
+                    ObjectManager::markOnlyLoadedObjects(selectedObjectFlags);
 
                     break;
                 }
@@ -1703,7 +1702,7 @@ namespace OpenLoco::Ui::Windows::Options
                     setPreferredCurrencyNameBuffer();
                     Config::write();
                     Scenario::loadPreferredCurrencyAlways();
-                    sub_4BF935();
+                    ObjectManager::markOnlyLoadedObjects(getLoadedSelectedObjectFlags());
 
                     break;
                 }
@@ -1730,7 +1729,7 @@ namespace OpenLoco::Ui::Windows::Options
             Config::write();
 
             Scenario::loadPreferredCurrencyAlways();
-            sub_4BF935();
+            ObjectManager::markOnlyLoadedObjects(getLoadedSelectedObjectFlags());
 
             w->invalidate();
         }
@@ -2739,13 +2738,7 @@ namespace OpenLoco::Ui::Windows::Options
         // TODO: reimplement nullptr check?
 
         __11364A0 = ptr;
-        sub_4BF935();
-    }
-
-    static void sub_4BF935()
-    {
-        // TODO: implement simplified ObjectManager::markInUseObjects that doesn't do the inUse part only the loaded part
-        call(0x004BF935);
+        ObjectManager::markOnlyLoadedObjects(getLoadedSelectedObjectFlags());
     }
 
     static void sub_4C13BE(Window* w)


### PR DESCRIPTION
i had held off doing this function as its a bit of silly function. We should just not do things like this and use a more sensible structure but decided its best to just implement it for now and rework object selection a later day.