### PR TITLE
Remove dead code calls

### DIFF
--- a/src/OpenLoco/src/Graphics/Gfx.cpp
+++ b/src/OpenLoco/src/Graphics/Gfx.cpp
@@ -205,16 +205,9 @@ namespace OpenLoco::Gfx
         // Vanilla setup scrolling text related globals here (unused)
     }
 
-    // 0x00452336
-    static void initialiseNoiseMaskMap()
-    {
-        call(0x00452336);
-    }
-
     void initialise()
     {
         initialiseCharacterWidths();
-        initialiseNoiseMaskMap();
 
         loadDefaultPalette();
 

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -168,11 +168,6 @@ namespace OpenLoco
         call(0x004058F5);
     }
 
-    static void sub_4062E0()
-    {
-        call(0x004062E0); // getTime unused Dead code
-    }
-
     static bool sub_4034FC(int32_t& a, int32_t& b)
     {
         auto result = ((int32_t(*)(int32_t&, int32_t&))(0x004034FC))(a, b);
@@ -281,7 +276,6 @@ namespace OpenLoco
 
         std::srand(std::time(nullptr));
         addr<0x0050C18C, int32_t>() = addr<0x00525348, int32_t>();
-        call(0x004078BE); // getSystemTime unused dead code?
 
         World::TileManager::allocateMapElements();
         Environment::resolvePaths();
@@ -298,7 +292,6 @@ namespace OpenLoco
         Gui::init();
 
         MessageManager::reset();
-        call(0x004969DA); // getLocalTime not used (dead code?)
         Scenario::reset();
 
         setScreenFlag(ScreenFlags::initialised);
@@ -760,7 +753,6 @@ namespace OpenLoco
                 VehicleManager::updateDaily();
                 IndustryManager::updateDaily();
                 MessageManager::updateDaily();
-                call(0x004969DA); // nop this sets the real time not used
                 WindowManager::updateDaily();
 
                 auto yesterday = calcDate(getCurrentDay() - 1);
@@ -916,7 +908,6 @@ namespace OpenLoco
             {
                 sub_4058F5();
             }
-            sub_4062E0();
             update();
         }
         sub_40567E();

--- a/src/OpenLoco/src/Ui/ProgressBar.cpp
+++ b/src/OpenLoco/src/Ui/ProgressBar.cpp
@@ -12,7 +12,6 @@ namespace OpenLoco::Ui::ProgressBar
 {
     static bool _isInternalWindow = false;
 
-
     void begin(std::string_view caption)
     {
         if (isInitialised())

--- a/src/OpenLoco/src/Ui/ProgressBar.cpp
+++ b/src/OpenLoco/src/Ui/ProgressBar.cpp
@@ -12,17 +12,6 @@ namespace OpenLoco::Ui::ProgressBar
 {
     static bool _isInternalWindow = false;
 
-    // 0x004CF5DA
-    static void loadingWindowCreate(std::string_view caption)
-    {
-        // TODO: platform-specific implementation?
-        static loco_global<char[512], 0x0112CC04> _stringFormatBuffer;
-        memset(_stringFormatBuffer, 0, 512);
-        caption.copy(_stringFormatBuffer, caption.size());
-
-        registers regs;
-        call(0x004CF5EE, regs);
-    }
 
     void begin(std::string_view caption)
     {
@@ -33,7 +22,8 @@ namespace OpenLoco::Ui::ProgressBar
         }
         else
         {
-            loadingWindowCreate(caption);
+            // Used to be the native progress bar
+            assert(false);
         }
     }
 
@@ -49,15 +39,6 @@ namespace OpenLoco::Ui::ProgressBar
         begin(_captionBuffer);
     }
 
-    // 0x004CF631
-    // TODO: platform-specific implementation?
-    static void updateLoadingWindow(uint8_t value)
-    {
-        registers regs;
-        regs.eax = value;
-        call(0x004CF631, regs);
-    }
-
     // 0x004CF621
     // eax: value
     void setProgress(int32_t value)
@@ -68,15 +49,9 @@ namespace OpenLoco::Ui::ProgressBar
         }
         else
         {
-            updateLoadingWindow(value);
+            // Used to be the native progress bar
+            assert(false);
         }
-    }
-
-    // 0x00408163
-    // TODO: platform-specific implementation?
-    static void destroyLoadingWindow()
-    {
-        call(0x00408163);
     }
 
     // 0x004CF60B
@@ -88,7 +63,8 @@ namespace OpenLoco::Ui::ProgressBar
         }
         else
         {
-            destroyLoadingWindow();
+            // Used to be the native progress bar
+            assert(false);
         }
     }
 


### PR DESCRIPTION
A little cleanup operation.
Removes all the dead time code.
Removes the dead progress bar code.
Removes the dead noise mask map code.