### PR TITLE
Bump vcpkg pin to v2024.07.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: lukka/run-vcpkg@v11.4
         with:
           vcpkgDirectory: '${{ github.workspace }}/vcpkg'
-          vcpkgGitCommitId: a34c873a9717a888f58dc05268dea15592c2f0ff
+          vcpkgGitCommitId: 1de2026f28ead93ff1773e6e680387643e914ea1
       - name: Build OpenLoco
         shell: cmd
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (WIN32)
         endif ()
         FetchContent_Declare(vcpkg
             GIT_REPOSITORY https://github.com/microsoft/vcpkg.git
-            GIT_TAG a34c873a9717a888f58dc05268dea15592c2f0ff)
+            GIT_TAG 1de2026f28ead93ff1773e6e680387643e914ea1)
         FetchContent_MakeAvailable(vcpkg)
 
         set(CMAKE_TOOLCHAIN_FILE "${vcpkg_SOURCE_DIR}/scripts/buildsystems/vcpkg.cmake"


### PR DESCRIPTION
This bumps vcpkg from [2024.03.25](https://github.com/microsoft/vcpkg/releases/tag/2024.03.25) to [2024.07.12](https://github.com/microsoft/vcpkg/releases/tag/2024.07.12).

~~Hopefully helps with #2514.~~