### PR TITLE
Integrate window loco_globals

### DIFF
--- a/src/OpenLoco/src/Windows/AboutMusic.cpp
+++ b/src/OpenLoco/src/Windows/AboutMusic.cpp
@@ -9,9 +9,6 @@
 #include "Objects/ObjectManager.h"
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::AboutMusic
 {

--- a/src/OpenLoco/src/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Windows/CompanyFaceSelection.cpp
@@ -27,7 +27,6 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
 {
     static loco_global<CompanyId, 0x9C68F2> _9C68F2; // Use in a game command??
     static loco_global<uint16_t, 0x112C1C1> _numberCompetitorObjects;
-    static loco_global<int32_t, 0x0113E72C> _cursorX;
 
     static WindowType _callingWindowType;
 
@@ -174,7 +173,9 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
             return;
         }
         self.invalidate();
-        Audio::playSound(Audio::SoundId::clickDown, _cursorX);
+
+        auto mousePos = Input::getMouseLocation();
+        Audio::playSound(Audio::SoundId::clickDown, mousePos.x);
 
         if (_callingWindowType == WindowType::company)
         {

--- a/src/OpenLoco/src/Windows/Error.cpp
+++ b/src/OpenLoco/src/Windows/Error.cpp
@@ -3,6 +3,7 @@
 #include "Graphics/ImageIds.h"
 #include "Graphics/SoftwareDrawingEngine.h"
 #include "Graphics/TextRenderer.h"
+#include "Input.h"
 #include "Localisation/FormatArguments.hpp"
 #include "Localisation/Formatting.h"
 #include "Localisation/StringManager.h"
@@ -20,11 +21,10 @@ using namespace OpenLoco::Interop;
 namespace OpenLoco::Ui::Windows::Error
 {
     static loco_global<bool, 0x00508F09> _suppressErrorSound;
-    static loco_global<char[512], 0x009C64B3> _errorText;
-    static loco_global<uint16_t, 0x009C66B3> _linebreakCount;
-    static loco_global<CompanyId, 0x009C68EC> _errorCompetitorId;
-    static loco_global<int32_t, 0x0113E72C> _cursorX;
-    static loco_global<int32_t, 0x0113E730> _cursorY;
+
+    static char _errorText[512];         // 0x009C64B3
+    static uint16_t _linebreakCount;     // 0x009C66B3
+    static CompanyId _errorCompetitorId; // 0x009C68EC
 
     namespace Common
     {
@@ -127,8 +127,9 @@ namespace OpenLoco::Ui::Windows::Error
 
             int x, y;
 
+            auto mousePos = Input::getMouseLocation();
             int maxY = Ui::height() - height;
-            y = _cursorY + 26; // Normally, we'd display the tooltip 26 lower
+            y = mousePos.y + 26; // Normally, we'd display the tooltip 26 lower
             if (y > maxY)
             {
                 // If y is too large, the tooltip could be forced below the cursor if we'd just clamped y,
@@ -137,7 +138,7 @@ namespace OpenLoco::Ui::Windows::Error
             }
             y = std::clamp(y, 22, maxY);
 
-            x = std::clamp(_cursorX - (width / 2), 0, Ui::width() - width);
+            x = std::clamp(mousePos.x - (width / 2), 0, Ui::width() - width);
 
             Ui::Size windowSize = { width, height };
 

--- a/src/OpenLoco/src/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Windows/IndustryList.cpp
@@ -29,20 +29,17 @@
 #include "Ui/WindowManager.h"
 #include "World/IndustryManager.h"
 #include <OpenLoco/Engine/World.hpp>
-#include <OpenLoco/Interop/Interop.hpp>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::IndustryList
 {
-    static loco_global<currency32_t, 0x00E0C39C> _dword_E0C39C;
-    static loco_global<bool, 0x00E0C3D9> _industryGhostPlaced;
-    static loco_global<World::Pos2, 0x00E0C3C2> _industryGhostPos;
-    static loco_global<IndustryId, 0x00E0C3C9> _industryLastPlacedId;
-    static loco_global<uint8_t, 0x00E0C3DA> _industryGhostType;
-    static loco_global<IndustryId, 0x00E0C3DB> _industryGhostId;
-    static loco_global<uint32_t, 0x00E0C394> _dword_E0C394;
-    static loco_global<uint32_t, 0x00E0C398> _dword_E0C398;
+    static currency32_t _dword_E0C39C;       // 0x00E0C39C
+    static bool _industryGhostPlaced;        // 0x00E0C3D9
+    static World::Pos2 _industryGhostPos;    // 0x00E0C3C2
+    static IndustryId _industryLastPlacedId; // 0x00E0C3C9
+    static uint8_t _industryGhostType;       // 0x00E0C3DA
+    static IndustryId _industryGhostId;      // 0x00E0C3DB
+    static uint32_t _dword_E0C394;           // 0x00E0C394
+    static uint32_t _dword_E0C398;           // 0x00E0C398
 
     namespace Common
     {
@@ -1126,7 +1123,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
             if (_industryGhostPlaced)
             {
-                if (*_industryGhostPos == placementArgs->pos && _industryGhostType == placementArgs->type)
+                if (_industryGhostPos == placementArgs->pos && _industryGhostType == placementArgs->type)
                 {
                     return;
                 }

--- a/src/OpenLoco/src/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Windows/IndustryList.cpp
@@ -38,8 +38,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
     static IndustryId _industryLastPlacedId; // 0x00E0C3C9
     static uint8_t _industryGhostType;       // 0x00E0C3DA
     static IndustryId _industryGhostId;      // 0x00E0C3DB
-    static uint32_t _dword_E0C394;           // 0x00E0C394
-    static uint32_t _dword_E0C398;           // 0x00E0C398
+    static Core::Prng _placementPrng;        // 0x00E0C394
 
     namespace Common
     {
@@ -1092,8 +1091,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
             GameCommands::IndustryPlacementArgs args;
             args.pos = *pos;
             args.type = industryListWnd->rowHover; // dl
-            args.srand0 = _dword_E0C394;
-            args.srand1 = _dword_E0C398;
+            args.srand0 = _placementPrng.srand_0();
+            args.srand1 = _placementPrng.srand_1();
             if (isEditorMode())
             {
                 args.buildImmediately = true; // bh
@@ -1153,8 +1152,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
             }
 
             gPrng2().randNext();
-            _dword_E0C394 = gPrng2().srand_0();
-            _dword_E0C398 = gPrng2().srand_1();
+            _placementPrng = gPrng2();
         }
 
         // 0x004585AD
@@ -1263,8 +1261,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
             updateBuildableIndustries(self);
 
             gPrng2().randNext();
-            _dword_E0C394 = gPrng2().srand_0();
-            _dword_E0C398 = gPrng2().srand_1();
+            _placementPrng = gPrng2();
         }
 
         // 0x004589E8

--- a/src/OpenLoco/src/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Windows/IndustryWindow.cpp
@@ -25,9 +25,7 @@
 #include "World/CompanyManager.h"
 #include "World/IndustryManager.h"
 #include <OpenLoco/Engine/World.hpp>
-#include <OpenLoco/Interop/Interop.hpp>
 
-using namespace OpenLoco::Interop;
 using namespace OpenLoco::GameCommands;
 
 namespace OpenLoco::Ui::Windows::Industry

--- a/src/OpenLoco/src/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Windows/KeyboardShortcuts.cpp
@@ -11,11 +11,9 @@
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
 #include <OpenLoco/Engine/Input/ShortcutManager.h>
-#include <OpenLoco/Interop/Interop.hpp>
 #include <SDL2/SDL.h>
 #include <unordered_map>
 
-using namespace OpenLoco::Interop;
 using namespace OpenLoco::Input;
 
 namespace OpenLoco::Ui::Windows::KeyboardShortcuts

--- a/src/OpenLoco/src/Windows/LandscapeGenerationConfirm.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGenerationConfirm.cpp
@@ -10,9 +10,6 @@
 #include "Scenario.h"
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::LandscapeGenerationConfirm
 {

--- a/src/OpenLoco/src/Windows/Main.cpp
+++ b/src/OpenLoco/src/Windows/Main.cpp
@@ -4,9 +4,6 @@
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
 #include "ViewportManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::Main
 {

--- a/src/OpenLoco/src/Windows/MapToolTip.cpp
+++ b/src/OpenLoco/src/Windows/MapToolTip.cpp
@@ -10,14 +10,11 @@
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
 #include "World/CompanyManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::MapToolTip
 {
-    static loco_global<CompanyId, 0x0050A040> _mapTooltipOwner;
-    static loco_global<uint16_t, 0x00523348> _mapTooltipTimeout;
+    static CompanyId _mapTooltipOwner;  // 0x0050A040
+    static uint16_t _mapTooltipTimeout; // 0x00523348
 
     enum widx
     {

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -41,17 +41,12 @@
 #include "World/StationManager.h"
 #include "World/TownManager.h"
 #include <OpenLoco/Core/Numerics.hpp>
-#include <OpenLoco/Interop/Interop.hpp>
 
-using namespace OpenLoco::Interop;
 using namespace OpenLoco::Ui::WindowManager;
 using namespace OpenLoco::World;
 
 namespace OpenLoco::Ui::Windows::MapWindow
 {
-    static loco_global<int32_t, 0x00523338> _cursorX2;
-    static loco_global<int32_t, 0x0052333C> _cursorY2;
-
     static constexpr int16_t kRenderedMapWidth = kMapColumns * 2;
     static constexpr int16_t kRenderedMapHeight = kRenderedMapWidth;
     static constexpr int32_t kRenderedMapSize = kRenderedMapWidth * kRenderedMapHeight;
@@ -64,28 +59,27 @@ namespace OpenLoco::Ui::Windows::MapWindow
         { -8, kMapRows },
     } };
 
-    static loco_global<uint8_t[256], 0x004FDC5C> _flashColours; // can be integrated (all 0x0A, except 0x15 at indices (11-14))
-    static loco_global<uint32_t, 0x00F253A4> _flashingItems;
+    static constexpr std::array<PaletteIndex_t, 256> kFlashColours = []() {
+        std::array<PaletteIndex_t, 256> colours;
+
+        std::fill(colours.begin(), colours.end(), PaletteIndex::index_0A);
+        std::fill(&colours[11], &colours[15], PaletteIndex::index_15);
+
+        return colours;
+    }(); // 0x004FDC5C
 
     static PaletteIndex_t* _mapPixels; // 0x00F253A8
     static PaletteIndex_t* _mapAltPixels;
 
-    static loco_global<uint32_t, 0x00F253AC> _drawMapRowIndex;
-    static std::array<uint16_t, 6> _vehicleTypeCounts = {
-        {
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        }
-    };
-    static loco_global<uint8_t[16], 0x00F253CE> _assignedIndustryColours;
-    static loco_global<uint8_t[19], 0x00F253DF> _routeToObjectIdMap;
-    static loco_global<uint8_t[19], 0x00F253F2> _routeColours;
-    static loco_global<uint8_t[8], 0x00F25404> _trackColours;
-    static loco_global<uint8_t[8], 0x00F2540C> _roadColours;
+    static std::array<uint16_t, 6> _vehicleTypeCounts = {};
+
+    static uint32_t _flashingItems;              // 0x00F253A4
+    static uint32_t _drawMapRowIndex;            // 0x00F253AC
+    static uint8_t _assignedIndustryColours[16]; // 0x00F253CE
+    static uint8_t _routeToObjectIdMap[19];      // 0x00F253DF
+    static uint8_t _routeColours[19];            // 0x00F253F2
+    static uint8_t _trackColours[8];             // 0x00F25404
+    static uint8_t _roadColours[8];              // 0x00F2540C
 
     enum widx
     {
@@ -285,7 +279,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                                 colour0 = colourFlash0 = PaletteIndex::index_0C;
                                 if (_flashingItems & (1 << 2))
                                 {
-                                    colourFlash0 = _flashColours[colourFlash0];
+                                    colourFlash0 = kFlashColours[colourFlash0];
                                 }
                             }
                             else
@@ -293,7 +287,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                                 colour0 = colourFlash0 = PaletteIndex::index_11;
                                 if (_flashingItems & (1 << 3))
                                 {
-                                    colourFlash0 = _flashColours[colourFlash0];
+                                    colourFlash0 = kFlashColours[colourFlash0];
                                 }
                             }
 
@@ -308,7 +302,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                             colour0 = colourFlash0 = PaletteIndex::index_BA;
                             if (_flashingItems & (1 << 4))
                             {
-                                colourFlash0 = _flashColours[colourFlash0];
+                                colourFlash0 = kFlashColours[colourFlash0];
                             }
                             colourFlash1 = colourFlash0;
                             colour1 = colour0;
@@ -324,7 +318,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                             colour0 = colourFlash0 = PaletteIndex::index_41;
                             if (_flashingItems & (1 << 0))
                             {
-                                colourFlash0 = _flashColours[colourFlash0];
+                                colourFlash0 = kFlashColours[colourFlash0];
                             }
                             colourFlash1 = colourFlash0;
                             colour1 = colour0;
@@ -358,7 +352,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                                 colour0 = colourFlash0 = PaletteIndex::index_11;
                                 if (_flashingItems & (1 << 3))
                                 {
-                                    colourFlash0 = _flashColours[colourFlash0];
+                                    colourFlash0 = kFlashColours[colourFlash0];
                                 }
                             }
                             else
@@ -366,7 +360,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                                 colour0 = colourFlash0 = PaletteIndex::index_0C;
                                 if (_flashingItems & (1 << 2))
                                 {
-                                    colourFlash0 = _flashColours[colourFlash0];
+                                    colourFlash0 = kFlashColours[colourFlash0];
                                 }
                             }
 
@@ -381,7 +375,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                             colour0 = colourFlash0 = PaletteIndex::index_7D;
                             if (_flashingItems & (1 << 1))
                             {
-                                colourFlash0 = _flashColours[colourFlash0];
+                                colourFlash0 = kFlashColours[colourFlash0];
                             }
                             colourFlash1 = colourFlash0;
                             colour1 = colour0;
@@ -684,7 +678,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                         {
                             if (_routeToObjectIdMap[firstFlashable] == colourFlash0)
                             {
-                                colourFlash0 = _flashColours[colourFlash0];
+                                colourFlash0 = kFlashColours[colourFlash0];
                             }
                         }
 
@@ -717,7 +711,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                         {
                             if (_routeToObjectIdMap[firstFlashable] == (roadEl->roadObjectId() | (1 << 7)))
                             {
-                                colourFlash0 = _flashColours[colourFlash0];
+                                colourFlash0 = kFlashColours[colourFlash0];
                             }
                         }
 
@@ -818,7 +812,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                             colourFlash1 = colourFlash0 = colour1 = colour0 = Colours::getShade(companyColour, 5);
                             if (_flashingItems & (1 << enumValue(owner)))
                             {
-                                colourFlash1 = colourFlash0 = _flashColours[colour0];
+                                colourFlash1 = colourFlash0 = kFlashColours[colour0];
                             }
                             break;
                         }
@@ -1678,7 +1672,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 {
                     if (mapFrameNumber & (1 << 2))
                     {
-                        colour = _flashColours[colour];
+                        colour = kFlashColours[colour];
                     }
                 }
             }
@@ -1693,7 +1687,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 {
                     if (mapFrameNumber & (1 << 2))
                     {
-                        colour = _flashColours[colour];
+                        colour = kFlashColours[colour];
                     }
                 }
             }
@@ -1756,7 +1750,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             {
                 if (!(mapFrameNumber & (1 << 2)))
                 {
-                    colour = _flashColours[colour];
+                    colour = kFlashColours[colour];
                 }
             }
         }

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -63,7 +63,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
         std::array<PaletteIndex_t, 256> colours;
 
         std::fill(colours.begin(), colours.end(), PaletteIndex::index_0A);
-        std::fill(&colours[11], &colours[15], PaletteIndex::index_15);
+        std::fill(colours.begin() + 11, colours.begin() + 15, PaletteIndex::index_15);
 
         return colours;
     }(); // 0x004FDC5C

--- a/src/OpenLoco/src/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Windows/MessageWindow.cpp
@@ -23,9 +23,6 @@
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
 #include "World/CompanyManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::MessageWindow
 {

--- a/src/OpenLoco/src/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/src/Windows/MusicSelection.cpp
@@ -11,9 +11,6 @@
 #include "OpenLoco.h"
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::MusicSelection
 {

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -50,12 +50,10 @@
 #include "World/CompanyManager.h"
 #include <OpenLoco/Core/EnumFlags.hpp>
 #include <OpenLoco/Diagnostics/Logging.h>
-#include <OpenLoco/Interop/Interop.hpp>
 #include <array>
 #include <numeric>
 
 using namespace OpenLoco::Diagnostics;
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 {

--- a/src/OpenLoco/src/Windows/ProgressBar.cpp
+++ b/src/OpenLoco/src/Windows/ProgressBar.cpp
@@ -8,13 +8,10 @@
 #include "Ui/Widget.h"
 #include "Ui/Window.h"
 #include "Ui/WindowManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
 
 #include <array>
 #include <string>
 #include <string_view>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::ProgressBar
 {

--- a/src/OpenLoco/src/Windows/PromptOkCancelWindow.cpp
+++ b/src/OpenLoco/src/Windows/PromptOkCancelWindow.cpp
@@ -10,18 +10,14 @@
 #include "Ui.h"
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
 
 #include <SDL2/SDL.h>
 #include <cstring>
 
-using namespace OpenLoco::Interop;
-
 namespace OpenLoco::Ui::Windows::PromptOkCancel
 {
-    static loco_global<uint8_t, 0x009D1C9A> _result;
-
     static char _descriptionBuffer[512];
+    static bool _result; // 0x009D1C9A
 
     enum widx
     {
@@ -70,7 +66,7 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
         window->setColour(WindowColour::secondary, AdvancedColour(Colour::mutedDarkRed).translucent());
         window->flags |= Ui::WindowFlags::transparent;
 
-        _result = 0;
+        _result = false;
 
         auto originalModal = WindowManager::getCurrentModalType();
         WindowManager::setCurrentModalType(WindowType::confirmationPrompt);
@@ -87,7 +83,7 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
             });
         WindowManager::setCurrentModalType(originalModal);
 
-        return _result != 0;
+        return _result;
     }
 
     // 0x00447125
@@ -120,7 +116,7 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
                 break;
 
             case widx::okButton:
-                _result = 1;
+                _result = true;
                 WindowManager::close(self.type);
                 break;
         }

--- a/src/OpenLoco/src/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioOptions.cpp
@@ -20,9 +20,6 @@
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
 #include "World/CompanyManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::ScenarioOptions
 {

--- a/src/OpenLoco/src/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Windows/ScenarioSelect.cpp
@@ -17,9 +17,7 @@
 #include "Ui/ScrollView.h"
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
 
-using namespace OpenLoco::Interop;
 using namespace OpenLoco::Diagnostics;
 
 namespace OpenLoco::Ui::Windows::ScenarioSelect

--- a/src/OpenLoco/src/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Windows/StationList.cpp
@@ -20,9 +20,6 @@
 #include "World/StationManager.h"
 #include "World/TownManager.h"
 #include <OpenLoco/Core/Exception.hpp>
-#include <OpenLoco/Interop/Interop.hpp>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::StationList
 {

--- a/src/OpenLoco/src/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Windows/TileInspector.cpp
@@ -39,10 +39,8 @@
 #include "World/CompanyManager.h"
 #include "World/Industry.h"
 #include "World/Station.h"
-#include <OpenLoco/Interop/Interop.hpp>
 #include <map>
 
-using namespace OpenLoco::Interop;
 using namespace OpenLoco::World;
 
 namespace OpenLoco::Ui::Windows::TileInspector

--- a/src/OpenLoco/src/Windows/TitleExit.cpp
+++ b/src/OpenLoco/src/Windows/TitleExit.cpp
@@ -12,9 +12,6 @@
 #include "Ui.h"
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::TitleExit
 {

--- a/src/OpenLoco/src/Windows/TitleLogo.cpp
+++ b/src/OpenLoco/src/Windows/TitleLogo.cpp
@@ -4,9 +4,6 @@
 #include "OpenLoco.h"
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::TitleLogo
 {

--- a/src/OpenLoco/src/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Windows/TitleMenu.cpp
@@ -27,11 +27,8 @@
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
 #include "ViewportManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
 #include <OpenLoco/Utility/String.hpp>
 #include <string_view>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::TitleMenu
 {

--- a/src/OpenLoco/src/Windows/TitleOptions.cpp
+++ b/src/OpenLoco/src/Windows/TitleOptions.cpp
@@ -9,9 +9,6 @@
 #include "Ui.h"
 #include "Ui/Widget.h"
 #include "Ui/WindowManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::TitleOptions
 {

--- a/src/OpenLoco/src/Windows/TitleVersion.cpp
+++ b/src/OpenLoco/src/Windows/TitleVersion.cpp
@@ -6,9 +6,6 @@
 #include "Ui/Widget.h"
 #include "Ui/Window.h"
 #include "Ui/WindowManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::TitleVersion
 {

--- a/src/OpenLoco/src/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Windows/TownWindow.cpp
@@ -24,9 +24,7 @@
 #include "World/CompanyManager.h"
 #include "World/TownManager.h"
 #include <OpenLoco/Engine/World.hpp>
-#include <OpenLoco/Interop/Interop.hpp>
 
-using namespace OpenLoco::Interop;
 using namespace OpenLoco::GameCommands;
 
 namespace OpenLoco::Ui::Windows::Town

--- a/src/OpenLoco/src/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Windows/VehicleList.cpp
@@ -25,12 +25,9 @@
 #include "Vehicles/VehicleManager.h"
 #include "World/CompanyManager.h"
 #include "World/StationManager.h"
-#include <OpenLoco/Interop/Interop.hpp>
 #include <OpenLoco/Utility/String.hpp>
 #include <stdexcept>
 #include <utility>
-
-using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::VehicleList
 {


### PR DESCRIPTION
This integrates quite a few `loco_global` properties in the `Ui::Windows` namespace, and removes `Interop.hpp` includes from many more compilations units.