### PR TITLE
Take selected track mod section into account when removing mods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 24.07+ (???)
 ------------------------------------------------------------------------
+- Change: [#2569] Removing overhead or third rail track mods now takes selected section mode into account.
 - Fix: [#1668] Crash when setting preferred currency to an object that no longer exists. (original bug)
 - Fix: [#2520] Crash when loading certain saves from the title screen.
 - Fix: [#2555] Crash when setting preferred company to an object that no longer exists.

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -1194,7 +1194,7 @@ namespace OpenLoco::Ui::ViewportInteraction
         args.index = track->sequenceIndex();
         args.trackObjType = track->trackObjectId();
         args.type = 1U << bh;
-        args.modSection = 0;
+        args.modSection = Windows::Construction::getLastSelectedTrackModSection();
 
         auto* trackObj = ObjectManager::get<TrackObject>(args.trackObjType);
         auto* trackExtraObj = ObjectManager::get<TrackExtraObject>(trackObj->mods[bh]);

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -1226,7 +1226,7 @@ namespace OpenLoco::Ui::ViewportInteraction
         args.index = road->sequenceIndex();
         args.roadObjType = road->roadObjectId();
         args.type = 1U << bh;
-        args.modSection = 0;
+        args.modSection = Windows::Construction::getLastSelectedTrackModSection();
 
         auto* roadObj = ObjectManager::get<RoadObject>(args.roadObjType);
         auto* roadExtraObj = ObjectManager::get<RoadExtraObject>(roadObj->mods[bh]);

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -168,6 +168,7 @@ namespace OpenLoco::Ui::Windows
         void removeConstructionGhosts();
         void registerHooks();
         uint16_t getLastSelectedMods();
+        uint16_t getLastSelectedTrackModSection();
     }
 
     namespace DragVehiclePart

--- a/src/OpenLoco/src/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Windows/Construction/Common.cpp
@@ -547,6 +547,11 @@ namespace OpenLoco::Ui::Windows::Construction
         return _lastSelectedMods;
     }
 
+    uint16_t getLastSelectedTrackModSection()
+    {
+        return _lastSelectedTrackModSection;
+    }
+
     namespace Common
     {
         struct TabInformation

--- a/src/OpenLoco/src/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Windows/Construction/Common.cpp
@@ -549,7 +549,14 @@ namespace OpenLoco::Ui::Windows::Construction
 
     uint16_t getLastSelectedTrackModSection()
     {
-        return _lastSelectedTrackModSection;
+        if (WindowManager::find(WindowType::construction) != nullptr)
+        {
+            return _lastSelectedTrackModSection;
+        }
+        else
+        {
+            return 0;
+        }
     }
 
     namespace Common


### PR DESCRIPTION
Following up on #2551, this changes the right-click track mod removal function to take the selected track mod section mode into account.