### PR TITLE
Fix #2520: Crash when loading from title screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 24.07+ (???)
 ------------------------------------------------------------------------
 - Fix: [#1668] Crash when setting preferred currency to an object that no longer exists. (original bug)
+- Fix: [#2520] Crash when loading certain saves from the title screen.
 - Fix: [#2555] Crash when setting preferred company to an object that no longer exists.
 - Fix: [#2556] Incorrect height markers on surfaces.
 - Fix: [#2557] Unable to change the fullscreen resolution.

--- a/src/OpenLoco/src/Audio/VehicleChannel.cpp
+++ b/src/OpenLoco/src/Audio/VehicleChannel.cpp
@@ -133,6 +133,12 @@ namespace OpenLoco::Audio
             return;
         }
 
+        if (!v->isVehicle2Or6())
+        {
+            stop();
+            return;
+        }
+
         auto* veh26 = v->asVehicle2Or6();
         if (veh26 == nullptr || ((veh26->soundFlags & Vehicles::SoundFlags::flag0) == Vehicles::SoundFlags::none))
         {

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -709,6 +709,7 @@ namespace OpenLoco::S5
                 EntityManager::reset();
             }
 
+            Audio::stopVehicleNoise();
             EntityManager::resetSpatialIndex();
             CompanyManager::updateColours();
             ObjectManager::sub_4748FA();


### PR DESCRIPTION
Went for some defense in depth here. We now always stop all vehicle sounds when loading and also protected the audio code from throwing exceptions when a vehicle isn't 2or6.