### PR TITLE
Hide scrollbars when there is nothing to scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix: [#2557] Unable to change the fullscreen resolution.
 - Fix: [#2574] Left turn tunnels do not draw.
 - Fix: [#2576] Incoming message sound effects option is not saved properly.
+- Fix: [#2578] Scrollbars do not always update correctly when a window is being resized.
 
 24.07 (2024-07-23)
 ------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 24.07+ (???)
 ------------------------------------------------------------------------
 - Change: [#2569] Removing overhead or third rail track mods now takes selected section mode into account.
+- Change: [#2578] Scrollbars are now hidden if the scrollable widget is not actually overflowing.
 - Change: [#2579] Error messages are now easier to read.
 - Fix: [#1668] Crash when setting preferred currency to an object that no longer exists. (original bug)
 - Fix: [#2520] Crash when loading certain saves from the title screen.

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -39,7 +39,7 @@ namespace OpenLoco::Input
 {
     static void stateScrollLeft(MouseButton cx, WidgetIndex_t edx, Ui::Window* window, Ui::Widget* widget, int16_t x, int16_t y);
     static void stateScrollRight(const MouseButton button, const int16_t x, const int16_t y);
-    static void stateResizing(MouseButton button, int16_t x, int16_t y, Ui::Window* window, Ui::Widget* widget, Ui::WidgetIndex_t widgetIndex);
+    static void stateResizing(MouseButton button, int16_t x, int16_t y);
     static void stateWidgetPressed(MouseButton button, int16_t x, int16_t y, Ui::Window* window, Ui::Widget* widget, Ui::WidgetIndex_t widgetIndex);
     static void stateNormal(MouseButton state, int16_t x, int16_t y, Ui::Window* window, Ui::Widget* widget, Ui::WidgetIndex_t widgetIndex);
     static void stateNormalHover(int16_t x, int16_t y, Ui::Window* window, Ui::Widget* widget, Ui::WidgetIndex_t widgetIndex);
@@ -397,7 +397,7 @@ namespace OpenLoco::Input
                 break;
 
             case State::resizing:
-                stateResizing(button, x, y, window, widget, widgetIndex);
+                stateResizing(button, x, y);
                 break;
 
             case State::scrollRight:
@@ -690,7 +690,7 @@ namespace OpenLoco::Input
     }
 
     // 0x004C7722
-    static void stateResizing(MouseButton button, int16_t x, int16_t y, Ui::Window* window, [[maybe_unused]] Ui::Widget* widget, [[maybe_unused]] Ui::WidgetIndex_t widgetIndex)
+    static void stateResizing(MouseButton button, int16_t x, int16_t y)
     {
         auto w = WindowManager::find(_dragWindowType, _dragWindowNumber);
         if (w == nullptr)
@@ -722,17 +722,17 @@ namespace OpenLoco::Input
 
                 if (w->hasFlags(Ui::WindowFlags::flag_16))
                 {
-                    x = window->var_88A - window->width + _dragLastX;
-                    y = window->var_88C - window->height + _dragLastY;
+                    x = w->var_88A - w->width + _dragLastX;
+                    y = w->var_88C - w->height + _dragLastY;
                     w->flags &= ~Ui::WindowFlags::flag_16;
                     doDefault = true;
                     break;
                 }
 
-                window->var_88A = window->width;
-                window->var_88C = window->height;
-                x = _dragLastX - window->x - window->width + Ui::width();
-                y = _dragLastY - window->y - window->height + Ui::height() - 27;
+                w->var_88A = w->width;
+                w->var_88C = w->height;
+                x = _dragLastX - w->x - w->width + Ui::width();
+                y = _dragLastY - w->y - w->height + Ui::height() - 27;
                 w->flags |= Ui::WindowFlags::flag_16;
                 if (y >= Ui::height() - 2)
                 {

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -786,11 +786,12 @@ namespace OpenLoco::Input
         w->flags |= Ui::WindowFlags::flag_15;
         w->callOnResize();
         w->callPrepareDraw();
+
         w->scrollAreas[0].contentWidth = -1;
         w->scrollAreas[0].contentHeight = -1;
         w->scrollAreas[1].contentWidth = -1;
         w->scrollAreas[1].contentHeight = -1;
-        window->updateScrollWidgets();
+        w->updateScrollWidgets();
         w->invalidate();
 
         _dragLastX = x;

--- a/src/OpenLoco/src/Ui/ScrollView.cpp
+++ b/src/OpenLoco/src/Ui/ScrollView.cpp
@@ -199,8 +199,10 @@ namespace OpenLoco::Ui::ScrollView
         auto top = widget->top + window->y;
         auto bottom = widget->bottom + window->y;
 
-        if (scroll.hasFlags(ScrollFlags::hscrollbarVisible)
-            && y >= (bottom - barWidth))
+        const bool needsHScroll = scroll.contentWidth > widget->width();
+        const bool needsVScroll = scroll.contentHeight > widget->height();
+
+        if (needsHScroll && scroll.hasFlags(ScrollFlags::hscrollbarVisible) && y >= (bottom - barWidth))
         {
             if (x < left + barWidth)
             {
@@ -241,7 +243,7 @@ namespace OpenLoco::Ui::ScrollView
 
             res.area = ScrollPart::hscrollbarThumb;
         }
-        else if (scroll.hasFlags(ScrollFlags::vscrollbarVisible) && x >= (right - barWidth))
+        else if (needsVScroll && scroll.hasFlags(ScrollFlags::vscrollbarVisible) && x >= (right - barWidth))
         {
             if (y < top + barWidth)
             {

--- a/src/OpenLoco/src/Ui/Widget.cpp
+++ b/src/OpenLoco/src/Ui/Widget.cpp
@@ -935,13 +935,13 @@ namespace OpenLoco::Ui
         const auto* scroll_area = &window->scrollAreas[widgetState.scrollviewIndex];
 
         tr.setCurrentFont(Gfx::Font::medium_bold);
-        if (scroll_area->hasFlags(Ui::ScrollFlags::hscrollbarVisible))
+        if (scroll_area->contentWidth > widget.width() && scroll_area->hasFlags(Ui::ScrollFlags::hscrollbarVisible))
         {
             draw_hscroll(drawingCtx, widget, widgetState);
             b -= 11;
         }
 
-        if (scroll_area->hasFlags(Ui::ScrollFlags::vscrollbarVisible))
+        if (scroll_area->contentHeight > widget.height() && scroll_area->hasFlags(Ui::ScrollFlags::vscrollbarVisible))
         {
             draw_vscroll(drawingCtx, widget, widgetState);
             r -= 11;


### PR DESCRIPTION
This PR changes the scrollview behaviour such that scrollbars are no longer drawn when the scrollview contents do not overflow the visible area.

Basically the same as https://github.com/OpenRCT2/OpenRCT2/pull/22491