### PR TITLE
Rework error window to improve text contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 24.07+ (???)
 ------------------------------------------------------------------------
 - Change: [#2569] Removing overhead or third rail track mods now takes selected section mode into account.
+- Change: [#2579] Error messages are now easier to read.
 - Fix: [#1668] Crash when setting preferred currency to an object that no longer exists. (original bug)
 - Fix: [#2520] Crash when loading certain saves from the title screen.
 - Fix: [#2555] Crash when setting preferred company to an object that no longer exists.


### PR DESCRIPTION
Basically the equivalent of https://github.com/OpenRCT2/OpenRCT2/pull/22357.

Before:
![Screenshot (1)](https://github.com/user-attachments/assets/bad4f72d-ab90-4e99-a2e8-3411d964cb51)

After:
![Screenshot](https://github.com/user-attachments/assets/40e62500-4dc9-42de-8da3-c3731a3030c4)