### PR TITLE
Fix #2574: Left turn tunnels not drawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix: [#2555] Crash when setting preferred company to an object that no longer exists.
 - Fix: [#2556] Incorrect height markers on surfaces.
 - Fix: [#2557] Unable to change the fullscreen resolution.
+- Fix: [#2574] Left turn tunnels do not draw.
 - Fix: [#2576] Incoming message sound effects option is not saved properly.
 
 24.07 (2024-07-23)

--- a/src/OpenLoco/src/Paint/PaintTrackData.h
+++ b/src/OpenLoco/src/Paint/PaintTrackData.h
@@ -53,7 +53,7 @@ namespace OpenLoco::Paint
             const std::array<uint8_t, 4>& _bridgeEdges,
             const std::array<uint8_t, 4>& _bridgeQuarters,
             const std::array<uint8_t, 4>& _bridgeType,
-            const std::array<int16_t, 4>& _tunnelHeights,
+            const std::array<std::array<int16_t, 4>, 4>& _tunnelHeights,
             const std::array<SegmentFlags, 4>& _segments,
             bool _isMergeable)
             : imageIndexOffsets(_imageIndexOffsets)
@@ -62,12 +62,10 @@ namespace OpenLoco::Paint
             , bridgeEdges(_bridgeEdges)
             , bridgeQuarters(_bridgeQuarters)
             , bridgeType(_bridgeType)
+            , tunnelHeights(_tunnelHeights)
             , segments(_segments)
             , isMergeable(_isMergeable)
         {
-            tunnelHeights = {};
-            tunnelHeights[0] = _tunnelHeights;
-            rotateTunnelHeights();
         }
         constexpr TrackPaintPiece(
             const std::array<std::array<uint32_t, 3>, 4>& _imageIndexOffsets,
@@ -185,11 +183,11 @@ namespace OpenLoco::Paint
                 reference.bridgeType[rotationTable[2]],
                 reference.bridgeType[rotationTable[3]],
             },
-            std::array<int16_t, 4>{
-                reference.tunnelHeights[0][rotationTable[0]],
-                reference.tunnelHeights[0][rotationTable[1]],
-                reference.tunnelHeights[0][rotationTable[2]],
-                reference.tunnelHeights[0][rotationTable[3]],
+            std::array<std::array<int16_t, 4>, 4>{
+                reference.tunnelHeights[rotationTable[0]],
+                reference.tunnelHeights[rotationTable[1]],
+                reference.tunnelHeights[rotationTable[2]],
+                reference.tunnelHeights[rotationTable[3]],
             },
             std::array<SegmentFlags, 4>{
                 reference.segments[rotationTable[0]],


### PR DESCRIPTION
I don't know why i decided to implement the tunnels different to every other property (and then mess it up :))

Found the source of this issue when implementing the road paint as it used the same style for the streetlight heights.