### PR TITLE
Add riverbeds to map generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 24.08+ (???)
 ------------------------------------------------------------------------
+- Feature: [#2597] The map generator now allows carving rivers through the landscape.
 - Change: [#2589] See-Through Bridges are now part of the viewing options
 - Change: [#2600] The lanscape can now be regenerated from all tabs in the Landscape Generation window.
 - Fix: [#2372] Large (16xN) stations could not be created without cheats.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2404,3 +2404,8 @@ strings:
   2349: "Show Options Window"
   2350: "See-through bridges"
   2351: "See-through bridges toggle"
+  2352: "{COLOUR WINDOW_2}No. of riverbeds:"
+  2353: "{COLOUR WINDOW_2}Minimum river width:"
+  2354: "{COLOUR WINDOW_2}Maximum river width:"
+  2355: "{COLOUR WINDOW_2}Riverbank width:"
+  2356: "{COLOUR WINDOW_2}Meander rate:"

--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -134,7 +134,7 @@ namespace OpenLoco::EditorController
         // New in OpenLoco
         options.generator = S5::LandGeneratorType::Original;
         options.numTerrainSmoothingPasses = 2;
-        options.numRiverbeds = 1;
+        options.numRiverbeds = 0;
         options.minRiverWidth = 10;
         options.maxRiverWidth = 20;
         options.riverbankWidth = 5;

--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -134,10 +134,11 @@ namespace OpenLoco::EditorController
         // New in OpenLoco
         options.generator = S5::LandGeneratorType::Original;
         options.numTerrainSmoothingPasses = 2;
-        options.numRiverbeds = 3;
+        options.numRiverbeds = 1;
         options.minRiverWidth = 10;
         options.maxRiverWidth = 20;
-        options.riverbankWidth = 20;
+        options.riverbankWidth = 5;
+        options.riverMeanderRate = 10;
 
         resetScreenAge();
         throw GameException::Interrupt;

--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -134,6 +134,10 @@ namespace OpenLoco::EditorController
         // New in OpenLoco
         options.generator = S5::LandGeneratorType::Original;
         options.numTerrainSmoothingPasses = 2;
+        options.numRiverbeds = 3;
+        options.minRiverWidth = 10;
+        options.maxRiverWidth = 20;
+        options.riverbankWidth = 20;
 
         resetScreenAge();
         throw GameException::Interrupt;

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1986,6 +1986,11 @@ namespace OpenLoco::StringIds
     constexpr StringId shortcut_show_options_window = 2349;
     constexpr StringId menuSeeThroughBridges = 2350;
     constexpr StringId shortcutSeeThroughBridges = 2351;
+    constexpr StringId number_riverbeds = 2352;
+    constexpr StringId minimum_river_width = 2353;
+    constexpr StringId maximum_river_width = 2354;
+    constexpr StringId riverbank_width = 2355;
+    constexpr StringId meander_rate = 2356;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -92,14 +92,14 @@ namespace OpenLoco::World::MapGenerator
                     {
                         // Western riverbank (high to low)
                         auto bankPos = riverbankWidth - xOffset;
-                        auto bankHeight = riverbankWidth * bankPos / riverbankWidth;
+                        auto bankHeight = heightMap[pos] * bankPos / riverbankWidth;
                         heightMap[pos] = std::max<uint8_t>(riverbedHeight, bankHeight);
                     }
                     else if (riverbankWidth > 0 && xOffset > easternBankOffset)
                     {
                         // Eastern riverbank (low to high)
                         auto bankPos = xOffset - easternBankOffset;
-                        auto bankHeight = riverbankWidth * bankPos / riverbankWidth;
+                        auto bankHeight = heightMap[pos] * bankPos / riverbankWidth;
                         heightMap[pos] = std::max<uint8_t>(riverbedHeight, bankHeight);
                     }
                     else

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -88,6 +88,13 @@ namespace OpenLoco::World::MapGenerator
                         pos = TilePos2(pos.y, pos.x);
                     }
 
+                    if (!validCoords(pos))
+                    {
+                        // We might meander back to a valid position later,
+                        // so we're only breaking out of the inner loop.
+                        break;
+                    }
+
                     if (riverbankWidth > 0 && xOffset < riverbankWidth)
                     {
                         // Western riverbank (high to low)

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -70,7 +70,7 @@ namespace OpenLoco::World::MapGenerator
             auto& gs = getGameState();
             const auto riverEastWest = gs.rng.randBool();
             const auto riverWidth = gs.rng.randNext(options.minRiverWidth, options.maxRiverWidth);
-            const auto riverbedHeight = gs.seaLevel > 0 ? gs.seaLevel - 1 : gs.seaLevel;
+            const auto riverbedHeight = gs.seaLevel > 0 ? gs.seaLevel - 1 : options.minLandHeight;
 
             // We'll be varying the bank width as we meander
             auto riverbankWidth = options.riverbankWidth;

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -88,14 +88,14 @@ namespace OpenLoco::World::MapGenerator
                         pos = TilePos2(pos.y, pos.x);
                     }
 
-                    if (xOffset < riverbankWidth)
+                    if (riverbankWidth > 0 && xOffset < riverbankWidth)
                     {
                         // Western riverbank (high to low)
                         auto bankPos = riverbankWidth - xOffset;
                         auto bankHeight = riverbankWidth * bankPos / riverbankWidth;
                         heightMap[pos] = std::max<uint8_t>(riverbedHeight, bankHeight);
                     }
-                    else if (xOffset > easternBankOffset)
+                    else if (riverbankWidth > 0 && xOffset > easternBankOffset)
                     {
                         // Eastern riverbank (low to high)
                         auto bankPos = xOffset - easternBankOffset;
@@ -110,17 +110,21 @@ namespace OpenLoco::World::MapGenerator
                 }
 
                 // Let the river meander slightly
-                if (yPos % 4 == 0)
+                const auto meanderRate = options.riverMeanderRate;
+                if (meanderRate > 0 && yPos % 4 == 0)
                 {
-                    const auto meanderRate = options.riverMeanderRate;
                     const auto halfMeanderRate = meanderRate / 2;
 
                     int8_t meanderOffset = getGameState().rng.randNext(0, meanderRate) - halfMeanderRate;
                     xStartPos += meanderOffset;
 
-                    riverbankWidth += meanderOffset / halfMeanderRate;
-                    easternBankOffset += meanderOffset / halfMeanderRate;
-                    totalRiverWidth += meanderOffset / halfMeanderRate * 2;
+                    // Adjust bank width slightly as well
+                    if (options.riverbankWidth > 0)
+                    {
+                        riverbankWidth += meanderOffset / halfMeanderRate;
+                        easternBankOffset += meanderOffset / halfMeanderRate;
+                        totalRiverWidth += meanderOffset / halfMeanderRate * 2;
+                    }
                 }
             }
         }

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -69,7 +69,7 @@ namespace OpenLoco::World::MapGenerator
         {
             const auto riverEastWest = getGameState().rng.randBool();
             const auto riverWidth = getGameState().rng.randNext(options.minRiverWidth, options.maxRiverWidth);
-            const auto riverbedHeight = options.minLandHeight;
+            const auto riverbedHeight = getGameState().seaLevel - 1;
 
             // We'll be varying the bank width as we meander
             auto riverbankWidth = options.riverbankWidth;

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -70,7 +70,7 @@ namespace OpenLoco::World::MapGenerator
             auto& gs = getGameState();
             const auto riverEastWest = gs.rng.randBool();
             const auto riverWidth = gs.rng.randNext(options.minRiverWidth, options.maxRiverWidth);
-            const auto riverbedHeight = gs.seaLevel > 0 ? gs.seaLevel - 1 : options.minLandHeight;
+            const auto riverbedHeight = std::max<uint8_t>(gs.seaLevel > 0 ? gs.seaLevel - 1 : 1, options.minLandHeight);
 
             // We'll be varying the bank width as we meander
             auto riverbankWidth = options.riverbankWidth;

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -77,8 +77,8 @@ namespace OpenLoco::World::MapGenerator
             auto easternBankOffset = riverWidth + riverbankWidth;
 
             // Pivot: generate a random X position
-            auto xStartPos = getGameState().rng.randNext(0.15 * kMapColumns, 0.85 * kMapColumns);
-            for (auto yPos = 0; yPos < kMapRows; yPos++)
+            auto xStartPos = getGameState().rng.randNext(0.15 * heightMap.width, 0.85 * heightMap.width);
+            for (auto yPos = 0; yPos < heightMap.height; yPos++)
             {
                 for (auto xOffset = 0; xOffset < totalRiverWidth; xOffset++)
                 {

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -67,9 +67,10 @@ namespace OpenLoco::World::MapGenerator
     {
         for (auto i = 0; i < options.numRiverbeds; i++)
         {
-            const auto riverEastWest = getGameState().rng.randBool();
-            const auto riverWidth = getGameState().rng.randNext(options.minRiverWidth, options.maxRiverWidth);
-            const auto riverbedHeight = getGameState().seaLevel - 1;
+            auto& gs = getGameState();
+            const auto riverEastWest = gs.rng.randBool();
+            const auto riverWidth = gs.rng.randNext(options.minRiverWidth, options.maxRiverWidth);
+            const auto riverbedHeight = gs.seaLevel > 0 ? gs.seaLevel - 1 : gs.seaLevel;
 
             // We'll be varying the bank width as we meander
             auto riverbankWidth = options.riverbankWidth;

--- a/src/OpenLoco/src/S5/S5.h
+++ b/src/OpenLoco/src/S5/S5.h
@@ -125,8 +125,9 @@ namespace OpenLoco::S5
         uint8_t minRiverWidth;
         uint8_t maxRiverWidth;
         uint8_t riverbankWidth;
+        uint8_t riverMeanderRate;
 
-        std::byte pad_41BD[343];
+        std::byte pad_41BD[342];
     };
 #pragma pack(pop)
 

--- a/src/OpenLoco/src/S5/S5.h
+++ b/src/OpenLoco/src/S5/S5.h
@@ -121,8 +121,12 @@ namespace OpenLoco::S5
         // new fields:
         LandGeneratorType generator;
         uint8_t numTerrainSmoothingPasses;
+        uint8_t numRiverbeds;
+        uint8_t minRiverWidth;
+        uint8_t maxRiverWidth;
+        uint8_t riverbankWidth;
 
-        std::byte pad_41BD[347];
+        std::byte pad_41BD[343];
     };
 #pragma pack(pop)
 

--- a/src/OpenLoco/src/Scenario.h
+++ b/src/OpenLoco/src/Scenario.h
@@ -94,6 +94,21 @@ namespace OpenLoco::Scenario
     constexpr uint8_t kMinSeaLevel = 0;
     constexpr uint8_t kMaxSeaLevel = 28;
 
+    constexpr uint8_t kMinNumRiverbeds = 0;
+    constexpr uint8_t kMaxNumRiverbeds = 4;
+
+    constexpr uint8_t kMinMinRiverWidth = 2;
+    constexpr uint8_t kMaxMinRiverWidth = 20;
+
+    constexpr uint8_t kMinMaxRiverWidth = 2;
+    constexpr uint8_t kMaxMaxRiverWidth = 30;
+
+    constexpr uint8_t kMinRiverbankWidth = 0;
+    constexpr uint8_t kMaxRiverbankWidth = 10;
+
+    constexpr uint8_t kMinRiverMeanderRate = 0;
+    constexpr uint8_t kMaxRiverMeanderRate = 20;
+
     constexpr uint8_t kMinBaseLandHeight = 0;
     constexpr uint8_t kMaxBaseLandHeight = 15;
 

--- a/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Windows/LandscapeGeneration.cpp
@@ -933,14 +933,53 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             sea_level = Common::widx::generate_now + 1,
             sea_level_down,
             sea_level_up,
+
+            num_riverbeds,
+            num_riverbeds_down,
+            num_riverbeds_up,
+
+            min_river_width,
+            min_river_width_down,
+            min_river_width_up,
+
+            max_river_width,
+            max_river_width_down,
+            max_river_width_up,
+
+            riverbank_width,
+            riverbank_width_down,
+            riverbank_width_up,
+
+            meander_rate,
+            meander_rate_down,
+            meander_rate_up,
         };
 
-        const uint64_t enabled_widgets = Common::enabled_widgets | (1 << widx::sea_level_up) | (1 << widx::sea_level_down);
-        const uint64_t holdable_widgets = (1 << widx::sea_level_up) | (1 << widx::sea_level_down);
+        // clang-format off
+        const uint64_t enabled_widgets = Common::enabled_widgets |
+            (1 << widx::sea_level_down) | (1 << widx::sea_level_up) |
+            (1 << widx::num_riverbeds_down) | (1 << widx::num_riverbeds_up) |
+            (1 << widx::min_river_width_down) | (1 << widx::min_river_width_up) |
+            (1 << widx::max_river_width_down) | (1 << widx::max_river_width_up) |
+            (1 << widx::riverbank_width_down) | (1 << widx::riverbank_width_up) |
+            (1 << widx::meander_rate_down) | (1 << widx::meander_rate_up);
+
+        const uint64_t holdable_widgets = (1 << widx::sea_level_up) | (1 << widx::sea_level_down) |
+            (1 << widx::num_riverbeds_down) | (1 << widx::num_riverbeds_up) |
+            (1 << widx::min_river_width_down) | (1 << widx::min_river_width_up) |
+            (1 << widx::max_river_width_down) | (1 << widx::max_river_width_up) |
+            (1 << widx::riverbank_width_down) | (1 << widx::riverbank_width_up) |
+            (1 << widx::meander_rate_down) | (1 << widx::meander_rate_up);
+        // clang-format on
 
         static constexpr Widget widgets[] = {
             common_options_widgets(217, StringIds::title_landscape_generation_water),
             makeStepperWidgets({ 256, 52 }, { 100, 12 }, WidgetType::textbox, WindowColour::secondary, StringIds::sea_level_units),
+            makeStepperWidgets({ 256, 68 }, { 100, 12 }, WidgetType::textbox, WindowColour::secondary, StringIds::uint16_raw),
+            makeStepperWidgets({ 256, 84 }, { 100, 12 }, WidgetType::textbox, WindowColour::secondary, StringIds::min_land_height_units),
+            makeStepperWidgets({ 256, 100 }, { 100, 12 }, WidgetType::textbox, WindowColour::secondary, StringIds::min_land_height_units),
+            makeStepperWidgets({ 256, 116 }, { 100, 12 }, WidgetType::textbox, WindowColour::secondary, StringIds::min_land_height_units),
+            makeStepperWidgets({ 256, 132 }, { 100, 12 }, WidgetType::textbox, WindowColour::secondary, StringIds::min_land_height_units),
             widgetEnd()
         };
 
@@ -956,19 +995,92 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                 point,
                 Colour::black,
                 StringIds::sea_level);
+
+            point.y = window.y + window.widgets[widx::num_riverbeds].top;
+            tr.drawStringLeft(
+                point,
+                Colour::black,
+                StringIds::number_riverbeds);
+
+            point.y = window.y + window.widgets[widx::min_river_width].top;
+            tr.drawStringLeft(
+                point,
+                Colour::black,
+                StringIds::minimum_river_width);
+
+            point.y = window.y + window.widgets[widx::max_river_width].top;
+            tr.drawStringLeft(
+                point,
+                Colour::black,
+                StringIds::maximum_river_width);
+
+            point.y = window.y + window.widgets[widx::riverbank_width].top;
+            tr.drawStringLeft(
+                point,
+                Colour::black,
+                StringIds::riverbank_width);
+
+            point.y = window.y + window.widgets[widx::meander_rate].top;
+            tr.drawStringLeft(
+                point,
+                Colour::black,
+                StringIds::meander_rate);
         }
 
         // 0x0043E173
         static void onMouseDown(Window& window, WidgetIndex_t widgetIndex)
         {
+            auto& gameState = getGameState();
+            auto& options = S5::getOptions();
+
             switch (widgetIndex)
             {
                 case widx::sea_level_up:
-                    getGameState().seaLevel = std::min<int8_t>(getGameState().seaLevel + 1, Scenario::kMaxSeaLevel);
+                    gameState.seaLevel = std::min<int8_t>(gameState.seaLevel + 1, Scenario::kMaxSeaLevel);
                     break;
 
                 case widx::sea_level_down:
-                    getGameState().seaLevel = std::max<int8_t>(Scenario::kMinSeaLevel, getGameState().seaLevel - 1);
+                    gameState.seaLevel = std::max<int8_t>(Scenario::kMinSeaLevel, gameState.seaLevel - 1);
+                    break;
+
+                case widx::num_riverbeds_up:
+                    options.numRiverbeds = std::min<int8_t>(options.numRiverbeds + 1, Scenario::kMaxNumRiverbeds);
+                    break;
+
+                case widx::num_riverbeds_down:
+                    options.numRiverbeds = std::max<int8_t>(Scenario::kMinNumRiverbeds, options.numRiverbeds - 1);
+                    break;
+
+                case widx::min_river_width_up:
+                    options.minRiverWidth = std::min<int8_t>(options.minRiverWidth + 1, Scenario::kMaxMinRiverWidth);
+                    break;
+
+                case widx::min_river_width_down:
+                    options.minRiverWidth = std::max<int8_t>(Scenario::kMinMinRiverWidth, options.minRiverWidth - 1);
+                    break;
+
+                case widx::max_river_width_up:
+                    options.maxRiverWidth = std::min<int8_t>(options.maxRiverWidth + 1, Scenario::kMaxMaxRiverWidth);
+                    break;
+
+                case widx::max_river_width_down:
+                    options.maxRiverWidth = std::max<int8_t>(Scenario::kMinMaxRiverWidth, options.maxRiverWidth - 1);
+                    break;
+
+                case widx::riverbank_width_up:
+                    options.riverbankWidth = std::min<int8_t>(options.riverbankWidth + 1, Scenario::kMaxRiverbankWidth);
+                    break;
+
+                case widx::riverbank_width_down:
+                    options.riverbankWidth = std::max<int8_t>(Scenario::kMinRiverbankWidth, options.riverbankWidth - 1);
+                    break;
+
+                case widx::meander_rate_up:
+                    options.riverMeanderRate = std::min<int8_t>(options.riverMeanderRate + 1, Scenario::kMaxRiverMeanderRate);
+                    break;
+
+                case widx::meander_rate_down:
+                    options.riverMeanderRate = std::max<int8_t>(Scenario::kMinRiverMeanderRate, options.riverMeanderRate - 1);
                     break;
 
                 default:
@@ -985,8 +1097,33 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         {
             Common::prepareDraw(window);
 
-            auto args = FormatArguments(window.widgets[widx::sea_level].textArgs);
-            args.push(getGameState().seaLevel);
+            auto& gameState = getGameState();
+            auto& options = S5::getOptions();
+
+            {
+                auto args = FormatArguments(window.widgets[widx::sea_level].textArgs);
+                args.push(gameState.seaLevel);
+            }
+            {
+                auto args = FormatArguments(window.widgets[widx::num_riverbeds].textArgs);
+                args.push<uint16_t>(options.numRiverbeds);
+            }
+            {
+                auto args = FormatArguments(window.widgets[widx::min_river_width].textArgs);
+                args.push<uint16_t>(options.minRiverWidth);
+            }
+            {
+                auto args = FormatArguments(window.widgets[widx::max_river_width].textArgs);
+                args.push<uint16_t>(options.maxRiverWidth);
+            }
+            {
+                auto args = FormatArguments(window.widgets[widx::riverbank_width].textArgs);
+                args.push<uint16_t>(options.riverbankWidth);
+            }
+            {
+                auto args = FormatArguments(window.widgets[widx::meander_rate].textArgs);
+                args.push<uint16_t>(options.riverMeanderRate);
+            }
         }
 
         static constexpr WindowEventList kEvents = {


### PR DESCRIPTION
Earlier this year, we moved the sea level settings to their own tab in the landscape generation window. This PR introduces the possibility to carve out river beds throughout the terrain map.

The resulting rivers aren't always the prettiest. Indeed, the code is a bit naive in places, and perhaps not the prettiest. Perhaps we can improve it a little over the course of the review process. Either way, I think it's a good start.

![Unnamed](https://github.com/user-attachments/assets/7c79df75-7453-4547-bec0-cb73a1cceba3)
