### PR TITLE
Limit heightmap generator to map size

### DIFF
--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -945,8 +945,7 @@ namespace OpenLoco::World::MapGenerator
         updateProgress(10);
 
         {
-            // Should be 384x384 (but generateLandscape goes out of bounds?)
-            HeightMap heightMap(512, 512, 512);
+            HeightMap heightMap(kMapRows, kMapRows, kMapRows);
 
             generateHeightMap(options, heightMap);
             updateProgress(25);


### PR DESCRIPTION
With all map generator code implemented, we can finally limit the heightmap generator to the actual map size. Provides a little speedup to the simplex noise based generator.