### PR TITLE
Fix selective minimap map blinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Change: [#2600] The lanscape can now be regenerated from all tabs in the Landscape Generation window.
 - Fix: [#2372] Large (16xN) stations could not be created without cheats.
 - Fix: [#2592] Industry ghosts always destroy first industry instead of ghost.
+- Fix: [#2601] Highlighted items don't always blink correctly in the mini maps for transport routes and ownership.
 - Fix: [#2604] Crash when viewing the brige tooltip in the construction window.
 
 24.08 (2024-08-19)

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -1752,13 +1752,17 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 colour = vehicleTypeColours[index];
             }
 
-            if (_flashingItems & (1 << enumValue(companyId)))
+            // clang-format off
+            auto vehicleType = train.head->vehicleType;
+            if ((widgetIndex == widx::tabOwnership && _flashingItems & (1 << enumValue(companyId))) ||
+                (widgetIndex == widx::tabVehicles && _flashingItems & (1 << enumValue(vehicleType))))
             {
-                if (!(mapFrameNumber & (1 << 2)))
+                if (mapFrameNumber & (1 << 2))
                 {
                     colour = kFlashColours[colour];
                 }
             }
+            // clang-format on
         }
 
         return colour;

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -687,14 +687,12 @@ namespace OpenLoco::Ui::Windows::MapWindow
                         {
                             if (_routeToObjectIdMap[firstFlashable] == trackObjectId)
                             {
-                                colourFlash1 = colourFlash0 = kFlashColours[colourFlash0];
+                                colourFlash0 = kFlashColours[colourFlash0];
                             }
                         }
-                        else
-                        {
-                            colourFlash1 = colourFlash0;
-                            colour1 = colour0;
-                        }
+
+                        colourFlash1 = colourFlash0;
+                        colour1 = colour0;
 
                         haveTrackOrRoad = true;
                         break;

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -623,6 +623,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 continue;
             }
 
+            bool haveTrackOrRoad = false; // ch
             PaletteIndex_t colourFlash0{}, colourFlash1{}, colour0{}, colour1{};
             auto tile = TileManager::get(pos);
             for (auto& el : tile)
@@ -635,20 +636,27 @@ namespace OpenLoco::Ui::Windows::MapWindow
                         if (surfaceEl == nullptr)
                             continue;
 
+                        uint8_t terrainColour0{}, terrainColour1{};
                         if (surfaceEl->water() == 0)
                         {
                             const auto* landObj = ObjectManager::get<LandObject>(surfaceEl->terrain());
                             const auto* landImage = Gfx::getG1Element(landObj->mapPixelImage);
-                            colourFlash0 = colourFlash1 = landImage->offset[0];
+                            terrainColour0 = landImage->offset[0];
+                            terrainColour1 = landImage->offset[1];
                         }
                         else
                         {
                             const auto* waterObj = ObjectManager::get<WaterObject>();
                             const auto* waterImage = Gfx::getG1Element(waterObj->mapPixelImage);
-                            colourFlash0 = colourFlash1 = waterImage->offset[0];
+                            terrainColour0 = waterImage->offset[0];
+                            terrainColour1 = waterImage->offset[1];
                         }
 
-                        colour0 = colour1 = colourFlash0;
+                        colour0 = colourFlash0 = terrainColour0;
+                        if (!haveTrackOrRoad)
+                        {
+                            colour1 = colourFlash1 = terrainColour1;
+                        }
                         break;
                     }
 
@@ -679,7 +687,6 @@ namespace OpenLoco::Ui::Windows::MapWindow
                         {
                             if (_routeToObjectIdMap[firstFlashable] == trackObjectId)
                             {
-                                // colourFlash1 = 0;
                                 colourFlash0 = kFlashColours[colourFlash0];
                             }
                         }
@@ -689,6 +696,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                             colour1 = colour0;
                         }
 
+                        haveTrackOrRoad = true;
                         break;
                     }
 
@@ -723,6 +731,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
                         colour1 = colour0;
                         colourFlash1 = colourFlash0;
+                        haveTrackOrRoad = true;
                         break;
                     }
 

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -671,18 +671,24 @@ namespace OpenLoco::Ui::Windows::MapWindow
                         if (trackEl == nullptr)
                             continue;
 
-                        colourFlash0 = _trackColours[trackEl->trackObjectId()];
+                        auto trackObjectId = trackEl->trackObjectId();
+                        colourFlash0 = colour0 = _trackColours[trackObjectId];
 
                         auto firstFlashable = Numerics::bitScanForward(_flashingItems);
                         if (firstFlashable != -1)
                         {
-                            if (_routeToObjectIdMap[firstFlashable] == colourFlash0)
+                            if (_routeToObjectIdMap[firstFlashable] == trackObjectId)
                             {
+                                // colourFlash1 = 0;
                                 colourFlash0 = kFlashColours[colourFlash0];
                             }
                         }
+                        else
+                        {
+                            colourFlash1 = colourFlash0;
+                            colour1 = colour0;
+                        }
 
-                        colour1 = colourFlash1 = colour0 = colourFlash0;
                         break;
                     }
 

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -63,7 +63,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
         std::array<PaletteIndex_t, 256> colours;
 
         std::fill(colours.begin(), colours.end(), PaletteIndex::index_0A);
-        std::fill(colours.begin() + 11, colours.begin() + 15, PaletteIndex::index_15);
+        std::fill(colours.begin() + 10, colours.begin() + 14, PaletteIndex::index_15);
 
         return colours;
     }(); // 0x004FDC5C

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -687,7 +687,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                         {
                             if (_routeToObjectIdMap[firstFlashable] == trackObjectId)
                             {
-                                colourFlash0 = kFlashColours[colourFlash0];
+                                colourFlash1 = colourFlash0 = kFlashColours[colourFlash0];
                             }
                         }
                         else

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -769,6 +769,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 continue;
             }
 
+            bool haveTrackOrRoad = false; // ch
             PaletteIndex_t colourFlash0{}, colourFlash1{}, colour0{}, colour1{};
             auto tile = TileManager::get(pos);
             for (auto& el : tile)
@@ -781,20 +782,27 @@ namespace OpenLoco::Ui::Windows::MapWindow
                         if (surfaceEl == nullptr)
                             continue;
 
+                        uint8_t terrainColour0{}, terrainColour1{};
                         if (surfaceEl->water() == 0)
                         {
                             const auto* landObj = ObjectManager::get<LandObject>(surfaceEl->terrain());
                             const auto* landImage = Gfx::getG1Element(landObj->mapPixelImage);
-                            colourFlash0 = colourFlash1 = landImage->offset[0];
+                            terrainColour0 = landImage->offset[0];
+                            terrainColour1 = landImage->offset[1];
                         }
                         else
                         {
                             const auto* waterObj = ObjectManager::get<WaterObject>();
                             const auto* waterImage = Gfx::getG1Element(waterObj->mapPixelImage);
-                            colourFlash0 = colourFlash1 = waterImage->offset[0];
+                            terrainColour0 = waterImage->offset[0];
+                            terrainColour1 = waterImage->offset[1];
                         }
 
-                        colour0 = colour1 = colourFlash0;
+                        colour0 = colourFlash0 = terrainColour0;
+                        if (!haveTrackOrRoad)
+                        {
+                            colour1 = colourFlash1 = terrainColour1;
+                        }
                         break;
                     }
 
@@ -829,8 +837,10 @@ namespace OpenLoco::Ui::Windows::MapWindow
                             {
                                 colourFlash1 = colourFlash0 = kFlashColours[colour0];
                             }
+                            haveTrackOrRoad = true;
                             break;
                         }
+
                         [[fallthrough]];
                     }
 


### PR DESCRIPTION
Fixes the selective blinking issues with the following:

- Vehicles:
  - Hovering 'Trains' blinks all vehicles
  - None of the other vehicle types blink
- Transport Routes:
  - Railroad track doesn't blink
  - Narrow gauge doesn't blink
  - Underground track is not rendered
- Ownership:
  - Underground track is not rendered

Regressions from #2443 (v24.06), so warrants a changelog entry.