### PR TITLE
Fix #2604. Bridge tooltip crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Change: [#2600] The lanscape can now be regenerated from all tabs in the Landscape Generation window.
 - Fix: [#2372] Large (16xN) stations could not be created without cheats.
 - Fix: [#2592] Industry ghosts always destroy first industry instead of ghost.
+- Fix: [#2604] Crash when viewing the brige tooltip in the construction window.
 
 24.08 (2024-08-19)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Localisation/StringManager.cpp
+++ b/src/OpenLoco/src/Localisation/StringManager.cpp
@@ -2,6 +2,7 @@
 #include "GameCommands/GameCommands.h"
 #include "GameState.h"
 #include "StringIds.h"
+#include <OpenLoco/Diagnostics/Logging.h>
 #include <OpenLoco/Interop/Interop.hpp>
 
 #include <cassert>
@@ -27,6 +28,11 @@ namespace OpenLoco::StringManager
 
     const char* getString(StringId id)
     {
+        if (id >= _strings.size())
+        {
+            Diagnostics::Logging::error("Tried to access invalid string id: {}", id);
+            return nullptr;
+        }
         char* str = _strings[id];
         return str;
     }

--- a/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Windows/Construction/ConstructionTab.cpp
@@ -2500,6 +2500,13 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             auto trackObj = ObjectManager::get<TrackObject>(_trackType);
             args.push(trackObj->name);
         }
+        Common::repositionTabs(&self);
+    }
+
+    static std::optional<FormatArguments> tooltip(Ui::Window&, WidgetIndex_t)
+    {
+        FormatArguments args{};
+        args.skip(2);
         if (_lastSelectedBridge != 0xFF)
         {
             auto bridgeObj = ObjectManager::get<BridgeObject>(_lastSelectedBridge);
@@ -2519,7 +2526,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
                 args.push<uint16_t>(bridgeObj->maxHeight);
             }
         }
-        Common::repositionTabs(&self);
+        return args;
     }
 
     // 0x004A0AE5
@@ -2961,6 +2968,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         .onUpdate = onUpdate,
         .onToolUpdate = onToolUpdate,
         .onToolDown = onToolDown,
+        .tooltip = tooltip,
         .cursor = cursor,
         .prepareDraw = prepareDraw,
         .draw = draw,


### PR DESCRIPTION
Bridge tooltip was just displaying any old junk from the global var.
This solves the problem two fold. Fixes the source of the issue (puts the correct values in the global). And fixes the crash (accessing the invalid string id).