### PR TITLE
Implement S5::drawScenarioPreviewImage

### DIFF
--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -201,7 +201,7 @@ namespace OpenLoco::EditorController
         if (Game::hasFlags(GameStateFlags::tileManagerLoaded))
         {
             options.scenarioFlags |= Scenario::ScenarioFlags::landscapeGenerationDone;
-            Game::sub_46DB4C(); // draw preview map
+            S5::drawScenarioPreviewImage();
         }
 
         options.maxCompetingCompanies = CompanyManager::getMaxCompetingCompanies();

--- a/src/OpenLoco/src/Game.cpp
+++ b/src/OpenLoco/src/Game.cpp
@@ -37,12 +37,6 @@ namespace OpenLoco::Game
 
     static loco_global<char[512], 0x0112CE04> _savePath;
 
-    // 0x0046DB4C
-    void sub_46DB4C()
-    {
-        call(0x0046DB4C); // draw preview map
-    }
-
     using Ui::Windows::PromptBrowse::browse_type;
 
     static bool openBrowsePrompt(StringId titleId, browse_type type, const char* filter)
@@ -120,7 +114,7 @@ namespace OpenLoco::Game
         if (hasFlags(GameStateFlags::tileManagerLoaded))
         {
             S5::getOptions().scenarioFlags |= Scenario::ScenarioFlags::landscapeGenerationDone;
-            sub_46DB4C();
+            S5::drawScenarioPreviewImage();
         }
 
         auto path = fs::u8path(&_pathLandscapes[0]).parent_path() / S5::getOptions().scenarioName;

--- a/src/OpenLoco/src/Game.h
+++ b/src/OpenLoco/src/Game.h
@@ -31,5 +31,4 @@ namespace OpenLoco::Game
     void setFlags(GameStateFlags flags);
     bool hasFlags(GameStateFlags flags);
     void removeFlags(GameStateFlags flags);
-    void sub_46DB4C();
 }

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -121,12 +121,12 @@ namespace OpenLoco::S5
         uint8_t tempPreview[128][128];
         auto* targetPtr = &tempPreview[0][0];
 
-        for (auto y = kTileSize; y < kMapHeight; y += kTileSize * kMapSkipFactor)
+        for (auto y = 1; y < kMapRows; y += kMapSkipFactor)
         {
-            for (auto x = kMapWidth - kTileSize * (kMapSkipFactor - 1); x > 0; x -= kTileSize * kMapSkipFactor)
+            for (auto x = kMapColumns - (kMapSkipFactor - 1); x > 0; x -= kMapSkipFactor)
             {
                 uint8_t colour = 0;
-                auto tile = TileManager::get(x, y);
+                auto tile = TileManager::get(TilePos2(x, y));
                 for (auto& el : tile)
                 {
                     switch (el.type())

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -155,10 +155,10 @@ namespace OpenLoco::S5
                         }
 
                         case ElementType::building:
+                        case ElementType::road:
                             colour = PaletteIndex::index_41;
                             break;
 
-                        case ElementType::road:
                         case ElementType::industry:
                             colour = PaletteIndex::index_7D;
                             break;

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -116,17 +116,18 @@ namespace OpenLoco::S5
     // 0x0046DB4C
     void drawScenarioPreviewImage()
     {
-        const auto kMapSkipFactor = kMapRows / 128; // sizeof? = 3
         auto& options = S5::getOptions();
         uint8_t tempPreview[128][128];
-        auto* targetPtr = &tempPreview[0][0];
+        const auto kPreviewSize = sizeof(tempPreview[0]);
+        const auto kMapSkipFactor = kMapRows / kPreviewSize;
 
-        for (auto y = 1; y < kMapRows; y += kMapSkipFactor)
+        for (auto y = 0U; y < kPreviewSize; y++)
         {
-            for (auto x = kMapColumns - (kMapSkipFactor - 1); x > 0; x -= kMapSkipFactor)
+            for (auto x = 0U; x < kPreviewSize; x++)
             {
                 uint8_t colour = 0;
-                auto tile = TileManager::get(TilePos2(x, y));
+                auto pos = TilePos2(kMapColumns - (x + 1) * kMapSkipFactor + 1, y * kMapSkipFactor + 1);
+                auto tile = TileManager::get(pos);
                 for (auto& el : tile)
                 {
                     switch (el.type())
@@ -173,7 +174,7 @@ namespace OpenLoco::S5
                 }
 
                 // TODO: write to S5Options instead
-                *targetPtr++ = colour;
+                tempPreview[y][x] = colour;
             }
         }
 
@@ -183,16 +184,16 @@ namespace OpenLoco::S5
         // Compare our version to original
         auto numMismatches = 0U;
         auto foundMismatch = false;
-        for (auto y = 0; y < 128; y++)
+        for (auto y = 0U; y < kPreviewSize; y++)
         {
-            for (auto x = 0; x < 128; x++)
+            for (auto x = 0U; x < kPreviewSize; x++)
             {
                 if (tempPreview[y][x] != options.preview[y][x])
                 {
                     if (!foundMismatch)
                     {
                         foundMismatch = true;
-                        printf("First preview mismatch at (%d, %d)!", y, x);
+                        printf("First preview mismatch at (%d, %d)!\n", y, x);
                     }
                     numMismatches++;
                 }

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -117,8 +117,7 @@ namespace OpenLoco::S5
     void drawScenarioPreviewImage()
     {
         auto& options = S5::getOptions();
-        uint8_t tempPreview[128][128];
-        const auto kPreviewSize = sizeof(tempPreview[0]);
+        const auto kPreviewSize = sizeof(options.preview[0]);
         const auto kMapSkipFactor = kMapRows / kPreviewSize;
 
         for (auto y = 0U; y < kPreviewSize; y++)
@@ -173,40 +172,8 @@ namespace OpenLoco::S5
                     }
                 }
 
-                // TODO: write to S5Options instead
-                tempPreview[y][x] = colour;
+                options.preview[y][x] = colour;
             }
-        }
-
-        // Call original function
-        call(0x0046DB4C);
-
-        // Compare our version to original
-        auto numMismatches = 0U;
-        auto foundMismatch = false;
-        for (auto y = 0U; y < kPreviewSize; y++)
-        {
-            for (auto x = 0U; x < kPreviewSize; x++)
-            {
-                if (tempPreview[y][x] != options.preview[y][x])
-                {
-                    if (!foundMismatch)
-                    {
-                        foundMismatch = true;
-                        printf("First preview mismatch at (%d, %d)!\n", y, x);
-                    }
-                    numMismatches++;
-                }
-            }
-        }
-
-        if (numMismatches > 0)
-        {
-            printf("Found %d mismatching bytes!\n", numMismatches);
-        }
-        else
-        {
-            printf("Previews match!");
         }
     }
 

--- a/src/OpenLoco/src/S5/S5.h
+++ b/src/OpenLoco/src/S5/S5.h
@@ -97,7 +97,7 @@ namespace OpenLoco::S5
         char scenarioName[64];                                // 0x2A
         char scenarioDetails[256];                            // 0x6A
         ObjectHeader scenarioText;                            // 0x16A
-        uint16_t numberOfForests;                             // 0x17a
+        uint16_t numberOfForests;                             // 0x17A
         uint8_t minForestRadius;                              // 0x17C
         uint8_t maxForestRadius;                              // 0x17D
         uint8_t minForestDensity;                             // 0x17E
@@ -456,6 +456,9 @@ namespace OpenLoco::S5
     constexpr const char* filterSV5 = "*.SV5";
 
     Options& getOptions();
+
+    void drawScenarioPreviewImage();
+
     bool exportGameStateToFile(const fs::path& path, SaveFlags flags);
     bool exportGameStateToFile(Stream& stream, SaveFlags flags);
     void registerHooks();


### PR DESCRIPTION
Implements the `S5::drawScenarioPreviewImage` function. During implementation, I ran this implementation and the vanilla function side-by-side to ensure a correct result. The code has since been cleaned up, and is now ready to be merged.