### PR TITLE
Adjust OriginalTerrainGenerator to adhere to heightMap dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 24.09+ (???)
 ------------------------------------------------------------------------
+- Fix: [#2613] Landscape types around cliffs aren't applied correctly.
+- Fix: [#2614] Randomly generated landscape can use invalid coordinates, leading to a crash.
 
 24.09 (2024-09-01)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
+++ b/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <OpenLoco/Diagnostics/Logging.h>
 #include <OpenLoco/Engine/World.hpp>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
+
+using namespace OpenLoco::Diagnostics;
 
 namespace OpenLoco::World::MapGenerator
 {
@@ -27,12 +30,18 @@ namespace OpenLoco::World::MapGenerator
         uint8_t& operator[](TilePos2 pos)
         {
             assert(pos.x >= 0 || pos.y >= 0 || pos.x < width || pos.y < height);
+            if (pos.x > 383 || pos.y > 383)
+                Logging::info("pos = ({}, {})", pos.x, pos.y);
+
             return _height[pos.y * width + pos.x];
         }
 
         const uint8_t& operator[](TilePos2 pos) const
         {
             assert(pos.x >= 0 || pos.y >= 0 || pos.x < width || pos.y < height);
+            if (pos.x > 383 || pos.y > 383)
+                Logging::info("pos = ({}, {})", pos.x, pos.y);
+
             return _height[pos.y * width + pos.x];
         }
 

--- a/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
+++ b/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
@@ -14,8 +14,8 @@ namespace OpenLoco::World::MapGenerator
         std::vector<uint8_t> _height;
 
     public:
-        int32_t const width;
-        int32_t const height;
+        const uint16_t width;
+        const uint16_t height;
 
         HeightMap(int32_t width, int32_t height)
             : _height(width * height)

--- a/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
+++ b/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
@@ -26,14 +26,6 @@ namespace OpenLoco::World::MapGenerator
         {
         }
 
-        HeightMap(const HeightMap& src)
-            : _height(src._height)
-            , width(src.width)
-            , height(src.height)
-            , pitch(src.pitch)
-        {
-        }
-
         uint8_t& operator[](TilePos2 pos)
         {
             assert(pos.x >= 0 || pos.y >= 0 || pos.x < width || pos.y < height);

--- a/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
+++ b/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
@@ -16,26 +16,24 @@ namespace OpenLoco::World::MapGenerator
     public:
         int32_t const width;
         int32_t const height;
-        int32_t const pitch;
 
-        HeightMap(int32_t width, int32_t height, int32_t pitch)
-            : _height(width * pitch)
+        HeightMap(int32_t width, int32_t height)
+            : _height(width * height)
             , width(width)
             , height(height)
-            , pitch(pitch)
         {
         }
 
         uint8_t& operator[](TilePos2 pos)
         {
             assert(pos.x >= 0 || pos.y >= 0 || pos.x < width || pos.y < height);
-            return _height[pos.y * pitch + pos.x];
+            return _height[pos.y * width + pos.x];
         }
 
         const uint8_t& operator[](TilePos2 pos) const
         {
             assert(pos.x >= 0 || pos.y >= 0 || pos.x < width || pos.y < height);
-            return _height[pos.y * pitch + pos.x];
+            return _height[pos.y * width + pos.x];
         }
 
         uint8_t* data()

--- a/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
+++ b/src/OpenLoco/src/Map/MapGenerator/HeightMap.h
@@ -1,13 +1,10 @@
 #pragma once
 
-#include <OpenLoco/Diagnostics/Logging.h>
 #include <OpenLoco/Engine/World.hpp>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
-
-using namespace OpenLoco::Diagnostics;
 
 namespace OpenLoco::World::MapGenerator
 {
@@ -30,18 +27,12 @@ namespace OpenLoco::World::MapGenerator
         uint8_t& operator[](TilePos2 pos)
         {
             assert(pos.x >= 0 || pos.y >= 0 || pos.x < width || pos.y < height);
-            if (pos.x > 383 || pos.y > 383)
-                Logging::info("pos = ({}, {})", pos.x, pos.y);
-
             return _height[pos.y * width + pos.x];
         }
 
         const uint8_t& operator[](TilePos2 pos) const
         {
             assert(pos.x >= 0 || pos.y >= 0 || pos.x < width || pos.y < height);
-            if (pos.x > 383 || pos.y > 383)
-                Logging::info("pos = ({}, {})", pos.x, pos.y);
-
             return _height[pos.y * width + pos.x];
         }
 

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -427,7 +427,7 @@ namespace OpenLoco::World::MapGenerator
         heightMap.resetMarkerFlags();
 
         // Mark tiles with sudden height changes in the next row
-        for (auto pos : getWorldRange())
+        for (auto pos : getDrawableTileRange())
         {
             auto heightA = heightMap.getHeight({ pos + TilePos2{ 0, 1 } });
             auto heightB = heightMap.getHeight({ pos + TilePos2{ 0, 1 } });

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -1020,7 +1020,7 @@ namespace OpenLoco::World::MapGenerator
         updateProgress(10);
 
         {
-            HeightMap heightMap(kMapRows, kMapRows, kMapRows);
+            HeightMap heightMap(kMapColumns, kMapRows);
 
             generateHeightMap(options, heightMap);
             updateProgress(25);

--- a/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
@@ -174,17 +174,13 @@ namespace OpenLoco::World::MapGenerator
     void OriginalTerrainGenerator::copyHeightMapFromG1(Gfx::G1Element* g1Element, HeightMap& heightMap)
     {
         auto* src = g1Element->offset;
-        auto* dst = heightMap.data();
 
-        // TODO: rewrite to use TilePos2
         for (auto y = kMapRows - 1; y > 0; y--)
         {
-            dst += kMapColumns;
-
-            for (auto x = kMapColumns; x > 0; x--)
+            for (auto x = kMapColumns - 1; x > 0; x--)
             {
-                dst--;
-                *dst = std::max<uint8_t>(*dst, *src);
+                auto height = std::max<uint8_t>(*src, heightMap[TilePos2(x, y)]);
+                heightMap[TilePos2(x, y)] = height;
                 src++;
             }
 

--- a/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
@@ -31,8 +31,8 @@ namespace OpenLoco::World::MapGenerator
         }
 
         // 0x00462718
-        const auto randX = (randomVal >> 14) & 0x1FF;
-        const auto randY = (randomVal >> 23) & 0x1FF;
+        const auto randX = (randomVal >> 14) % (kMapColumns - 1);
+        const auto randY = (randomVal >> 23) % (kMapRows - 1);
         if (randX < 2 || randY < 2)
         {
             return;
@@ -58,7 +58,7 @@ namespace OpenLoco::World::MapGenerator
 
         if ((options.scenarioFlags & Scenario::ScenarioFlags::hillsEdgeOfMap) == Scenario::ScenarioFlags::none)
         {
-            if ((randX + featureWidth >= 382) || (randY + featureHeight >= 382))
+            if ((randX + featureWidth >= kMapColumns - 2) || (randY + featureHeight >= kMapRows - 2))
             {
                 return;
             }
@@ -86,16 +86,16 @@ namespace OpenLoco::World::MapGenerator
         int32_t x = randX;
         for (auto j = 0; j < featureWidth; ++j)
         {
-            int32_t y = (featureHeight + randY - 1) & 0x1FF;
+            int32_t y = (featureHeight + randY - 1) % (kMapRows - 1);
             for (auto i = 0; i < featureHeight; ++i)
             {
                 const auto data = *src++;
                 heightMap[TilePos2(x, y)] = std::max(data, heightMap[TilePos2(x, y)]);
                 y--;
-                y &= 0x1FF;
+                y %= kMapRows - 1;
             }
             x++;
-            x &= 0x1FF;
+            x %= kMapColumns - 1;
         }
     }
 
@@ -111,10 +111,10 @@ namespace OpenLoco::World::MapGenerator
                 const auto data = *src++;
                 heightMap[TilePos2(x, y)] = std::max(data, heightMap[TilePos2(x, y)]);
                 y++;
-                y &= 0x1FF;
+                y %= kMapRows - 1;
             }
             x++;
-            x &= 0x1FF;
+            x %= kMapColumns - 1;
         }
     }
 
@@ -124,16 +124,16 @@ namespace OpenLoco::World::MapGenerator
         int32_t y = randY;
         for (auto j = 0; j < featureHeight; ++j)
         {
-            int32_t x = (randX + featureWidth - 1) & 0x1FF;
+            int32_t x = (randX + featureWidth - 1) % (kMapColumns - 1);
             for (auto i = 0; i < featureWidth; ++i)
             {
                 const auto data = *src++;
                 heightMap[TilePos2(x, y)] = std::max(data, heightMap[TilePos2(x, y)]);
                 x--;
-                x &= 0x1FF;
+                x %= kMapColumns - 1;
             }
             y++;
-            y &= 0x1FF;
+            y %= kMapRows - 1;
         }
     }
 
@@ -151,10 +151,10 @@ namespace OpenLoco::World::MapGenerator
                 heightMap[TilePos2(x, y)] = std::max(data, heightMap[TilePos2(x, y)]);
 
                 x++;
-                x &= 0x1FF;
+                x %= kMapColumns - 1;
             }
             y++;
-            y &= 0x1FF;
+            y %= kMapRows - 1;
         }
     }
 
@@ -176,7 +176,7 @@ namespace OpenLoco::World::MapGenerator
         auto* src = g1Element->offset;
         auto* dst = heightMap.data();
 
-        for (auto y = kMapRows; y > 0; y--)
+        for (auto y = kMapRows - 1; y > 0; y--)
         {
             dst += kMapColumns;
 

--- a/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
@@ -176,18 +176,18 @@ namespace OpenLoco::World::MapGenerator
         auto* src = g1Element->offset;
         auto* dst = heightMap.data();
 
-        for (auto y = World::kMapRows; y > 0; y--)
+        for (auto y = kMapRows; y > 0; y--)
         {
-            dst += World::kMapColumns;
+            dst += kMapColumns;
 
-            for (auto x = World::kMapColumns; x > 0; x--)
+            for (auto x = kMapColumns; x > 0; x--)
             {
                 dst--;
                 *dst = std::max<uint8_t>(*dst, *src);
                 src++;
             }
 
-            src += World::kMapPitch;
+            src += kMapPitch;
         }
     }
 
@@ -197,7 +197,7 @@ namespace OpenLoco::World::MapGenerator
         auto seaLevel = getGameState().seaLevel;
         auto* dst = heightMap.data();
 
-        for (auto i = World::kMapPitch * (World::kMapPitch - 1) - 1; i > 0; i--)
+        for (auto i = kMapPitch * (kMapPitch - 1) - 1; i > 0; i--)
         {
             if (seaLevel != *(dst))
                 continue;
@@ -205,16 +205,16 @@ namespace OpenLoco::World::MapGenerator
             if (seaLevel != *(dst + 1))
                 continue;
 
-            if (seaLevel != *(dst + World::kMapPitch))
+            if (seaLevel != *(dst + kMapPitch))
                 continue;
 
-            if (seaLevel != *(dst + World::kMapPitch + 1))
+            if (seaLevel != *(dst + kMapPitch + 1))
                 continue;
 
             *dst += 1;
             *(dst + 1) += 1;
-            *(dst + World::kMapPitch) += 1;
-            *(dst + World::kMapPitch + 1) += 1;
+            *(dst + kMapPitch) += 1;
+            *(dst + kMapPitch + 1) += 1;
 
             dst++;
         }

--- a/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
@@ -31,8 +31,8 @@ namespace OpenLoco::World::MapGenerator
         }
 
         // 0x00462718
-        const auto randX = (randomVal >> 14) % (heightMap.width - 1);
-        const auto randY = (randomVal >> 23) % (heightMap.height - 1);
+        const uint32_t randX = getGameState().rng.randNext(heightMap.width - 1);
+        const uint32_t randY = getGameState().rng.randNext(heightMap.height - 1);
         if (randX < 2 || randY < 2)
         {
             return;

--- a/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
@@ -31,8 +31,8 @@ namespace OpenLoco::World::MapGenerator
         }
 
         // 0x00462718
-        const auto randX = (randomVal >> 14) % (kMapColumns - 1);
-        const auto randY = (randomVal >> 23) % (kMapRows - 1);
+        const auto randX = (randomVal >> 14) % (heightMap.width - 1);
+        const auto randY = (randomVal >> 23) % (heightMap.height - 1);
         if (randX < 2 || randY < 2)
         {
             return;
@@ -58,7 +58,7 @@ namespace OpenLoco::World::MapGenerator
 
         if ((options.scenarioFlags & Scenario::ScenarioFlags::hillsEdgeOfMap) == Scenario::ScenarioFlags::none)
         {
-            if ((randX + featureWidth >= kMapColumns - 2) || (randY + featureHeight >= kMapRows - 2))
+            if ((randX + featureWidth >= heightMap.width - 2U) || (randY + featureHeight >= heightMap.height - 2U))
             {
                 return;
             }
@@ -86,16 +86,16 @@ namespace OpenLoco::World::MapGenerator
         int32_t x = randX;
         for (auto j = 0; j < featureWidth; ++j)
         {
-            int32_t y = (featureHeight + randY - 1) % (kMapRows - 1);
+            int32_t y = (featureHeight + randY - 1) % (heightMap.height - 1);
             for (auto i = 0; i < featureHeight; ++i)
             {
                 const auto data = *src++;
                 heightMap[TilePos2(x, y)] = std::max(data, heightMap[TilePos2(x, y)]);
                 y--;
-                y %= kMapRows - 1;
+                y %= heightMap.height - 1;
             }
             x++;
-            x %= kMapColumns - 1;
+            x %= heightMap.width - 1;
         }
     }
 
@@ -111,10 +111,10 @@ namespace OpenLoco::World::MapGenerator
                 const auto data = *src++;
                 heightMap[TilePos2(x, y)] = std::max(data, heightMap[TilePos2(x, y)]);
                 y++;
-                y %= kMapRows - 1;
+                y %= heightMap.height - 1;
             }
             x++;
-            x %= kMapColumns - 1;
+            x %= heightMap.width - 1;
         }
     }
 
@@ -124,16 +124,16 @@ namespace OpenLoco::World::MapGenerator
         int32_t y = randY;
         for (auto j = 0; j < featureHeight; ++j)
         {
-            int32_t x = (randX + featureWidth - 1) % (kMapColumns - 1);
+            int32_t x = (randX + featureWidth - 1) % (heightMap.width - 1);
             for (auto i = 0; i < featureWidth; ++i)
             {
                 const auto data = *src++;
                 heightMap[TilePos2(x, y)] = std::max(data, heightMap[TilePos2(x, y)]);
                 x--;
-                x %= kMapColumns - 1;
+                x %= heightMap.width - 1;
             }
             y++;
-            y %= kMapRows - 1;
+            y %= heightMap.height - 1;
         }
     }
 
@@ -151,10 +151,10 @@ namespace OpenLoco::World::MapGenerator
                 heightMap[TilePos2(x, y)] = std::max(data, heightMap[TilePos2(x, y)]);
 
                 x++;
-                x %= kMapColumns - 1;
+                x %= heightMap.width - 1;
             }
             y++;
-            y %= kMapRows - 1;
+            y %= heightMap.height - 1;
         }
     }
 
@@ -175,9 +175,9 @@ namespace OpenLoco::World::MapGenerator
     {
         auto* src = g1Element->offset;
 
-        for (auto y = kMapRows - 1; y > 0; y--)
+        for (auto y = heightMap.height - 1; y > 0; y--)
         {
-            for (auto x = kMapColumns - 1; x > 0; x--)
+            for (auto x = heightMap.width - 1; x > 0; x--)
             {
                 auto height = std::max<uint8_t>(*src, heightMap[TilePos2(x, y)]);
                 heightMap[TilePos2(x, y)] = height;
@@ -193,9 +193,9 @@ namespace OpenLoco::World::MapGenerator
     {
         const auto seaLevel = getGameState().seaLevel;
 
-        for (auto y = kMapRows - 1; y > 0; y--)
+        for (auto y = heightMap.height - 1; y > 0; y--)
         {
-            for (auto x = kMapColumns - 1; x > 0; x--)
+            for (auto x = heightMap.width - 1; x > 0; x--)
             {
                 if (seaLevel != heightMap[TilePos2(x + 0, y + 0)])
                     continue;

--- a/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
@@ -176,6 +176,7 @@ namespace OpenLoco::World::MapGenerator
         auto* src = g1Element->offset;
         auto* dst = heightMap.data();
 
+        // TODO: rewrite to use TilePos2
         for (auto y = kMapRows - 1; y > 0; y--)
         {
             dst += kMapColumns;
@@ -197,6 +198,7 @@ namespace OpenLoco::World::MapGenerator
         auto seaLevel = getGameState().seaLevel;
         auto* dst = heightMap.data();
 
+        // TODO: rewrite to use TilePos2
         for (auto i = kMapPitch * (kMapPitch - 1) - 1; i > 0; i--)
         {
             if (seaLevel != *(dst))

--- a/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
@@ -193,9 +193,9 @@ namespace OpenLoco::World::MapGenerator
     {
         const auto seaLevel = getGameState().seaLevel;
 
-        for (auto y = heightMap.height - 1; y > 0; y--)
+        for (auto y = 0; y < heightMap.height - 2; y++)
         {
-            for (auto x = heightMap.width - 1; x > 0; x--)
+            for (auto x = 0; x < heightMap.width - 2; x++)
             {
                 if (seaLevel != heightMap[TilePos2(x + 0, y + 0)])
                     continue;

--- a/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
@@ -195,30 +195,29 @@ namespace OpenLoco::World::MapGenerator
     // 0x00462590
     void OriginalTerrainGenerator::capSeaLevels(HeightMap& heightMap)
     {
-        auto seaLevel = getGameState().seaLevel;
-        auto* dst = heightMap.data();
+        const auto seaLevel = getGameState().seaLevel;
 
-        // TODO: rewrite to use TilePos2
-        for (auto i = kMapPitch * (kMapPitch - 1) - 1; i > 0; i--)
+        for (auto y = kMapRows - 1; y > 0; y--)
         {
-            if (seaLevel != *(dst))
-                continue;
+            for (auto x = kMapColumns - 1; x > 0; x--)
+            {
+                if (seaLevel != heightMap[TilePos2(x + 0, y + 0)])
+                    continue;
 
-            if (seaLevel != *(dst + 1))
-                continue;
+                if (seaLevel != heightMap[TilePos2(x + 1, y + 0)])
+                    continue;
 
-            if (seaLevel != *(dst + kMapPitch))
-                continue;
+                if (seaLevel != heightMap[TilePos2(x + 0, y + 1)])
+                    continue;
 
-            if (seaLevel != *(dst + kMapPitch + 1))
-                continue;
+                if (seaLevel != heightMap[TilePos2(x + 1, y + 1)])
+                    continue;
 
-            *dst += 1;
-            *(dst + 1) += 1;
-            *(dst + kMapPitch) += 1;
-            *(dst + kMapPitch + 1) += 1;
-
-            dst++;
+                heightMap[TilePos2(x + 0, y + 0)] += 1;
+                heightMap[TilePos2(x + 1, y + 0)] += 1;
+                heightMap[TilePos2(x + 0, y + 1)] += 1;
+                heightMap[TilePos2(x + 1, y + 1)] += 1;
+            }
         }
     }
 


### PR DESCRIPTION
This PR addresses issue #2614:
* Found a bug in `generateTerrainAroundCliffs` where it would go one tile past the bounds
* `OriginalTerrainGenerator` was hardcoding `& 0x1FF` (511), which I've replaced with `% heightMap.width - 1` (or height, as appropriate)

Bonus:
* Removed the superfluous `pitch` parameter from the HeightMap class, instead using `width`