### PR TITLE
Increment progress bar for generateTerrain substeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 24.09+ (???)
 ------------------------------------------------------------------------
+- Change: [#2617] Report terrain generation progress more incrementally, so it doesn't appear stuck.
 - Fix: [#2613] Landscape types around cliffs aren't applied correctly.
 - Fix: [#2614] Randomly generated landscape can use invalid coordinates, leading to a crash.
 - Fix: [#2618] Reversed car components displayed incorrectly in vehicle window.

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -43,6 +43,12 @@ namespace OpenLoco::World::MapGenerator
 
     static fs::path _pngHeightmapPath{};
 
+    static void updateProgress(uint8_t value)
+    {
+        Ui::processMessagesMini();
+        Ui::ProgressBar::setProgress(value);
+    }
+
     // 0x004624F0
     static void generateHeightMap(const S5::Options& options, HeightMap& heightMap)
     {
@@ -494,16 +500,20 @@ namespace OpenLoco::World::MapGenerator
             }
         }
 
-        for (const auto pattern : {
-                 LandDistributionPattern::farFromWater,
-                 LandDistributionPattern::nearWater,
-                 LandDistributionPattern::onMountains,
-                 LandDistributionPattern::farFromMountains,
-                 LandDistributionPattern::inSmallRandomAreas,
-                 LandDistributionPattern::inLargeRandomAreas,
-                 LandDistributionPattern::aroundCliffs,
-             })
+        constexpr std::array landDistributionPatterns = {
+            LandDistributionPattern::farFromWater,
+            LandDistributionPattern::nearWater,
+            LandDistributionPattern::onMountains,
+            LandDistributionPattern::farFromMountains,
+            LandDistributionPattern::inSmallRandomAreas,
+            LandDistributionPattern::inLargeRandomAreas,
+            LandDistributionPattern::aroundCliffs,
+        };
+
+        for (auto i = 0U; i < landDistributionPatterns.size(); i++)
         {
+            updateProgress(55 + 12 * i);
+
             for (uint8_t landObjectIdx = 0; landObjectIdx < ObjectManager::getMaxObjects(ObjectType::land); ++landObjectIdx)
             {
                 const auto* landObj = ObjectManager::get<LandObject>(landObjectIdx);
@@ -512,11 +522,11 @@ namespace OpenLoco::World::MapGenerator
                     continue;
                 }
                 const auto typePattern = S5::getOptions().landDistributionPatterns[landObjectIdx];
-                if (typePattern != pattern)
+                if (typePattern != landDistributionPatterns[i])
                 {
                     continue;
                 }
-                _generateFuncs[enumValue(pattern)](heightMap, landObjectIdx);
+                _generateFuncs[i](heightMap, landObjectIdx);
             }
         }
     }
@@ -714,12 +724,6 @@ namespace OpenLoco::World::MapGenerator
         }
 
         return false;
-    }
-
-    static void updateProgress(uint8_t value)
-    {
-        Ui::processMessagesMini();
-        Ui::ProgressBar::setProgress(value);
     }
 
     // 0x004597FD
@@ -1039,10 +1043,10 @@ namespace OpenLoco::World::MapGenerator
         }
 
         generateSurfaceVariation();
-        updateProgress(65);
+        updateProgress(175);
 
         generateTrees();
-        updateProgress(75);
+        updateProgress(200);
 
         generateTowns();
         updateProgress(225);

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -521,12 +521,15 @@ namespace OpenLoco::World::MapGenerator
                 {
                     continue;
                 }
+
                 const auto typePattern = S5::getOptions().landDistributionPatterns[landObjectIdx];
-                if (typePattern != landDistributionPatterns[i])
+                const auto distPattern = landDistributionPatterns[i];
+                if (typePattern != distPattern)
                 {
                     continue;
                 }
-                _generateFuncs[i](heightMap, landObjectIdx);
+
+                _generateFuncs[enumValue(distPattern)](heightMap, landObjectIdx);
             }
         }
     }


### PR DESCRIPTION
The `generateTerrain` function represents a big chunk of the map generation process, with the full map being iterated over for number of patterns times the number of surface styles times! Unfortunately, we were only reporting progress at the start and end of the entire function. This PR changes this such that progress is now reported for every distribution pattern involved.