### PR TITLE
Group object selection tabs by category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 24.09.1+ (???)
 ------------------------------------------------------------------------
+- Feature: [#2629] The object selection window now groups relevant object tabs together.
 - Fix: [#2612] Crash when constructing trams underground with Shift key pressed.
 - Fix: [#2625] Crash when resizing the window during the Intro.
 

--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -210,7 +210,11 @@ namespace OpenLoco::Ui
         uint16_t var_850 = 0;
         uint16_t var_852 = 0;
         uint16_t var_854 = 0; // used to limit updates
-        uint16_t var_856 = 0;
+        union
+        {
+            uint16_t filterLevel;     // ObjectSelectionWindow
+            uint16_t numTicksVisible; // TimePanel
+        };
         uint16_t var_858 = 0;
         union
         {

--- a/src/OpenLoco/src/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Windows/MapWindow.cpp
@@ -2333,7 +2333,6 @@ namespace OpenLoco::Ui::Windows::MapWindow
         window->currentTab = 0;
         window->savedView.mapX = 1;
         window->var_854 = 0;
-        window->var_856 = 0;
 
         assignIndustryColours();
         assignRouteColours();

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -107,40 +107,50 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     };
 
     static constexpr std::array<MainTabInfo, kMaxObjectTypes> _mainTabInfo = {
-        MainTabInfo{ StringIds::object_interface_styles,      ObjectType::interfaceSkin, ImageIds::tab_object_settings,        {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_sounds,                ObjectType::sound,         ImageIds::tab_object_audio,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_world_region,          ObjectType::region,        ImageIds::tab_object_world,           {},              ObjectTabFlags::none },
         MainTabInfo{ StringIds::object_currency,              ObjectType::currency,      ImageIds::tab_object_currency,        {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_animation_effects,     ObjectType::steam,         ImageIds::tab_object_smoke,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        MainTabInfo{ StringIds::object_cliffs,                ObjectType::cliffEdge,     ImageIds::tab_object_cliff,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        MainTabInfo{ StringIds::object_water,                 ObjectType::water,         ImageIds::tab_object_water,           {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_land,                  ObjectType::land,          ImageIds::tab_object_landscape,       {},              ObjectTabFlags::advanced },
         MainTabInfo{ StringIds::object_town_names,            ObjectType::townNames,     ImageIds::tab_object_town_names,      {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_cargo,                 ObjectType::cargo,         ImageIds::tab_object_cargo,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        MainTabInfo{ StringIds::object_walls,                 ObjectType::wall,          ImageIds::tab_object_walls,           {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_signals,               ObjectType::trackSignal,   ImageIds::tab_object_signals,         {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_level_crossing,        ObjectType::levelCrossing, ImageIds::tab_object_level_crossings, {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_street_lights,         ObjectType::streetLight,   ImageIds::tab_object_streetlights,    {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_tunnels,               ObjectType::tunnel,        ImageIds::tab_object_tunnels,         {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        MainTabInfo{ StringIds::object_bridges,               ObjectType::bridge,        ImageIds::tab_object_bridges,         {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_track_stations,        ObjectType::trainStation,  ImageIds::tab_object_track_stations,  {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_track_extras,          ObjectType::trackExtra,    ImageIds::tab_object_track_mods,      {},              ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
-        MainTabInfo{ StringIds::object_tracks,                ObjectType::track,         ImageIds::tab_object_track,           {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_road_stations,         ObjectType::roadStation,   ImageIds::tab_object_road_stations,   {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_road_extras,           ObjectType::roadExtra,     ImageIds::tab_object_road_mods,       {},              ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
-        MainTabInfo{ StringIds::object_roads,                 ObjectType::road,          ImageIds::tab_object_road,            {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_airports,              ObjectType::airport,       ImageIds::tab_object_airports,        {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_docks,                 ObjectType::dock,          ImageIds::tab_object_docks,           {},              ObjectTabFlags::advanced },
+
         MainTabInfo{ StringIds::object_vehicles,              ObjectType::vehicle,       ImageIds::tab_object_vehicles,        kVehicleSubTabs, ObjectTabFlags::advanced },
+
+        MainTabInfo{ StringIds::object_land,                  ObjectType::land,          ImageIds::tab_object_landscape,       {},              ObjectTabFlags::advanced },
         MainTabInfo{ StringIds::object_trees,                 ObjectType::tree,          ImageIds::tab_object_trees,           {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_water,                 ObjectType::water,         ImageIds::tab_object_water,           {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_walls,                 ObjectType::wall,          ImageIds::tab_object_walls,           {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_map_generation_data,   ObjectType::hillShapes,    ImageIds::tab_object_map,             {},              ObjectTabFlags::advanced },
         MainTabInfo{ StringIds::object_snow,                  ObjectType::snow,          ImageIds::tab_object_snow,            {},              ObjectTabFlags::advanced },
         MainTabInfo{ StringIds::object_climate,               ObjectType::climate,       ImageIds::tab_object_climate,         {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_map_generation_data,   ObjectType::hillShapes,    ImageIds::tab_object_map,             {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_cliffs,                ObjectType::cliffEdge,     ImageIds::tab_object_cliff,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+
+        MainTabInfo{ StringIds::object_tracks,                ObjectType::track,         ImageIds::tab_object_track,           {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_track_stations,        ObjectType::trainStation,  ImageIds::tab_object_track_stations,  {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_track_extras,          ObjectType::trackExtra,    ImageIds::tab_object_track_mods,      {},              ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
+        MainTabInfo{ StringIds::object_signals,               ObjectType::trackSignal,   ImageIds::tab_object_signals,         {},              ObjectTabFlags::advanced },
+
+        MainTabInfo{ StringIds::object_roads,                 ObjectType::road,          ImageIds::tab_object_road,            {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_road_stations,         ObjectType::roadStation,   ImageIds::tab_object_road_stations,   {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_road_extras,           ObjectType::roadExtra,     ImageIds::tab_object_road_mods,       {},              ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
+        MainTabInfo{ StringIds::object_level_crossing,        ObjectType::levelCrossing, ImageIds::tab_object_level_crossings, {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_street_lights,         ObjectType::streetLight,   ImageIds::tab_object_streetlights,    {},              ObjectTabFlags::advanced },
+
+        MainTabInfo{ StringIds::object_airports,              ObjectType::airport,       ImageIds::tab_object_airports,        {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_docks,                 ObjectType::dock,          ImageIds::tab_object_docks,           {},              ObjectTabFlags::advanced },
+
         MainTabInfo{ StringIds::object_buildings,             ObjectType::building,      ImageIds::tab_object_buildings,       {},              ObjectTabFlags::advanced },
         MainTabInfo{ StringIds::object_scaffolding,           ObjectType::scaffolding,   ImageIds::tab_object_construction,    {},              ObjectTabFlags::advanced },
         MainTabInfo{ StringIds::object_industries,            ObjectType::industry,      ImageIds::tab_object_industries,      {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_world_region,          ObjectType::region,        ImageIds::tab_object_world,           {},              ObjectTabFlags::none },
+        MainTabInfo{ StringIds::object_cargo,                 ObjectType::cargo,         ImageIds::tab_object_cargo,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+
+        MainTabInfo{ StringIds::object_bridges,               ObjectType::bridge,        ImageIds::tab_object_bridges,         {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_tunnels,               ObjectType::tunnel,        ImageIds::tab_object_tunnels,         {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+
+        MainTabInfo{ StringIds::object_interface_styles,      ObjectType::interfaceSkin, ImageIds::tab_object_settings,        {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_scenario_descriptions, ObjectType::scenarioText,  ImageIds::tab_object_scenarios,       {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_sounds,                ObjectType::sound,         ImageIds::tab_object_audio,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_animation_effects,     ObjectType::steam,         ImageIds::tab_object_smoke,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+
         MainTabInfo{ StringIds::object_company_owners,        ObjectType::competitor,    ImageIds::tab_object_companies,       {},              ObjectTabFlags::hideInEditor },
-        MainTabInfo{ StringIds::object_scenario_descriptions, ObjectType::scenarioText,  ImageIds::tab_object_scenarios,       {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden }
+
     };
     // clang-format on
 
@@ -267,9 +277,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x004731EE
-    static void repositionTargetTab(Window* self, ObjectType targetTab)
+    static void repositionTargetTab(Window* self, uint8_t targetTab)
     {
-        self->currentTab = enumValue(targetTab);
+        self->currentTab = targetTab;
         for (auto i = 0U; i < std::size(_tabPositions); i++)
         {
             // Ended up in a position without info? Reassign positions first.
@@ -280,7 +290,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 return;
             }
 
-            if (_tabPositions[i].index == enumValue(targetTab))
+            if (_tabPositions[i].index == targetTab)
             {
                 // Found current tab, and its in bottom row? No change required
                 if (_tabPositions[i].row == 0)
@@ -292,9 +302,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         }
     }
 
-    static bool shouldShowTab(int8_t objectType, FilterLevel filterLevel)
+    static bool shouldShowTab(int8_t index, FilterLevel filterLevel)
     {
-        const ObjectTabFlags tabFlags = _mainTabInfo[objectType].flags;
+        const ObjectTabFlags tabFlags = _mainTabInfo[index].flags;
 
         if (filterLevel == FilterLevel::expert)
             return true;
@@ -303,6 +313,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             return false;
 
         // Skip all types that don't have any objects
+        auto objectType = enumValue(_mainTabInfo[index].objectType);
         if (_tabObjectCounts[objectType] == 0)
             return false;
 
@@ -331,13 +342,13 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         uint8_t rowCapacity = kPrimaryTabRowCapacity;
         uint8_t tabPos = 0;
 
-        for (int8_t currentType = kMaxObjectTypes - 1; currentType >= 0; currentType--)
+        for (auto i = 0U; i < _mainTabInfo.size(); i++)
         {
-            if (!shouldShowTab(currentType, FilterLevel(self->var_856)))
+            if (!shouldShowTab(i, FilterLevel(self->var_856)))
                 continue;
 
             // Assign tab position
-            _tabPositions[tabPos].index = static_cast<uint8_t>(currentType);
+            _tabPositions[tabPos].index = i;
             _tabPositions[tabPos].row = currentRow;
             tabPos++;
 
@@ -354,8 +365,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         // Add a marker to denote the last tab
         _tabPositions[tabPos].index = 0xFF;
 
-        const auto firstTabIndex = ObjectType(_tabPositions[0].index);
-        repositionTargetTab(self, firstTabIndex);
+        repositionTargetTab(self, _tabPositions[0].index);
     }
 
     static bool contains(const std::string_view& a, const std::string_view& b)
@@ -486,8 +496,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         window->object = nullptr;
 
         assignTabPositions(window);
-        repositionTargetTab(window, ObjectType::region);
-        populateTabObjectList(ObjectType::region, static_cast<FilterFlags>(window->var_858));
+        static_assert(_mainTabInfo[0].objectType == ObjectType::region);
+        repositionTargetTab(window, 0);
+        populateTabObjectList(ObjectType::region, FilterFlags(window->var_858));
 
         ObjectManager::freeTemporaryObject();
 
@@ -509,10 +520,11 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         return window;
     }
 
-    static void switchTab(Window& self, ObjectType newTab);
+    static void switchTab(Window& self, uint8_t tabIndex);
 
     Window& openInTab(ObjectType objectType)
     {
+        // TODO: look up actual index
         auto& window = *open();
         auto& info = _mainTabInfo[enumValue(objectType)];
 
@@ -526,7 +538,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         }
 
         assignTabPositions(&window);
-        switchTab(window, objectType);
+        // TODO: look up actual index
+        switchTab(window, enumValue(objectType));
         return window;
     }
 
@@ -1162,14 +1175,45 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             auto* w = WindowManager::find(WindowType::objectSelection);
             if (w != nullptr)
             {
-                repositionTargetTab(w, res.value());
+                auto objectType = res.value();
+                auto targetTab = 0;
+                auto targetSubTab = 0;
+                for (auto i = 0U; i < _mainTabInfo.size(); i++)
+                {
+                    if (objectType == _mainTabInfo[i].objectType)
+                    {
+                        targetTab = i;
+                        break;
+                    }
+
+                    auto& subTabs = _mainTabInfo[i].subTabs;
+                    if (subTabs.empty())
+                        continue;
+
+                    for (auto j = 0U; j < subTabs.size(); j++)
+                    {
+                        if (objectType == subTabs[j].subObjectType)
+                        {
+                            targetTab = i;
+                            targetSubTab = j;
+                            break;
+                        }
+                    }
+
+                    if (targetSubTab != 0)
+                        break;
+                }
+
+                repositionTargetTab(w, targetTab);
+
                 w->rowHover = -1;
                 w->object = nullptr;
                 w->scrollAreas[0].contentWidth = 0;
                 ObjectManager::freeTemporaryObject();
                 w->invalidate();
 
-                populateTabObjectList(res.value(), static_cast<FilterFlags>(w->var_858));
+                w->currentSecondaryTab = targetSubTab;
+                populateTabObjectList(objectType, static_cast<FilterFlags>(w->var_858));
 
                 auto objIndex = getFirstAvailableSelectedObject(w);
                 if (objIndex.index != -1)
@@ -1184,15 +1228,16 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         }
     }
 
-    static void switchTab(Window& self, ObjectType newTab)
+    static void switchTab(Window& self, uint8_t tabIndex)
     {
-        repositionTargetTab(&self, newTab);
+        repositionTargetTab(&self, tabIndex);
 
         const auto& currentTab = _mainTabInfo[self.currentTab];
         _filterByVehicleType = currentTab.objectType == ObjectType::vehicle;
         _currentVehicleType = VehicleType::train;
 
-        populateTabObjectList(newTab, FilterFlags(self.var_858));
+        auto objectType = _mainTabInfo[tabIndex].objectType;
+        populateTabObjectList(objectType, FilterFlags(self.var_858));
 
         self.rowHover = -1;
         self.object = nullptr;
@@ -1254,7 +1299,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
                 if (clickedTab != -1 && self.currentTab != clickedTab)
                 {
-                    switchTab(self, ObjectType(clickedTab));
+                    // auto objectType = _mainTabInfo[clickedTab].objectType;
+                    switchTab(self, clickedTab);
                 }
 
                 break;
@@ -1346,24 +1392,27 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             if ((tabFlags & ObjectTabFlags::advanced) != ObjectTabFlags::none)
             {
                 currentTab = _tabPositions[0].index;
-                populateTabObjectList(static_cast<ObjectType>(currentTab), static_cast<FilterFlags>(self.var_858));
+                auto objectType = _mainTabInfo[currentTab].objectType;
+                populateTabObjectList(objectType, static_cast<FilterFlags>(self.var_858));
             }
 
-            repositionTargetTab(&self, static_cast<ObjectType>(currentTab));
+            repositionTargetTab(&self, currentTab);
         }
 
         // Toggle vanilla objects
         else if (itemIndex == 4)
         {
             self.var_858 = enumValue(FilterFlags(self.var_858) ^ FilterFlags::vanilla);
-            populateTabObjectList(static_cast<ObjectType>(self.currentTab), static_cast<FilterFlags>(self.var_858));
+            auto objectType = _mainTabInfo[self.currentTab].objectType;
+            populateTabObjectList(objectType, FilterFlags(self.var_858));
         }
 
         // Toggle custom objects
         else if (itemIndex == 5)
         {
             self.var_858 = enumValue(FilterFlags(self.var_858) ^ FilterFlags::custom);
-            populateTabObjectList(static_cast<ObjectType>(self.currentTab), static_cast<FilterFlags>(self.var_858));
+            auto objectType = _mainTabInfo[self.currentTab].objectType;
+            populateTabObjectList(objectType, FilterFlags(self.var_858));
         }
 
         self.invalidate();

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -207,7 +207,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static loco_global<uint16_t[33], 0x00112C181> _tabObjectCounts;
 
     // 0x0112C21C
-    static TabPosition _tabPositions[36];
+    static TabPosition _tabPositions[std::size(kMainTabInfo)];
     static std::vector<TabObjectEntry> _tabObjectList;
     static uint16_t _numVisibleObjectsListed;
     static bool _filterByVehicleType = false;

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -243,7 +243,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         objectImage,
     };
 
-    static constexpr uint8_t kNumSecondaryTabs = 8;
+    static constexpr uint8_t kMaxNumSecondaryTabs = 8;
 
     static constexpr auto widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, { 600, 398 }, WindowColour::primary),
@@ -519,7 +519,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             args.push(kMainTabInfo[self.currentTab].name);
 
         // Toggle secondary tabs
-        for (auto i = 0U; i < kNumSecondaryTabs; i++)
+        for (auto i = 0U; i < kMaxNumSecondaryTabs; i++)
         {
             const auto widgetIndex = i + widx::secondaryTab1;
 

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -76,7 +76,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(ObjectTabFlags);
 
-    struct TabDisplayInfo
+    struct MainTabInfo
     {
         StringId name;
         uint32_t image;
@@ -84,41 +84,41 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     };
 
     // clang-format off
-    static constexpr std::array<TabDisplayInfo, kMaxObjectTypes> _tabDisplayInfo = {
-        TabDisplayInfo{ StringIds::object_interface_styles,      ImageIds::tab_object_settings,        ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_sounds,                ImageIds::tab_object_audio,           ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        TabDisplayInfo{ StringIds::object_currency,              ImageIds::tab_object_currency,        ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_animation_effects,     ImageIds::tab_object_smoke,           ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        TabDisplayInfo{ StringIds::object_cliffs,                ImageIds::tab_object_cliff,           ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        TabDisplayInfo{ StringIds::object_water,                 ImageIds::tab_object_water,           ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_land,                  ImageIds::tab_object_landscape,       ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_town_names,            ImageIds::tab_object_town_names,      ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_cargo,                 ImageIds::tab_object_cargo,           ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        TabDisplayInfo{ StringIds::object_walls,                 ImageIds::tab_object_walls,           ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_signals,               ImageIds::tab_object_signals,         ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_level_crossing,        ImageIds::tab_object_level_crossings, ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_street_lights,         ImageIds::tab_object_streetlights,    ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_tunnels,               ImageIds::tab_object_tunnels,         ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        TabDisplayInfo{ StringIds::object_bridges,               ImageIds::tab_object_bridges,         ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_track_stations,        ImageIds::tab_object_track_stations,  ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_track_extras,          ImageIds::tab_object_track_mods,      ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
-        TabDisplayInfo{ StringIds::object_tracks,                ImageIds::tab_object_track,           ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_road_stations,         ImageIds::tab_object_road_stations,   ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_road_extras,           ImageIds::tab_object_road_mods,       ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
-        TabDisplayInfo{ StringIds::object_roads,                 ImageIds::tab_object_road,            ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_airports,              ImageIds::tab_object_airports,        ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_docks,                 ImageIds::tab_object_docks,           ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_vehicles,              ImageIds::tab_object_vehicles,        ObjectTabFlags::advanced | ObjectTabFlags::filterByVehicleType },
-        TabDisplayInfo{ StringIds::object_trees,                 ImageIds::tab_object_trees,           ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_snow,                  ImageIds::tab_object_snow,            ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_climate,               ImageIds::tab_object_climate,         ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_map_generation_data,   ImageIds::tab_object_map,             ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_buildings,             ImageIds::tab_object_buildings,       ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_scaffolding,           ImageIds::tab_object_construction,    ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_industries,            ImageIds::tab_object_industries,      ObjectTabFlags::advanced },
-        TabDisplayInfo{ StringIds::object_world_region,          ImageIds::tab_object_world,           ObjectTabFlags::none },
-        TabDisplayInfo{ StringIds::object_company_owners,        ImageIds::tab_object_companies,       ObjectTabFlags::hideInEditor },
-        TabDisplayInfo{ StringIds::object_scenario_descriptions, ImageIds::tab_object_scenarios,       ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden }
+    static constexpr std::array<MainTabInfo, kMaxObjectTypes> _mainTabInfo = {
+        MainTabInfo{ StringIds::object_interface_styles,      ImageIds::tab_object_settings,        ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_sounds,                ImageIds::tab_object_audio,           ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_currency,              ImageIds::tab_object_currency,        ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_animation_effects,     ImageIds::tab_object_smoke,           ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_cliffs,                ImageIds::tab_object_cliff,           ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_water,                 ImageIds::tab_object_water,           ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_land,                  ImageIds::tab_object_landscape,       ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_town_names,            ImageIds::tab_object_town_names,      ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_cargo,                 ImageIds::tab_object_cargo,           ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_walls,                 ImageIds::tab_object_walls,           ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_signals,               ImageIds::tab_object_signals,         ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_level_crossing,        ImageIds::tab_object_level_crossings, ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_street_lights,         ImageIds::tab_object_streetlights,    ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_tunnels,               ImageIds::tab_object_tunnels,         ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_bridges,               ImageIds::tab_object_bridges,         ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_track_stations,        ImageIds::tab_object_track_stations,  ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_track_extras,          ImageIds::tab_object_track_mods,      ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
+        MainTabInfo{ StringIds::object_tracks,                ImageIds::tab_object_track,           ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_road_stations,         ImageIds::tab_object_road_stations,   ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_road_extras,           ImageIds::tab_object_road_mods,       ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
+        MainTabInfo{ StringIds::object_roads,                 ImageIds::tab_object_road,            ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_airports,              ImageIds::tab_object_airports,        ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_docks,                 ImageIds::tab_object_docks,           ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_vehicles,              ImageIds::tab_object_vehicles,        ObjectTabFlags::advanced | ObjectTabFlags::filterByVehicleType },
+        MainTabInfo{ StringIds::object_trees,                 ImageIds::tab_object_trees,           ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_snow,                  ImageIds::tab_object_snow,            ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_climate,               ImageIds::tab_object_climate,         ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_map_generation_data,   ImageIds::tab_object_map,             ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_buildings,             ImageIds::tab_object_buildings,       ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_scaffolding,           ImageIds::tab_object_construction,    ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_industries,            ImageIds::tab_object_industries,      ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_world_region,          ImageIds::tab_object_world,           ObjectTabFlags::none },
+        MainTabInfo{ StringIds::object_company_owners,        ImageIds::tab_object_companies,       ObjectTabFlags::hideInEditor },
+        MainTabInfo{ StringIds::object_scenario_descriptions, ImageIds::tab_object_scenarios,       ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden }
     };
     // clang-format on
 
@@ -272,7 +272,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     static bool shouldShowTab(int8_t objectType, FilterLevel filterLevel)
     {
-        const ObjectTabFlags tabFlags = _tabDisplayInfo[objectType].flags;
+        const ObjectTabFlags tabFlags = _mainTabInfo[objectType].flags;
 
         if (filterLevel == FilterLevel::expert)
             return true;
@@ -492,7 +492,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     Window& openInTab(ObjectType objectType)
     {
         auto& window = *open();
-        auto& info = _tabDisplayInfo[enumValue(objectType)];
+        auto& info = _mainTabInfo[enumValue(objectType)];
 
         if ((info.flags & ObjectTabFlags::alwaysHidden) != ObjectTabFlags::none)
         {
@@ -521,9 +521,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         // Update the title.
         auto args = FormatArguments(self.widgets[widx::caption].textArgs);
-        args.push(_tabDisplayInfo[self.currentTab].name);
+        args.push(_mainTabInfo[self.currentTab].name);
 
-        const auto& tabFlags = _tabDisplayInfo[self.currentTab].flags;
+        const auto& tabFlags = _mainTabInfo[self.currentTab].flags;
         const bool showSecondaryTabs = (tabFlags & ObjectTabFlags::filterByVehicleType) != ObjectTabFlags::none;
         for (int i = widx::vehicleTypeTrain; i <= widx::vehicleTypeShip; i++)
         {
@@ -578,14 +578,14 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                     image = Gfx::recolour(ImageIds::selected_tab, self->getColour(WindowColour::secondary).c());
                     drawingCtx.drawImage(xPos, yPos, image);
 
-                    image = Gfx::recolour(_tabDisplayInfo[_tabPositions[index].index].image, Colour::mutedSeaGreen);
+                    image = Gfx::recolour(_mainTabInfo[_tabPositions[index].index].image, Colour::mutedSeaGreen);
                     drawingCtx.drawImage(xPos, yPos, image);
                 }
                 else
                 {
                     drawingCtx.drawImage(xPos, yPos, image);
 
-                    image = Gfx::recolour(_tabDisplayInfo[_tabPositions[index].index].image, Colour::mutedSeaGreen);
+                    image = Gfx::recolour(_mainTabInfo[_tabPositions[index].index].image, Colour::mutedSeaGreen);
                     drawingCtx.drawImage(xPos, yPos, image);
 
                     image = Gfx::recolourTranslucent(ImageIds::tab, ExtColour::unk33);
@@ -619,7 +619,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     static void drawVehicleTabs(Window* self, Gfx::DrawingContext& drawingCtx)
     {
-        const auto& tabFlags = _tabDisplayInfo[self->currentTab].flags;
+        const auto& tabFlags = _mainTabInfo[self->currentTab].flags;
         const bool showSecondaryTabs = (tabFlags & ObjectTabFlags::filterByVehicleType) != ObjectTabFlags::none;
         if (!showSecondaryTabs)
         {
@@ -1170,7 +1170,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     {
         repositionTargetTab(&self, newTab);
 
-        const auto& tabFlags = _tabDisplayInfo[self.currentTab].flags;
+        const auto& tabFlags = _mainTabInfo[self.currentTab].flags;
         _filterByVehicleType = (tabFlags & ObjectTabFlags::filterByVehicleType) != ObjectTabFlags::none;
         _currentVehicleType = VehicleType::train;
 
@@ -1312,7 +1312,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             assignTabPositions(&self);
 
             auto currentTab = self.currentTab;
-            const ObjectTabFlags tabFlags = _tabDisplayInfo[currentTab].flags;
+            const ObjectTabFlags tabFlags = _mainTabInfo[currentTab].flags;
             if ((tabFlags & ObjectTabFlags::advanced) != ObjectTabFlags::none)
             {
                 currentTab = _tabPositions[0].index;

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -123,12 +123,14 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     };
 
     static constexpr std::array kTrackSubTabs{
+        SubTabInfo{ StringIds::object_tracks,         ObjectType::track,        {}, ImageIds::tab_object_track,          1, 1, ObjectTabFlags::advanced                                      },
         SubTabInfo{ StringIds::object_track_stations, ObjectType::trainStation, {}, ImageIds::tab_object_track_stations, 1, 1, ObjectTabFlags::advanced                                      },
         SubTabInfo{ StringIds::object_track_extras,   ObjectType::trackExtra,   {}, ImageIds::tab_object_track_mods,     1, 1, ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
         SubTabInfo{ StringIds::object_signals,        ObjectType::trackSignal,  {}, ImageIds::tab_object_signals,        1, 1, ObjectTabFlags::advanced                                      },
     };
 
     static constexpr std::array kRoadSubTabs{
+        SubTabInfo{ StringIds::object_roads,          ObjectType::road,          {}, ImageIds::tab_object_road,            1, 1, ObjectTabFlags::advanced                                      },
         SubTabInfo{ StringIds::object_road_stations,  ObjectType::roadStation,   {}, ImageIds::tab_object_road_stations,   1, 1, ObjectTabFlags::advanced                                      },
         SubTabInfo{ StringIds::object_road_extras,    ObjectType::roadExtra,     {}, ImageIds::tab_object_road_mods,       1, 1, ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
         SubTabInfo{ StringIds::object_level_crossing, ObjectType::levelCrossing, {}, ImageIds::tab_object_level_crossings, 1, 1, ObjectTabFlags::advanced                                      },

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -946,11 +946,16 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             drawingCtx.drawRect(self.x + widget.left + 1, self.y + widget.top + 1, widget.width() - 2, widget.height() - 2, colour, Gfx::RectFlags::none);
         }
 
-        auto type = self.currentTab;
+        ObjectType type{};
+        auto& currentTab = kMainTabInfo[self.currentTab];
+        if (!currentTab.subTabs.empty())
+            type = currentTab.subTabs[self.currentSecondaryTab].objectType;
+        else
+            type = currentTab.objectType;
 
         auto args = FormatArguments();
-        args.push(_112C1C5[type]);
-        args.push(ObjectManager::getMaxObjects(static_cast<ObjectType>(type)));
+        args.push(_112C1C5[enumValue(type)]);
+        args.push(ObjectManager::getMaxObjects(type));
 
         {
             auto point = Point(self.x + 3, self.y + self.height - 12);

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -207,7 +207,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static loco_global<uint16_t[33], 0x00112C181> _tabObjectCounts;
 
     // 0x0112C21C
-    static TabPosition _tabPositions[std::size(kMainTabInfo)];
+    static std::array<TabPosition, std::size(kMainTabInfo) + 1> _tabPositions;
     static std::vector<TabObjectEntry> _tabObjectList;
     static uint16_t _numVisibleObjectsListed;
     static bool _filterByVehicleType = false;

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -509,7 +509,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         const auto& currentTab = kMainTabInfo[self.currentTab];
         const auto& subTabs = currentTab.subTabs;
-        const bool showSecondaryTabs = !subTabs.empty();
+        const bool showSecondaryTabs = !subTabs.empty() && FilterLevel(self.var_856) != FilterLevel::beginner;
 
         // Update page title
         auto args = FormatArguments(self.widgets[widx::caption].textArgs);

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -544,16 +544,14 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         if (showSecondaryTabs)
         {
-            self.widgets[widx::scrollview].top = 85 - 23 + 28;
+            self.widgets[widx::scrollview].top = 62 + 28;
             self.widgets[widx::scrollviewFrame].type = WidgetType::panel;
             self.widgets[widx::scrollviewFrame].top = self.widgets[widx::scrollview].top - 2;
-            self.widgets[widx::objectImage].top = 68 + 28;
         }
         else
         {
-            self.widgets[widx::scrollview].top = 85 - 23;
+            self.widgets[widx::scrollview].top = 62;
             self.widgets[widx::scrollviewFrame].type = WidgetType::none;
-            self.widgets[widx::objectImage].top = 68;
         }
     }
 

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -97,6 +97,12 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     };
 
     // clang-format off
+    static constexpr std::array kWorldRegionSubTabs{
+        SubTabInfo{ StringIds::object_world_region, ObjectType::region,    {}, ObjectTabFlags::none,     ImageIds::tab_object_world,      1, 1 },
+        SubTabInfo{ StringIds::object_currency,     ObjectType::currency,  {}, ObjectTabFlags::advanced, ImageIds::tab_object_currency,   1, 1 },
+        SubTabInfo{ StringIds::object_town_names,   ObjectType::townNames, {}, ObjectTabFlags::advanced, ImageIds::tab_object_town_names, 1, 1 },
+    };
+
     static constexpr std::array kVehicleSubTabs{
         SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::train,    ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_train_frame0,    8, 1 },
         SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::bus,      ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_bus_frame0,      8, 1 },
@@ -106,51 +112,57 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::ship,     ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_ship_frame0,     8, 3 },
     };
 
+    static constexpr std::array kLandSubTabs{
+        SubTabInfo{ StringIds::object_land,                ObjectType::land,       {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_landscape, 1, 1 },
+        SubTabInfo{ StringIds::object_trees,               ObjectType::tree,       {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_trees,     1, 1 },
+        SubTabInfo{ StringIds::object_water,               ObjectType::water,      {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_water,     1, 1 },
+        SubTabInfo{ StringIds::object_walls,               ObjectType::wall,       {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_walls,     1, 1 },
+        SubTabInfo{ StringIds::object_map_generation_data, ObjectType::hillShapes, {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_map,       1, 1 },
+        SubTabInfo{ StringIds::object_snow,                ObjectType::snow,       {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_snow,      1, 1 },
+        SubTabInfo{ StringIds::object_climate,             ObjectType::climate,    {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_climate,   1, 1 },
+        SubTabInfo{ StringIds::object_cliffs,              ObjectType::cliffEdge,  {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_cliff,     1, 1 },
+    };
+
+    static constexpr std::array kTrackSubTabs{
+        SubTabInfo{ StringIds::object_track_stations, ObjectType::trainStation, {}, ObjectTabFlags::advanced,                                      ImageIds::tab_object_track_stations, 1, 1 },
+        SubTabInfo{ StringIds::object_track_extras,   ObjectType::trackExtra,   {}, ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular, ImageIds::tab_object_track_mods,     1, 1 },
+        SubTabInfo{ StringIds::object_signals,        ObjectType::trackSignal,  {}, ObjectTabFlags::advanced,                                      ImageIds::tab_object_signals,        1, 1 },
+    };
+
+    static constexpr std::array kRoadSubTabs{
+        SubTabInfo{ StringIds::object_road_stations,  ObjectType::roadStation,   {}, ObjectTabFlags::advanced,                                      ImageIds::tab_object_road_stations,   1, 1 },
+        SubTabInfo{ StringIds::object_road_extras,    ObjectType::roadExtra,     {}, ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular, ImageIds::tab_object_road_mods,       1, 1 },
+        SubTabInfo{ StringIds::object_level_crossing, ObjectType::levelCrossing, {}, ObjectTabFlags::advanced,                                      ImageIds::tab_object_level_crossings, 1, 1 },
+        SubTabInfo{ StringIds::object_street_lights,  ObjectType::streetLight,   {}, ObjectTabFlags::advanced,                                      ImageIds::tab_object_streetlights,    1, 1 },
+    };
+
+    static constexpr std::array kBuildingSubTabs{
+        SubTabInfo{ StringIds::object_buildings,   ObjectType::building,    {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_buildings,    1, 1 },
+        SubTabInfo{ StringIds::object_industries,  ObjectType::industry,    {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_industries,   1, 1 },
+        SubTabInfo{ StringIds::object_scaffolding, ObjectType::scaffolding, {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_construction, 1, 1 },
+        SubTabInfo{ StringIds::object_cargo,       ObjectType::cargo,       {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_cargo,        1, 1 },
+    };
+
+    static constexpr std::array kMiscSubTabs{
+        SubTabInfo{ StringIds::object_interface_styles,      ObjectType::interfaceSkin, {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_settings,  1, 1 },
+        SubTabInfo{ StringIds::object_scenario_descriptions, ObjectType::scenarioText,  {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_scenarios, 1, 1 },
+        SubTabInfo{ StringIds::object_sounds,                ObjectType::sound,         {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_audio,     1, 1 },
+        SubTabInfo{ StringIds::object_animation_effects,     ObjectType::steam,         {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_smoke,     1, 1 },
+    };
+
     static constexpr std::array<MainTabInfo, kMaxObjectTypes> _mainTabInfo = {
-        MainTabInfo{ StringIds::object_world_region,          ObjectType::region,        ImageIds::tab_object_world,           {},              ObjectTabFlags::none },
-        MainTabInfo{ StringIds::object_currency,              ObjectType::currency,      ImageIds::tab_object_currency,        {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_town_names,            ObjectType::townNames,     ImageIds::tab_object_town_names,      {},              ObjectTabFlags::advanced },
-
-        MainTabInfo{ StringIds::object_vehicles,              ObjectType::vehicle,       ImageIds::tab_object_vehicles,        kVehicleSubTabs, ObjectTabFlags::advanced },
-
-        MainTabInfo{ StringIds::object_land,                  ObjectType::land,          ImageIds::tab_object_landscape,       {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_trees,                 ObjectType::tree,          ImageIds::tab_object_trees,           {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_water,                 ObjectType::water,         ImageIds::tab_object_water,           {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_walls,                 ObjectType::wall,          ImageIds::tab_object_walls,           {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_map_generation_data,   ObjectType::hillShapes,    ImageIds::tab_object_map,             {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_snow,                  ObjectType::snow,          ImageIds::tab_object_snow,            {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_climate,               ObjectType::climate,       ImageIds::tab_object_climate,         {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_cliffs,                ObjectType::cliffEdge,     ImageIds::tab_object_cliff,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-
-        MainTabInfo{ StringIds::object_tracks,                ObjectType::track,         ImageIds::tab_object_track,           {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_track_stations,        ObjectType::trainStation,  ImageIds::tab_object_track_stations,  {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_track_extras,          ObjectType::trackExtra,    ImageIds::tab_object_track_mods,      {},              ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
-        MainTabInfo{ StringIds::object_signals,               ObjectType::trackSignal,   ImageIds::tab_object_signals,         {},              ObjectTabFlags::advanced },
-
-        MainTabInfo{ StringIds::object_roads,                 ObjectType::road,          ImageIds::tab_object_road,            {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_road_stations,         ObjectType::roadStation,   ImageIds::tab_object_road_stations,   {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_road_extras,           ObjectType::roadExtra,     ImageIds::tab_object_road_mods,       {},              ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
-        MainTabInfo{ StringIds::object_level_crossing,        ObjectType::levelCrossing, ImageIds::tab_object_level_crossings, {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_street_lights,         ObjectType::streetLight,   ImageIds::tab_object_streetlights,    {},              ObjectTabFlags::advanced },
-
-        MainTabInfo{ StringIds::object_airports,              ObjectType::airport,       ImageIds::tab_object_airports,        {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_docks,                 ObjectType::dock,          ImageIds::tab_object_docks,           {},              ObjectTabFlags::advanced },
-
-        MainTabInfo{ StringIds::object_buildings,             ObjectType::building,      ImageIds::tab_object_buildings,       {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_scaffolding,           ObjectType::scaffolding,   ImageIds::tab_object_construction,    {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_industries,            ObjectType::industry,      ImageIds::tab_object_industries,      {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_cargo,                 ObjectType::cargo,         ImageIds::tab_object_cargo,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-
-        MainTabInfo{ StringIds::object_bridges,               ObjectType::bridge,        ImageIds::tab_object_bridges,         {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_tunnels,               ObjectType::tunnel,        ImageIds::tab_object_tunnels,         {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-
-        MainTabInfo{ StringIds::object_interface_styles,      ObjectType::interfaceSkin, ImageIds::tab_object_settings,        {},              ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_scenario_descriptions, ObjectType::scenarioText,  ImageIds::tab_object_scenarios,       {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        MainTabInfo{ StringIds::object_sounds,                ObjectType::sound,         ImageIds::tab_object_audio,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        MainTabInfo{ StringIds::object_animation_effects,     ObjectType::steam,         ImageIds::tab_object_smoke,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-
-        MainTabInfo{ StringIds::object_company_owners,        ObjectType::competitor,    ImageIds::tab_object_companies,       {},              ObjectTabFlags::hideInEditor },
-
+        MainTabInfo{ StringIds::object_world_region,          ObjectType::region,        ImageIds::tab_object_world,           kWorldRegionSubTabs, ObjectTabFlags::none },
+        MainTabInfo{ StringIds::object_vehicles,              ObjectType::vehicle,       ImageIds::tab_object_vehicles,        kVehicleSubTabs,     ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_land,                  ObjectType::land,          ImageIds::tab_object_landscape,       kLandSubTabs,        ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_tracks,                ObjectType::track,         ImageIds::tab_object_track,           kTrackSubTabs,       ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_roads,                 ObjectType::road,          ImageIds::tab_object_road,            kRoadSubTabs,        ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_airports,              ObjectType::airport,       ImageIds::tab_object_airports,        {},                  ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_docks,                 ObjectType::dock,          ImageIds::tab_object_docks,           {},                  ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_buildings,             ObjectType::building,      ImageIds::tab_object_buildings,       kBuildingSubTabs,    ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_bridges,               ObjectType::bridge,        ImageIds::tab_object_bridges,         {},                  ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_tunnels,               ObjectType::tunnel,        ImageIds::tab_object_tunnels,         {},                  ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_interface_styles,      ObjectType::interfaceSkin, ImageIds::tab_object_settings,        kMiscSubTabs,        ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_company_owners,        ObjectType::competitor,    ImageIds::tab_object_companies,       {},                  ObjectTabFlags::hideInEditor },
     };
     // clang-format on
 
@@ -228,6 +240,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         secondaryTab4,
         secondaryTab5,
         secondaryTab6,
+        secondaryTab7,
+        secondaryTab8,
         scrollviewFrame,
         scrollview,
         objectImage,
@@ -247,13 +261,15 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         makeWidget({ 4, 68 }, { 246, 14 }, WidgetType::textbox, WindowColour::secondary),
         makeWidget({ 254, 68 }, { 38, 14 }, WidgetType::button, WindowColour::secondary, StringIds::clearInput),
 
-        // Secondary (vehicle type) tabs
-        makeRemapWidget({ 3, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trains),
-        makeRemapWidget({ 34, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_buses),
-        makeRemapWidget({ 65, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trucks),
-        makeRemapWidget({ 96, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trams),
-        makeRemapWidget({ 127, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_aircraft),
-        makeRemapWidget({ 158, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_ships),
+        // Secondary tabs
+        makeRemapWidget({ 3, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 34, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 65, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 96, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 127, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 158, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 189, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 220, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
 
         // Scroll and preview areas
         Widgets::Panel({ 3, 83 }, { 290, 303 }, WindowColour::secondary),
@@ -565,7 +581,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             args.push(_mainTabInfo[self.currentTab].name);
 
         // Toggle secondary tabs
-        for (auto i = 0U; i < 6U; i++)
+        for (auto i = 0U; i < 8U; i++)
         {
             bool subTabIsVisible = showSecondaryTabs && i < subTabs.size();
 
@@ -651,7 +667,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     static void drawSecondaryTabs(Window* self, Gfx::DrawingContext& drawingCtx)
     {
-        const auto& subTabs = _mainTabInfo[self->currentTab].subTabs;
+        const auto& currentTab = _mainTabInfo[self->currentTab];
+        const auto& subTabs = currentTab.subTabs;
         const bool showSecondaryTabs = !subTabs.empty();
         if (!showSecondaryTabs)
         {
@@ -660,7 +677,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         auto skin = ObjectManager::get<InterfaceSkinObject>();
 
-        for (auto i = 0U; i < 6; i++)
+        for (auto i = 0U; i < subTabs.size(); i++)
         {
             auto& tabData = subTabs[i];
             auto frame = 0;
@@ -670,7 +687,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             }
 
             auto widgetIndex = i + widx::secondaryTab1;
-            auto image = Gfx::recolour(skin->img + tabData.baseImage + frame, CompanyManager::getCompanyColour(CompanyId::neutral));
+            auto baseImage = currentTab.objectType == ObjectType::vehicle ? skin->img : 0;
+            auto image = Gfx::recolour(baseImage + tabData.baseImage + frame, CompanyManager::getCompanyColour(CompanyId::neutral));
             Widget::drawTab(self, drawingCtx, image, widgetIndex);
         }
     }
@@ -1321,6 +1339,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             case widx::secondaryTab4:
             case widx::secondaryTab5:
             case widx::secondaryTab6:
+            case widx::secondaryTab7:
+            case widx::secondaryTab8:
             {
                 auto& subTabs = _mainTabInfo[self.currentTab].subTabs;
                 auto previousSubType = subTabs[self.currentSecondaryTab].subObjectType;

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -60,8 +60,6 @@ using namespace OpenLoco::Diagnostics;
 namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 {
     static constexpr int kRowHeight = 12;
-    static constexpr int kPrimaryTabRowCapacity = 19;
-    static constexpr int kSecondaryTabRowCapacity = 18;
     static constexpr Ui::Size32 kWindowSize = { 600, 398 };
 
     enum class ObjectTabFlags : uint8_t

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -146,31 +146,27 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static constexpr std::array kMiscSubTabs{
         SubTabInfo{ StringIds::object_interface_styles,      ObjectType::interfaceSkin, {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_settings,  1, 1 },
         SubTabInfo{ StringIds::object_scenario_descriptions, ObjectType::scenarioText,  {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_scenarios, 1, 1 },
-        SubTabInfo{ StringIds::object_sounds,                ObjectType::sound,         {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_audio,     1, 1 },
         SubTabInfo{ StringIds::object_animation_effects,     ObjectType::steam,         {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_smoke,     1, 1 },
+        SubTabInfo{ StringIds::object_sounds,                ObjectType::sound,         {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_audio,     1, 1 },
     };
 
-    static constexpr std::array<MainTabInfo, kMaxObjectTypes> _mainTabInfo = {
-        MainTabInfo{ StringIds::object_world_region,          ObjectType::region,        ImageIds::tab_object_world,           kWorldRegionSubTabs, ObjectTabFlags::none },
-        MainTabInfo{ StringIds::object_vehicles,              ObjectType::vehicle,       ImageIds::tab_object_vehicles,        kVehicleSubTabs,     ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_land,                  ObjectType::land,          ImageIds::tab_object_landscape,       kLandSubTabs,        ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_tracks,                ObjectType::track,         ImageIds::tab_object_track,           kTrackSubTabs,       ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_roads,                 ObjectType::road,          ImageIds::tab_object_road,            kRoadSubTabs,        ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_airports,              ObjectType::airport,       ImageIds::tab_object_airports,        {},                  ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_docks,                 ObjectType::dock,          ImageIds::tab_object_docks,           {},                  ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_buildings,             ObjectType::building,      ImageIds::tab_object_buildings,       kBuildingSubTabs,    ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_bridges,               ObjectType::bridge,        ImageIds::tab_object_bridges,         {},                  ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_tunnels,               ObjectType::tunnel,        ImageIds::tab_object_tunnels,         {},                  ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        MainTabInfo{ StringIds::object_interface_styles,      ObjectType::interfaceSkin, ImageIds::tab_object_settings,        kMiscSubTabs,        ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_company_owners,        ObjectType::competitor,    ImageIds::tab_object_companies,       {},                  ObjectTabFlags::hideInEditor },
+    static constexpr std::array kMainTabInfo{
+        MainTabInfo{ StringIds::object_world_region,     ObjectType::region,        ImageIds::tab_object_world,     kWorldRegionSubTabs, ObjectTabFlags::none                                    },
+        MainTabInfo{ StringIds::object_vehicles,         ObjectType::vehicle,       ImageIds::tab_object_vehicles,  kVehicleSubTabs,     ObjectTabFlags::advanced                                },
+        MainTabInfo{ StringIds::object_land,             ObjectType::land,          ImageIds::tab_object_landscape, kLandSubTabs,        ObjectTabFlags::advanced                                },
+        MainTabInfo{ StringIds::object_tracks,           ObjectType::track,         ImageIds::tab_object_track,     kTrackSubTabs,       ObjectTabFlags::advanced                                },
+        MainTabInfo{ StringIds::object_roads,            ObjectType::road,          ImageIds::tab_object_road,      kRoadSubTabs,        ObjectTabFlags::advanced                                },
+        MainTabInfo{ StringIds::object_airports,         ObjectType::airport,       ImageIds::tab_object_airports,  {},                  ObjectTabFlags::advanced                                },
+        MainTabInfo{ StringIds::object_docks,            ObjectType::dock,          ImageIds::tab_object_docks,     {},                  ObjectTabFlags::advanced                                },
+        MainTabInfo{ StringIds::object_buildings,        ObjectType::building,      ImageIds::tab_object_buildings, kBuildingSubTabs,    ObjectTabFlags::advanced                                },
+        MainTabInfo{ StringIds::object_bridges,          ObjectType::bridge,        ImageIds::tab_object_bridges,   {},                  ObjectTabFlags::advanced                                },
+        MainTabInfo{ StringIds::object_tunnels,          ObjectType::tunnel,        ImageIds::tab_object_tunnels,   {},                  ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_interface_styles, ObjectType::interfaceSkin, ImageIds::tab_object_settings,  kMiscSubTabs,        ObjectTabFlags::advanced                                },
+        MainTabInfo{ StringIds::object_company_owners,   ObjectType::competitor,    ImageIds::tab_object_companies, {},                  ObjectTabFlags::hideInEditor                            },
     };
     // clang-format on
 
-    struct TabPosition
-    {
-        uint8_t index;
-        uint8_t row;
-    };
+    using TabPosition = uint8_t;
 
     enum class Visibility : uint8_t
     {
@@ -251,76 +247,36 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         Widgets::Frame({ 0, 0 }, { 600, 398 }, WindowColour::primary),
         makeWidget({ 1, 1 }, { 598, 13 }, WidgetType::caption_25, WindowColour::primary, StringIds::title_object_selection),
         makeWidget({ 585, 2 }, { 13, 13 }, WidgetType::buttonWithImage, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-        Widgets::Panel({ 0, 65 }, { 600, 333 }, WindowColour::secondary),
+        Widgets::Panel({ 0, 42 }, { 600, 356 }, WindowColour::secondary),
 
         // Primary tab area
-        makeWidget({ 3, 15 }, { 589, 50 }, WidgetType::wt_6, WindowColour::secondary),
+        makeWidget({ 3, 15 }, { 589, 27 }, WidgetType::wt_6, WindowColour::secondary),
 
         // Filter options
         makeDropdownWidgets({ 492, 20 }, { 100, 12 }, WindowColour::primary, StringIds::empty),
-        makeWidget({ 4, 68 }, { 246, 14 }, WidgetType::textbox, WindowColour::secondary),
-        makeWidget({ 254, 68 }, { 38, 14 }, WidgetType::button, WindowColour::secondary, StringIds::clearInput),
+        makeWidget({ 4, 45 }, { 246, 14 }, WidgetType::textbox, WindowColour::secondary),
+        makeWidget({ 254, 45 }, { 38, 14 }, WidgetType::button, WindowColour::secondary, StringIds::clearInput),
 
         // Secondary tabs
-        makeRemapWidget({ 3, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
-        makeRemapWidget({ 34, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
-        makeRemapWidget({ 65, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
-        makeRemapWidget({ 96, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
-        makeRemapWidget({ 127, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
-        makeRemapWidget({ 158, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
-        makeRemapWidget({ 189, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
-        makeRemapWidget({ 220, 85 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 3, 62 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 34, 62 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 65, 62 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 96, 62 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 127, 62 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 158, 62 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 189, 62 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
+        makeRemapWidget({ 220, 62 }, { 31, 27 }, WidgetType::none, WindowColour::secondary, ImageIds::tab),
 
         // Scroll and preview areas
         Widgets::Panel({ 3, 83 }, { 290, 303 }, WindowColour::secondary),
         makeWidget({ 4, 85 }, { 288, 300 }, WidgetType::scrollview, WindowColour::secondary, Scrollbars::vertical),
-        makeWidget({ 391, 68 }, { 114, 114 }, WidgetType::buttonWithImage, WindowColour::secondary)
+        makeWidget({ 391, 45 }, { 114, 114 }, WidgetType::buttonWithImage, WindowColour::secondary)
 
     );
 
-    // 0x0047322A
-    static void rotateTabs(uint8_t newStartPosition)
-    {
-        auto isSentinel = [](auto& entry) { return entry.index == 0xFF; };
-        auto sentinelPos = std::find_if(std::begin(_tabPositions), std::end(_tabPositions), isSentinel);
-
-        std::rotate(std::begin(_tabPositions), std::begin(_tabPositions) + newStartPosition, sentinelPos);
-
-        for (uint8_t i = 0; _tabPositions[i].index != 0xFF; i++)
-        {
-            _tabPositions[i].row = i < kPrimaryTabRowCapacity ? 0 : 1;
-        }
-    }
-
-    // 0x004731EE
-    static void repositionTargetTab(Window* self, uint8_t targetTab)
-    {
-        self->currentTab = targetTab;
-        for (auto i = 0U; i < std::size(_tabPositions); i++)
-        {
-            // Ended up in a position without info? Reassign positions first.
-            if (_tabPositions[i].index == 0xFF)
-            {
-                self->var_856 = enumValue(FilterLevel::advanced);
-                assignTabPositions(self);
-                return;
-            }
-
-            if (_tabPositions[i].index == targetTab)
-            {
-                // Found current tab, and its in bottom row? No change required
-                if (_tabPositions[i].row == 0)
-                    return;
-                // Otherwise, we'll rotate the tabs around, such that this one is in the bottom row
-                else
-                    return rotateTabs(i);
-            }
-        }
-    }
-
     static bool shouldShowTab(int8_t index, FilterLevel filterLevel)
     {
-        const ObjectTabFlags tabFlags = _mainTabInfo[index].flags;
+        const ObjectTabFlags tabFlags = kMainTabInfo[index].flags;
 
         if (filterLevel == FilterLevel::expert)
             return true;
@@ -329,7 +285,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             return false;
 
         // Skip all types that don't have any objects
-        auto objectType = enumValue(_mainTabInfo[index].objectType);
+        auto objectType = enumValue(kMainTabInfo[index].objectType);
         if (_tabObjectCounts[objectType] == 0)
             return false;
 
@@ -353,35 +309,19 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     // 0x00473154
     static void assignTabPositions(Window* self)
     {
-        uint8_t currentRow = 0;
-        uint8_t currentPos = 0;
-        uint8_t rowCapacity = kPrimaryTabRowCapacity;
         uint8_t tabPos = 0;
-
-        for (auto i = 0U; i < _mainTabInfo.size(); i++)
+        for (auto i = 0U; i < kMainTabInfo.size(); i++)
         {
             if (!shouldShowTab(i, FilterLevel(self->var_856)))
                 continue;
 
             // Assign tab position
-            _tabPositions[tabPos].index = i;
-            _tabPositions[tabPos].row = currentRow;
+            _tabPositions[tabPos] = i;
             tabPos++;
-
-            // Distribute tabs over two rows -- ensure there's capacity left in current row
-            currentPos++;
-            if (currentPos >= rowCapacity)
-            {
-                currentPos = 0;
-                rowCapacity = kSecondaryTabRowCapacity;
-                currentRow++;
-            }
         }
 
         // Add a marker to denote the last tab
-        _tabPositions[tabPos].index = 0xFF;
-
-        repositionTargetTab(self, _tabPositions[0].index);
+        _tabPositions[tabPos] = 0xFF;
     }
 
     static bool contains(const std::string_view& a, const std::string_view& b)
@@ -512,8 +452,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         window->object = nullptr;
 
         assignTabPositions(window);
-        static_assert(_mainTabInfo[0].objectType == ObjectType::region);
-        repositionTargetTab(window, 0);
+        static_assert(kMainTabInfo[0].objectType == ObjectType::region);
         populateTabObjectList(ObjectType::region, FilterFlags(window->var_858));
 
         ObjectManager::freeTemporaryObject();
@@ -542,7 +481,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     {
         // TODO: look up actual index
         auto& window = *open();
-        auto& info = _mainTabInfo[enumValue(objectType)];
+        auto& info = kMainTabInfo[enumValue(objectType)];
 
         if ((info.flags & ObjectTabFlags::alwaysHidden) != ObjectTabFlags::none)
         {
@@ -570,7 +509,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             self.widgets[widx::closeButton].type = WidgetType::none;
         }
 
-        const auto& subTabs = _mainTabInfo[self.currentTab].subTabs;
+        const auto& subTabs = kMainTabInfo[self.currentTab].subTabs;
         const bool showSecondaryTabs = !subTabs.empty();
 
         // Update page title
@@ -578,7 +517,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         if (showSecondaryTabs)
             args.push(subTabs[self.currentSecondaryTab].name);
         else
-            args.push(_mainTabInfo[self.currentTab].name);
+            args.push(kMainTabInfo[self.currentTab].name);
 
         // Toggle secondary tabs
         for (auto i = 0U; i < 8U; i++)
@@ -601,14 +540,14 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         if (showSecondaryTabs)
         {
-            self.widgets[widx::scrollview].top = 85 + 28;
+            self.widgets[widx::scrollview].top = 85 - 23 + 28;
             self.widgets[widx::scrollviewFrame].type = WidgetType::panel;
             self.widgets[widx::scrollviewFrame].top = self.widgets[widx::scrollview].top - 2;
             self.widgets[widx::objectImage].top = 68 + 28;
         }
         else
         {
-            self.widgets[widx::scrollview].top = 85;
+            self.widgets[widx::scrollview].top = 85 - 23;
             self.widgets[widx::scrollviewFrame].type = WidgetType::none;
             self.widgets[widx::objectImage].top = 68;
         }
@@ -617,57 +556,40 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static loco_global<uint16_t[kMaxObjectTypes], 0x0112C1C5> _112C1C5;
     static loco_global<uint32_t, 0x0112C209> _112C209;
 
-    static constexpr uint8_t kRowOffsetX = 10;
-    static constexpr uint8_t kRowOffsetY = 24;
-
     // 0x0047328D
     static void drawTabs(Window* self, Gfx::DrawingContext& drawingCtx)
     {
-        auto y = self->widgets[widx::panel].top + self->y - 26;
-        auto x = self->x + 3;
+        auto yPos = self->y + self->widgets[widx::tabArea].top;
+        auto xPos = self->x + 3;
 
-        for (auto row = 1; row >= 0; row--)
+        for (auto index = 0; _tabPositions[index] != 0xFF; index++)
         {
-            auto xPos = x + (row * kRowOffsetX);
-            auto yPos = y - (row * kRowOffsetY);
-            for (auto index = 0; _tabPositions[index].index != 0xFF; index++)
+            auto image = Gfx::recolour(ImageIds::tab, self->getColour(WindowColour::secondary).c());
+            if (_tabPositions[index] == self->currentTab)
             {
-                if (_tabPositions[index].row != row)
-                    continue;
+                image = Gfx::recolour(ImageIds::selected_tab, self->getColour(WindowColour::secondary).c());
+                drawingCtx.drawImage(xPos, yPos, image);
 
-                auto image = Gfx::recolour(ImageIds::tab, self->getColour(WindowColour::secondary).c());
-                if (_tabPositions[index].index == self->currentTab)
-                {
-                    image = Gfx::recolour(ImageIds::selected_tab, self->getColour(WindowColour::secondary).c());
-                    drawingCtx.drawImage(xPos, yPos, image);
-
-                    image = Gfx::recolour(_mainTabInfo[_tabPositions[index].index].image, Colour::mutedSeaGreen);
-                    drawingCtx.drawImage(xPos, yPos, image);
-                }
-                else
-                {
-                    drawingCtx.drawImage(xPos, yPos, image);
-
-                    image = Gfx::recolour(_mainTabInfo[_tabPositions[index].index].image, Colour::mutedSeaGreen);
-                    drawingCtx.drawImage(xPos, yPos, image);
-
-                    image = Gfx::recolourTranslucent(ImageIds::tab, ExtColour::unk33);
-                    drawingCtx.drawImage(xPos, yPos, image);
-
-                    if (row < 1)
-                    {
-                        auto colour = Colours::getShade(self->getColour(WindowColour::secondary).c(), 7);
-                        drawingCtx.drawRect(xPos, yPos + 26, 31, 1, colour, Gfx::RectFlags::none);
-                    }
-                }
-                xPos += 31;
+                image = Gfx::recolour(kMainTabInfo[_tabPositions[index]].image, Colour::mutedSeaGreen);
+                drawingCtx.drawImage(xPos, yPos, image);
             }
+            else
+            {
+                drawingCtx.drawImage(xPos, yPos, image);
+
+                image = Gfx::recolour(kMainTabInfo[_tabPositions[index]].image, Colour::mutedSeaGreen);
+                drawingCtx.drawImage(xPos, yPos, image);
+
+                image = Gfx::recolourTranslucent(ImageIds::tab, ExtColour::unk33);
+                drawingCtx.drawImage(xPos, yPos, image);
+            }
+            xPos += 31;
         }
     }
 
     static void drawSecondaryTabs(Window* self, Gfx::DrawingContext& drawingCtx)
     {
-        const auto& currentTab = _mainTabInfo[self->currentTab];
+        const auto& currentTab = kMainTabInfo[self->currentTab];
         const auto& subTabs = currentTab.subTabs;
         const bool showSecondaryTabs = !subTabs.empty();
         if (!showSecondaryTabs)
@@ -1196,15 +1118,15 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 auto objectType = res.value();
                 auto targetTab = 0;
                 auto targetSubTab = 0;
-                for (auto i = 0U; i < _mainTabInfo.size(); i++)
+                for (auto i = 0U; i < kMainTabInfo.size(); i++)
                 {
-                    if (objectType == _mainTabInfo[i].objectType)
+                    if (objectType == kMainTabInfo[i].objectType)
                     {
                         targetTab = i;
                         break;
                     }
 
-                    auto& subTabs = _mainTabInfo[i].subTabs;
+                    auto& subTabs = kMainTabInfo[i].subTabs;
                     if (subTabs.empty())
                         continue;
 
@@ -1222,14 +1144,13 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                         break;
                 }
 
-                repositionTargetTab(w, targetTab);
-
                 w->rowHover = -1;
                 w->object = nullptr;
                 w->scrollAreas[0].contentWidth = 0;
                 ObjectManager::freeTemporaryObject();
                 w->invalidate();
 
+                w->currentTab = targetTab;
                 w->currentSecondaryTab = targetSubTab;
                 populateTabObjectList(objectType, static_cast<FilterFlags>(w->var_858));
 
@@ -1248,13 +1169,12 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     static void switchTab(Window& self, uint8_t tabIndex)
     {
-        repositionTargetTab(&self, tabIndex);
-
-        const auto& currentTab = _mainTabInfo[self.currentTab];
+        self.currentTab = tabIndex;
+        const auto& currentTab = kMainTabInfo[self.currentTab];
         _filterByVehicleType = currentTab.objectType == ObjectType::vehicle;
         _currentVehicleType = VehicleType::train;
 
-        auto objectType = _mainTabInfo[tabIndex].objectType;
+        auto objectType = kMainTabInfo[tabIndex].objectType;
         populateTabObjectList(objectType, FilterFlags(self.var_858));
 
         self.rowHover = -1;
@@ -1288,36 +1208,27 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             case widx::tabArea:
             {
                 int clickedTab = -1;
-                int y = widgets[widx::panel].top + self.y - 26;
-                int x = self.x + 3;
+                int yPos = self.y + widgets[widx::tabArea].top;
+                int xPos = self.x + 3;
                 auto mousePos = Input::getCursorPressedLocation();
 
-                for (int row = 0; row < 2; row++)
+                for (int i = 0; _tabPositions[i] != 0xFF; i++)
                 {
-                    auto xPos = x + (row * kRowOffsetX);
-                    auto yPos = y - (row * kRowOffsetY);
-
-                    for (int i = 0; _tabPositions[i].index != 0xFF; i++)
+                    if (mousePos.x >= xPos && mousePos.y >= yPos)
                     {
-                        if (_tabPositions[i].row != row)
-                            continue;
-
-                        if (mousePos.x >= xPos && mousePos.y >= yPos)
+                        if (mousePos.x < xPos + 31 && yPos + 27 > mousePos.y)
                         {
-                            if (mousePos.x < xPos + 31 && yPos + 27 > mousePos.y)
-                            {
-                                clickedTab = _tabPositions[i].index;
-                                break;
-                            }
+                            clickedTab = _tabPositions[i];
+                            break;
                         }
-
-                        xPos += 31;
                     }
+
+                    xPos += 31;
                 }
 
                 if (clickedTab != -1 && self.currentTab != clickedTab)
                 {
-                    // auto objectType = _mainTabInfo[clickedTab].objectType;
+                    // auto objectType = kMainTabInfo[clickedTab].objectType;
                     switchTab(self, clickedTab);
                 }
 
@@ -1342,7 +1253,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             case widx::secondaryTab7:
             case widx::secondaryTab8:
             {
-                auto& subTabs = _mainTabInfo[self.currentTab].subTabs;
+                auto& subTabs = kMainTabInfo[self.currentTab].subTabs;
                 auto previousSubType = subTabs[self.currentSecondaryTab].subObjectType;
 
                 self.currentSecondaryTab = w - widx::secondaryTab1;
@@ -1408,22 +1319,20 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             assignTabPositions(&self);
 
             auto currentTab = self.currentTab;
-            const ObjectTabFlags tabFlags = _mainTabInfo[currentTab].flags;
+            const ObjectTabFlags tabFlags = kMainTabInfo[currentTab].flags;
             if ((tabFlags & ObjectTabFlags::advanced) != ObjectTabFlags::none)
             {
-                currentTab = _tabPositions[0].index;
-                auto objectType = _mainTabInfo[currentTab].objectType;
-                populateTabObjectList(objectType, static_cast<FilterFlags>(self.var_858));
+                currentTab = _tabPositions[0];
+                auto objectType = kMainTabInfo[currentTab].objectType;
+                populateTabObjectList(objectType, FilterFlags(self.var_858));
             }
-
-            repositionTargetTab(&self, currentTab);
         }
 
         // Toggle vanilla objects
         else if (itemIndex == 4)
         {
             self.var_858 = enumValue(FilterFlags(self.var_858) ^ FilterFlags::vanilla);
-            auto objectType = _mainTabInfo[self.currentTab].objectType;
+            auto objectType = kMainTabInfo[self.currentTab].objectType;
             populateTabObjectList(objectType, FilterFlags(self.var_858));
         }
 
@@ -1431,7 +1340,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         else if (itemIndex == 5)
         {
             self.var_858 = enumValue(FilterFlags(self.var_858) ^ FilterFlags::custom);
-            auto objectType = _mainTabInfo[self.currentTab].objectType;
+            auto objectType = kMainTabInfo[self.currentTab].objectType;
             populateTabObjectList(objectType, FilterFlags(self.var_858));
         }
 

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -473,7 +473,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         return window;
     }
 
-    static void switchTab(Window& self, uint8_t tabIndex);
+    static void switchPrimaryTab(Window& self, uint8_t tabIndex);
 
     Window& openInTab(ObjectType objectType)
     {
@@ -492,7 +492,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         assignTabPositions(&window);
         // TODO: look up actual index
-        switchTab(window, enumValue(objectType));
+        switchPrimaryTab(window, enumValue(objectType));
         return window;
     }
 
@@ -1165,9 +1165,11 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         }
     }
 
-    static void switchTab(Window& self, uint8_t tabIndex)
+    static void switchPrimaryTab(Window& self, uint8_t tabIndex)
     {
         self.currentTab = tabIndex;
+        self.currentSecondaryTab = 0;
+
         const auto& currentTab = kMainTabInfo[self.currentTab];
         _filterByVehicleType = currentTab.objectType == ObjectType::vehicle;
         _currentVehicleType = VehicleType::train;
@@ -1226,8 +1228,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
                 if (clickedTab != -1 && self.currentTab != clickedTab)
                 {
-                    // auto objectType = kMainTabInfo[clickedTab].objectType;
-                    switchTab(self, clickedTab);
+                    switchPrimaryTab(self, clickedTab);
                 }
 
                 break;

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -167,13 +167,14 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     using TabPosition = uint8_t;
 
+    // Used for TabObjectEntry::display
     enum class Visibility : uint8_t
     {
         hidden = 0,
         shown = 1,
     };
 
-    // Used for var_856
+    // Used for Window::filterLevel
     enum class FilterLevel : uint8_t
     {
         beginner = 0,
@@ -181,7 +182,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         expert = 2,
     };
 
-    // Used for var_858
+    // Used for Window::var_858
     enum class FilterFlags : uint8_t
     {
         none = 0,
@@ -324,7 +325,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         _tabPositions.clear();
         for (auto i = 0U; i < kMainTabInfo.size(); i++)
         {
-            if (!shouldShowPrimaryTab(i, FilterLevel(self->var_856)))
+            if (!shouldShowPrimaryTab(i, FilterLevel(self->filterLevel)))
                 continue;
 
             // Assign tab position
@@ -454,7 +455,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         window->initScrollWidgets();
         window->frameNo = 0;
         window->rowHover = -1;
-        window->var_856 = enumValue(isEditorMode() ? FilterLevel::beginner : FilterLevel::advanced);
+        window->filterLevel = enumValue(isEditorMode() ? FilterLevel::beginner : FilterLevel::advanced);
         window->var_858 = enumValue(FilterFlags::vanilla | FilterFlags::custom);
         window->currentSecondaryTab = 0;
         window->object = nullptr;
@@ -489,7 +490,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     Window& openInTab(ObjectType objectType)
     {
         auto& window = *open();
-        window.var_856 = enumValue(FilterLevel::advanced);
+        window.filterLevel = enumValue(FilterLevel::advanced);
         assignTabPositions(&window);
         switchTabByObjectType(window, objectType);
         return window;
@@ -508,7 +509,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         const auto& currentTab = kMainTabInfo[self.currentTab];
         const auto& subTabs = currentTab.subTabs;
-        const bool showSecondaryTabs = !subTabs.empty() && FilterLevel(self.var_856) != FilterLevel::beginner;
+        const bool showSecondaryTabs = !subTabs.empty() && FilterLevel(self.filterLevel) != FilterLevel::beginner;
 
         // Update page title
         auto args = FormatArguments(self.widgets[widx::caption].textArgs);
@@ -522,7 +523,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         {
             const auto widgetIndex = i + widx::secondaryTab1;
 
-            const bool subTabIsVisible = showSecondaryTabs && i < subTabs.size() && shouldShowSubTab(subTabs, i, FilterLevel(self.var_856));
+            const bool subTabIsVisible = showSecondaryTabs && i < subTabs.size() && shouldShowSubTab(subTabs, i, FilterLevel(self.filterLevel));
             if (!subTabIsVisible)
                 self.disabledWidgets |= 1ULL << widgetIndex;
             else
@@ -912,7 +913,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             };
 
             FormatArguments args{};
-            args.push(levelStringIds[self.var_856]);
+            args.push(levelStringIds[self.filterLevel]);
 
             auto& widget = self.widgets[widx::filterLabel];
             auto point = Point(self.x + widget.left, self.y + widget.top);
@@ -1311,7 +1312,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             Dropdown::add(5, StringIds::dropdown_without_checkmark, StringIds::objSelectionFilterCustom);
 
             // Mark current level
-            Dropdown::setItemSelected(self.var_856);
+            Dropdown::setItemSelected(self.filterLevel);
 
             // Show vanilla objects?
             if ((FilterFlags(self.var_858) & FilterFlags::vanilla) != FilterFlags::none)
@@ -1330,7 +1331,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         if (itemIndex < 0)
         {
-            self.var_856 = (self.var_856 ^ 1) % 3;
+            self.filterLevel = (self.filterLevel ^ 1) % 3;
             assignTabPositions(&self);
         }
 
@@ -1346,7 +1347,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 currentObjectType = currentSubType.objectType;
             }
 
-            self.var_856 = itemIndex;
+            self.filterLevel = itemIndex;
             assignTabPositions(&self);
 
             // Switch back to previously selected object type, if possible

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -79,10 +79,10 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         StringId name;
         ObjectType objectType;
         VehicleType vehicleType;
-        ObjectTabFlags flags;
         uint32_t baseImage;
         uint8_t animationLength;
         uint8_t animationDivisor;
+        ObjectTabFlags flags;
     };
 
     struct MainTabInfo
@@ -96,56 +96,56 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     // clang-format off
     static constexpr std::array kWorldRegionSubTabs{
-        SubTabInfo{ StringIds::object_world_region, ObjectType::region,    {}, ObjectTabFlags::none,     ImageIds::tab_object_world,      1, 1 },
-        SubTabInfo{ StringIds::object_currency,     ObjectType::currency,  {}, ObjectTabFlags::advanced, ImageIds::tab_object_currency,   1, 1 },
-        SubTabInfo{ StringIds::object_town_names,   ObjectType::townNames, {}, ObjectTabFlags::advanced, ImageIds::tab_object_town_names, 1, 1 },
+        SubTabInfo{ StringIds::object_world_region, ObjectType::region,    {}, ImageIds::tab_object_world,      1, 1, ObjectTabFlags::none     },
+        SubTabInfo{ StringIds::object_currency,     ObjectType::currency,  {}, ImageIds::tab_object_currency,   1, 1, ObjectTabFlags::advanced },
+        SubTabInfo{ StringIds::object_town_names,   ObjectType::townNames, {}, ImageIds::tab_object_town_names, 1, 1, ObjectTabFlags::advanced },
     };
 
     static constexpr std::array kVehicleSubTabs{
-        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::train,    ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_train_frame0,    8, 1 },
-        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::bus,      ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_bus_frame0,      8, 1 },
-        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::truck,    ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_truck_frame0,    8, 1 },
-        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::tram,     ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_tram_frame0,     8, 1 },
-        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::aircraft, ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_aircraft_frame0, 8, 2 },
-        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::ship,     ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_ship_frame0,     8, 3 },
+        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::train,    InterfaceSkin::ImageIds::tab_vehicle_train_frame0,    8, 1, ObjectTabFlags::none },
+        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::bus,      InterfaceSkin::ImageIds::tab_vehicle_bus_frame0,      8, 1, ObjectTabFlags::none },
+        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::truck,    InterfaceSkin::ImageIds::tab_vehicle_truck_frame0,    8, 1, ObjectTabFlags::none },
+        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::tram,     InterfaceSkin::ImageIds::tab_vehicle_tram_frame0,     8, 1, ObjectTabFlags::none },
+        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::aircraft, InterfaceSkin::ImageIds::tab_vehicle_aircraft_frame0, 8, 2, ObjectTabFlags::none },
+        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::ship,     InterfaceSkin::ImageIds::tab_vehicle_ship_frame0,     8, 3, ObjectTabFlags::none },
     };
 
     static constexpr std::array kLandSubTabs{
-        SubTabInfo{ StringIds::object_land,                ObjectType::land,       {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_landscape, 1, 1 },
-        SubTabInfo{ StringIds::object_trees,               ObjectType::tree,       {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_trees,     1, 1 },
-        SubTabInfo{ StringIds::object_water,               ObjectType::water,      {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_water,     1, 1 },
-        SubTabInfo{ StringIds::object_walls,               ObjectType::wall,       {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_walls,     1, 1 },
-        SubTabInfo{ StringIds::object_map_generation_data, ObjectType::hillShapes, {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_map,       1, 1 },
-        SubTabInfo{ StringIds::object_snow,                ObjectType::snow,       {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_snow,      1, 1 },
-        SubTabInfo{ StringIds::object_climate,             ObjectType::climate,    {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_climate,   1, 1 },
-        SubTabInfo{ StringIds::object_cliffs,              ObjectType::cliffEdge,  {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_cliff,     1, 1 },
+        SubTabInfo{ StringIds::object_land,                ObjectType::land,       {}, ImageIds::tab_object_landscape, 1, 1, ObjectTabFlags::advanced                                },
+        SubTabInfo{ StringIds::object_trees,               ObjectType::tree,       {}, ImageIds::tab_object_trees,     1, 1, ObjectTabFlags::advanced                                },
+        SubTabInfo{ StringIds::object_water,               ObjectType::water,      {}, ImageIds::tab_object_water,     1, 1, ObjectTabFlags::advanced                                },
+        SubTabInfo{ StringIds::object_walls,               ObjectType::wall,       {}, ImageIds::tab_object_walls,     1, 1, ObjectTabFlags::advanced                                },
+        SubTabInfo{ StringIds::object_map_generation_data, ObjectType::hillShapes, {}, ImageIds::tab_object_map,       1, 1, ObjectTabFlags::advanced                                },
+        SubTabInfo{ StringIds::object_snow,                ObjectType::snow,       {}, ImageIds::tab_object_snow,      1, 1, ObjectTabFlags::advanced                                },
+        SubTabInfo{ StringIds::object_climate,             ObjectType::climate,    {}, ImageIds::tab_object_climate,   1, 1, ObjectTabFlags::advanced                                },
+        SubTabInfo{ StringIds::object_cliffs,              ObjectType::cliffEdge,  {}, ImageIds::tab_object_cliff,     1, 1, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
     };
 
     static constexpr std::array kTrackSubTabs{
-        SubTabInfo{ StringIds::object_track_stations, ObjectType::trainStation, {}, ObjectTabFlags::advanced,                                      ImageIds::tab_object_track_stations, 1, 1 },
-        SubTabInfo{ StringIds::object_track_extras,   ObjectType::trackExtra,   {}, ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular, ImageIds::tab_object_track_mods,     1, 1 },
-        SubTabInfo{ StringIds::object_signals,        ObjectType::trackSignal,  {}, ObjectTabFlags::advanced,                                      ImageIds::tab_object_signals,        1, 1 },
+        SubTabInfo{ StringIds::object_track_stations, ObjectType::trainStation, {}, ImageIds::tab_object_track_stations, 1, 1, ObjectTabFlags::advanced                                      },
+        SubTabInfo{ StringIds::object_track_extras,   ObjectType::trackExtra,   {}, ImageIds::tab_object_track_mods,     1, 1, ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
+        SubTabInfo{ StringIds::object_signals,        ObjectType::trackSignal,  {}, ImageIds::tab_object_signals,        1, 1, ObjectTabFlags::advanced                                      },
     };
 
     static constexpr std::array kRoadSubTabs{
-        SubTabInfo{ StringIds::object_road_stations,  ObjectType::roadStation,   {}, ObjectTabFlags::advanced,                                      ImageIds::tab_object_road_stations,   1, 1 },
-        SubTabInfo{ StringIds::object_road_extras,    ObjectType::roadExtra,     {}, ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular, ImageIds::tab_object_road_mods,       1, 1 },
-        SubTabInfo{ StringIds::object_level_crossing, ObjectType::levelCrossing, {}, ObjectTabFlags::advanced,                                      ImageIds::tab_object_level_crossings, 1, 1 },
-        SubTabInfo{ StringIds::object_street_lights,  ObjectType::streetLight,   {}, ObjectTabFlags::advanced,                                      ImageIds::tab_object_streetlights,    1, 1 },
+        SubTabInfo{ StringIds::object_road_stations,  ObjectType::roadStation,   {}, ImageIds::tab_object_road_stations,   1, 1, ObjectTabFlags::advanced                                      },
+        SubTabInfo{ StringIds::object_road_extras,    ObjectType::roadExtra,     {}, ImageIds::tab_object_road_mods,       1, 1, ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
+        SubTabInfo{ StringIds::object_level_crossing, ObjectType::levelCrossing, {}, ImageIds::tab_object_level_crossings, 1, 1, ObjectTabFlags::advanced                                      },
+        SubTabInfo{ StringIds::object_street_lights,  ObjectType::streetLight,   {}, ImageIds::tab_object_streetlights,    1, 1, ObjectTabFlags::advanced                                      },
     };
 
     static constexpr std::array kBuildingSubTabs{
-        SubTabInfo{ StringIds::object_buildings,   ObjectType::building,    {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_buildings,    1, 1 },
-        SubTabInfo{ StringIds::object_industries,  ObjectType::industry,    {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_industries,   1, 1 },
-        SubTabInfo{ StringIds::object_scaffolding, ObjectType::scaffolding, {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_construction, 1, 1 },
-        SubTabInfo{ StringIds::object_cargo,       ObjectType::cargo,       {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_cargo,        1, 1 },
+        SubTabInfo{ StringIds::object_buildings,   ObjectType::building,    {}, ImageIds::tab_object_buildings,    1, 1, ObjectTabFlags::advanced                                },
+        SubTabInfo{ StringIds::object_industries,  ObjectType::industry,    {}, ImageIds::tab_object_industries,   1, 1, ObjectTabFlags::advanced                                },
+        SubTabInfo{ StringIds::object_scaffolding, ObjectType::scaffolding, {}, ImageIds::tab_object_construction, 1, 1, ObjectTabFlags::advanced                                },
+        SubTabInfo{ StringIds::object_cargo,       ObjectType::cargo,       {}, ImageIds::tab_object_cargo,        1, 1, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
     };
 
     static constexpr std::array kMiscSubTabs{
-        SubTabInfo{ StringIds::object_interface_styles,      ObjectType::interfaceSkin, {}, ObjectTabFlags::advanced,                                ImageIds::tab_object_settings,  1, 1 },
-        SubTabInfo{ StringIds::object_scenario_descriptions, ObjectType::scenarioText,  {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_scenarios, 1, 1 },
-        SubTabInfo{ StringIds::object_animation_effects,     ObjectType::steam,         {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_smoke,     1, 1 },
-        SubTabInfo{ StringIds::object_sounds,                ObjectType::sound,         {}, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden, ImageIds::tab_object_audio,     1, 1 },
+        SubTabInfo{ StringIds::object_interface_styles,      ObjectType::interfaceSkin, {}, ImageIds::tab_object_settings,  1, 1, ObjectTabFlags::advanced                                },
+        SubTabInfo{ StringIds::object_scenario_descriptions, ObjectType::scenarioText,  {}, ImageIds::tab_object_scenarios, 1, 1, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        SubTabInfo{ StringIds::object_animation_effects,     ObjectType::steam,         {}, ImageIds::tab_object_smoke,     1, 1, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        SubTabInfo{ StringIds::object_sounds,                ObjectType::sound,         {}, ImageIds::tab_object_audio,     1, 1, ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
     };
 
     static constexpr std::array kMainTabInfo{

--- a/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Windows/ObjectSelectionWindow.cpp
@@ -76,49 +76,71 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(ObjectTabFlags);
 
+    struct SubTabInfo
+    {
+        StringId name;
+        ObjectType subObjectType;
+        VehicleType vehicleType;
+        ObjectTabFlags subFlags;
+        uint32_t baseImage;
+        uint8_t animationLength;
+        uint8_t animationDivisor;
+    };
+
     struct MainTabInfo
     {
         StringId name;
+        ObjectType objectType;
         uint32_t image;
+        std::span<const SubTabInfo> subTabs;
         ObjectTabFlags flags;
     };
 
     // clang-format off
+    static constexpr std::array kVehicleSubTabs{
+        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::train,    ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_train_frame0,    8, 1 },
+        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::bus,      ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_bus_frame0,      8, 1 },
+        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::truck,    ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_truck_frame0,    8, 1 },
+        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::tram,     ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_tram_frame0,     8, 1 },
+        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::aircraft, ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_aircraft_frame0, 8, 2 },
+        SubTabInfo{ StringIds::object_vehicles, ObjectType::vehicle, VehicleType::ship,     ObjectTabFlags::none, InterfaceSkin::ImageIds::tab_vehicle_ship_frame0,     8, 3 },
+    };
+
     static constexpr std::array<MainTabInfo, kMaxObjectTypes> _mainTabInfo = {
-        MainTabInfo{ StringIds::object_interface_styles,      ImageIds::tab_object_settings,        ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_sounds,                ImageIds::tab_object_audio,           ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        MainTabInfo{ StringIds::object_currency,              ImageIds::tab_object_currency,        ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_animation_effects,     ImageIds::tab_object_smoke,           ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        MainTabInfo{ StringIds::object_cliffs,                ImageIds::tab_object_cliff,           ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        MainTabInfo{ StringIds::object_water,                 ImageIds::tab_object_water,           ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_land,                  ImageIds::tab_object_landscape,       ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_town_names,            ImageIds::tab_object_town_names,      ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_cargo,                 ImageIds::tab_object_cargo,           ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        MainTabInfo{ StringIds::object_walls,                 ImageIds::tab_object_walls,           ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_signals,               ImageIds::tab_object_signals,         ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_level_crossing,        ImageIds::tab_object_level_crossings, ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_street_lights,         ImageIds::tab_object_streetlights,    ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_tunnels,               ImageIds::tab_object_tunnels,         ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
-        MainTabInfo{ StringIds::object_bridges,               ImageIds::tab_object_bridges,         ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_track_stations,        ImageIds::tab_object_track_stations,  ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_track_extras,          ImageIds::tab_object_track_mods,      ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
-        MainTabInfo{ StringIds::object_tracks,                ImageIds::tab_object_track,           ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_road_stations,         ImageIds::tab_object_road_stations,   ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_road_extras,           ImageIds::tab_object_road_mods,       ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
-        MainTabInfo{ StringIds::object_roads,                 ImageIds::tab_object_road,            ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_airports,              ImageIds::tab_object_airports,        ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_docks,                 ImageIds::tab_object_docks,           ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_vehicles,              ImageIds::tab_object_vehicles,        ObjectTabFlags::advanced | ObjectTabFlags::filterByVehicleType },
-        MainTabInfo{ StringIds::object_trees,                 ImageIds::tab_object_trees,           ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_snow,                  ImageIds::tab_object_snow,            ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_climate,               ImageIds::tab_object_climate,         ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_map_generation_data,   ImageIds::tab_object_map,             ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_buildings,             ImageIds::tab_object_buildings,       ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_scaffolding,           ImageIds::tab_object_construction,    ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_industries,            ImageIds::tab_object_industries,      ObjectTabFlags::advanced },
-        MainTabInfo{ StringIds::object_world_region,          ImageIds::tab_object_world,           ObjectTabFlags::none },
-        MainTabInfo{ StringIds::object_company_owners,        ImageIds::tab_object_companies,       ObjectTabFlags::hideInEditor },
-        MainTabInfo{ StringIds::object_scenario_descriptions, ImageIds::tab_object_scenarios,       ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden }
+        MainTabInfo{ StringIds::object_interface_styles,      ObjectType::interfaceSkin, ImageIds::tab_object_settings,        {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_sounds,                ObjectType::sound,         ImageIds::tab_object_audio,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_currency,              ObjectType::currency,      ImageIds::tab_object_currency,        {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_animation_effects,     ObjectType::steam,         ImageIds::tab_object_smoke,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_cliffs,                ObjectType::cliffEdge,     ImageIds::tab_object_cliff,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_water,                 ObjectType::water,         ImageIds::tab_object_water,           {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_land,                  ObjectType::land,          ImageIds::tab_object_landscape,       {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_town_names,            ObjectType::townNames,     ImageIds::tab_object_town_names,      {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_cargo,                 ObjectType::cargo,         ImageIds::tab_object_cargo,           {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_walls,                 ObjectType::wall,          ImageIds::tab_object_walls,           {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_signals,               ObjectType::trackSignal,   ImageIds::tab_object_signals,         {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_level_crossing,        ObjectType::levelCrossing, ImageIds::tab_object_level_crossings, {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_street_lights,         ObjectType::streetLight,   ImageIds::tab_object_streetlights,    {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_tunnels,               ObjectType::tunnel,        ImageIds::tab_object_tunnels,         {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden },
+        MainTabInfo{ StringIds::object_bridges,               ObjectType::bridge,        ImageIds::tab_object_bridges,         {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_track_stations,        ObjectType::trainStation,  ImageIds::tab_object_track_stations,  {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_track_extras,          ObjectType::trackExtra,    ImageIds::tab_object_track_mods,      {},              ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
+        MainTabInfo{ StringIds::object_tracks,                ObjectType::track,         ImageIds::tab_object_track,           {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_road_stations,         ObjectType::roadStation,   ImageIds::tab_object_road_stations,   {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_road_extras,           ObjectType::roadExtra,     ImageIds::tab_object_road_mods,       {},              ObjectTabFlags::advanced | ObjectTabFlags::showEvenIfSingular },
+        MainTabInfo{ StringIds::object_roads,                 ObjectType::road,          ImageIds::tab_object_road,            {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_airports,              ObjectType::airport,       ImageIds::tab_object_airports,        {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_docks,                 ObjectType::dock,          ImageIds::tab_object_docks,           {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_vehicles,              ObjectType::vehicle,       ImageIds::tab_object_vehicles,        kVehicleSubTabs, ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_trees,                 ObjectType::tree,          ImageIds::tab_object_trees,           {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_snow,                  ObjectType::snow,          ImageIds::tab_object_snow,            {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_climate,               ObjectType::climate,       ImageIds::tab_object_climate,         {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_map_generation_data,   ObjectType::hillShapes,    ImageIds::tab_object_map,             {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_buildings,             ObjectType::building,      ImageIds::tab_object_buildings,       {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_scaffolding,           ObjectType::scaffolding,   ImageIds::tab_object_construction,    {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_industries,            ObjectType::industry,      ImageIds::tab_object_industries,      {},              ObjectTabFlags::advanced },
+        MainTabInfo{ StringIds::object_world_region,          ObjectType::region,        ImageIds::tab_object_world,           {},              ObjectTabFlags::none },
+        MainTabInfo{ StringIds::object_company_owners,        ObjectType::competitor,    ImageIds::tab_object_companies,       {},              ObjectTabFlags::hideInEditor },
+        MainTabInfo{ StringIds::object_scenario_descriptions, ObjectType::scenarioText,  ImageIds::tab_object_scenarios,       {},              ObjectTabFlags::advanced | ObjectTabFlags::alwaysHidden }
     };
     // clang-format on
 
@@ -190,12 +212,12 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         filterDropdown,
         textInput,
         clearButton,
-        vehicleTypeTrain,
-        vehicleTypeBus,
-        vehicleTypeTruck,
-        vehicleTypeTram,
-        vehicleTypeAircraft,
-        vehicleTypeShip,
+        secondaryTab1,
+        secondaryTab2,
+        secondaryTab3,
+        secondaryTab4,
+        secondaryTab5,
+        secondaryTab6,
         scrollviewFrame,
         scrollview,
         objectImage,
@@ -519,23 +541,37 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             self.widgets[widx::closeButton].type = WidgetType::none;
         }
 
-        // Update the title.
-        auto args = FormatArguments(self.widgets[widx::caption].textArgs);
-        args.push(_mainTabInfo[self.currentTab].name);
+        const auto& subTabs = _mainTabInfo[self.currentTab].subTabs;
+        const bool showSecondaryTabs = !subTabs.empty();
 
-        const auto& tabFlags = _mainTabInfo[self.currentTab].flags;
-        const bool showSecondaryTabs = (tabFlags & ObjectTabFlags::filterByVehicleType) != ObjectTabFlags::none;
-        for (int i = widx::vehicleTypeTrain; i <= widx::vehicleTypeShip; i++)
+        // Update page title
+        auto args = FormatArguments(self.widgets[widx::caption].textArgs);
+        if (showSecondaryTabs)
+            args.push(subTabs[self.currentSecondaryTab].name);
+        else
+            args.push(_mainTabInfo[self.currentTab].name);
+
+        // Toggle secondary tabs
+        for (auto i = 0U; i < 6U; i++)
         {
-            self.widgets[i].type = showSecondaryTabs ? WidgetType::tab : WidgetType::none;
+            bool subTabIsVisible = showSecondaryTabs && i < subTabs.size();
+
+            const auto widgetIndex = i + widx::secondaryTab1;
+            self.widgets[widgetIndex].type = subTabIsVisible ? WidgetType::tab : WidgetType::none;
+
+            if (subTabIsVisible)
+                self.enabledWidgets |= 1ULL << widgetIndex;
+            else
+                self.enabledWidgets &= ~(1ULL << widgetIndex);
+
+            if (self.currentSecondaryTab == i)
+                self.activatedWidgets |= 1ULL << widgetIndex;
+            else
+                self.activatedWidgets &= ~(1ULL << widgetIndex);
         }
 
-        self.activatedWidgets &= ~((1ULL << widx::vehicleTypeTrain) | (1ULL << widx::vehicleTypeBus) | (1ULL << widx::vehicleTypeTruck) | (1ULL << widx::vehicleTypeTram) | (1ULL << widx::vehicleTypeAircraft) | (1ULL << widx::vehicleTypeShip));
         if (showSecondaryTabs)
         {
-            self.activatedWidgets |= 1ULL << (widx::vehicleTypeTrain + self.currentSecondaryTab);
-            self.enabledWidgets |= (1ULL << widx::vehicleTypeTrain) | (1ULL << widx::vehicleTypeBus) | (1ULL << widx::vehicleTypeTruck) | (1ULL << widx::vehicleTypeTram) | (1ULL << widx::vehicleTypeAircraft) | (1ULL << widx::vehicleTypeShip);
-
             self.widgets[widx::scrollview].top = 85 + 28;
             self.widgets[widx::scrollviewFrame].type = WidgetType::panel;
             self.widgets[widx::scrollviewFrame].top = self.widgets[widx::scrollview].top - 2;
@@ -543,8 +579,6 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         }
         else
         {
-            self.enabledWidgets &= ~((1ULL << widx::vehicleTypeTrain) | (1ULL << widx::vehicleTypeBus) | (1ULL << widx::vehicleTypeTruck) | (1ULL << widx::vehicleTypeTram) | (1ULL << widx::vehicleTypeAircraft) | (1ULL << widx::vehicleTypeShip));
-
             self.widgets[widx::scrollview].top = 85;
             self.widgets[widx::scrollviewFrame].type = WidgetType::none;
             self.widgets[widx::objectImage].top = 68;
@@ -602,25 +636,10 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         }
     }
 
-    struct VehicleTabData
+    static void drawSecondaryTabs(Window* self, Gfx::DrawingContext& drawingCtx)
     {
-        uint32_t image;
-        uint8_t frameSpeed;
-    };
-
-    static constexpr std::array<VehicleTabData, 6> tabIconByVehicleType{
-        VehicleTabData{ InterfaceSkin::ImageIds::tab_vehicle_train_frame0, 1 },
-        VehicleTabData{ InterfaceSkin::ImageIds::tab_vehicle_bus_frame0, 1 },
-        VehicleTabData{ InterfaceSkin::ImageIds::tab_vehicle_truck_frame0, 1 },
-        VehicleTabData{ InterfaceSkin::ImageIds::tab_vehicle_tram_frame0, 1 },
-        VehicleTabData{ InterfaceSkin::ImageIds::tab_vehicle_aircraft_frame0, 2 },
-        VehicleTabData{ InterfaceSkin::ImageIds::tab_vehicle_ship_frame0, 3 },
-    };
-
-    static void drawVehicleTabs(Window* self, Gfx::DrawingContext& drawingCtx)
-    {
-        const auto& tabFlags = _mainTabInfo[self->currentTab].flags;
-        const bool showSecondaryTabs = (tabFlags & ObjectTabFlags::filterByVehicleType) != ObjectTabFlags::none;
+        const auto& subTabs = _mainTabInfo[self->currentTab].subTabs;
+        const bool showSecondaryTabs = !subTabs.empty();
         if (!showSecondaryTabs)
         {
             return;
@@ -628,19 +647,18 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         auto skin = ObjectManager::get<InterfaceSkinObject>();
 
-        for (int i = widx::vehicleTypeTrain; i <= widx::vehicleTypeShip; i++)
+        for (auto i = 0U; i < 6; i++)
         {
-            auto vehicleType = i - widx::vehicleTypeTrain;
-            auto& tabData = tabIconByVehicleType.at(vehicleType);
-
+            auto& tabData = subTabs[i];
             auto frame = 0;
-            if (self->currentSecondaryTab == vehicleType)
+            if (self->currentSecondaryTab == i)
             {
-                frame = (self->frameNo >> tabData.frameSpeed) & 0x7;
+                frame = (self->frameNo >> tabData.animationDivisor) % tabData.animationLength;
             }
 
-            auto image = Gfx::recolour(skin->img + tabData.image + frame, CompanyManager::getCompanyColour(CompanyId::neutral));
-            Widget::drawTab(self, drawingCtx, image, i);
+            auto widgetIndex = i + widx::secondaryTab1;
+            auto image = Gfx::recolour(skin->img + tabData.baseImage + frame, CompanyManager::getCompanyColour(CompanyId::neutral));
+            Widget::drawTab(self, drawingCtx, image, widgetIndex);
         }
     }
 
@@ -926,7 +944,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         self.draw(drawingCtx);
 
         drawTabs(&self, drawingCtx);
-        drawVehicleTabs(&self, drawingCtx);
+        drawSecondaryTabs(&self, drawingCtx);
         drawSearchBox(self, drawingCtx);
 
         {
@@ -1170,8 +1188,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     {
         repositionTargetTab(&self, newTab);
 
-        const auto& tabFlags = _mainTabInfo[self.currentTab].flags;
-        _filterByVehicleType = (tabFlags & ObjectTabFlags::filterByVehicleType) != ObjectTabFlags::none;
+        const auto& currentTab = _mainTabInfo[self.currentTab];
+        _filterByVehicleType = currentTab.objectType == ObjectType::vehicle;
         _currentVehicleType = VehicleType::train;
 
         populateTabObjectList(newTab, FilterFlags(self.var_858));
@@ -1251,16 +1269,28 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 break;
             }
 
-            case widx::vehicleTypeTrain:
-            case widx::vehicleTypeBus:
-            case widx::vehicleTypeTruck:
-            case widx::vehicleTypeTram:
-            case widx::vehicleTypeAircraft:
-            case widx::vehicleTypeShip:
+            case widx::secondaryTab1:
+            case widx::secondaryTab2:
+            case widx::secondaryTab3:
+            case widx::secondaryTab4:
+            case widx::secondaryTab5:
+            case widx::secondaryTab6:
             {
-                self.currentSecondaryTab = w - widx::vehicleTypeTrain;
+                auto& subTabs = _mainTabInfo[self.currentTab].subTabs;
+                auto previousSubType = subTabs[self.currentSecondaryTab].subObjectType;
+
+                self.currentSecondaryTab = w - widx::secondaryTab1;
+                auto currentSubType = subTabs[self.currentSecondaryTab].subObjectType;
                 _currentVehicleType = static_cast<VehicleType>(self.currentSecondaryTab);
-                applyFilterToObjectList(FilterFlags(self.var_858));
+
+                // Do we need to reload the object list?
+                auto flags = FilterFlags(self.var_858);
+                if (previousSubType != currentSubType)
+                {
+                    populateTabObjectList(subTabs[self.currentSecondaryTab].subObjectType, flags);
+                }
+
+                applyFilterToObjectList(flags);
                 self.initScrollWidgets();
                 self.invalidate();
             }

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -73,7 +73,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
         window->setWidgets(_widgets);
         window->enabledWidgets = (1 << Widx::map_chat_menu) | (1 << Widx::date_btn) | (1 << Widx::pause_btn) | (1 << Widx::normal_speed_btn) | (1 << Widx::fast_forward_btn) | (1 << Widx::extra_fast_forward_btn);
         window->var_854 = 0;
-        window->var_856 = 0;
+        window->numTicksVisible = 0;
         window->initScrollWidgets();
 
         auto skin = ObjectManager::get<InterfaceSkinObject>();
@@ -165,7 +165,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
         StringId format = StringIds::date_daymonthyear;
         if (isPaused() && (getPauseFlags() & (1 << 2)) == 0)
         {
-            if (self.var_856 >= 30)
+            if (self.numTicksVisible >= 30)
             {
                 format = StringIds::toolbar_status_paused;
             }
@@ -387,10 +387,10 @@ namespace OpenLoco::Ui::Windows::TimePanel
             w.var_854 = 0;
         }
 
-        w.var_856 += 1;
-        if (w.var_856 >= 60)
+        w.numTicksVisible += 1;
+        if (w.numTicksVisible >= 60)
         {
-            w.var_856 = 0;
+            w.numTicksVisible = 0;
         }
 
         if (_50A004 & (1 << 1))


### PR DESCRIPTION
This PR groups tabs in the object selection window such that related elements appear together. This is done in a way analogous to the vehicles tab, which was already using sub-tabs for each of the vehicle types.

Grouping these items together brings the number of main tabs down from 20 (advanced) or 34 (expert) to just 12. This makes the window less cluttered, and thereby hopefully makes it easier to find the right tab.

Before:
![Unnamed (1)](https://github.com/user-attachments/assets/d3759d7a-aca1-4ad7-9554-b5bd2f459537)

After:
![Unnamed](https://github.com/user-attachments/assets/08e2bafe-1fbc-41a9-83ee-bb454985d048)

To do:
- [x] Apply flags to hide secondary tabs as needed
- [x] Fix `openInTab` (doesn't look up object type)
- [x] Clean up things a bit more
- [ ] Are we satisfied with (the order of) these categories? -> ask @LeftofZen 
- [ ] Should we drop beginner/advanced/expert mode? -> probably not