### PR TITLE
Advanced color fix

### DIFF
--- a/src/Interop/include/OpenLoco/Interop/Interop.hpp
+++ b/src/Interop/include/OpenLoco/Interop/Interop.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <OpenLoco/Core/Exception.hpp>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -340,6 +341,7 @@ namespace OpenLoco::Interop
 
         reference operator[](int idx)
         {
+            assert(idx >= 0 && static_cast<size_t>(idx) < size());
 #ifndef NDEBUG
             if (idx < 0 || static_cast<size_t>(idx) >= size())
             {

--- a/src/OpenLoco/src/Graphics/Colour.h
+++ b/src/OpenLoco/src/Graphics/Colour.h
@@ -215,8 +215,12 @@ namespace OpenLoco
         }
 
         constexpr explicit operator Colour() const { return static_cast<Colour>(enumValue(_c) & ~(outlineFlag | insetFlag | translucentFlag)); }
-        [[nodiscard]] constexpr Colour c() const { return _c; }
+
+        // Returns the Colour without any additional flags set.
+        [[nodiscard]] constexpr Colour c() const { return static_cast<Colour>(*this); }
+
         constexpr explicit operator uint8_t() const { return enumValue(_c); }
+
         [[nodiscard]] constexpr uint8_t u8() const { return static_cast<uint8_t>(*this); }
 
         [[nodiscard]] constexpr AdvancedColour outline() const
@@ -237,18 +241,18 @@ namespace OpenLoco
         }
         [[nodiscard]] constexpr bool isTranslucent() const { return enumValue(_c) & translucentFlag; }
 
-        [[nodiscard]] constexpr AdvancedColour opaque()
+        [[nodiscard]] constexpr AdvancedColour opaque() const
         {
             return { static_cast<Colour>(enumValue(_c) & ~translucentFlag) };
         }
         [[nodiscard]] constexpr bool isOpaque() const { return !isTranslucent(); }
 
-        [[nodiscard]] constexpr AdvancedColour clearInset()
+        [[nodiscard]] constexpr AdvancedColour clearInset() const
         {
             return { static_cast<Colour>(enumValue(_c) & ~insetFlag) };
         }
 
-        [[nodiscard]] constexpr AdvancedColour clearOutline()
+        [[nodiscard]] constexpr AdvancedColour clearOutline() const
         {
             return { static_cast<Colour>(enumValue(_c) & ~outlineFlag) };
         }


### PR DESCRIPTION
Small mistake I made, the static_cast was used to invoke the type operator which strips the data of all flags first. Also added an assert in interop, the exception thrown doesn't typically provide a meaningful call stack.

Also there were a few missing const keywords.