### PR TITLE
Change TimePanel window width to match widgets

### DIFF
--- a/src/OpenLoco/src/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/src/Windows/PlayerInfoPanel.cpp
@@ -26,7 +26,7 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::PlayerInfoPanel
 {
-    static constexpr Ui::Size32 kWindowSize = { 140, 29 };
+    static constexpr Ui::Size32 kWindowSize = { 140, 27 };
 
     namespace Widx
     {

--- a/src/OpenLoco/src/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/src/Windows/PlayerInfoPanel.cpp
@@ -26,7 +26,7 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::PlayerInfoPanel
 {
-    static constexpr Ui::Size32 kWindowSize = { 140, 27 };
+    static constexpr Ui::Size32 kWindowSize = { 140, 29 };
 
     namespace Widx
     {

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -28,7 +28,7 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::TimePanel
 {
-    static constexpr Ui::Size32 kWindowSize = { 145, 27 };
+    static constexpr Ui::Size32 kWindowSize = { 140, 29 };
 
     namespace Widx
     {

--- a/src/OpenLoco/src/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Windows/TimePanel.cpp
@@ -28,7 +28,7 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::Ui::Windows::TimePanel
 {
-    static constexpr Ui::Size32 kWindowSize = { 140, 29 };
+    static constexpr Ui::Size32 kWindowSize = { 140, 27 };
 
     namespace Widx
     {


### PR DESCRIPTION
Noticed there was a 5px gap between the time panel and the game window border, leading to the news ticker being rendered incorrectly. This corrects that.

Originally, I had changed the window height from 27px to 29px as well, however the bottom border seems to have been cut off intentionally.