### PR TITLE
Fix drawLine being off by one in horizontal-to-vertical transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: [#2612] Crash when constructing trams underground with Shift key pressed.
 - Fix: [#2625] Crash when resizing the window during the Intro.
 - Fix: [#2628] Crash when a train has no cars.
+- Fix: [#2657] Lines depicting aircraft routes are drawn slightly fuzzy in the map window.
 
 24.09.1 (2024-09-07)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
@@ -927,7 +927,7 @@ namespace OpenLoco::Gfx
 
                     // Reset non vertical line vars
                     xStart = x + 1;
-                    length = 1;
+                    length = 0; // NB: will be incremented in next iteration
                     y += yStep;
                     error += deltaX;
                 }


### PR DESCRIPTION
While working on #2646, it was discovered that our `drawLine` implementation has an off by one issue in horizontal-to-vertical transitions. This affects the map window as well, specifically rendering aircraft routes. Fixing the issue finally brings these in line with vanilla again.

Before:
![Screenshot](https://github.com/user-attachments/assets/8f53dbae-4423-4d9f-9ceb-bd64be25ad8d)

After:
![Screenshot (3)](https://github.com/user-attachments/assets/64e2023c-8db3-41bf-b031-5888769f4b99)
