### PR TITLE
Allow resizing company charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#1687] Objects can be placed in sub folders in new custom object folder.
 - Feature: [#2629] The object selection window now groups relevant object tabs together.
+- Change: [#2666] The charts in the company list window can now be resized.
 - Fix: [#2612] Crash when constructing trams underground with Shift key pressed.
 - Fix: [#2625] Crash when resizing the window during the Intro.
 - Fix: [#2628] Crash when a train has no cars.

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -694,8 +694,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _graphSettings.dataTypeSize = 2;
             _graphSettings.xLabel = StringIds::rawdate_short;
             _graphSettings.yLabel = StringIds::percentage_one_decimal_place;
-            _graphSettings.xAxisTickIncrement = 4;
-            _graphSettings.xAxisLabelIncrement = 12;
+            _graphSettings.xAxisTickIncrement = (_graphSettings.width - _graphSettings.xOffset) / 120;
+            _graphSettings.xAxisLabelIncrement = _graphSettings.xAxisTickIncrement * 3;
             _graphSettings.dword_113DD86 = 0;
             _graphSettings.yAxisStepSize = 100;
             _graphSettings.flags = GraphFlags::dataFrontToBack;
@@ -787,8 +787,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _graphSettings.dataTypeSize = 4;
             _graphSettings.xLabel = StringIds::rawdate_short;
             _graphSettings.yLabel = StringIds::cargo_units_delivered;
-            _graphSettings.xAxisTickIncrement = 4;
-            _graphSettings.xAxisLabelIncrement = 12;
+            _graphSettings.xAxisTickIncrement = (_graphSettings.width - _graphSettings.xOffset) / 120;
+            _graphSettings.xAxisLabelIncrement = _graphSettings.xAxisTickIncrement * 3;
             _graphSettings.dword_113DD86 = 0;
             _graphSettings.yAxisStepSize = 1000;
             _graphSettings.flags = GraphFlags::dataFrontToBack;
@@ -880,8 +880,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _graphSettings.dataTypeSize = 4;
             _graphSettings.xLabel = StringIds::rawdate_short;
             _graphSettings.yLabel = StringIds::cargo_units_delivered;
-            _graphSettings.xAxisTickIncrement = 4;
-            _graphSettings.xAxisLabelIncrement = 12;
+            _graphSettings.xAxisTickIncrement = (_graphSettings.width - _graphSettings.xOffset) / 120;
+            _graphSettings.xAxisLabelIncrement = _graphSettings.xAxisTickIncrement * 3;
             _graphSettings.dword_113DD86 = 0;
             _graphSettings.yAxisStepSize = 1000;
             _graphSettings.flags = GraphFlags::dataFrontToBack;
@@ -973,8 +973,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _graphSettings.dataTypeSize = 6;
             _graphSettings.xLabel = StringIds::rawdate_short;
             _graphSettings.yLabel = StringIds::small_company_value_currency;
-            _graphSettings.xAxisTickIncrement = 4;
-            _graphSettings.xAxisLabelIncrement = 12;
+            _graphSettings.xAxisTickIncrement = (_graphSettings.width - _graphSettings.xOffset) / 120;
+            _graphSettings.xAxisLabelIncrement = _graphSettings.xAxisTickIncrement * 3;
             _graphSettings.dword_113DD86 = 0;
             _graphSettings.yAxisStepSize = 10000;
             _graphSettings.flags = GraphFlags::dataFrontToBack;
@@ -1136,8 +1136,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _graphSettings.dataTypeSize = 4;
             _graphSettings.xLabel = StringIds::cargo_delivered_days;
             _graphSettings.yLabel = StringIds::cargo_delivered_currency;
-            _graphSettings.xAxisTickIncrement = 5;
-            _graphSettings.xAxisLabelIncrement = 20;
+            _graphSettings.xAxisTickIncrement = (_graphSettings.width - _graphSettings.xOffset) / 60;
+            _graphSettings.xAxisLabelIncrement = _graphSettings.xAxisTickIncrement * 4;
             _graphSettings.dword_113DD86 = 0;
             _graphSettings.yAxisStepSize = 0;
             _graphSettings.flags = GraphFlags::none;

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -695,7 +695,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _graphSettings.xLabel = StringIds::rawdate_short;
             _graphSettings.yLabel = StringIds::percentage_one_decimal_place;
             _graphSettings.xAxisTickIncrement = (_graphSettings.width - _graphSettings.xOffset) / 120;
-            _graphSettings.xAxisLabelIncrement = _graphSettings.xAxisTickIncrement * 3;
+            _graphSettings.xAxisLabelIncrement = 12;
             _graphSettings.dword_113DD86 = 0;
             _graphSettings.yAxisStepSize = 100;
             _graphSettings.flags = GraphFlags::dataFrontToBack;
@@ -788,7 +788,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _graphSettings.xLabel = StringIds::rawdate_short;
             _graphSettings.yLabel = StringIds::cargo_units_delivered;
             _graphSettings.xAxisTickIncrement = (_graphSettings.width - _graphSettings.xOffset) / 120;
-            _graphSettings.xAxisLabelIncrement = _graphSettings.xAxisTickIncrement * 3;
+            _graphSettings.xAxisLabelIncrement = 12;
             _graphSettings.dword_113DD86 = 0;
             _graphSettings.yAxisStepSize = 1000;
             _graphSettings.flags = GraphFlags::dataFrontToBack;
@@ -881,7 +881,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _graphSettings.xLabel = StringIds::rawdate_short;
             _graphSettings.yLabel = StringIds::cargo_units_delivered;
             _graphSettings.xAxisTickIncrement = (_graphSettings.width - _graphSettings.xOffset) / 120;
-            _graphSettings.xAxisLabelIncrement = _graphSettings.xAxisTickIncrement * 3;
+            _graphSettings.xAxisLabelIncrement = 12;
             _graphSettings.dword_113DD86 = 0;
             _graphSettings.yAxisStepSize = 1000;
             _graphSettings.flags = GraphFlags::dataFrontToBack;
@@ -974,7 +974,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _graphSettings.xLabel = StringIds::rawdate_short;
             _graphSettings.yLabel = StringIds::small_company_value_currency;
             _graphSettings.xAxisTickIncrement = (_graphSettings.width - _graphSettings.xOffset) / 120;
-            _graphSettings.xAxisLabelIncrement = _graphSettings.xAxisTickIncrement * 3;
+            _graphSettings.xAxisLabelIncrement = 12;
             _graphSettings.dword_113DD86 = 0;
             _graphSettings.yAxisStepSize = 10000;
             _graphSettings.flags = GraphFlags::dataFrontToBack;
@@ -1137,7 +1137,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             _graphSettings.xLabel = StringIds::cargo_delivered_days;
             _graphSettings.yLabel = StringIds::cargo_delivered_currency;
             _graphSettings.xAxisTickIncrement = (_graphSettings.width - _graphSettings.xOffset) / 60;
-            _graphSettings.xAxisLabelIncrement = _graphSettings.xAxisTickIncrement * 4;
+            _graphSettings.xAxisLabelIncrement = 20;
             _graphSettings.dword_113DD86 = 0;
             _graphSettings.yAxisStepSize = 0;
             _graphSettings.flags = GraphFlags::none;

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -33,6 +33,9 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
     namespace Common
     {
+        static constexpr Ui::Size32 kMaxWindowSize = { 800, 940 }; // NB: frame background is only 800px :(
+        static constexpr Ui::Size32 kMinWindowSize = { 300, 272 };
+
         enum widx
         {
             frame,
@@ -77,8 +80,6 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
     namespace CompanyList
     {
-        static constexpr Ui::Size32 kMaxWindowSize = { 640, 470 };
-        static constexpr Ui::Size32 kMinWindowSize = { 300, 272 };
         static constexpr Ui::Size32 kWindowSize = { 640, 272 };
 
         static constexpr uint8_t kRowHeight = 25;
@@ -154,7 +155,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x004363CB
         static void onResize(Window& self)
         {
-            self.setSize(kMinWindowSize, kMaxWindowSize);
+            self.setSize(Common::kMinWindowSize, Common::kMaxWindowSize);
         }
 
         // 0x00437BA0
@@ -520,10 +521,10 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x00436198
         static void tabReset(Window* self)
         {
-            self->minWidth = kMinWindowSize.width;
-            self->minHeight = kMinWindowSize.height;
-            self->maxWidth = kMaxWindowSize.width;
-            self->maxHeight = kMaxWindowSize.height;
+            self->minWidth = Common::kMinWindowSize.width;
+            self->minHeight = Common::kMinWindowSize.height;
+            self->maxWidth = Common::kMaxWindowSize.width;
+            self->maxHeight = Common::kMaxWindowSize.height;
             self->width = kWindowSize.width;
             self->height = kWindowSize.height;
             self->var_83C = 0;
@@ -590,10 +591,10 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         window->currentTab = 0;
-        window->minWidth = CompanyList::kMinWindowSize.width;
-        window->minHeight = CompanyList::kMinWindowSize.height;
-        window->maxWidth = CompanyList::kMaxWindowSize.width;
-        window->maxHeight = CompanyList::kMaxWindowSize.height;
+        window->minWidth = Common::kMinWindowSize.width;
+        window->minHeight = Common::kMinWindowSize.height;
+        window->maxWidth = Common::kMaxWindowSize.width;
+        window->maxHeight = Common::kMaxWindowSize.height;
 
         window->invalidate();
 
@@ -644,7 +645,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x004366D7
         static void onResize(Window& self)
         {
-            self.setSize(kWindowSize, kWindowSize);
+            self.setSize(kWindowSize, Common::kMaxWindowSize);
         }
 
         // 0x00436490
@@ -737,7 +738,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x004369FB
         static void onResize(Window& self)
         {
-            self.setSize(kWindowSize, kWindowSize);
+            self.setSize(kWindowSize, Common::kMaxWindowSize);
         }
 
         // 0x004367B4
@@ -830,7 +831,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x00436D1F
         static void onResize(Window& self)
         {
-            self.setSize(kWindowSize, kWindowSize);
+            self.setSize(kWindowSize, Common::kMaxWindowSize);
         }
 
         // 0x00436AD8
@@ -923,7 +924,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x00437043
         static void onResize(Window& self)
         {
-            self.setSize(kWindowSize, kWindowSize);
+            self.setSize(kWindowSize, Common::kMaxWindowSize);
         }
 
         // 0x00436DFC
@@ -1016,7 +1017,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x0043737D
         static void onResize(Window& self)
         {
-            self.setSize(kWindowSize, kWindowSize);
+            self.setSize(kWindowSize, Common::kMaxWindowSize);
         }
 
         // 0x004F9442

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -31,6 +31,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
     static uint16_t _hoverItemTicks;     // 0x009C68C7
     static GraphSettings _graphSettings; // 0x0113DC7A
 
+    static constexpr auto kLegendMargin = 6;
     static constexpr auto kLegendWidth = 100;
     static constexpr auto kWindowPadding = 4;
 
@@ -659,7 +660,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             _graphSettings.left = self.x + 4;
             _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 4;
-            _graphSettings.width = self.width - kLegendWidth - 2 * kWindowPadding;
+            _graphSettings.width = self.width - kLegendWidth - kLegendMargin - 2 * kWindowPadding;
             _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
             _graphSettings.xOffset = 40;
@@ -752,7 +753,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             _graphSettings.left = self.x + 4;
             _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 4;
-            _graphSettings.width = self.width - kLegendWidth - 2 * kWindowPadding;
+            _graphSettings.width = self.width - kLegendWidth - kLegendMargin - 2 * kWindowPadding;
             _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
             _graphSettings.xOffset = 45;
@@ -845,7 +846,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             _graphSettings.left = self.x + 4;
             _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 4;
-            _graphSettings.width = self.width - kLegendWidth - 2 * kWindowPadding;
+            _graphSettings.width = self.width - kLegendWidth - kLegendMargin - 2 * kWindowPadding;
             _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
             _graphSettings.xOffset = 65;
@@ -938,7 +939,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             _graphSettings.left = self.x + 4;
             _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 4;
-            _graphSettings.width = self.width - kLegendWidth - 2 * kWindowPadding;
+            _graphSettings.width = self.width - kLegendWidth - kLegendMargin - 2 * kWindowPadding;
             _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
             _graphSettings.xOffset = 90;
@@ -1106,7 +1107,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             _graphSettings.left = self.x + 4;
             _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 14;
-            _graphSettings.width = self.width - kLegendWidth - 2 * kWindowPadding;
+            _graphSettings.width = self.width - kLegendWidth - kLegendMargin - 2 * kWindowPadding;
             _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 20 - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
             _graphSettings.xOffset = 80;

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -1173,20 +1173,24 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 drawGraphLegend(&self, drawingCtx, x, y);
             }
 
+            auto canvasMidX = _graphSettings.xOffset + (_graphSettings.width - _graphSettings.xOffset) / 2;
+
+            // Chart title
             {
-                auto point = Point(self.x + 8, self.widgets[Common::widx::panel].top + self.y + 1);
+                auto point = Point(self.x + canvasMidX, self.widgets[Common::widx::panel].top + self.y + 1);
 
                 FormatArguments args{};
                 args.push<uint16_t>(100);
                 args.push<uint16_t>(10);
 
-                tr.drawStringLeft(point, Colour::black, StringIds::cargo_deliver_graph_title, args);
+                tr.drawStringCentred(point, Colour::black, StringIds::cargo_deliver_graph_title, args);
             }
 
+            // X axis label ("Transit time")
             {
-                auto point = Point(self.x + 160, self.height + self.y - 13);
+                auto point = Point(self.x + canvasMidX, self.height + self.y - 13);
 
-                tr.drawStringLeft(point, Colour::black, StringIds::cargo_transit_time);
+                tr.drawStringCentred(point, Colour::black, StringIds::cargo_transit_time);
             }
         }
 

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -659,8 +659,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             _graphSettings.left = self.x + 4;
             _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 4;
-            _graphSettings.width = 520;
-            _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 8;
+            _graphSettings.width = self.width - kLegendWidth - 2 * kWindowPadding;
+            _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
             _graphSettings.xOffset = 40;
             _graphSettings.yAxisLabelIncrement = 20;
@@ -752,8 +752,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             _graphSettings.left = self.x + 4;
             _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 4;
-            _graphSettings.width = 525;
-            _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 8;
+            _graphSettings.width = self.width - kLegendWidth - 2 * kWindowPadding;
+            _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
             _graphSettings.xOffset = 45;
             _graphSettings.yAxisLabelIncrement = 25;
@@ -845,8 +845,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             _graphSettings.left = self.x + 4;
             _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 4;
-            _graphSettings.width = 545;
-            _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 8;
+            _graphSettings.width = self.width - kLegendWidth - 2 * kWindowPadding;
+            _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
             _graphSettings.xOffset = 65;
             _graphSettings.yAxisLabelIncrement = 25;
@@ -938,8 +938,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             _graphSettings.left = self.x + 4;
             _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 4;
-            _graphSettings.width = 570;
-            _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 8;
+            _graphSettings.width = self.width - kLegendWidth - 2 * kWindowPadding;
+            _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
             _graphSettings.xOffset = 90;
             _graphSettings.yAxisLabelIncrement = 25;
@@ -1106,8 +1106,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             _graphSettings.left = self.x + 4;
             _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 14;
-            _graphSettings.width = 380;
-            _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 28;
+            _graphSettings.width = self.width - kLegendWidth - 2 * kWindowPadding;
+            _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 20 - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
             _graphSettings.xOffset = 80;
             _graphSettings.yAxisLabelIncrement = 25;

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -31,6 +31,9 @@ namespace OpenLoco::Ui::Windows::CompanyList
     static uint16_t _hoverItemTicks;     // 0x009C68C7
     static GraphSettings _graphSettings; // 0x0113DC7A
 
+    static constexpr auto kLegendWidth = 100;
+    static constexpr auto kWindowPadding = 4;
+
     namespace Common
     {
         static constexpr Ui::Size32 kMaxWindowSize = { 800, 940 }; // NB: frame background is only 800px :(
@@ -1164,7 +1167,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             }
 
             {
-                auto x = self.width + self.x - 104;
+                auto x = self.width + self.x - kLegendWidth - kWindowPadding;
                 auto y = self.y + 52;
 
                 drawGraphLegend(&self, drawingCtx, x, y);
@@ -1197,7 +1200,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 auto* frontWindow = WindowManager::findAt(location);
                 const auto xDiff = location.x - x;
                 const auto yDiff = location.y - y;
-                if (frontWindow != nullptr && frontWindow == self && xDiff <= 100 && xDiff >= 0 && yDiff < 320 && yDiff >= 0)
+                if (frontWindow != nullptr && frontWindow == self && xDiff <= kLegendWidth && xDiff >= 0 && yDiff < 320 && yDiff >= 0)
                 {
                     auto listY = yDiff;
                     uint8_t cargoItem = 0;
@@ -1398,7 +1401,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 auto* frontWindow = WindowManager::findAt(location);
                 const auto xDiff = location.x - x;
                 const auto yDiff = location.y - y;
-                if (frontWindow != nullptr && frontWindow == self && xDiff <= 100 && xDiff >= 0 && yDiff < 150 && yDiff >= 0)
+                if (frontWindow != nullptr && frontWindow == self && xDiff <= kLegendWidth && xDiff >= 0 && yDiff < 150 && yDiff >= 0)
                 {
                     auto listY = yDiff;
                     for (auto& company : CompanyManager::companies())
@@ -1430,8 +1433,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             self.callPrepareDraw();
             WindowManager::invalidateWidget(WindowType::townList, self.number, self.currentTab + Common::widx::tab_company_list);
 
-            auto x = self.width - 104 + self.x;
-            auto y = self.y + 52;
+            auto legendX = self.x + self.width - kWindowPadding - kLegendWidth;
+            auto legendY = self.y + 52;
 
             switch (self.currentTab + widx::tab_company_list)
             {
@@ -1441,13 +1444,13 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 case widx::tab_values:
                 {
                     _hoverItemTicks++;
-                    setLegendHover(&self, x, y);
+                    setLegendHover(&self, legendX, legendY);
                     break;
                 }
                 case widx::tab_payment_rates:
                 {
                     _hoverItemTicks++;
-                    CargoPaymentRates::setLegendHover(&self, x, y);
+                    CargoPaymentRates::setLegendHover(&self, legendX, legendY);
                     break;
                 }
                 case widx::tab_speed_records:
@@ -1745,7 +1748,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 Ui::drawGraph(_graphSettings, self, drawingCtx);
             }
 
-            auto x = self->width + self->x - 104;
+            auto x = self->width + self->x - kLegendWidth - kWindowPadding;
             auto y = self->y + 52;
 
             Common::drawGraphLegend(self, drawingCtx, x, y);

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -214,7 +214,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     {
         self.flags |= WindowFlags::resizable;
         self.minWidth = 350;
-        self.maxWidth = 800;
+        self.maxWidth = 800; // NB: frame background is only 800px :(
         self.maxHeight = 800;
 
         Ui::Size32 kMinWindowSize = { self.minWidth, self.minHeight };


### PR DESCRIPTION
This PR changes the company list window such that tabs with charts are now made resizeable, following up on the work in #2646.

### Standard chart
![Screenshot](https://github.com/user-attachments/assets/5dec9fe5-4e24-4162-9410-2a715080992a)

### Resized chart
![Screenshot (1)](https://github.com/user-attachments/assets/db8755b8-375a-46b8-ba3c-8bfc8f492de2)