### PR TITLE
Fix cargo text alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+24.10+ (???)
+------------------------------------------------------------------------
+- Fix: [#2676] Cargo labels are misaligned in vehicle window.
+
 24.10 (2024-10-20)
 ------------------------------------------------------------------------
 - Feature: [#1687] Objects can be placed in sub folders in new custom object folder.

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -1974,7 +1974,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                         FormatArguments args{};
                         args.push<StringId>(StringIds::cargo_empty);
 
-                        auto point = Point(width, cargoTextHeight + 5);
+                        auto point = Point(width - 24, cargoTextHeight + 5);
                         tr.drawStringLeft(point, Colour::black, strFormat, args);
                     }
                 }

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -1966,8 +1966,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
                         {
                             cargoTextHeight += 5;
                         }
-                        drawCargoText(drawingCtx, width, cargoTextHeight, strFormat, body->primaryCargo.qty, body->primaryCargo.type, body->primaryCargo.townFrom);
-                        drawCargoText(drawingCtx, width, cargoTextHeight, strFormat, front->secondaryCargo.qty, front->secondaryCargo.type, front->secondaryCargo.townFrom);
+                        drawCargoText(drawingCtx, width - 24, cargoTextHeight, strFormat, body->primaryCargo.qty, body->primaryCargo.type, body->primaryCargo.townFrom);
+                        drawCargoText(drawingCtx, width - 24, cargoTextHeight, strFormat, front->secondaryCargo.qty, front->secondaryCargo.type, front->secondaryCargo.townFrom);
                     }
                     else
                     {

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -1946,15 +1946,20 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 StringId strFormat = StringIds::black_stringid;
                 auto front = car.front;
                 auto body = car.body;
+
+                // Draw hover background if applicable
                 if (front->id == EntityId(self.rowHover))
                 {
                     drawingCtx.fillRect(0, y, self.width, y + self.rowHeight - 1, enumValue(ExtColour::unk30), Gfx::RectFlags::transparent);
                     strFormat = StringIds::wcolour2_stringid;
                 }
+
+                constexpr auto kCargoXPos = 24;
+
                 // Get width of the drawing
                 auto width = getWidthVehicleInline(car);
                 // Actually draw it
-                width = drawVehicleInline(drawingCtx, car, Ui::Point(24 - width, y + (self.rowHeight - 22) / 2), VehicleInlineMode::basic);
+                drawVehicleInline(drawingCtx, car, Ui::Point(kCargoXPos - width, y + (self.rowHeight - 22) / 2), VehicleInlineMode::basic);
 
                 if (body->primaryCargo.type != 0xFF)
                 {
@@ -1965,15 +1970,15 @@ namespace OpenLoco::Ui::Windows::Vehicle
                         {
                             cargoTextYPos += 5;
                         }
-                        drawCargoText(drawingCtx, width - 24, cargoTextYPos, strFormat, body->primaryCargo.qty, body->primaryCargo.type, body->primaryCargo.townFrom);
-                        drawCargoText(drawingCtx, width - 24, cargoTextYPos, strFormat, front->secondaryCargo.qty, front->secondaryCargo.type, front->secondaryCargo.townFrom);
+                        drawCargoText(drawingCtx, kCargoXPos, cargoTextYPos, strFormat, body->primaryCargo.qty, body->primaryCargo.type, body->primaryCargo.townFrom);
+                        drawCargoText(drawingCtx, kCargoXPos, cargoTextYPos, strFormat, front->secondaryCargo.qty, front->secondaryCargo.type, front->secondaryCargo.townFrom);
                     }
                     else
                     {
                         FormatArguments args{};
                         args.push<StringId>(StringIds::cargo_empty);
 
-                        auto point = Point(width - 24, cargoTextYPos + 5);
+                        auto point = Point(kCargoXPos, cargoTextYPos + 5);
                         tr.drawStringLeft(point, Colour::black, strFormat, args);
                     }
                 }

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -1825,7 +1825,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             return (object->hasFlags(VehicleObjectFlags::refittable));
         }
 
-        // 004B3DDE
+        // 0x004B3DDE
         static void prepareDraw(Window& self)
         {
             Common::setActiveTabs(&self);
@@ -1864,7 +1864,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             Widget::leftAlignTabs(self, Common::widx::tabMain, Common::widx::tabRoute);
         }
 
-        // 004B3F0D
+        // 0x004B3F0D
         static void draw(Ui::Window& self, Gfx::DrawingContext& drawingCtx)
         {
             auto tr = Gfx::TextRenderer(drawingCtx);
@@ -1928,7 +1928,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             y += 10;
         }
 
-        // 004B3F62
+        // 0x004B3F62
         static void drawScroll(Window& self, Gfx::DrawingContext& drawingCtx, [[maybe_unused]] const uint32_t i)
         {
             auto tr = Gfx::TextRenderer(drawingCtx);
@@ -1983,7 +1983,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
         }
 
-        // 004B41BD
+        // 0x004B41BD
         static void onMouseUp(Window& self, const WidgetIndex_t i)
         {
             switch (i)
@@ -2006,7 +2006,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
         }
 
-        // 004B41E2
+        // 0x004B41E2
         static void onMouseDown(Window& self, const WidgetIndex_t i)
         {
             switch (i)
@@ -2017,7 +2017,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
         }
 
-        // 004B41E9
+        // 0x004B41E9
         static void onDropdown(Window& self, const WidgetIndex_t i, const int16_t dropdownIndex)
         {
             switch (i)

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -1954,27 +1954,26 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 // Get width of the drawing
                 auto width = getWidthVehicleInline(car);
                 // Actually draw it
-                width = drawVehicleInline(drawingCtx, car, Ui::Point(24 - width, (self.rowHeight - 22) / 2 + y), VehicleInlineMode::basic);
+                width = drawVehicleInline(drawingCtx, car, Ui::Point(24 - width, y + (self.rowHeight - 22) / 2), VehicleInlineMode::basic);
 
                 if (body->primaryCargo.type != 0xFF)
                 {
-
-                    int16_t cargoTextHeight = self.rowHeight / 2 + y - ((self.rowHeight - 22) / 2) - 10;
+                    int16_t cargoTextYPos = y + self.rowHeight / 2 - ((self.rowHeight - 22) / 2) - 10;
                     if (front->secondaryCargo.qty != 0 || body->primaryCargo.qty != 0)
                     {
                         if (body->primaryCargo.qty == 0 || front->secondaryCargo.qty == 0)
                         {
-                            cargoTextHeight += 5;
+                            cargoTextYPos += 5;
                         }
-                        drawCargoText(drawingCtx, width - 24, cargoTextHeight, strFormat, body->primaryCargo.qty, body->primaryCargo.type, body->primaryCargo.townFrom);
-                        drawCargoText(drawingCtx, width - 24, cargoTextHeight, strFormat, front->secondaryCargo.qty, front->secondaryCargo.type, front->secondaryCargo.townFrom);
+                        drawCargoText(drawingCtx, width - 24, cargoTextYPos, strFormat, body->primaryCargo.qty, body->primaryCargo.type, body->primaryCargo.townFrom);
+                        drawCargoText(drawingCtx, width - 24, cargoTextYPos, strFormat, front->secondaryCargo.qty, front->secondaryCargo.type, front->secondaryCargo.townFrom);
                     }
                     else
                     {
                         FormatArguments args{};
                         args.push<StringId>(StringIds::cargo_empty);
 
-                        auto point = Point(width - 24, cargoTextHeight + 5);
+                        auto point = Point(width - 24, cargoTextYPos + 5);
                         tr.drawStringLeft(point, Colour::black, strFormat, args);
                     }
                 }


### PR DESCRIPTION
The cargo text labels are spaced too far from the vehicle sprite. This was introduced sometime between v24.06 and v24.07; I'm assuming by #2513.

v24.06:
![Screenshot-v24 06](https://github.com/user-attachments/assets/a43c3747-783e-4632-8186-00e97fb47880)

v24.07:
![Screenshot-v24 07](https://github.com/user-attachments/assets/9b36af02-c101-4cc8-912a-5cc5d992e80d)

This PR:
![Screenshot](https://github.com/user-attachments/assets/651db8d2-448d-4d10-8790-cc7a741147c3)
