### PR TITLE
Fix #2678. Train bogie body draw order and body bound box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#2697] Add initial OpenGraphics custom assets.
 - Fix: [#2676] Cargo labels are misaligned in vehicle window.
+- Fix: [#2678] Incorrect vehicle draw order and general vehicle clipping.
 - Fix: [#2690] Inability to remove certain track pieces.
 - Fix: [#2691] Scenarios with original procedural terrain generation could crash.
 - Fix: [#2692] Inability to place certain track pieces.

--- a/src/OpenLoco/src/Paint/PaintVehicle.cpp
+++ b/src/OpenLoco/src/Paint/PaintVehicle.cpp
@@ -211,28 +211,28 @@ namespace OpenLoco::Paint
         else
         {
             auto& componentObject = vehObject->carComponents[body->bodyIndex];
-            auto offsetModifier = componentObject.frontBogiePosition - componentObject.backBogiePosition;
+            auto overhangLength = componentObject.frontBogiePosition - componentObject.backBogiePosition;
             if (body->has38Flags(Flags38::isReversed))
             {
-                offsetModifier = -offsetModifier;
+                overhangLength = -overhangLength;
             }
 
             if (componentObject.bodySpriteInd & SpriteIndex::flag_unk7)
             {
-                offsetModifier = -offsetModifier;
+                overhangLength = -overhangLength;
             }
 
-            const auto unk1 = Math::Trigonometry::computeXYVector(offsetModifier, originalYaw) / 8;
-            boundBoxOffsets.x = unk1.x;
-            boundBoxOffsets.y = unk1.y;
-            offsetModifier = sprite.halfLength * 2 - 4;
+            const auto overhangOffset = Math::Trigonometry::computeXYVector(overhangLength, originalYaw) / 8;
+            boundBoxOffsets.x = overhangOffset.x;
+            boundBoxOffsets.y = overhangOffset.y;
+            const auto bodyLength = sprite.halfLength * 2 - 4;
             originalYaw &= 0x1F;
-            boundBoxOffsets.x += (_5001B4[originalYaw * 4] * offsetModifier) >> 8;
-            boundBoxOffsets.y += (_5001B4[originalYaw * 4 + 1] * offsetModifier) >> 8;
+            boundBoxOffsets.x += (_5001B4[originalYaw * 4] * bodyLength) >> 8;
+            boundBoxOffsets.y += (_5001B4[originalYaw * 4 + 1] * bodyLength) >> 8;
             boundBoxOffsets.z = body->position.z + 11;
             boundBoxSize = {
-                static_cast<coord_t>((_5001B4[originalYaw * 4 + 2] * offsetModifier) >> 8),
-                static_cast<coord_t>((_5001B4[originalYaw * 4 + 3] * offsetModifier) >> 8),
+                static_cast<coord_t>((_5001B4[originalYaw * 4 + 2] * bodyLength) >> 8),
+                static_cast<coord_t>((_5001B4[originalYaw * 4 + 3] * bodyLength) >> 8),
                 15
             };
         }

--- a/src/OpenLoco/src/Paint/PaintVehicle.cpp
+++ b/src/OpenLoco/src/Paint/PaintVehicle.cpp
@@ -222,7 +222,7 @@ namespace OpenLoco::Paint
                 offsetModifier = -offsetModifier;
             }
 
-            const auto unk1 = Math::Trigonometry::computeXYVector(offsetModifier, originalYaw) / 2;
+            const auto unk1 = Math::Trigonometry::computeXYVector(offsetModifier, originalYaw) / 8;
             boundBoxOffsets.x = unk1.x;
             boundBoxOffsets.y = unk1.y;
             offsetModifier = sprite.halfLength * 2 - 4;

--- a/src/OpenLoco/src/Ui/Windows/DragVehiclePart.cpp
+++ b/src/OpenLoco/src/Ui/Windows/DragVehiclePart.cpp
@@ -85,7 +85,8 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
             {
                 if (car.front == _dragCarComponent)
                 {
-                    drawVehicleInline(drawingCtx, car, { 0, 19 }, VehicleInlineMode::basic, VehiclePartsToDraw::both);
+                    drawVehicleInline(drawingCtx, car, { 0, 19 }, VehicleInlineMode::basic, VehiclePartsToDraw::bogies);
+                    drawVehicleInline(drawingCtx, car, { 0, 19 }, VehicleInlineMode::basic, VehiclePartsToDraw::bodies);
                     break;
                 }
             }

--- a/src/OpenLoco/src/Ui/Windows/DragVehiclePart.cpp
+++ b/src/OpenLoco/src/Ui/Windows/DragVehiclePart.cpp
@@ -85,7 +85,7 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
             {
                 if (car.front == _dragCarComponent)
                 {
-                    drawVehicleInline(drawingCtx, car, { 0, 19 }, VehicleInlineMode::basic);
+                    drawVehicleInline(drawingCtx, car, { 0, 19 }, VehicleInlineMode::basic, VehiclePartsToDraw::both);
                     break;
                 }
             }

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -1624,7 +1624,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 const auto disableColour = car.front == _dragCarComponent
                     ? std::make_optional(self.getColour(WindowColour::secondary).c())
                     : std::nullopt;
-                auto x = drawVehicleInline(drawingCtx, car, { 0, y }, VehicleInlineMode::basic, disableColour);
+                auto x = drawVehicleInline(drawingCtx, car, { 0, y }, VehicleInlineMode::basic, VehiclePartsToDraw::both, disableColour);
 
                 auto vehicleObj = ObjectManager::get<VehicleObject>(car.front->objectId);
                 FormatArguments args{};
@@ -1960,7 +1960,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 // Get width of the drawing
                 auto width = getWidthVehicleInline(car);
                 // Actually draw it
-                drawVehicleInline(drawingCtx, car, Ui::Point(kCargoXPos - width, y + (self.rowHeight - 22) / 2), VehicleInlineMode::basic);
+                drawVehicleInline(drawingCtx, car, Ui::Point(kCargoXPos - width, y + (self.rowHeight - 22) / 2), VehicleInlineMode::basic, VehiclePartsToDraw::both);
 
                 if (body->primaryCargo.type != 0xFF)
                 {

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -1624,7 +1624,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 const auto disableColour = car.front == _dragCarComponent
                     ? std::make_optional(self.getColour(WindowColour::secondary).c())
                     : std::nullopt;
-                auto x = drawVehicleInline(drawingCtx, car, { 0, y }, VehicleInlineMode::basic, VehiclePartsToDraw::both, disableColour);
+                drawVehicleInline(drawingCtx, car, { 0, y }, VehicleInlineMode::basic, VehiclePartsToDraw::bogies, disableColour);
+                auto x = drawVehicleInline(drawingCtx, car, { 0, y }, VehicleInlineMode::basic, VehiclePartsToDraw::bodies, disableColour);
 
                 auto vehicleObj = ObjectManager::get<VehicleObject>(car.front->objectId);
                 FormatArguments args{};
@@ -1960,7 +1961,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 // Get width of the drawing
                 auto width = getWidthVehicleInline(car);
                 // Actually draw it
-                drawVehicleInline(drawingCtx, car, Ui::Point(kCargoXPos - width, y + (self.rowHeight - 22) / 2), VehicleInlineMode::basic, VehiclePartsToDraw::both);
+                drawVehicleInline(drawingCtx, car, Ui::Point(kCargoXPos - width, y + (self.rowHeight - 22) / 2), VehicleInlineMode::basic, VehiclePartsToDraw::bogies);
+                drawVehicleInline(drawingCtx, car, Ui::Point(kCargoXPos - width, y + (self.rowHeight - 22) / 2), VehicleInlineMode::basic, VehiclePartsToDraw::bodies);
 
                 if (body->primaryCargo.type != 0xFF)
                 {

--- a/src/OpenLoco/src/Vehicles/VehicleDraw.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleDraw.cpp
@@ -584,8 +584,22 @@ namespace OpenLoco
 
         auto screenDistDrawItems = toScreenDistDrawItems(drawItems, yaw);
 
+        // Draw all bogies
         for (auto& item : screenDistDrawItems.items)
         {
+            if (item.isBody)
+            {
+                continue;
+            }
+            drawingCtx.drawImage(loc + Ui::Point(item.dist, 0), item.image);
+        }
+        // Then draw the bodies
+        for (auto& item : screenDistDrawItems.items)
+        {
+            if (!item.isBody)
+            {
+                continue;
+            }
             drawingCtx.drawImage(loc + Ui::Point(item.dist, 0), item.image);
         }
         return screenDistDrawItems.totalDistance;

--- a/src/OpenLoco/src/Vehicles/VehicleDraw.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleDraw.cpp
@@ -609,7 +609,7 @@ namespace OpenLoco
 
         for (auto& item : screenDistDrawItems.items)
         {
-            if (parts == VehiclePartsToDraw::body && !item.isBody)
+            if (parts == VehiclePartsToDraw::bodies && !item.isBody)
             {
                 continue;
             }
@@ -648,13 +648,15 @@ namespace OpenLoco
     // 0x004B6D43
     int16_t drawTrainInline(Gfx::DrawingContext& drawingCtx, const Vehicles::Vehicle& train, Ui::Point loc)
     {
+        const auto startX = loc.x;
         for (auto& car : train.cars)
         {
             loc.x += drawVehicleInline(drawingCtx, car, loc, VehicleInlineMode::animated, VehiclePartsToDraw::bogies);
         }
+        loc.x = startX;
         for (auto& car : train.cars)
         {
-            loc.x += drawVehicleInline(drawingCtx, car, loc, VehicleInlineMode::animated, VehiclePartsToDraw::body);
+            loc.x += drawVehicleInline(drawingCtx, car, loc, VehicleInlineMode::animated, VehiclePartsToDraw::bodies);
         }
         return loc.x;
     }

--- a/src/OpenLoco/src/Vehicles/VehicleDraw.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleDraw.cpp
@@ -592,7 +592,7 @@ namespace OpenLoco
     }
 
     // 0x004B6D93
-    int16_t drawVehicleInline(Gfx::DrawingContext& drawingCtx, const Vehicles::Car& car, Ui::Point loc, VehicleInlineMode mode, std::optional<Colour> disabled)
+    int16_t drawVehicleInline(Gfx::DrawingContext& drawingCtx, const Vehicles::Car& car, Ui::Point loc, VehicleInlineMode mode, VehiclePartsToDraw parts, std::optional<Colour> disabled)
     {
         // This has been simplified from vanilla.
 
@@ -609,6 +609,14 @@ namespace OpenLoco
 
         for (auto& item : screenDistDrawItems.items)
         {
+            if (parts == VehiclePartsToDraw::body && !item.isBody)
+            {
+                continue;
+            }
+            if (parts == VehiclePartsToDraw::bogies && item.isBody)
+            {
+                continue;
+            }
             if (disabled.has_value())
             {
                 const auto shade1 = Colours::getShade(disabled.value(), 5);
@@ -640,10 +648,13 @@ namespace OpenLoco
     // 0x004B6D43
     int16_t drawTrainInline(Gfx::DrawingContext& drawingCtx, const Vehicles::Vehicle& train, Ui::Point loc)
     {
-        // Vanilla does this slightly differently draw bogie then draw body
         for (auto& car : train.cars)
         {
-            loc.x += drawVehicleInline(drawingCtx, car, loc, VehicleInlineMode::animated);
+            loc.x += drawVehicleInline(drawingCtx, car, loc, VehicleInlineMode::animated, VehiclePartsToDraw::bogies);
+        }
+        for (auto& car : train.cars)
+        {
+            loc.x += drawVehicleInline(drawingCtx, car, loc, VehicleInlineMode::animated, VehiclePartsToDraw::body);
         }
         return loc.x;
     }

--- a/src/OpenLoco/src/Vehicles/VehicleDraw.h
+++ b/src/OpenLoco/src/Vehicles/VehicleDraw.h
@@ -32,9 +32,8 @@ namespace OpenLoco
     };
     enum class VehiclePartsToDraw : uint8_t
     {
-        both, // Bogies and bodies
         bogies,
-        body
+        bodies
     };
     int16_t drawVehicleInline(Gfx::DrawingContext& drawingCtx, const Vehicles::Car& car, Ui::Point loc, VehicleInlineMode mode, VehiclePartsToDraw parts, std::optional<Colour> disabled = std::nullopt);
     int16_t getWidthVehicleInline(const Vehicles::Car& car);

--- a/src/OpenLoco/src/Vehicles/VehicleDraw.h
+++ b/src/OpenLoco/src/Vehicles/VehicleDraw.h
@@ -30,7 +30,13 @@ namespace OpenLoco
         basic,
         animated
     };
-    int16_t drawVehicleInline(Gfx::DrawingContext& drawingCtx, const Vehicles::Car& car, Ui::Point loc, VehicleInlineMode mode, std::optional<Colour> disabled = std::nullopt);
+    enum class VehiclePartsToDraw : uint8_t
+    {
+        both, // Bogies and bodies
+        bogies,
+        body
+    };
+    int16_t drawVehicleInline(Gfx::DrawingContext& drawingCtx, const Vehicles::Car& car, Ui::Point loc, VehicleInlineMode mode, VehiclePartsToDraw parts, std::optional<Colour> disabled = std::nullopt);
     int16_t getWidthVehicleInline(const Vehicles::Car& car);
     int16_t drawTrainInline(Gfx::DrawingContext& drawingCtx, const Vehicles::Vehicle& train, Ui::Point loc);
 }


### PR DESCRIPTION
Mistake from #2513 caused the vehicle paint to have wrong bound boxes and a change from implementing the vehicle draw inline caused bogies which overlap other bodies to change ordering.

Possible source of 1st bug of #2540