### PR TITLE
Fix modulo operation on negatives in terrain gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 24.10+ (???)
 ------------------------------------------------------------------------
 - Fix: [#2676] Cargo labels are misaligned in vehicle window.
-- Fix: [#2691] Scenarios with original procedural terrain generation would crash.
+- Fix: [#2691] Scenarios with original procedural terrain generation could crash.
 
 24.10 (2024-10-20)
 ------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 24.10+ (???)
 ------------------------------------------------------------------------
 - Fix: [#2676] Cargo labels are misaligned in vehicle window.
+- Fix: [#2691] Scenarios with original procedural terrain generation would crash.
 
 24.10 (2024-10-20)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
@@ -92,7 +92,7 @@ namespace OpenLoco::World::MapGenerator
                 const auto data = *src++;
                 heightMap[TilePos2(x, y)] = std::max(data, heightMap[TilePos2(x, y)]);
                 auto mod = heightMap.height - 1;
-                y = (--y + mod) % mod;
+                y = (y - 1 + mod) % mod;
             }
             x++;
             x %= heightMap.width - 1;
@@ -130,7 +130,7 @@ namespace OpenLoco::World::MapGenerator
                 const auto data = *src++;
                 heightMap[TilePos2(x, y)] = std::max(data, heightMap[TilePos2(x, y)]);
                 auto mod = heightMap.width - 1;
-                x = (--x + mod) % mod;
+                x = (x - 1 + mod) % mod;
             }
             y++;
             y %= heightMap.height - 1;

--- a/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/OriginalTerrainGenerator.cpp
@@ -91,8 +91,8 @@ namespace OpenLoco::World::MapGenerator
             {
                 const auto data = *src++;
                 heightMap[TilePos2(x, y)] = std::max(data, heightMap[TilePos2(x, y)]);
-                y--;
-                y %= heightMap.height - 1;
+                auto mod = heightMap.height - 1;
+                y = (--y + mod) % mod;
             }
             x++;
             x %= heightMap.width - 1;
@@ -129,8 +129,8 @@ namespace OpenLoco::World::MapGenerator
             {
                 const auto data = *src++;
                 heightMap[TilePos2(x, y)] = std::max(data, heightMap[TilePos2(x, y)]);
-                x--;
-                x %= heightMap.width - 1;
+                auto mod = heightMap.width - 1;
+                x = (--x + mod) % mod;
             }
             y++;
             y %= heightMap.height - 1;


### PR DESCRIPTION
Fixes #2680

Side note, these 4 blit functions seem a little strange - I would have expected four functions following
```
 [x++, y++]
 [x++, y--]
 [x--, y++]
 [x--, y--]
```
but instead it seems the x and y loops are switched, which is a confusing and non-standard way to do this IMO