### PR TITLE
Simplify & modularise music playlist code

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,12 +15,12 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Peter Gaál (petergaal)
 * Joe Bloomfield (Svelbeard)
 * Benjamin Sutas (LeftofZen)
+* LeeSpork
 
 ## Bugfixes
 * seifer7
 * Ryan D. (rctdude2)
 * Soham Roy (sohamroy19)
-* LeeSpork
 
 ## Translations
 * Dutch - Michael Steenbeek (Gymnasiast)

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -1107,7 +1107,7 @@ namespace OpenLoco::Audio
         // Assumes there is no more than one occurence of that song in the playlist.
         if (playlist.size() > 1)
         {
-            auto position = std::find(playlist.begin(), playlist.end(), _lastSong);
+            auto position = std::find(playlist.begin(), playlist.end(), *_lastSong);
             if (position != playlist.end())
             {
                 playlist.erase(position);

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -1060,9 +1060,12 @@ namespace OpenLoco::Audio
         }
     }
 
-    static void addSelectedPlaylistToPlaylist(std::vector<uint8_t>& playlist)
+    std::vector<uint8_t> makeSelectedPlaylist()
     {
         using MusicPlaylistType = Config::MusicPlaylistType;
+
+        std::vector<uint8_t> playlist = std::vector<uint8_t>();
+
         switch (Config::get().old.musicPlaylist)
         {
             case MusicPlaylistType::currentEra:
@@ -1075,12 +1078,6 @@ namespace OpenLoco::Audio
                 addCustomSelectionSongsToPlaylist(playlist);
                 break;
         }
-    }
-
-    std::vector<uint8_t> makeSelectedPlaylist()
-    {
-        std::vector<uint8_t> playlist = std::vector<uint8_t>();
-        addSelectedPlaylistToPlaylist(playlist);
 
         return playlist;
     }
@@ -1090,9 +1087,7 @@ namespace OpenLoco::Audio
         using MusicPlaylistType = Config::MusicPlaylistType;
 
         static std::vector<uint8_t> playlist;
-        playlist.clear();
-
-        addSelectedPlaylistToPlaylist(playlist);
+        playlist = makeSelectedPlaylist();
 
         const auto& cfg = Config::get().old;
 

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -1091,8 +1091,7 @@ namespace OpenLoco::Audio
     {
         using MusicPlaylistType = Config::MusicPlaylistType;
 
-        static std::vector<uint8_t> playlist;
-        playlist = makeSelectedPlaylist();
+        auto playlist = makeSelectedPlaylist();
 
         const auto& cfg = Config::get().old;
 

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -1079,8 +1079,7 @@ namespace OpenLoco::Audio
 
     std::vector<uint8_t> makeSelectedPlaylist()
     {
-        static std::vector<uint8_t> playlist;
-        playlist.clear();
+        std::vector<uint8_t> playlist = std::vector<uint8_t>();
         addSelectedPlaylistToPlaylist(playlist);
 
         return playlist;
@@ -1089,9 +1088,13 @@ namespace OpenLoco::Audio
     static int32_t chooseNextMusicTrack()
     {
         using MusicPlaylistType = Config::MusicPlaylistType;
-        const auto& cfg = Config::get().old;
 
-        static std::vector<uint8_t> playlist = makeSelectedPlaylist();
+        static std::vector<uint8_t> playlist;
+        playlist.clear();
+
+        addSelectedPlaylistToPlaylist(playlist);
+
+        const auto& cfg = Config::get().old;
 
         if (playlist.empty() && cfg.musicPlaylist != MusicPlaylistType::currentEra)
         {

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -25,7 +25,7 @@
 #include <OpenLoco/Interop/Interop.hpp>
 #include <array>
 #include <cassert>
-#include <numeric> // std::iota
+#include <numeric>
 #include <unordered_map>
 
 #ifdef _WIN32
@@ -1037,7 +1037,7 @@ namespace OpenLoco::Audio
 
     static std::vector<uint8_t> makeCurrentEraPlaylist()
     {
-        std::vector<uint8_t> playlist = std::vector<uint8_t>();
+        auto playlist = std::vector<uint8_t>();
         auto currentYear = getCurrentYear();
 
         for (auto i = 0; i < kNumMusicTracks; i++)
@@ -1054,7 +1054,7 @@ namespace OpenLoco::Audio
 
     static std::vector<uint8_t> makeCustomSelectionPlaylist()
     {
-        std::vector<uint8_t> playlist = std::vector<uint8_t>();
+        auto playlist = std::vector<uint8_t>();
 
         const auto& cfg = Config::get().old;
         for (auto i = 0; i < kNumMusicTracks; i++)
@@ -1075,18 +1075,16 @@ namespace OpenLoco::Audio
         switch (Config::get().old.musicPlaylist)
         {
             case MusicPlaylistType::currentEra:
-            default:
                 return makeCurrentEraPlaylist();
-                break;
 
             case MusicPlaylistType::all:
                 return makeAllMusicPlaylist();
-                break;
 
             case MusicPlaylistType::custom:
                 return makeCustomSelectionPlaylist();
-                break;
         }
+
+        throw Exception::RuntimeError("Invalid MusicPlaylistType");
     }
 
     static int32_t chooseNextMusicTrack()

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -25,8 +25,8 @@
 #include <OpenLoco/Interop/Interop.hpp>
 #include <array>
 #include <cassert>
-#include <unordered_map>
 #include <numeric> // std::iota
+#include <unordered_map>
 
 #ifdef _WIN32
 #define __HAS_DEFAULT_DEVICE__

--- a/src/OpenLoco/src/Audio/Audio.h
+++ b/src/OpenLoco/src/Audio/Audio.h
@@ -134,6 +134,8 @@ namespace OpenLoco::Audio
     void stopMusic();
     void playMusic(Environment::PathId sample, int32_t volume, bool loop);
 
+    std::vector<uint8_t> makeSelectedPlaylist();
+
     void resetSoundObjects();
 
     bool isAudioEnabled();

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -1226,18 +1226,10 @@ namespace OpenLoco::Ui::Windows::Options
 
 #pragma mark - Widget 11
 
-        /**
-         * Returns a vector of music track IDs that this dropdown is to be populated with.
-         */
-        static auto getTracks()
-        {
-            return Audio::makeSelectedPlaylist();
-        }
-
         // 0x004C0875
         static void currentlyPlayingMouseDown(Window* w)
         {
-            auto tracks = getTracks();
+            auto tracks = Audio::makeSelectedPlaylist();
 
             Widget dropdown = w->widgets[Widx::currently_playing];
             Dropdown::show(w->x + dropdown.left, w->y + dropdown.top, dropdown.width() - 4, dropdown.height(), w->getColour(WindowColour::secondary), tracks.size(), 0x80);
@@ -1260,7 +1252,7 @@ namespace OpenLoco::Ui::Windows::Options
             if (ax == -1)
                 return;
 
-            auto tracks = getTracks();
+            auto tracks = Audio::makeSelectedPlaylist();
             int track = tracks.at(ax);
             if (track == _currentSong)
                 return;

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -1226,55 +1226,18 @@ namespace OpenLoco::Ui::Windows::Options
 
 #pragma mark - Widget 11
 
-        static std::vector<int> get_available_tracks()
+        /**
+         * Returns a vector of music track IDs that this dropdown is to be populated with.
+         */
+        static auto getTracks()
         {
-            auto vector = std::vector<int>();
-
-            if (Config::get().old.musicPlaylist == Config::MusicPlaylistType::currentEra)
-            {
-                uint16_t year = getCurrentYear();
-                for (int i = 0; i < Audio::kNumMusicTracks; i++)
-                {
-                    auto info = Audio::getMusicInfo(i);
-                    if (year >= info->startYear && year <= info->endYear)
-                    {
-                        vector.push_back(i);
-                    }
-                }
-            }
-            else if (Config::get().old.musicPlaylist == Config::MusicPlaylistType::all)
-            {
-                for (int i = 0; i < Audio::kNumMusicTracks; i++)
-                {
-                    vector.push_back(i);
-                }
-            }
-            else if (Config::get().old.musicPlaylist == Config::MusicPlaylistType::custom)
-            {
-                for (int i = 0; i < Audio::kNumMusicTracks; i++)
-                {
-                    if (Config::get().old.enabledMusic[i] & 1)
-                    {
-                        vector.push_back(i);
-                    }
-                }
-
-                if (vector.size() == 0)
-                {
-                    for (int i = 0; i < Audio::kNumMusicTracks; i++)
-                    {
-                        vector.push_back(i);
-                    }
-                }
-            }
-
-            return vector;
+            return Audio::makeSelectedPlaylist();
         }
 
         // 0x004C0875
         static void currentlyPlayingMouseDown(Window* w)
         {
-            auto tracks = get_available_tracks();
+            auto tracks = getTracks();
 
             Widget dropdown = w->widgets[Widx::currently_playing];
             Dropdown::show(w->x + dropdown.left, w->y + dropdown.top, dropdown.width() - 4, dropdown.height(), w->getColour(WindowColour::secondary), tracks.size(), 0x80);
@@ -1297,7 +1260,7 @@ namespace OpenLoco::Ui::Windows::Options
             if (ax == -1)
                 return;
 
-            auto tracks = get_available_tracks();
+            auto tracks = getTracks();
             int track = tracks.at(ax);
             if (track == _currentSong)
                 return;


### PR DESCRIPTION
-  In Audio.cpp, removed the `excludeTrack` parameter from all functions that had it, and removed `trackToExclude` in `playBackgroundMusic()`.
    - Instead of needing a track to exclude as a parameter, `chooseNextMusicTrack()` removes `_lastSong` from the playlist it creates, if it is present and not the only song in the playlist. Preventing this function from choosing _lastSong appeared to be the intention of excludeTrack, so this simplifies that.
- Decomposed parts of `chooseNextMusicTrack()`, creating `addCustomSelectionSongsToPlaylist()` and `addSelectedPlaylistToPlaylist()`.
- Removed duplicate logic by replacing the function in Options.cpp that gets the list of music for the "Currently playing" dropdown with one that re-uses Audio.cpp's logic for generating the list of music.