### PR TITLE
Enable correct reporting for __cplusplus

### DIFF
--- a/cmake/OpenLocoUtility.cmake
+++ b/cmake/OpenLocoUtility.cmake
@@ -9,6 +9,7 @@ function(loco_thirdparty_target_compile_link_flags TARGET)
         $<$<CONFIG:Release>:/Oi>            # Intrinsics
         $<$<CONFIG:RelWithDebInfo>:/Oi>     # Intrinsics
         /Zc:char8_t-                        # Enable char8_t<->char conversion :(
+        /Zc:__cplusplus                     # Enable correct reporting for __cplusplus
     )
 
     # GNU/CLANG


### PR DESCRIPTION
Spotted this one because of SFL in where it doesn't check for the alternative _MSC_LANG. I have a PR for SFL where it makes up for MSVC but until then this will do plus its a good thing to do anyway.