### PR TITLE
Make "Show Options Window" keyboard shortcut work in title screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 24.10+ (???)
 ------------------------------------------------------------------------
 - Feature: [#2697] Add initial OpenGraphics custom assets.
+- Feature: [#2708] "Show Options Window" keyboard shortcut now works in the title screen.
 - Fix: [#2676] Cargo labels are misaligned in vehicle window.
 - Fix: [#2678] Incorrect vehicle draw order and general vehicle clipping.
 - Fix: [#2690] Inability to remove certain track pieces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 24.10+ (???)
 ------------------------------------------------------------------------
 - Feature: [#2697] Add initial OpenGraphics custom assets.
-- Feature: [#2708] "Show Options Window" keyboard shortcut now works in the title screen.
+- Change: [#2708] "Show Options Window" keyboard shortcut now works in the title screen.
 - Fix: [#2676] Cargo labels are misaligned in vehicle window.
 - Fix: [#2678] Incorrect vehicle draw order and general vehicle clipping.
 - Fix: [#2690] Inability to remove certain track pieces.

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -358,6 +358,11 @@ namespace OpenLoco::Input
 
             if (tryShortcut(Shortcut::screenshot, nextKey->keyCode, _keyModifier))
                 continue;
+
+            if (tryShortcut(Shortcut::showOptionsWindow, nextKey->keyCode, _keyModifier))
+            {
+                continue;
+            }
         }
     }
 


### PR DESCRIPTION
The keyboard shortcut to open the Options window did not work from the title screen, despite it being possible to open it using a mouse. This fixes that by adding check for the shortcut when the game is in title mode.