### PR TITLE
Improve performance of station rendering

### DIFF
--- a/src/OpenLoco/src/Objects/TrainStationObject.cpp
+++ b/src/OpenLoco/src/Objects/TrainStationObject.cpp
@@ -148,14 +148,14 @@ namespace OpenLoco
         std::fill(std::begin(manualPower), std::end(manualPower), nullptr);
     }
 
-    std::vector<TrainStationObject::CargoOffset> TrainStationObject::getCargoOffsets(const uint8_t rotation, const uint8_t nibble) const
+    sfl::static_vector<TrainStationObject::CargoOffset, 16> TrainStationObject::getCargoOffsets(const uint8_t rotation, const uint8_t nibble) const
     {
         assert(rotation < 4 && nibble < 4);
 
         const auto* bytes = cargoOffsetBytes[rotation][nibble];
         uint8_t z = *reinterpret_cast<const uint8_t*>(bytes);
         bytes++;
-        std::vector<CargoOffset> result;
+        sfl::static_vector<CargoOffset, 16> result;
         while (*bytes != static_cast<std::byte>(0xFF))
         {
             result.push_back({
@@ -171,6 +171,12 @@ namespace OpenLoco
                 },
             });
             bytes += 4;
+
+            // The game can't handle anything larger than 16 so we've made the static vector 16 max
+            if (result.size() == result.max_size())
+            {
+                break;
+            }
         }
         return result;
     }

--- a/src/OpenLoco/src/Objects/TrainStationObject.cpp
+++ b/src/OpenLoco/src/Objects/TrainStationObject.cpp
@@ -148,14 +148,14 @@ namespace OpenLoco
         std::fill(std::begin(manualPower), std::end(manualPower), nullptr);
     }
 
-    sfl::static_vector<TrainStationObject::CargoOffset, 16> TrainStationObject::getCargoOffsets(const uint8_t rotation, const uint8_t nibble) const
+    sfl::static_vector<TrainStationObject::CargoOffset, Limits::kMaxStationCargoDensity> TrainStationObject::getCargoOffsets(const uint8_t rotation, const uint8_t nibble) const
     {
         assert(rotation < 4 && nibble < 4);
 
         const auto* bytes = cargoOffsetBytes[rotation][nibble];
         uint8_t z = *reinterpret_cast<const uint8_t*>(bytes);
         bytes++;
-        sfl::static_vector<CargoOffset, 16> result;
+        sfl::static_vector<CargoOffset, Limits::kMaxStationCargoDensity> result;
         while (*bytes != static_cast<std::byte>(0xFF))
         {
             result.push_back({

--- a/src/OpenLoco/src/Objects/TrainStationObject.h
+++ b/src/OpenLoco/src/Objects/TrainStationObject.h
@@ -7,8 +7,8 @@
 #include <OpenLoco/Engine/World.hpp>
 #include <array>
 #include <cstddef>
+#include <sfl/static_vector.hpp>
 #include <span>
-#include <vector>
 
 namespace OpenLoco
 {
@@ -59,7 +59,7 @@ namespace OpenLoco
         bool validate() const;
         void load(const LoadedObjectHandle& handle, std::span<const std::byte> data, ObjectManager::DependentObjects*);
         void unload();
-        std::vector<CargoOffset> getCargoOffsets(const uint8_t rotation, const uint8_t nibble) const;
+        sfl::static_vector<CargoOffset, 16> getCargoOffsets(const uint8_t rotation, const uint8_t nibble) const;
         constexpr bool hasFlags(TrainStationFlags flagsToTest) const
         {
             return (flags & flagsToTest) != TrainStationFlags::none;

--- a/src/OpenLoco/src/Objects/TrainStationObject.h
+++ b/src/OpenLoco/src/Objects/TrainStationObject.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Engine/Limits.h"
 #include "Map/Track/TrackEnum.h"
 #include "Object.h"
 #include "Types.hpp"
@@ -59,7 +60,7 @@ namespace OpenLoco
         bool validate() const;
         void load(const LoadedObjectHandle& handle, std::span<const std::byte> data, ObjectManager::DependentObjects*);
         void unload();
-        sfl::static_vector<CargoOffset, 16> getCargoOffsets(const uint8_t rotation, const uint8_t nibble) const;
+        sfl::static_vector<CargoOffset, Limits::kMaxStationCargoDensity> getCargoOffsets(const uint8_t rotation, const uint8_t nibble) const;
         constexpr bool hasFlags(TrainStationFlags flagsToTest) const
         {
             return (flags & flagsToTest) != TrainStationFlags::none;

--- a/src/OpenLoco/src/Paint/PaintStation.cpp
+++ b/src/OpenLoco/src/Paint/PaintStation.cpp
@@ -20,7 +20,7 @@
 namespace OpenLoco::Paint
 {
     // 0x0042F550
-    void paintStationCargo(PaintSession& session, const World::StationElement& elStation, const uint8_t flags, const uint32_t cargoTypes, const std::vector<TrainStationObject::CargoOffset>& cargoOffsets, const int16_t offsetZ, const World::Pos3& boundBoxOffset, const World::Pos3& boundBoxSize)
+    void paintStationCargo(PaintSession& session, const World::StationElement& elStation, const uint8_t flags, const uint32_t cargoTypes, std::span<const std::array<World::Pos3, 2>> cargoOffsets, const int16_t offsetZ, const World::Pos3& boundBoxOffset, const World::Pos3& boundBoxSize)
     {
         if (elStation.isGhost())
         {

--- a/src/OpenLoco/src/Paint/PaintStation.h
+++ b/src/OpenLoco/src/Paint/PaintStation.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <OpenLoco/Engine/World.hpp>
-#include <vector>
+#include <array>
+#include <span>
 
 namespace OpenLoco::World
 {
@@ -13,5 +14,5 @@ namespace OpenLoco::Paint
 
     void paintStation(PaintSession& session, const World::StationElement& elStation);
 
-    void paintStationCargo(PaintSession& session, const World::StationElement& elStation, const uint8_t flags, const uint32_t cargoTypes, const std::vector<std::array<World::Pos3, 2>>& cargoOffsets, const int16_t offsetZ, const World::Pos3& boundBoxOffset, const World::Pos3& boundBoxSize);
+    void paintStationCargo(PaintSession& session, const World::StationElement& elStation, const uint8_t flags, const uint32_t cargoTypes, std::span<const std::array<World::Pos3, 2>> cargoOffsets, const int16_t offsetZ, const World::Pos3& boundBoxOffset, const World::Pos3& boundBoxSize);
 }

--- a/src/OpenLoco/src/Paint/PaintTrainStation.cpp
+++ b/src/OpenLoco/src/Paint/PaintTrainStation.cpp
@@ -8,7 +8,6 @@
 #include "PaintStation.h"
 #include "Ui/ViewportInteraction.h"
 #include "World/CompanyManager.h"
-#include <sfl/small_vector.hpp>
 
 namespace OpenLoco::Paint
 {

--- a/src/OpenLoco/src/Paint/PaintTrainStation.cpp
+++ b/src/OpenLoco/src/Paint/PaintTrainStation.cpp
@@ -8,6 +8,7 @@
 #include "PaintStation.h"
 #include "Ui/ViewportInteraction.h"
 #include "World/CompanyManager.h"
+#include <sfl/small_vector.hpp>
 
 namespace OpenLoco::Paint
 {

--- a/src/OpenLoco/src/S5/Limits.h
+++ b/src/OpenLoco/src/S5/Limits.h
@@ -25,4 +25,5 @@ namespace OpenLoco::S5::Limits
     constexpr size_t maxNormalEntities = kMaxEntities - kMaxMoneyEntities;
     // Money is not counted in this limit
     constexpr size_t kMaxMiscEntities = 4000;
+    constexpr size_t kMaxStationCargoDensity = 15;
 }

--- a/src/OpenLoco/src/World/Station.cpp
+++ b/src/OpenLoco/src/World/Station.cpp
@@ -786,7 +786,7 @@ namespace OpenLoco
                     newDensity += (1 << cargoObj->var_14) - 1;
                     newDensity >>= cargoObj->var_14;
 
-                    newDensity = std::min(newDensity, 15);
+                    newDensity = std::min<int32_t>(newDensity, Limits::kMaxStationCargoDensity - 1);
                 }
             }
             if (stationCargo.densityPerTile != newDensity)


### PR DESCRIPTION
This was actually producing a noticeable slow down in rendering due to the allocation/deallocation of the vector. The engine can't actually handle anything larger than 16 so I've switched it to a static_vector. Note: Need patch in sfl to make the span work.