### PR TITLE
Fix crash when river meander rate is 1 unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix: [#2690] Inability to remove certain track pieces.
 - Fix: [#2691] Scenarios with original procedural terrain generation could crash.
 - Fix: [#2692] Inability to place certain track pieces.
+- Fix: [#2717] Crash when generating a landscape with the river meander rate set to 1.
 
 24.10 (2024-10-20)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -132,7 +132,7 @@ namespace OpenLoco::World::MapGenerator
                     xStartPos += meanderOffset;
 
                     // Adjust bank width slightly as well
-                    if (options.riverbankWidth > 0)
+                    if (options.riverbankWidth > 0 and halfMeanderRate != 0)
                     {
                         riverbankWidth += meanderOffset / halfMeanderRate;
                         easternBankOffset += meanderOffset / halfMeanderRate;

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -132,7 +132,7 @@ namespace OpenLoco::World::MapGenerator
                     xStartPos += meanderOffset;
 
                     // Adjust bank width slightly as well
-                    if (options.riverbankWidth > 0 and halfMeanderRate != 0)
+                    if (options.riverbankWidth > 0 && halfMeanderRate != 0)
                     {
                         riverbankWidth += meanderOffset / halfMeanderRate;
                         easternBankOffset += meanderOffset / halfMeanderRate;


### PR DESCRIPTION
Quick fix that prevents division by 0 when generating riverbanks. This was able to happen if the player set the river meander rate to "1 units" when generating landscape in the scenario editor with non-zero number of rivers and riverbank width.