### PR TITLE
Fix #2718 - North arrow image not changing to reflect rotation on the Map window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix: [#2691] Scenarios with original procedural terrain generation could crash.
 - Fix: [#2692] Inability to place certain track pieces.
 - Fix: [#2717] Crash when generating a landscape with the river meander rate set to 1.
+- Fix: [#2721] North arrow image not changing to reflect rotation on the Map window.
 
 24.10 (2024-10-20)
 ------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Fix: [#2691] Scenarios with original procedural terrain generation could crash.
 - Fix: [#2692] Inability to place certain track pieces.
 - Fix: [#2717] Crash when generating a landscape with the river meander rate set to 1.
-- Fix: [#2721] North arrow image not changing to reflect rotation on the Map window.
+- Fix: [#2718] North arrow image not changing to reflect rotation on the Map window.
 
 24.10 (2024-10-20)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -1156,10 +1156,16 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
         // tabOverall
         {
-            uint32_t imageId = skin->img;
-            imageId += InterfaceSkin::ImageIds::toolbar_menu_map_north;
+            // TODO: use same list as top toolbar and time panel
+            static constexpr uint32_t kMapSpritesByRotation[] = {
+                InterfaceSkin::ImageIds::toolbar_menu_map_north,
+                InterfaceSkin::ImageIds::toolbar_menu_map_west,
+                InterfaceSkin::ImageIds::toolbar_menu_map_south,
+                InterfaceSkin::ImageIds::toolbar_menu_map_east,
+            };
+            uint32_t mapSprite = skin->img + kMapSpritesByRotation[WindowManager::getCurrentRotation()];
 
-            Widget::drawTab(self, drawingCtx, imageId, widx::tabOverall);
+            Widget::drawTab(self, drawingCtx, mapSprite, widx::tabOverall);
         }
 
         // tabVehicles,


### PR DESCRIPTION
Fixes #2718.

Implementation based on existing implementations of the same feature from other windows: https://github.com/OpenLoco/OpenLoco/blob/31b6d16f985289d68434994a82d2cc2ada399f9b/src/OpenLoco/src/Ui/Windows/TimePanel.cpp#L142 and https://github.com/OpenLoco/OpenLoco/blob/31b6d16f985289d68434994a82d2cc2ada399f9b/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp#L92