### PR TITLE
Prevent object loading crashing on malformed imagetables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix: [#2718] North arrow image not changing to reflect rotation on the Map window.
 - Fix: [#2722] Crash when buses restarted automatically.
 - Fix: [#2723] Crash when creating a scenario with more than 15 predefined competitor objects.
+- Fix: [#2724] Crash on malformed objects with broken image tables.
 - Fix: [#2725] Currency preference selection shows invalid data.
 - Fix: [#2727] Bankruptcy warnings do not appear.
 - Fix: [#2735] Map generator does not set the season on trees.

--- a/src/OpenLoco/src/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/src/Objects/ObjectManager.cpp
@@ -462,8 +462,17 @@ namespace OpenLoco::ObjectManager
         _isTemporaryObject = 0xFF;
 
         DependentObjects dependencies;
-        callObjectLoad({ preLoadObj->header.getType(), 0 }, *preLoadObj->object, preLoadObj->objectData, &dependencies);
-
+        try
+        {
+            callObjectLoad({ preLoadObj->header.getType(), 0 }, *preLoadObj->object, preLoadObj->objectData, &dependencies);
+        }
+        catch (Exception::OutOfRange&) // catches the ImageTable incorrectly sized which can cause bad crashes
+        {
+            freeTemporaryObject();
+            _isTemporaryObject = 0;
+            _isPartialLoaded = false;
+            return std::nullopt;
+        }
         _isTemporaryObject = 0;
         _isPartialLoaded = false;
 


### PR DESCRIPTION
If an object has a malformed image table it would be dangerous to try continue loading it as it may cause all sorts of crashes.