### PR TITLE
Fix #2727. Bankruptcy warnings do not appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix: [#2717] Crash when generating a landscape with the river meander rate set to 1.
 - Fix: [#2718] North arrow image not changing to reflect rotation on the Map window.
 - Fix: [#2725] Currency preference selection shows invalid data.
+- Fix: [#2727] Bankruptcy warnings do not appear.
 
 24.10 (2024-10-20)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/World/Company.cpp
+++ b/src/OpenLoco/src/World/Company.cpp
@@ -606,7 +606,7 @@ namespace OpenLoco
                 numMonthsInTheRed++;
                 if (numMonthsInTheRed == 9)
                 {
-                    const auto message = GameCommands::getUpdatingCompanyId() == id() ? MessageType::bankruptcyDeclared2 : MessageType::bankruptcyDeclared;
+                    const auto message = CompanyManager::getControllingId() == id() ? MessageType::bankruptcyDeclared2 : MessageType::bankruptcyDeclared;
                     MessageManager::post(message, id(), enumValue(id()), 0xFFFFU);
 
                     challengeFlags |= CompanyFlags::bankrupt;
@@ -618,7 +618,7 @@ namespace OpenLoco
                     companyEmotionEvent(id(), Emotion::dejected);
                     stopAllCompanyVehicles(id());
                 }
-                if (id() == GameCommands::getUpdatingCompanyId())
+                if (id() == CompanyManager::getControllingId())
                 {
                     if (numMonthsInTheRed == 3)
                     {


### PR DESCRIPTION
Mistake made whilst implementing.