### PR TITLE
Ghosts shown when planting clusters of trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#2697] Add initial OpenGraphics custom assets.
 - Change: [#2708] "Show Options Window" keyboard shortcut now works in the title screen.
+- Change: [#2733] Ghosts are now shown when planting clusters of trees.
 - Fix: [#2676] Cargo labels are misaligned in vehicle window.
 - Fix: [#2678] Incorrect vehicle draw order and general vehicle clipping.
 - Fix: [#2690] Inability to remove certain track pieces.

--- a/src/OpenLoco/src/Map/Tree.h
+++ b/src/OpenLoco/src/Map/Tree.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "GameCommands/Terraform/CreateTree.h"
 #include <OpenLoco/Engine/World.hpp>
 #include <optional>
 #include <vector>
-#include "GameCommands/Terraform/CreateTree.h"
 
 namespace OpenLoco::World
 {

--- a/src/OpenLoco/src/Map/Tree.h
+++ b/src/OpenLoco/src/Map/Tree.h
@@ -2,10 +2,14 @@
 
 #include <OpenLoco/Engine/World.hpp>
 #include <optional>
+#include <vector>
+#include "GameCommands/Terraform/CreateTree.h"
 
 namespace OpenLoco::World
 {
     std::optional<uint8_t> getRandomTreeTypeFromSurface(const World::TilePos2& loc, bool unk);
     bool placeRandomTree(const World::Pos2& pos, std::optional<uint8_t> treeType);
     bool placeTreeCluster(const World::TilePos2& centreLoc, const uint16_t range, const uint16_t density, const std::optional<uint8_t> treeType);
+    std::vector<GameCommands::TreePlacementArgs> placeTreeClusterPre(const World::TilePos2& centreLoc, const uint16_t range, const uint16_t density, const std::optional<uint8_t> treeType);
+    bool placeTreeCluster(std::vector<GameCommands::TreePlacementArgs> argsVector);
 }

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -560,10 +560,10 @@ namespace OpenLoco::Ui::Windows::Terraform
                     }
                 }
 
-            removeTreeGhost();
-            _terraformGhostQuadrant = placementArgs->quadrant;
-            _terraformGhostTreeRotationFlag = placementArgs->rotation | (placementArgs->buildImmediately ? 0x8000 : 0);
-            _lastTreeCost = placeTreeGhost(*placementArgs);
+                removeTreeGhost();
+                _terraformGhostQuadrant = placementArgs->quadrant;
+                _terraformGhostTreeRotationFlag = placementArgs->rotation | (placementArgs->buildImmediately ? 0x8000 : 0);
+                _lastTreeCost = placeTreeGhost(*placementArgs);
             }
             else // tree cluster mode is not none
             {


### PR DESCRIPTION
Now when you are planting clusters of trees, ghosts are shown.

This works by creating ghosts when it detects that you have moved your mouse to a different tile quadrant, and storing the construction arguments of these ghosts so that they can be placed for real when you click.