### PR TITLE
Fix map generator not updating tree seasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix: [#2723] Crash when creating a scenario with more than 15 predefined competitor objects.
 - Fix: [#2725] Currency preference selection shows invalid data.
 - Fix: [#2727] Bankruptcy warnings do not appear.
+- Fix: [#2735] Map generator does not set the season on trees.
 
 24.10 (2024-10-20)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -628,7 +628,7 @@ namespace OpenLoco::World::MapGenerator
         for (auto& pos : World::getDrawableTileRange())
         {
             auto tile = TileManager::get(pos);
-            for (auto el : tile)
+            for (auto& el : tile)
             {
                 auto* treeEl = el.as<TreeElement>();
                 if (treeEl == nullptr)

--- a/src/OpenLoco/src/Objects/ObjectIndex.cpp
+++ b/src/OpenLoco/src/Objects/ObjectIndex.cpp
@@ -801,17 +801,17 @@ namespace OpenLoco::ObjectManager
         for (const auto pos : World::getWorldRange())
         {
             const auto tile = World::TileManager::get(pos);
-            for (auto el : tile)
+            for (const auto& el : tile)
             {
-                auto* elSurface = el.as<World::SurfaceElement>();
-                auto* elTrack = el.as<World::TrackElement>();
-                auto* elStation = el.as<World::StationElement>();
-                auto* elSignal = el.as<World::SignalElement>();
-                auto* elBuilding = el.as<World::BuildingElement>();
-                auto* elTree = el.as<World::TreeElement>();
-                auto* elWall = el.as<World::WallElement>();
-                auto* elRoad = el.as<World::RoadElement>();
-                auto* elIndustry = el.as<World::IndustryElement>();
+                const auto* elSurface = el.as<World::SurfaceElement>();
+                const auto* elTrack = el.as<World::TrackElement>();
+                const auto* elStation = el.as<World::StationElement>();
+                const auto* elSignal = el.as<World::SignalElement>();
+                const auto* elBuilding = el.as<World::BuildingElement>();
+                const auto* elTree = el.as<World::TreeElement>();
+                const auto* elWall = el.as<World::WallElement>();
+                const auto* elRoad = el.as<World::RoadElement>();
+                const auto* elIndustry = el.as<World::IndustryElement>();
 
                 if (elSurface != nullptr)
                 {

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -649,7 +649,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                 }
                 const auto tile = TileManager::get(searchPos);
                 bool surfaceFound = false;
-                for (auto el : tile)
+                for (const auto& el : tile)
                 {
                     if (surfaceFound)
                     {

--- a/src/OpenLoco/src/Vehicles/OrderManager.cpp
+++ b/src/OpenLoco/src/Vehicles/OrderManager.cpp
@@ -524,7 +524,7 @@ namespace OpenLoco::Vehicles::OrderManager
 
                     // Override with our best guess for track element and direction
                     bool fixed = false;
-                    for (auto tileElement : tile)
+                    for (const auto& tileElement : tile)
                     {
                         Logging::info("Considering element...");
                         auto* trackElement = tileElement.as<World::TrackElement>();


### PR DESCRIPTION
Tile uses TileElement* as its iterator type so for ranged loops will dereference the pointer and when the var is not declared a ref it will naturally do a copy. I think we should use custom iterators instead of pointers, I also don't really like the fact that a call  to end() is not the complexity of O(1)