### PR TITLE
Fix game appearing blurry when it shouldn't

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix: [#2725] Currency preference selection shows invalid data.
 - Fix: [#2727] Bankruptcy warnings do not appear.
 - Fix: [#2735] Map generator does not set the season on trees.
+- Fix: [#2739] Game appearing blurry when using a Windows scale factor of 2 with an odd resolution.
 
 24.10 (2024-10-20)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.cpp
@@ -154,11 +154,16 @@ namespace OpenLoco::Gfx
             return;
         }
 
-        if (scaleFactor > 1.0f)
+        if (scaleFactor != 1.0f)
         {
-            const auto scale = std::ceil(scaleFactor);
             // We only need this texture when we have a scale above 1x, this texture uses the actual canvas size.
-            SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
+            int scale = 1;
+            if (scaleFactor < 2.0f)
+            {
+                // Makes the game appear blurry
+                scale = 2;
+                SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
+            }
             _scaledScreenTexture = SDL_CreateTexture(_renderer, pixelFormat, SDL_TEXTUREACCESS_TARGET, width * scale, height * scale);
             if (_scaledScreenTexture == nullptr)
             {


### PR DESCRIPTION
Now the game will only be blurry when the window scale factor is between 1 and 2.

Before this, the game could incorrectly appeared blurry at a scale of 2 (#2739).

No differences when using scale factors above 2 are viable (or at least noticeable) by my testing.
