### PR TITLE
Update sound pausing on title screen to match original behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Fix: [#2727] Bankruptcy warnings do not appear.
 - Fix: [#2735] Map generator does not set the season on trees.
 - Fix: [#2742] Sound effects playing when title screen is paused.
-- Fix [#2743] Title music not playing while scenario is loading.
+- Fix: [#2743] Title music not playing while scenario is loading.
 
 24.10 (2024-10-20)
 ------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Fix: [#2725] Currency preference selection shows invalid data.
 - Fix: [#2727] Bankruptcy warnings do not appear.
 - Fix: [#2735] Map generator does not set the season on trees.
+- Fix: [#2742] Sound effects playing when title screen is paused.
+- Fix [#2743] Title music not playing while scenario is loading.
 
 24.10 (2024-10-20)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -367,7 +367,11 @@ namespace OpenLoco::Audio
         _audioIsPaused = true;
         stopVehicleNoise();
         stopAmbientNoise();
-        stopMusic();
+        // Do not stop title screen music
+        if (!isTitleMode())
+        {
+            stopMusic();
+        }
     }
 
     // 0x00489C58

--- a/src/OpenLoco/src/Game.cpp
+++ b/src/OpenLoco/src/Game.cpp
@@ -40,10 +40,7 @@ namespace OpenLoco::Game
 
     static bool openBrowsePrompt(StringId titleId, browse_type type, const char* filter)
     {
-        if (!isTitleMode())
-        {
-            Audio::pauseSound();
-        }
+        Audio::pauseSound();
         setPauseFlag(1 << 2);
         Gfx::invalidateScreen();
         Gfx::renderAndUpdate();

--- a/src/OpenLoco/src/Ui/Windows/PromptSaveWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptSaveWindow.cpp
@@ -71,10 +71,7 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
             window->flags |= Ui::WindowFlags::transparent;
 
             setPauseFlag(1 << 1);
-            if (!isTitleMode())
-            {
-                Audio::pauseSound();
-            }
+            Audio::pauseSound();
             WindowManager::invalidate(WindowType::timeToolbar);
         }
 


### PR DESCRIPTION
Effects:
- Fixes #2742
- Music no longer stops when loading into a scenario (so you now have more than just the loading bar train to keep you company whilst you wait)

Both of these effects match original Locomotion behaviour.