### PR TITLE
Add "Custom" scenario group

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
@@ -1127,6 +1127,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             StringIds::scenario_group_medium,
             StringIds::scenario_group_challenging,
             StringIds::scenario_group_expert,
+            StringIds::objSelectionFilterCustom,
         };
 
         // 0x0043F14B

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -27,6 +27,8 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 {
     static constexpr Ui::Size32 kWindowSize = { 610, 412 };
 
+    static constexpr int kNumTabs = 6;
+
     namespace widx
     {
         enum
@@ -67,7 +69,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     static void initTabs(Window* self)
     {
         uint16_t xPos = 3;
-        for (int i = 0; i < 5; i++)
+        for (int i = 0; i < kNumTabs; i++)
         {
             Widget& widget = self->widgets[widx::tab0 + i];
             if (ScenarioManager::hasScenariosForCategory(i))
@@ -139,7 +141,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
         if (self->widgets[widx::tab0 + selectedTab].type == WidgetType::none)
         {
             selectedTab = 0;
-            for (int i = 0; i < 5; i++)
+            for (int i = 0; i < kNumTabs; i++)
             {
                 if (self->widgets[widx::tab0 + i].type == WidgetType::none)
                 {
@@ -183,7 +185,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
         };
 
         // Draw tab captions.
-        for (int i = 0; i < 6; i++)
+        for (int i = 0; i < kNumTabs; i++)
         {
             Widget& widget = self.widgets[widx::tab0 + i];
             if (widget.type == WidgetType::none)

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -50,8 +50,8 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
         makeWidget({ 1, 1 }, { 608, 13 }, WidgetType::caption_25, WindowColour::primary, StringIds::select_scenario_for_new_game),
         Widgets::ImageButton({ 595, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
         makeWidget({ 0, 48 }, { 610, 364 }, WidgetType::wt_3, WindowColour::secondary),
-        Widgets::Tab({ 3, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab), // Beginner tab
-        Widgets::Tab({ 94, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab), // Easy tab
+        Widgets::Tab({ 3, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),   // Beginner tab
+        Widgets::Tab({ 94, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),  // Easy tab
         Widgets::Tab({ 185, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab), // Medium tab
         Widgets::Tab({ 276, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab), // Challenging tab
         Widgets::Tab({ 367, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab), // Expert tab

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -40,6 +40,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             tab2,
             tab3,
             tab4,
+            tab5,
             list,
         };
     }
@@ -49,11 +50,12 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
         makeWidget({ 1, 1 }, { 608, 13 }, WidgetType::caption_25, WindowColour::primary, StringIds::select_scenario_for_new_game),
         Widgets::ImageButton({ 595, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
         makeWidget({ 0, 48 }, { 610, 364 }, WidgetType::wt_3, WindowColour::secondary),
-        Widgets::Tab({ 3, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
-        Widgets::Tab({ 94, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
-        Widgets::Tab({ 185, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
-        Widgets::Tab({ 276, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
-        Widgets::Tab({ 367, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
+        Widgets::Tab({ 3, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab), // Beginner tab
+        Widgets::Tab({ 94, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab), // Easy tab
+        Widgets::Tab({ 185, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab), // Medium tab
+        Widgets::Tab({ 276, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab), // Challenging tab
+        Widgets::Tab({ 367, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab), // Expert tab
+        Widgets::Tab({ 458, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab), // Custom tab
         makeWidget({ 3, 52 }, { 431, 356 }, WidgetType::scrollview, WindowColour::secondary, Scrollbars::vertical)
 
     );
@@ -121,7 +123,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             getEvents());
 
         self->setWidgets(_widgets);
-        self->enabledWidgets = (1 << widx::close) | (1 << widx::tab0) | (1 << widx::tab1) | (1 << widx::tab2) | (1 << widx::tab3) | (1 << widx::tab4);
+        self->enabledWidgets = (1 << widx::close) | (1 << widx::tab0) | (1 << widx::tab1) | (1 << widx::tab2) | (1 << widx::tab3) | (1 << widx::tab4) | (1 << widx::tab5);
         self->initScrollWidgets();
 
         self->setColour(WindowColour::primary, Colour::black);
@@ -157,7 +159,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     // 0x00443995
     static void prepareDraw(Window& self)
     {
-        self.activatedWidgets &= ~((1 << widx::tab0) | (1 << widx::tab1) | (1 << widx::tab2) | (1 << widx::tab3) | (1 << widx::tab4));
+        self.activatedWidgets &= ~((1 << widx::tab0) | (1 << widx::tab1) | (1 << widx::tab2) | (1 << widx::tab3) | (1 << widx::tab4) | (1 << widx::tab5));
         self.activatedWidgets |= (1ULL << (self.currentTab + static_cast<uint8_t>(widx::tab0)));
     }
 
@@ -177,10 +179,11 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             StringIds::scenario_group_medium,
             StringIds::scenario_group_challenging,
             StringIds::scenario_group_expert,
+            StringIds::objSelectionFilterCustom,
         };
 
         // Draw tab captions.
-        for (int i = 0; i < 5; i++)
+        for (int i = 0; i < 6; i++)
         {
             Widget& widget = self.widgets[widx::tab0 + i];
             if (widget.type == WidgetType::none)
@@ -462,6 +465,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             case widx::tab2:
             case widx::tab3:
             case widx::tab4:
+            case widx::tab5:
             {
                 uint8_t selectedCategory = widgetIndex - widx::tab0;
                 if (self.currentTab == selectedCategory)


### PR DESCRIPTION
- Adds a 6th tab to the Select Scenario window.
- Allows selecting a 6th "Scenario Group" option in the Scenario Options window when creating a custom scenario.

**To do**
- [ ] Use a different StringId instead of reusing (?)
- [ ] Changelog
- [ ] Make "Custom" the default instead of "Medium" in scenario editor
- [x] Disable/hide tab if there are no scenarios in the "Custom" group (?)
- [ ] Have the group catch all scenarios not in vanilla groups?

Note that scenarios in this 6th group will not show up in any tab in older versions of OpenLoco or the original Locomotion.

Thoughts?

**Screenshots**
The group with two custom scenarios in it:
![Two scenarios in Select Scenario Custom tab](https://github.com/user-attachments/assets/a836a85a-becc-4ed5-bba8-e9edcfb65645)

Creating a scenario in custom group in the scenario editor:
![Scenario Options with Custom group selected](https://github.com/user-attachments/assets/8e005f91-6304-48b6-87b0-e1b3e3b6ae50)



