### PR TITLE
Remove interop for _paintHead, refactor uses, isolate PaintEntry

### DIFF
--- a/src/OpenLoco/src/Paint/Paint.cpp
+++ b/src/OpenLoco/src/Paint/Paint.cpp
@@ -1011,12 +1011,10 @@ namespace OpenLoco::Paint
     // 0x0045E7B5
     void PaintSession::arrangeStructs()
     {
-        // Create a new dummy paint struct that will act as the head
-        // that all others attach to.
-        _paintHead = _nextFreePaintStruct;
-        _nextFreePaintStruct++;
-        PaintStruct* ps = &(*_paintHead)->basic;
-        *ps = PaintStruct{};
+        PaintStruct* psHead = &_paintHead;
+        *psHead = PaintStruct{};
+
+        auto* ps = psHead;
         ps->nextQuadrantPS = nullptr;
 
         uint32_t quadrantIndex = _quadrantBackIndex;
@@ -1041,7 +1039,7 @@ namespace OpenLoco::Paint
         } while (++quadrantIndex <= _quadrantFrontIndex);
 
         PaintStruct* psCache = arrangeStructsHelper(
-            &(*_paintHead)->basic, _quadrantBackIndex & 0xFFFF, QuadrantFlags::neighbour, currentRotation);
+            psHead, _quadrantBackIndex & 0xFFFF, QuadrantFlags::neighbour, currentRotation);
 
         quadrantIndex = _quadrantBackIndex;
         while (++quadrantIndex < _quadrantFrontIndex)
@@ -1247,7 +1245,7 @@ namespace OpenLoco::Paint
     {
         const Gfx::RenderTarget& rt = drawingCtx.currentRenderTarget();
 
-        for (const auto* ps = (*_paintHead)->basic.nextQuadrantPS; ps != nullptr; ps = ps->nextQuadrantPS)
+        for (const auto* ps = _paintHead.nextQuadrantPS; ps != nullptr; ps = ps->nextQuadrantPS)
         {
             const bool shouldCull = shouldTryCullPaintStruct(*ps, _viewFlags);
 
@@ -1510,7 +1508,7 @@ namespace OpenLoco::Paint
     {
         InteractionArg info{};
 
-        for (auto* ps = (*_paintHead)->basic.nextQuadrantPS; ps != nullptr; ps = ps->nextQuadrantPS)
+        for (auto* ps = _paintHead.nextQuadrantPS; ps != nullptr; ps = ps->nextQuadrantPS)
         {
             // Check main paint struct
             if (isSpriteInteractedWith(getRenderTarget(), ps->imageId, ps->vpPos))

--- a/src/OpenLoco/src/Paint/Paint.cpp
+++ b/src/OpenLoco/src/Paint/Paint.cpp
@@ -1011,11 +1011,9 @@ namespace OpenLoco::Paint
     // 0x0045E7B5
     void PaintSession::arrangeStructs()
     {
-        PaintStruct* psHead = &_paintHead;
-        *psHead = PaintStruct{};
+        PaintStruct psHead{};
 
-        auto* ps = psHead;
-        ps->nextQuadrantPS = nullptr;
+        auto* ps = &psHead;
 
         uint32_t quadrantIndex = _quadrantBackIndex;
         if (quadrantIndex == std::numeric_limits<uint32_t>::max())
@@ -1039,13 +1037,15 @@ namespace OpenLoco::Paint
         } while (++quadrantIndex <= _quadrantFrontIndex);
 
         PaintStruct* psCache = arrangeStructsHelper(
-            psHead, _quadrantBackIndex & 0xFFFF, QuadrantFlags::neighbour, currentRotation);
+            &psHead, _quadrantBackIndex & 0xFFFF, QuadrantFlags::neighbour, currentRotation);
 
         quadrantIndex = _quadrantBackIndex;
         while (++quadrantIndex < _quadrantFrontIndex)
         {
             psCache = arrangeStructsHelper(psCache, quadrantIndex & 0xFFFF, QuadrantFlags::none, currentRotation);
         }
+
+        _paintHead = psHead.nextQuadrantPS;
     }
 
     static bool isTypeCullableBuilding(const Ui::ViewportInteraction::InteractionItem type)
@@ -1245,7 +1245,7 @@ namespace OpenLoco::Paint
     {
         const Gfx::RenderTarget& rt = drawingCtx.currentRenderTarget();
 
-        for (const auto* ps = _paintHead.nextQuadrantPS; ps != nullptr; ps = ps->nextQuadrantPS)
+        for (const auto* ps = _paintHead; ps != nullptr; ps = ps->nextQuadrantPS)
         {
             const bool shouldCull = shouldTryCullPaintStruct(*ps, _viewFlags);
 
@@ -1508,7 +1508,7 @@ namespace OpenLoco::Paint
     {
         InteractionArg info{};
 
-        for (auto* ps = _paintHead.nextQuadrantPS; ps != nullptr; ps = ps->nextQuadrantPS)
+        for (auto* ps = _paintHead; ps != nullptr; ps = ps->nextQuadrantPS)
         {
             // Check main paint struct
             if (isSpriteInteractedWith(getRenderTarget(), ps->imageId, ps->vpPos))

--- a/src/OpenLoco/src/Paint/Paint.h
+++ b/src/OpenLoco/src/Paint/Paint.h
@@ -170,14 +170,6 @@ namespace OpenLoco::Paint
     };
     assert_struct_size(PaintStruct, 0x34);
 
-    union PaintEntry
-    {
-        PaintStruct basic;
-        AttachedPaintStruct attached;
-        PaintStringStruct string;
-    };
-    assert_struct_size(PaintEntry, 0x34);
-
     struct SupportHeight
     {
         uint16_t height;
@@ -441,9 +433,17 @@ namespace OpenLoco::Paint
         void generateTilesAndEntities(GenerationParameters&& p);
         void finaliseOrdering(std::span<PaintStruct*> paintStructs);
 
+        union PaintEntry
+        {
+            PaintStruct basic;
+            AttachedPaintStruct attached;
+            PaintStringStruct string;
+        };
+        assert_struct_size(PaintEntry, 0x34);
+
         inline static Interop::loco_global<const Gfx::RenderTarget*, 0x00E0C3E0> _renderTarget;
         inline static Interop::loco_global<PaintEntry*, 0x00E0C404> _endOfPaintStructArray;
-        inline static Interop::loco_global<PaintEntry*, 0x00E0C408> _paintHead;
+        PaintStruct _paintHead{};
         inline static Interop::loco_global<PaintEntry*, 0x00E0C40C> _nextFreePaintStruct;
         inline static Interop::loco_global<PaintEntry[4000], 0x00E0C410> _paintEntries;
         inline static Interop::loco_global<coord_t, 0x00E3F090> _spritePositionX;
@@ -530,14 +530,18 @@ namespace OpenLoco::Paint
         template<typename T>
         T* allocatePaintStruct()
         {
+            static_assert(std::same_as<T, PaintStruct> || std::same_as<T, AttachedPaintStruct> || std::same_as<T, PaintStringStruct>);
+
             auto* ps = *_nextFreePaintStruct;
             if (ps >= *_endOfPaintStructArray)
             {
                 return nullptr;
             }
-            *_nextFreePaintStruct = reinterpret_cast<PaintEntry*>(reinterpret_cast<uintptr_t>(*_nextFreePaintStruct) + sizeof(T));
+            (*_nextFreePaintStruct)++;
+
             auto* specificPs = reinterpret_cast<T*>(ps);
             *specificPs = {}; // Zero out the struct
+
             return specificPs;
         }
         void attachStringStruct(PaintStringStruct& psString);

--- a/src/OpenLoco/src/Paint/Paint.h
+++ b/src/OpenLoco/src/Paint/Paint.h
@@ -443,7 +443,7 @@ namespace OpenLoco::Paint
 
         inline static Interop::loco_global<const Gfx::RenderTarget*, 0x00E0C3E0> _renderTarget;
         inline static Interop::loco_global<PaintEntry*, 0x00E0C404> _endOfPaintStructArray;
-        PaintStruct _paintHead{};
+        PaintStruct* _paintHead{};
         inline static Interop::loco_global<PaintEntry*, 0x00E0C40C> _nextFreePaintStruct;
         inline static Interop::loco_global<PaintEntry[4000], 0x00E0C410> _paintEntries;
         inline static Interop::loco_global<coord_t, 0x00E3F090> _spritePositionX;


### PR DESCRIPTION
This much I can already refactor without breaking any existing interop code, there is mostly the bridges left but this has no effect on it.