### PR TITLE
Screenshots directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#2697] Add initial OpenGraphics custom assets.
 - Change: [#2708] "Show Options Window" keyboard shortcut now works in the title screen.
-- Change: [#2758] Screenshots are now saved in a "screenshots" folder.
+- Change: [#2758] Screenshots are now saved in a dedicated `screenshots` subfolder in OpenLoco's user config folder.
 - Fix: [#2676] Cargo labels are misaligned in vehicle window.
 - Fix: [#2678] Incorrect vehicle draw order and general vehicle clipping.
 - Fix: [#2690] Inability to remove certain track pieces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#2697] Add initial OpenGraphics custom assets.
 - Change: [#2708] "Show Options Window" keyboard shortcut now works in the title screen.
+- Change: [#2758] Screenshots are now saved in a "screenshots" folder.
 - Fix: [#2676] Cargo labels are misaligned in vehicle window.
 - Fix: [#2678] Incorrect vehicle draw order and general vehicle clipping.
 - Fix: [#2690] Inability to remove certain track pieces.

--- a/src/OpenLoco/src/Environment.cpp
+++ b/src/OpenLoco/src/Environment.cpp
@@ -304,6 +304,7 @@ namespace OpenLoco::Environment
             case PathId::landscape:
             case PathId::heightmap:
             case PathId::customObjects:
+            case PathId::screenshots:
                 return Platform::getUserDirectory();
             case PathId::languageFiles:
             case PathId::objects:
@@ -319,7 +320,7 @@ namespace OpenLoco::Environment
 
     static fs::path getSubPath(PathId id)
     {
-        static constexpr std::array<const char*, 59> kPaths = {
+        static constexpr std::array<const char*, 60> kPaths = {
             "Data/g1.DAT",
             "plugin.dat",
             "plugin2.dat",
@@ -379,6 +380,7 @@ namespace OpenLoco::Environment
             "heightmap",
             "objects",
             "objects",
+            "screenshots",
         };
 
         size_t index = (size_t)id;

--- a/src/OpenLoco/src/Environment.h
+++ b/src/OpenLoco/src/Environment.h
@@ -65,6 +65,7 @@ namespace OpenLoco::Environment
         heightmap,
         customObjects,
         objects,
+        screenshots,
     };
 
     void autoCreateDirectory(const fs::path& path);

--- a/src/OpenLoco/src/Ui/Screenshot.cpp
+++ b/src/OpenLoco/src/Ui/Screenshot.cpp
@@ -1,5 +1,6 @@
 #include "Screenshot.h"
 #include "Entities/EntityManager.h"
+#include "Environment.h"
 #include "Graphics/Gfx.h"
 #include "Graphics/SoftwareDrawingEngine.h"
 #include "Localisation/FormatArguments.hpp"
@@ -148,7 +149,8 @@ namespace OpenLoco::Ui
     // 0x00452667
     static std::string prepareSaveScreenshot(const Gfx::RenderTarget& rt)
     {
-        auto basePath = Platform::getUserDirectory();
+        auto screenshotsFolderPath = Environment::getPathNoWarning(Environment::PathId::screenshots);
+        Environment::autoCreateDirectory(screenshotsFolderPath);
         std::string scenarioName = S5::getOptions().scenarioName;
 
         if (scenarioName.length() == 0)
@@ -161,9 +163,9 @@ namespace OpenLoco::Ui
         int16_t suffix;
         for (suffix = 1; suffix < std::numeric_limits<int16_t>().max(); suffix++)
         {
-            if (!fs::exists(basePath / fileName))
+            if (!fs::exists(screenshotsFolderPath / fileName))
             {
-                path = basePath / fileName;
+                path = screenshotsFolderPath / fileName;
                 break;
             }
 


### PR DESCRIPTION
Taking a screenshot will now save it into a folder named "screenshots" (which gets auto-created if not present).

i.e. `%appdata%\OpenLoco\screenshots\` instead of just `%appdata%\OpenLoco\`
