### PR TITLE
Edit road vehicle length check for clarity

### DIFF
--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -23,7 +23,7 @@ namespace OpenLoco::Vehicles
 {
     using CargoTotalArray = std::array<uint32_t, ObjectManager::getMaxObjects(ObjectType::cargo)>;
 
-    constexpr auto kMaxVehicleLength = 176; // TODO: Units?
+    constexpr auto kMaxRoadVehicleLength = 176; // TODO: Units?
 
     enum class Flags38 : uint8_t
     {

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -570,23 +570,18 @@ namespace OpenLoco::Vehicles
                 }
             }
         }
-        if (mode != TransportMode::road)
+
+        if (mode == TransportMode::road && trackType == 0xFF)
         {
-            return true;
+            auto curTotalLength = getVehicleTotalLength();
+            auto additionalNewLength = ObjectManager::get<VehicleObject>(vehicleTypeId)->getLength();
+            if (curTotalLength + additionalNewLength > kMaxRoadVehicleLength)
+            {
+                GameCommands::setErrorText(StringIds::vehicle_too_long);
+                return false;
+            }
         }
 
-        if (trackType != 0xFF)
-        {
-            return true;
-        }
-
-        auto curTotalLength = getVehicleTotalLength();
-        auto additionalNewLength = ObjectManager::get<VehicleObject>(vehicleTypeId)->getLength();
-        if (curTotalLength + additionalNewLength > kMaxVehicleLength)
-        {
-            GameCommands::setErrorText(StringIds::vehicle_too_long);
-            return false;
-        }
         return true;
     }
 


### PR DESCRIPTION
- Renamed `kMaxVehicleLength` to `kMaxRoadVehicleLength`, because it is evidentially specifically for road vehicles.
- Inverted the conditions for running the length check to make the logic easier to follow.