### PR TITLE
Run simulate test only when the secret is available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on: [push, pull_request, workflow_dispatch]
 env:
   OPENLOCO_BUILD_SERVER: GitHub
+  ASSETS_SSH_KEY: ${{ secrets.ASSETS_SSH_KEY }}
 jobs:
   check-code-formatting:
     name: Check code formatting
@@ -48,22 +49,22 @@ jobs:
           path: artifacts
           if-no-files-found: error
       - name: Checkout Assets
-        if: ${{ github.repository == 'OpenLoco/OpenLoco' }}
+        if: ${{ github.repository == 'OpenLoco/OpenLoco' && env.ASSETS_SSH_KEY != null }} 
         uses: actions/checkout@v4
         with:
-          ssh-key: ${{ secrets.ASSETS_SSH_KEY }}
+          ssh-key: ${{ env.ASSETS_SSH_KEY }}
           repository: OpenLoco/LocomotionAssets
           ref: gog
           path: LocomotionAssets
       - name: Checkout Test Data
-        if: ${{ github.repository == 'OpenLoco/OpenLoco' }}
+        if: ${{ github.repository == 'OpenLoco/OpenLoco' && env.ASSETS_SSH_KEY != null }} 
         uses: actions/checkout@v4
         with:
           repository: OpenLoco/TestData
           ref: 57034171c02e62376c87116abcdc2893dfacfd86
           path: TestData
       - name: Run Simulate Test
-        if: ${{ github.repository == 'OpenLoco/OpenLoco' }}
+        if: ${{ github.repository == 'OpenLoco/OpenLoco' && env.ASSETS_SSH_KEY != null }} 
         shell: bash
         run: |
           set -e


### PR DESCRIPTION
I think this is a better approach, the secret is only available when the branch comes from this repository in the PR or its an action caused by this repo and not a fork.