### PR TITLE
Show object filenames without directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Feature: [#2697] Add initial OpenGraphics custom assets.
 - Change: [#2708] "Show Options Window" keyboard shortcut now works in the title screen.
 - Change: [#2758] Screenshots are now saved in a dedicated `screenshots` subfolder in OpenLoco's user config folder.
+- Change: [#2770] The Object Selection window no longer shows full paths for filenames.
 - Fix: [#2676] Cargo labels are misaligned in vehicle window.
 - Fix: [#2678] Incorrect vehicle draw order and general vehicle clipping.
 - Fix: [#2690] Inability to remove certain track pieces.

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -902,9 +902,11 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         auto tr = Gfx::TextRenderer(drawingCtx);
 
+        // Draw object filename
         {
+            auto filename = fs::u8path(indexEntry._filepath).filename().u8string();
             auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
-            strncpy(buffer, indexEntry._filepath.c_str(), indexEntry._filepath.length() + 1);
+            strncpy(buffer, filename.c_str(), filename.length() + 1);
 
             FormatArguments args{};
             args.push<StringId>(StringIds::buffer_1250);


### PR DESCRIPTION
Recently, we reworked the way objects are indexed (#2650), allowing for multiple folders to be scanned for object files. As a direct result, requesting an object entry's filename now returns the full path. This PR changes the object selection window such that only the actual filename is shown again.

Before:
![Anonyme](https://github.com/user-attachments/assets/496341e0-7cd4-406c-b0fe-d68b409763d6)

After:
![Anonyme (1)](https://github.com/user-attachments/assets/e4b5d455-fde3-4244-b327-32cf48fb2dd6)
