### PR TITLE
Fixes #54 -- hitting "Stop" on a ship while it's "unloading" breaks vehicle state transition system

### DIFF
--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -2097,31 +2097,29 @@ namespace OpenLoco::Vehicles
             vehType2->var_5A = 0;
             return true;
         }
-        else
+
+        status = Status::travelling;
+        status = sub_427BF2();
+        advanceToNextRoutableOrder();
+        if ((updateWaterMotion(WaterMotionFlags::none) & WaterMotionFlags::hasReachedDock) == WaterMotionFlags::none)
         {
-            status = Status::travelling;
-            status = sub_427BF2();
-            advanceToNextRoutableOrder();
-            if ((updateWaterMotion(WaterMotionFlags::none) & WaterMotionFlags::hasReachedDock) == WaterMotionFlags::none)
-            {
-                return true;
-            }
-
-            if (hasVehicleFlags(VehicleFlags::commandStop))
-            {
-                status = Status::stopped;
-                vehType2->currentSpeed = 0.0_mph;
-                vehType2->var_5A = 0;
-                return true;
-            }
-
-            vehType2->currentSpeed = 0.0_mph;
-            setStationVisitedTypes();
-            checkIfAtOrderStation();
-            updateLastJourneyAverageSpeed();
-            beginUnloading();
             return true;
         }
+
+        if (hasVehicleFlags(VehicleFlags::commandStop))
+        {
+            status = Status::stopped;
+            vehType2->currentSpeed = 0.0_mph;
+            vehType2->var_5A = 0;
+            return true;
+        }
+
+        vehType2->currentSpeed = 0.0_mph;
+        setStationVisitedTypes();
+        checkIfAtOrderStation();
+        updateLastJourneyAverageSpeed();
+        beginUnloading();
+        return true;
     }
 
     /** 0x00427122

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -2061,19 +2061,6 @@ namespace OpenLoco::Vehicles
             }
         }
 
-        if (hasVehicleFlags(VehicleFlags::commandStop))
-        {
-            if ((updateWaterMotion(WaterMotionFlags::isStopping) & WaterMotionFlags::hasReachedADestination) == WaterMotionFlags::none)
-            {
-                return true;
-            }
-
-            status = Status::stopped;
-            vehType2->currentSpeed = 0.0_mph;
-            vehType2->var_5A = 0;
-            return true;
-        }
-
         if (status == Status::unloading)
         {
             updateUnloadCargo();
@@ -2092,6 +2079,19 @@ namespace OpenLoco::Vehicles
             status = sub_427BF2();
             updateWaterMotion(WaterMotionFlags::isLeavingDock);
             produceLeavingDockSound();
+            return true;
+        }
+
+        if (hasVehicleFlags(VehicleFlags::commandStop))
+        {
+            if ((updateWaterMotion(WaterMotionFlags::isStopping) & WaterMotionFlags::hasReachedADestination) == WaterMotionFlags::none)
+            {
+                return true;
+            }
+
+            status = Status::stopped;
+            vehType2->currentSpeed = 0.0_mph;
+            vehType2->var_5A = 0;
             return true;
         }
         else

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -2097,7 +2097,7 @@ namespace OpenLoco::Vehicles
             vehType2->var_5A = 0;
             return true;
         }
-
+        
         status = Status::travelling;
         status = sub_427BF2();
         advanceToNextRoutableOrder();

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -2043,6 +2043,7 @@ namespace OpenLoco::Vehicles
         Vehicle train(head);
         train.cars.firstCar.body->sub_4AAB0B();
 
+        // Behavior if the vehicle is already stationary
         if (status == Status::stopped)
         {
             if (hasVehicleFlags(VehicleFlags::commandStop))
@@ -2061,6 +2062,7 @@ namespace OpenLoco::Vehicles
             }
         }
 
+        // Behavior if the vehicle is unloading or loading
         if (status == Status::unloading)
         {
             updateUnloadCargo();
@@ -2082,6 +2084,7 @@ namespace OpenLoco::Vehicles
             return true;
         }
 
+        // What to do when stop command is issued
         if (hasVehicleFlags(VehicleFlags::commandStop))
         {
             if ((updateWaterMotion(WaterMotionFlags::isStopping) & WaterMotionFlags::hasReachedADestination) == WaterMotionFlags::none)

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -2097,7 +2097,7 @@ namespace OpenLoco::Vehicles
             vehType2->var_5A = 0;
             return true;
         }
-        
+
         status = Status::travelling;
         status = sub_427BF2();
         advanceToNextRoutableOrder();


### PR DESCRIPTION
Thanks to Duncanspumpkin for helping me figure this one out.

I believe the issue boiled down to the fact that the vehicle state transition system checked for stop commands before checking to see if the vehicle was loading or unloading. Comparing to code from land and air, this seems to be the main difference. 