### PR TITLE
Rename var_5E to wheelSlipping

### DIFF
--- a/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
@@ -128,7 +128,7 @@ namespace OpenLoco::GameCommands
         newBogie->secondaryCargo.acceptedTypes = 0;
         newBogie->secondaryCargo.type = 0xFF;
         newBogie->secondaryCargo.qty = 0;
-        newBogie->var_5E = 0;
+        newBogie->wheelSlipping = 0;
         newBogie->breakdownFlags = BreakdownFlags::none;
         newBogie->var_60 = 0; // different to createbody
         newBogie->var_61 = 0; // different to createbody
@@ -249,7 +249,7 @@ namespace OpenLoco::GameCommands
         newBody->primaryCargo.type = 0xFF;
         newBody->primaryCargo.qty = 0;
         newBody->var_55 = 0; // different to create bogie
-        newBody->var_5E = 0;
+        newBody->wheelSlipping = 0;
         newBody->breakdownFlags = BreakdownFlags::none;
 
         // different to create bogie

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -583,7 +583,7 @@ namespace OpenLoco::Vehicles
         int8_t var_55;
         uint32_t creationDay; // 0x56
         uint32_t var_5A;
-        uint8_t var_5E;
+        uint8_t wheelSlipping; // 0x5E
         BreakdownFlags breakdownFlags;
 
         const VehicleObject* getObject() const;
@@ -643,7 +643,7 @@ namespace OpenLoco::Vehicles
         uint8_t pad_55;
         uint32_t creationDay; // 0x56
         uint32_t var_5A;
-        uint8_t var_5E;
+        uint8_t wheelSlipping; // 0x5E
         BreakdownFlags breakdownFlags;
         uint8_t var_60;
         uint8_t var_61;

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -583,7 +583,7 @@ namespace OpenLoco::Vehicles
         int8_t var_55;
         uint32_t creationDay; // 0x56
         uint32_t var_5A;
-        uint8_t wheelSlipping; // 0x5E
+        uint8_t wheelSlipping; // 0x5E timeout that counts up
         BreakdownFlags breakdownFlags;
 
         const VehicleObject* getObject() const;
@@ -643,7 +643,7 @@ namespace OpenLoco::Vehicles
         uint8_t pad_55;
         uint32_t creationDay; // 0x56
         uint32_t var_5A;
-        uint8_t wheelSlipping; // 0x5E
+        uint8_t wheelSlipping; // 0x5E timeout that counts up
         BreakdownFlags breakdownFlags;
         uint8_t var_60;
         uint8_t var_61;

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -24,6 +24,7 @@ namespace OpenLoco::Vehicles
     using CargoTotalArray = std::array<uint32_t, ObjectManager::getMaxObjects(ObjectType::cargo)>;
 
     constexpr auto kMaxVehicleLength = 176; // TODO: Units?
+    constexpr uint8_t kWheelSlippingDuration = 63; // In ticks
 
     enum class Flags38 : uint8_t
     {

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -23,7 +23,7 @@ namespace OpenLoco::Vehicles
 {
     using CargoTotalArray = std::array<uint32_t, ObjectManager::getMaxObjects(ObjectType::cargo)>;
 
-    constexpr auto kMaxVehicleLength = 176; // TODO: Units?
+    constexpr auto kMaxRoadVehicleLength = 176;    // TODO: Units?
     constexpr uint8_t kWheelSlippingDuration = 63; // In ticks
 
     enum class Flags38 : uint8_t

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -24,7 +24,7 @@ namespace OpenLoco::Vehicles
     using CargoTotalArray = std::array<uint32_t, ObjectManager::getMaxObjects(ObjectType::cargo)>;
 
     constexpr auto kMaxRoadVehicleLength = 176;    // TODO: Units?
-    constexpr uint8_t kWheelSlippingDuration = 63; // In ticks
+    constexpr uint8_t kWheelSlippingDuration = 64; // In ticks
 
     enum class Flags38 : uint8_t
     {

--- a/src/OpenLoco/src/Vehicles/Vehicle2.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle2.cpp
@@ -37,7 +37,7 @@ namespace OpenLoco::Vehicles
     };
 
     // 0x004A9BA0
-    static bool shouldSetVar5E(const Vehicle& train, VehicleBogie& frontBogie)
+    static bool shouldSetWheelSlipping(const Vehicle& train, VehicleBogie& frontBogie)
     {
         const auto* vehObject = ObjectManager::get<VehicleObject>(frontBogie.objectId);
         if (train.head->status != Status::travelling)
@@ -50,13 +50,14 @@ namespace OpenLoco::Vehicles
             return false;
         }
 
-        // This code seems dead as no aircraft reach this code so its never a helicopter
+        // In the vanilla vehicle objects, this flag is set exclusively for vehicles that are steam engines (and helicopters, but no aircraft reach this code)
         if (vehObject->power == 0 || !vehObject->hasFlags(VehicleObjectFlags::isHelicopter))
         {
             return false;
         }
 
-        if (frontBogie.var_5E != 0)
+        // Only start wheel slipping if it is not wheel slipping already
+        if (frontBogie.wheelSlipping != 0)
         {
             return false;
         }
@@ -154,10 +155,11 @@ namespace OpenLoco::Vehicles
 
         Vehicle train(head);
         train.cars.applyToComponents([](auto& component) {
-            if (component.var_5E != 0)
+            // If the vehicle is wheel slipping, then its wheel slipping value is incremented.
+            if (component.wheelSlipping != 0)
             {
-                component.var_5E++;
-                component.var_5E &= 0x3F;
+                component.wheelSlipping++;
+                component.wheelSlipping &= 0x3F;
             }
         });
 
@@ -167,14 +169,14 @@ namespace OpenLoco::Vehicles
         for (auto& car : train.cars)
         {
             auto* frontBogie = car.front;
-            if (shouldSetVar5E(train, *frontBogie))
+            if (shouldSetWheelSlipping(train, *frontBogie))
             {
                 car.applyToComponents([](auto& component) {
-                    component.var_5E = 1;
+                    component.wheelSlipping = 1;
                 });
             }
 
-            if (frontBogie->var_5E != 0)
+            if (frontBogie->wheelSlipping != 0)
             {
                 dh = 1;
             }

--- a/src/OpenLoco/src/Vehicles/Vehicle2.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle2.cpp
@@ -159,7 +159,10 @@ namespace OpenLoco::Vehicles
             if (component.wheelSlipping != 0)
             {
                 component.wheelSlipping++;
-                component.wheelSlipping &= 0x3F;
+                if (component.wheelSlipping > kWheelSlippingDuration)
+                {
+                    component.wheelSlipping = 0;
+                }
             }
         });
 

--- a/src/OpenLoco/src/Vehicles/Vehicle2.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle2.cpp
@@ -167,7 +167,7 @@ namespace OpenLoco::Vehicles
         });
 
         bool isOnRackRail = true; // Note has been inverted
-        uint8_t dh = 0;
+        bool isWheelSlipping = false;
         int32_t ebp = 0;
         for (auto& car : train.cars)
         {
@@ -181,7 +181,7 @@ namespace OpenLoco::Vehicles
 
             if (frontBogie->wheelSlipping != 0)
             {
-                dh = 1;
+                isWheelSlipping = true;
             }
             if (_500170[enumValue(frontBogie->spritePitch)] <= -19182)
             {
@@ -206,7 +206,7 @@ namespace OpenLoco::Vehicles
                 }
             }
         }
-        if (isOnRackRail && dh == 0)
+        if (isOnRackRail && !isWheelSlipping)
         {
             // calculating power when it's broken down
             const auto power = has73Flags(Flags73::isBrokenDown) ? totalPower / 4 : totalPower;

--- a/src/OpenLoco/src/Vehicles/Vehicle2.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle2.cpp
@@ -37,7 +37,7 @@ namespace OpenLoco::Vehicles
     };
 
     // 0x004A9BA0
-    static bool shouldSetWheelSlipping(const Vehicle& train, VehicleBogie& frontBogie)
+    static bool shouldStartWheelSlipping(const Vehicle& train, VehicleBogie& frontBogie)
     {
         const auto* vehObject = ObjectManager::get<VehicleObject>(frontBogie.objectId);
         if (train.head->status != Status::travelling)
@@ -172,7 +172,7 @@ namespace OpenLoco::Vehicles
         for (auto& car : train.cars)
         {
             auto* frontBogie = car.front;
-            if (shouldSetWheelSlipping(train, *frontBogie))
+            if (shouldStartWheelSlipping(train, *frontBogie))
             {
                 car.applyToComponents([](auto& component) {
                     component.wheelSlipping = 1;

--- a/src/OpenLoco/src/Vehicles/Vehicle2.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle2.cpp
@@ -159,7 +159,7 @@ namespace OpenLoco::Vehicles
             if (component.wheelSlipping != 0)
             {
                 component.wheelSlipping++;
-                if (component.wheelSlipping > kWheelSlippingDuration)
+                if (component.wheelSlipping >= kWheelSlippingDuration)
                 {
                     component.wheelSlipping = 0;
                 }

--- a/src/OpenLoco/src/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBody.cpp
@@ -72,9 +72,9 @@ namespace OpenLoco::Vehicles
         if (wheelSlipping != 0)
         {
             int32_t var_1136130 = wheelSlipping;
-            if (wheelSlipping > 32)
+            if (wheelSlipping > kWheelSlippingDuration / 2)
             {
-                var_1136130 = 64 - var_1136130;
+                var_1136130 = kWheelSlippingDuration - var_1136130;
             }
 
             _vehicleUpdate_var_1136130 += var_1136130 * 320 + 500;

--- a/src/OpenLoco/src/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBody.cpp
@@ -69,10 +69,10 @@ namespace OpenLoco::Vehicles
             invalidateSprite();
         }
         uint32_t backup1136130 = _vehicleUpdate_var_1136130;
-        if (var_5E != 0)
+        if (wheelSlipping != 0)
         {
-            int32_t var_1136130 = var_5E;
-            if (var_5E > 32)
+            int32_t var_1136130 = wheelSlipping;
+            if (wheelSlipping > 32)
             {
                 var_1136130 = 64 - var_1136130;
             }
@@ -1133,7 +1133,7 @@ namespace OpenLoco::Vehicles
                 return;
             }
 
-            if (var_5E != 0)
+            if (wheelSlipping != 0)
             {
                 return;
             }

--- a/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
@@ -70,9 +70,9 @@ namespace OpenLoco::Vehicles
         _vehicleUpdate_frontBogieHasMoved = hasMoved;
 
         const int32_t stash1136130 = _vehicleUpdate_var_1136130;
-        if (var_5E != 0)
+        if (wheelSlipping != 0)
         {
-            auto unk = var_5E;
+            auto unk = wheelSlipping;
             if (unk > 32)
             {
                 unk = 64 - unk;

--- a/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
@@ -73,9 +73,9 @@ namespace OpenLoco::Vehicles
         if (wheelSlipping != 0)
         {
             auto unk = wheelSlipping;
-            if (unk > 32)
+            if (unk > kWheelSlippingDuration / 2)
             {
-                unk = 64 - unk;
+                unk = kWheelSlippingDuration - unk;
             }
             _vehicleUpdate_var_1136130 = 500 + unk * 320;
         }

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -857,7 +857,7 @@ namespace OpenLoco::Vehicles
         }
         else if (vehType2_2->var_5A == 1)
         {
-            if (!(vehType2or6->isVehicle2()) || train.cars.firstCar.front->var_5E == 0)
+            if (!(vehType2or6->isVehicle2()) || train.cars.firstCar.front->wheelSlipping == 0)
             {
                 targetFrequency = snd->var_07 + (vehType2_2->currentSpeed.getRaw() >> snd->speedFreqFactor);
                 targetVolume = snd->var_09;
@@ -963,7 +963,7 @@ namespace OpenLoco::Vehicles
 
         if (var5aEqual1Code == true)
         {
-            if (!(vehType2or6->isVehicle2()) || train.cars.firstCar.front->var_5E == 0)
+            if (!(vehType2or6->isVehicle2()) || train.cars.firstCar.front->wheelSlipping == 0)
             {
                 auto speed = std::max(vehType2_2->currentSpeed, 7.0_mph);
 

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -582,7 +582,7 @@ namespace OpenLoco::Vehicles
 
         auto curTotalLength = getVehicleTotalLength();
         auto additionalNewLength = ObjectManager::get<VehicleObject>(vehicleTypeId)->getLength();
-        if (curTotalLength + additionalNewLength > kMaxVehicleLength)
+        if (curTotalLength + additionalNewLength > kMaxRoadVehicleLength)
         {
             GameCommands::setErrorText(StringIds::vehicle_too_long);
             return false;


### PR DESCRIPTION
As discussed in Discord, I discovered that var_5E appears to be used for wheelslipping.

Observed behaviour is that when var_5E of the front bogey != 0, the vehicle is wheel slipping. This can be seen happening in-game randomly to vanilla steam engines when they are setting off. The function `shouldSetVar5E` (renamed here to `shouldStartWheelSlipping`) seems to determine when the vehicle should start wheel slipping.


Also rename `kMaxVehicleLength` to `kMaxRoadVehicleLength`.
