### PR TITLE
Fix "Next music track" button behaviour

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -1253,9 +1253,8 @@ namespace OpenLoco::Ui::Windows::Options
                 return;
             }
 
+            // By stopping the music, the next time OpenLoco::tick() calls Audio::playBackgroundMusic(), it will detect that the channel is not playing anything and it will play the next music track.
             Audio::stopMusic();
-
-            _currentSong = -1;
 
             w->invalidate();
         }


### PR DESCRIPTION
Fixes #2703 and #2704.

Simply removes the line of code that caused both issues, and adds a comment explaining how stopping the music causes the next track to play.