### PR TITLE
Fix #2785. Unique names for industries not respected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 24.11+ (???)
 ------------------------------------------------------------------------
 - Fix: [#2776, #2777] Bridge support image ordering incorrect and invisible bridge platforms over buildings.
+- Fix: [#2785] Unique names for industries incorrectly generated.
 
 24.11 (2024-11-28)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/GameCommands/Company/RenameCompanyName.cpp
+++ b/src/OpenLoco/src/GameCommands/Company/RenameCompanyName.cpp
@@ -88,7 +88,7 @@ namespace OpenLoco::GameCommands
         }
 
         // Allocate a string id for the new name.
-        StringId allocatedStringId = StringManager::userStringAllocate(renameStringBuffer, 0);
+        StringId allocatedStringId = StringManager::userStringAllocate(renameStringBuffer, false);
         if (allocatedStringId == StringIds::empty)
         {
             return GameCommands::FAILURE;

--- a/src/OpenLoco/src/GameCommands/Company/RenameCompanyOwner.cpp
+++ b/src/OpenLoco/src/GameCommands/Company/RenameCompanyOwner.cpp
@@ -93,7 +93,7 @@ namespace OpenLoco::GameCommands
         }
 
         // Allocate a string id for the new name.
-        StringId allocatedStringId = StringManager::userStringAllocate(renameStringBuffer, 0);
+        StringId allocatedStringId = StringManager::userStringAllocate(renameStringBuffer, false);
         if (allocatedStringId == StringIds::empty)
         {
             return GameCommands::FAILURE;

--- a/src/OpenLoco/src/GameCommands/General/RenameStation.cpp
+++ b/src/OpenLoco/src/GameCommands/General/RenameStation.cpp
@@ -91,7 +91,7 @@ namespace OpenLoco::GameCommands
         else
         {
             // Allocate a string id for the new name.
-            StringId allocatedStringId = StringManager::userStringAllocate(renameStringBuffer, 0);
+            StringId allocatedStringId = StringManager::userStringAllocate(renameStringBuffer, true);
             if (allocatedStringId == StringIds::empty)
             {
                 return GameCommands::FAILURE;

--- a/src/OpenLoco/src/GameCommands/Industries/RenameIndustry.cpp
+++ b/src/OpenLoco/src/GameCommands/Industries/RenameIndustry.cpp
@@ -82,7 +82,7 @@ namespace OpenLoco::GameCommands
         }
 
         // Allocate a string id for the new name.
-        StringId allocatedStringId = StringManager::userStringAllocate(renameStringBuffer, 0);
+        StringId allocatedStringId = StringManager::userStringAllocate(renameStringBuffer, true);
         if (allocatedStringId == StringIds::empty)
         {
             return GameCommands::FAILURE;

--- a/src/OpenLoco/src/GameCommands/Town/RenameTown.cpp
+++ b/src/OpenLoco/src/GameCommands/Town/RenameTown.cpp
@@ -80,7 +80,7 @@ namespace OpenLoco::GameCommands
         }
 
         // Allocate a string id for the new name.
-        StringId allocatedStringId = StringManager::userStringAllocate(renameStringBuffer, 0);
+        StringId allocatedStringId = StringManager::userStringAllocate(renameStringBuffer, true);
         if (allocatedStringId == StringIds::empty)
         {
             return GameCommands::FAILURE;

--- a/src/OpenLoco/src/GameCommands/Vehicles/RenameVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/RenameVehicle.cpp
@@ -77,7 +77,7 @@ namespace OpenLoco::GameCommands
         StringId allocatedStringId = StringIds::empty;
         if (strlen(renameStringBuffer) != 0)
         {
-            allocatedStringId = StringManager::userStringAllocate(renameStringBuffer, 0);
+            allocatedStringId = StringManager::userStringAllocate(renameStringBuffer, true);
             if (allocatedStringId == StringIds::empty)
             {
                 return FAILURE;

--- a/src/OpenLoco/src/Localisation/StringManager.cpp
+++ b/src/OpenLoco/src/Localisation/StringManager.cpp
@@ -52,7 +52,7 @@ namespace OpenLoco::StringManager
     }
 
     // 0x00496522
-    StringId userStringAllocate(char* str /* edi */, uint8_t cl)
+    StringId userStringAllocate(char* str, bool mustBeUnique)
     {
         auto bestSlot = -1;
         for (auto i = 0u; i < Limits::kMaxUserStrings; ++i)
@@ -62,7 +62,7 @@ namespace OpenLoco::StringManager
             {
                 bestSlot = i;
             }
-            else if (cl > 0)
+            else if (mustBeUnique)
             {
                 if (strcmp(str, userStr) == 0)
                 {

--- a/src/OpenLoco/src/Localisation/StringManager.h
+++ b/src/OpenLoco/src/Localisation/StringManager.h
@@ -34,7 +34,7 @@ namespace OpenLoco::StringManager
     const char* swapString(StringId id, const char* src);
     const char* getString(StringId id);
 
-    StringId userStringAllocate(char* str, uint8_t cl);
+    StringId userStringAllocate(char* str, bool mustBeUnique);
     const char* getUserString(StringId id);
     void emptyUserString(StringId stringId);
     bool isUserString(StringId id);

--- a/src/OpenLoco/src/World/IndustryManager.cpp
+++ b/src/OpenLoco/src/World/IndustryManager.cpp
@@ -641,7 +641,7 @@ namespace OpenLoco::IndustryManager
                     args.push<uint16_t>(unique);
                     char buffer[512]{};
                     StringManager::formatString(buffer, indObj->var_02 + 1, args);
-                    const auto newName = StringManager::userStringAllocate(buffer, 0);
+                    const auto newName = StringManager::userStringAllocate(buffer, true);
                     if (newName == StringIds::empty)
                     {
                         continue;

--- a/src/OpenLoco/src/World/StationManager.cpp
+++ b/src/OpenLoco/src/World/StationManager.cpp
@@ -445,7 +445,7 @@ namespace OpenLoco::StationManager
         FormatArguments args{};
         args.push(stationId);
         StringManager::formatString(stationName, StringIds::station_name_ordinal, args);
-        return StringManager::userStringAllocate(stationName, 0);
+        return StringManager::userStringAllocate(stationName, true);
     }
 
     // 0x0049088B

--- a/src/OpenLoco/src/World/TownManager.cpp
+++ b/src/OpenLoco/src/World/TownManager.cpp
@@ -180,7 +180,7 @@ namespace OpenLoco::TownManager
                 continue;
             }
 
-            StringId newNameId = StringManager::userStringAllocate(buffer, 0);
+            StringId newNameId = StringManager::userStringAllocate(buffer, true);
             if (newNameId == StringIds::empty)
             {
                 continue;


### PR DESCRIPTION
`userStringAllocate` was implemented back to front for the unique name parameter. In addition all callers weren't passing whether it should be unique or not.