### PR TITLE
Allow for zero frequency sound objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fix: [#2778] News has celebration sound for player company going bankrupt.
 - Fix: [#2785] Unique names for industries incorrectly generated.
 - Fix: [#2791] Station cargo image incorrect for high quantities of cargo.
-- Fix: [#2806] Objects with zeroed base sound frequency do not play.
+- Fix: [#2806] Vehicle objects with zeroed base sound frequency are inaudible.
 
 24.11 (2024-11-28)
 ------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix: [#2778] News has celebration sound for player company going bankrupt.
 - Fix: [#2785] Unique names for industries incorrectly generated.
 - Fix: [#2791] Station cargo image incorrect for high quantities of cargo.
+- Fix: [#2806] Objects with zeroed base sound frequency do not play.
 
 24.11 (2024-11-28)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Audio/Channel.cpp
+++ b/src/OpenLoco/src/Audio/Channel.cpp
@@ -45,7 +45,7 @@ namespace OpenLoco::Audio
     {
         _attributes.freq = freq;
         // If frequency is around zero don't adjust the frequency at all
-        // this matches dsounds DSBFREQUENCY_MIN == 100Hz that vanilla used
+        // this matches dsound's DSBFREQUENCY_MIN == 100Hz that vanilla used
         if (std::abs(freq) < 100)
         {
             _source.setPitch(1.0f);

--- a/src/OpenLoco/src/Audio/Channel.cpp
+++ b/src/OpenLoco/src/Audio/Channel.cpp
@@ -44,8 +44,9 @@ namespace OpenLoco::Audio
     void Channel::setFrequency(int32_t freq)
     {
         _attributes.freq = freq;
-        // If frequency is zero don't adjust the frequency at all
-        if (freq == 0)
+        // If frequency is around zero don't adjust the frequency at all
+        // this matches dsounds DSBFREQUENCY_MIN == 100Hz that vanilla used
+        if (std::abs(freq) < 100)
         {
             _source.setPitch(1.0f);
         }

--- a/src/OpenLoco/src/Audio/Channel.cpp
+++ b/src/OpenLoco/src/Audio/Channel.cpp
@@ -44,7 +44,15 @@ namespace OpenLoco::Audio
     void Channel::setFrequency(int32_t freq)
     {
         _attributes.freq = freq;
-        _source.setPitch(OpenAL::freqFromLoco(freq));
+        // If frequency is zero don't adjust the frequency at all
+        if (freq == 0)
+        {
+            _source.setPitch(1.0f);
+        }
+        else
+        {
+            _source.setPitch(OpenAL::freqFromLoco(freq));
+        }
     }
 
     bool Channel::isPlaying() const


### PR DESCRIPTION
It seems some objects e.g. `CARVWBAM` were relying on the dsound function that skipped setting frequency if the frequency value was zero.