### PR TITLE
Improve performance of collision checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+25.01 (???)
+------------------------------------------------------------------------
+- Fix: [#2810] Large performance regression when there are a lot of vehicles.
+
+
 24.12 (2024-12-27)
 ------------------------------------------------------------------------
 - Fix: [#2667] Music stops working when only one track is selected or available.

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -279,47 +279,21 @@ namespace OpenLoco::Vehicles
         World::TilePos2{ -1, 1 },
     };
 
-    static bool checkTrainForSelfCollision(const Vehicle& collideTrain, const EntityId sourceVehicleId, const EntityId& candidateVehicleId)
+    // If candidate within 7 vehicle components of src we ignore a self collision
+    // TODO: If we stored the car index this could be simplified
+    static bool ignoreSelfCollision(VehicleBase& sourceVehicleId, const VehicleBase& candidateVehicleId)
     {
-        bool noSelfCollision = false;
-        bool carFound = false;
-        uint32_t numCarsToCheck = 0;
-        for (auto& car : collideTrain.cars)
+        auto* src = &sourceVehicleId;
+        for (uint32_t i = 0; i < 7; ++i)
         {
-            for (auto& carComponent : car)
-            {
-
-                if (!carFound)
-                {
-                    carComponent.applyToComponents([&carFound, &numCarsToCheck, targetId = candidateVehicleId](auto& c) {
-                        if (c.id == targetId)
-                        {
-                            carFound = true;
-                            numCarsToCheck = 3;
-                        }
-                    });
-                }
-                if (carFound)
-                {
-                    carComponent.applyToComponents([&noSelfCollision, targetId = sourceVehicleId](auto& c) {
-                        if (c.id == targetId)
-                        {
-                            noSelfCollision = true;
-                        }
-                    });
-                }
-            }
-            if (noSelfCollision)
+            if (src == &candidateVehicleId)
             {
                 return true;
             }
-            if (carFound)
+            src = src->nextVehicleComponent();
+            if (src == nullptr)
             {
-                numCarsToCheck--;
-                if (numCarsToCheck == 0)
-                {
-                    break;
-                }
+                return false;
             }
         }
         return false;
@@ -381,11 +355,11 @@ namespace OpenLoco::Vehicles
                     return vehicleBase->id;
                 }
 
-                if (checkTrainForSelfCollision(srcTrain, bogie.id, vehicleBase->id))
+                if (ignoreSelfCollision(bogie, *vehicleBase))
                 {
                     continue;
                 }
-                if (checkTrainForSelfCollision(srcTrain, vehicleBase->id, bogie.id))
+                if (ignoreSelfCollision(*vehicleBase, bogie))
                 {
                     continue;
                 }

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -279,10 +279,9 @@ namespace OpenLoco::Vehicles
         World::TilePos2{ -1, 1 },
     };
 
-    static bool checkTrainForSelfCollision(const EntityId sourceVehicleId, const VehicleBase& candidateVehicle)
+    static bool checkTrainForSelfCollision(const Vehicle& collideTrain, const EntityId sourceVehicleId, const EntityId& candidateVehicleId)
     {
         bool noSelfCollision = false;
-        Vehicle collideTrain(candidateVehicle.getHead());
         bool carFound = false;
         uint32_t numCarsToCheck = 0;
         for (auto& car : collideTrain.cars)
@@ -292,7 +291,7 @@ namespace OpenLoco::Vehicles
 
                 if (!carFound)
                 {
-                    carComponent.applyToComponents([&carFound, &numCarsToCheck, targetId = candidateVehicle.id](auto& c) {
+                    carComponent.applyToComponents([&carFound, &numCarsToCheck, targetId = candidateVehicleId](auto& c) {
                         if (c.id == targetId)
                         {
                             carFound = true;
@@ -382,11 +381,11 @@ namespace OpenLoco::Vehicles
                     return vehicleBase->id;
                 }
 
-                if (checkTrainForSelfCollision(bogie.id, *vehicleBase))
+                if (checkTrainForSelfCollision(srcTrain, bogie.id, vehicleBase->id))
                 {
                     continue;
                 }
-                if (checkTrainForSelfCollision(vehicleBase->id, bogie))
+                if (checkTrainForSelfCollision(srcTrain, vehicleBase->id, bogie.id))
                 {
                     continue;
                 }

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -279,21 +279,21 @@ namespace OpenLoco::Vehicles
         World::TilePos2{ -1, 1 },
     };
 
-    // If candidate within 7 vehicle components of src we ignore a self collision
+    // If candidate within 8 vehicle components of src we ignore a self collision
     // TODO: If we stored the car index this could be simplified
     static bool ignoreSelfCollision(VehicleBase& sourceVehicleId, const VehicleBase& candidateVehicleId)
     {
         auto* src = &sourceVehicleId;
-        for (uint32_t i = 0; i < 7; ++i)
+        for (uint32_t i = 0; i < 8; ++i)
         {
-            if (src == &candidateVehicleId)
-            {
-                return true;
-            }
             src = src->nextVehicleComponent();
             if (src == nullptr)
             {
                 return false;
+            }
+            if (src == &candidateVehicleId)
+            {
+                return true;
             }
         }
         return false;
@@ -315,7 +315,7 @@ namespace OpenLoco::Vehicles
             for (auto* entity : EntityManager::EntityTileList(World::toWorldSpace(inspectionPos)))
             {
                 auto* vehicleBase = entity->asBase<VehicleBase>();
-                if (vehicleBase == nullptr)
+                if (vehicleBase == nullptr || vehicleBase == &bogie)
                 {
                     continue;
                 }


### PR DESCRIPTION
~~One of the reasons this is slow is due to having to recreate the train. But we can skip that as we have already removed the ability to do this fancier check on non-selves.~~

Switch to vanilla style for this calc.