### PR TITLE
Move copyRect implementation to SoftwareDrawingEngine, use better names

### DIFF
--- a/src/OpenLoco/src/Graphics/Gfx.cpp
+++ b/src/OpenLoco/src/Graphics/Gfx.cpp
@@ -489,4 +489,12 @@ namespace OpenLoco::Gfx
         return ImageId(imageId);
     }
 
+    // 0x00451DCB
+    void movePixelsOnScreen(int16_t dstX, int16_t dstY, int16_t width, int16_t height, int16_t srcX, int16_t srcY)
+    {
+        auto& drawingEngine = getDrawingEngine();
+        auto& screenRT = drawingEngine.getScreenRT();
+
+        drawingEngine.movePixels(screenRT, dstX, dstY, width, height, srcX, srcY);
+    }
 }

--- a/src/OpenLoco/src/Graphics/Gfx.h
+++ b/src/OpenLoco/src/Graphics/Gfx.h
@@ -157,6 +157,9 @@ namespace OpenLoco::Gfx
     void render(Ui::Rect rect);
     void render(int16_t left, int16_t top, int16_t right, int16_t bottom);
 
+    // Moves the pixels on screen.
+    void movePixelsOnScreen(int16_t dstX, int16_t dstY, int16_t width, int16_t height, int16_t srcX, int16_t srcY);
+
     // Renders all invalidated regions and processes new messages.
     void renderAndUpdate();
 

--- a/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.cpp
@@ -363,4 +363,52 @@ namespace OpenLoco::Gfx
         return _screenRT;
     }
 
+    void SoftwareDrawingEngine::movePixels(
+        const RenderTarget& rt,
+        int16_t dstX,
+        int16_t dstY,
+        int16_t width,
+        int16_t height,
+        int16_t srcX,
+        int16_t srcY)
+    {
+        if (dstX == 0 && dstY == 0)
+        {
+            return;
+        }
+
+        // Adjust for move off canvas.
+        // NOTE: when zooming, there can be x, y, dx, dy combinations that go off the
+        // canvas; hence the checks. This code should ultimately not be called when
+        // zooming because this function is specific to updating the screen on move
+        int32_t lmargin = std::min(dstX - srcX, 0);
+        int32_t rmargin = std::min((int32_t)rt.width - (dstX - srcX + width), 0);
+        int32_t tmargin = std::min(dstY - srcY, 0);
+        int32_t bmargin = std::min((int32_t)rt.height - (dstY - srcY + height), 0);
+
+        dstX -= lmargin;
+        dstY -= tmargin;
+        width += lmargin + rmargin;
+        height += tmargin + bmargin;
+
+        int32_t stride = rt.width + rt.pitch;
+        uint8_t* to = rt.bits + dstY * stride + dstX;
+        uint8_t* from = rt.bits + (dstY - srcY) * stride + dstX - srcX;
+
+        if (srcY > 0)
+        {
+            // If positive dy, reverse directions
+            to += (height - 1) * stride;
+            from += (height - 1) * stride;
+            stride = -stride;
+        }
+
+        // Move bytes
+        for (int32_t i = 0; i < height; i++)
+        {
+            std::memmove(to, from, width);
+            to += stride;
+            from += stride;
+        }
+    }
 }

--- a/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.h
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.h
@@ -59,6 +59,16 @@ namespace OpenLoco::Gfx
 
         const RenderTarget& getScreenRT();
 
+        // Moves the pixels in the specified render target.
+        void movePixels(
+            const RenderTarget& rt,
+            int16_t dstX,
+            int16_t dstY,
+            int16_t width,
+            int16_t height,
+            int16_t srcX,
+            int16_t srcY);
+
     private:
         SDL_Renderer* _renderer{};
         SDL_Window* _window{};

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -1938,52 +1938,6 @@ namespace OpenLoco::Ui::WindowManager
         viewportRedrawAfterShift(window, viewport, dX, dY);
     }
 
-    // 0x00451DCB
-    static void copyRect(int16_t x, int16_t y, int16_t width, int16_t height, int16_t dx, int16_t dy)
-    {
-        if (dx == 0 && dy == 0)
-        {
-            return;
-        }
-
-        auto _width = Ui::width();
-        auto _height = Ui::height();
-        Gfx::RenderTarget& rt = _screenRT;
-
-        // Adjust for move off screen
-        // NOTE: when zooming, there can be x, y, dx, dy combinations that go off the
-        // screen; hence the checks. This code should ultimately not be called when
-        // zooming because this function is specific to updating the screen on move
-        int32_t lmargin = std::min(x - dx, 0);
-        int32_t rmargin = std::min((int32_t)_width - (x - dx + width), 0);
-        int32_t tmargin = std::min(y - dy, 0);
-        int32_t bmargin = std::min((int32_t)_height - (y - dy + height), 0);
-        x -= lmargin;
-        y -= tmargin;
-        width += lmargin + rmargin;
-        height += tmargin + bmargin;
-
-        int32_t stride = rt.width + rt.pitch;
-        uint8_t* to = rt.bits + y * stride + x;
-        uint8_t* from = rt.bits + (y - dy) * stride + x - dx;
-
-        if (dy > 0)
-        {
-            // If positive dy, reverse directions
-            to += (height - 1) * stride;
-            from += (height - 1) * stride;
-            stride = -stride;
-        }
-
-        // Move bytes
-        for (int32_t i = 0; i < height; i++)
-        {
-            memmove(to, from, width);
-            to += stride;
-            from += stride;
-        }
-    }
-
     /**
      * 0x004C6B09
      *
@@ -2076,7 +2030,7 @@ namespace OpenLoco::Ui::WindowManager
             else
             {
                 // update whole block ?
-                copyRect(left, top, viewport->width, viewport->height, x, y);
+                Gfx::movePixelsOnScreen(left, top, viewport->width, viewport->height, x, y);
 
                 if (x > 0)
                 {


### PR DESCRIPTION
This makes a bit more sense if we ever want a different rendering engine to handle those things.