### PR TITLE
Fix FPS counter not being properly invalidated

### DIFF
--- a/src/OpenLoco/src/Graphics/FPSCounter.cpp
+++ b/src/OpenLoco/src/Graphics/FPSCounter.cpp
@@ -57,6 +57,6 @@ namespace OpenLoco::Gfx
         tr.drawString(point, Colour::black, buffer);
 
         // Make area dirty so the text doesn't get drawn over the last
-        invalidateRegion(point.x - 16, point.y - 4, point.x + 16, 16);
+        invalidateRegion(point.x, point.y, point.x + stringWidth, point.y + 16);
     }
 }


### PR DESCRIPTION
Now with pretty big numbers I noticed its wrong.
![image](https://github.com/user-attachments/assets/f50eb78a-e9da-44e0-b937-d54eaad2ff8c)

The provided point is at the start of the string not the center also use the string width which is already obtained rather than hardcoded numbers.