### PR TITLE
Default the font to medium bold, small regression

### DIFF
--- a/src/OpenLoco/src/Graphics/TextRenderer.cpp
+++ b/src/OpenLoco/src/Graphics/TextRenderer.cpp
@@ -2125,4 +2125,14 @@ namespace OpenLoco::Gfx
         return Impl::wrapString(font, buffer, stringWidth);
     }
 
+    uint16_t TextRenderer::getLineHeight(Font font)
+    {
+        return Impl::getLineHeight(font);
+    }
+
+    uint16_t TextRenderer::getSmallerLineHeight(Font font)
+    {
+        return Impl::getSmallerLineHeight(font);
+    }
+
 }

--- a/src/OpenLoco/src/Graphics/TextRenderer.h
+++ b/src/OpenLoco/src/Graphics/TextRenderer.h
@@ -27,7 +27,7 @@ namespace OpenLoco::Gfx
     {
         DrawingContext& _ctx;
         TextDrawFlags _currentFontFlags{};
-        Font _currentFontSpriteBase{};
+        Font _currentFontSpriteBase{ Font::medium_bold };
 
     public:
         TextRenderer(DrawingContext& ctx);
@@ -50,6 +50,9 @@ namespace OpenLoco::Gfx
 
         std::pair<uint16_t, uint16_t> wrapString(char* buffer, uint16_t stringWidth) const;
         static std::pair<uint16_t, uint16_t> wrapString(Font font, char* buffer, uint16_t stringWidth);
+
+        static uint16_t getLineHeight(Font font);
+        static uint16_t getSmallerLineHeight(Font font);
 
         Ui::Point drawString(
             Ui::Point origin,


### PR DESCRIPTION
It currently defaults to medium_normal but majority of the UI uses the bold font so lets make that the default instead. Also added getters necessary to compute the layout later, we might have variable fonts at some point so can't have that static in all widgets.