### PR TITLE
Fix #2613. Crash when unpacking objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 25.01 (???)
 ------------------------------------------------------------------------
+- Fix: [#2613] Crash when unpacking objects from a save file.
 - Fix: [#2805] Inflation calculation potentially going wrong with large values.
 - Fix: [#2810] Large performance regression when there are a lot of vehicles.
 - Fix: [#2818] Incorrect bridge segment shown on some rotations.

--- a/src/OpenLoco/src/Environment.cpp
+++ b/src/OpenLoco/src/Environment.cpp
@@ -262,6 +262,8 @@ namespace OpenLoco::Environment
         setDirectory(_pathLandscapes, landscapeDirectory / "*.SC5");
         setDirectory(_pathScenarios, basePath / "Scenarios/*.SC5");
         setDirectory(_pathObjects, basePath / "ObjData/*.DAT");
+
+        autoCreateDirectory(getPath(PathId::customObjects));
     }
 
     class ThousandsSepFacet : public std::numpunct<char>

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -677,8 +677,10 @@ namespace OpenLoco::S5
             // Any packed objects to install?
             if (!file->packedObjects.empty())
             {
-                const auto progressStep = 50 / file->packedObjects.size();
-                auto currentProgress = 100;
+                // For now installing objects can't be done with a progress bar
+                // revert this when objects do not change the current game state
+                Ui::ProgressBar::end();
+
                 bool objectInstalled = false;
 
                 for (auto [object, data] : file->packedObjects)
@@ -687,15 +689,15 @@ namespace OpenLoco::S5
                     {
                         objectInstalled = true;
                     }
-
-                    currentProgress += progressStep;
-                    Ui::ProgressBar::setProgress(currentProgress);
                 }
 
                 if (objectInstalled)
                 {
                     ObjectManager::loadIndex();
                 }
+
+                // See above. restart progress bar
+                Ui::ProgressBar::begin(StringIds::loading);
             }
 
             Ui::ProgressBar::setProgress(150);


### PR DESCRIPTION
Could do with a few people checking this works. I was surprised that I didn't need to adjust the progress bar in `ObjectManager::loadIndex();`. It does fix the issue though on my system.