### PR TITLE
Fix station window scrollview width off-by-one

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -358,7 +358,7 @@ namespace OpenLoco::Ui::Windows::Station
         {
             Common::prepareDraw(self);
 
-            self.widgets[widx::scrollview].right = self.width - 24;
+            self.widgets[widx::scrollview].right = self.width - 25;
             self.widgets[widx::scrollview].bottom = self.height - 14;
 
             self.widgets[widx::status_bar].top = self.height - 12;

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -358,7 +358,7 @@ namespace OpenLoco::Ui::Windows::Station
         {
             Common::prepareDraw(self);
 
-            self.widgets[widx::scrollview].right = self.width - 25;
+            self.widgets[widx::scrollview].right = self.width - 26;
             self.widgets[widx::scrollview].bottom = self.height - 14;
 
             self.widgets[widx::status_bar].top = self.height - 12;


### PR DESCRIPTION
Before:
<img width="336" alt="Screenshot 2025-01-28 at 23 51 08" src="https://github.com/user-attachments/assets/d4aa16cc-4fe0-4f7f-a19f-3455df0d3ec2" />

After:
<img width="339" alt="Screenshot 2025-01-28 at 23 50 30" src="https://github.com/user-attachments/assets/ddafc15d-0c58-4f10-940d-57ae5ce62cc2" />

