### PR TITLE
Fix crash when ai attempts dock placement

### DIFF
--- a/src/OpenLoco/src/World/CompanyAi.cpp
+++ b/src/OpenLoco/src/World/CompanyAi.cpp
@@ -1774,6 +1774,11 @@ namespace OpenLoco
 
         const auto direction = directionWaterIndustry == 0xFFU ? directionLand : directionWaterIndustry;
 
+        if (direction == 0xFFU)
+        {
+            return true;
+        }
+
         // Same as air
         const bool shouldCreatePort = [&thought, aiStationIdx, minPos, maxPos]() {
             const auto [acceptedCargo, producedCargo] = calcAcceptedCargoAi(minPos, maxPos);


### PR DESCRIPTION
This can happen when the ai finds a tile that isn't appropriate (wrong water height) but does have some water.
Vanilla doesn't suffer from this as it uses a global variable that is never reset to an invalid direction. That causes its own issues...