### PR TITLE
rename some steam effect variables

### DIFF
--- a/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
@@ -248,7 +248,7 @@ namespace OpenLoco::GameCommands
         newBody->primaryCargo.acceptedTypes = 0;
         newBody->primaryCargo.type = 0xFF;
         newBody->primaryCargo.qty = 0;
-        newBody->var_55 = 0; // different to create bogie
+        newBody->chuffSoundIndex = 0; // different to create bogie
         newBody->wheelSlipping = 0;
         newBody->breakdownFlags = BreakdownFlags::none;
 

--- a/src/OpenLoco/src/Objects/SteamObject.h
+++ b/src/OpenLoco/src/Objects/SteamObject.h
@@ -17,7 +17,7 @@ namespace OpenLoco
         none = 0U,
         applyWind = 1U << 0,
         disperseOnCollision = 1U << 1,
-        unk2 = 1U << 2,
+        hasTunnelSounds = 1U << 2,
         unk3 = 1U << 3,
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(SteamObjectFlags);

--- a/src/OpenLoco/src/Objects/VehicleObject.h
+++ b/src/OpenLoco/src/Objects/VehicleObject.h
@@ -98,9 +98,9 @@ namespace OpenLoco
 
     struct VehicleObjectSimpleAnimation
     {
-        uint8_t objectId;         // 0x00 (object loader fills this in)
-        uint8_t emitterVerticalPos;           // 0x01
-        SimpleAnimationType type; // 0x02
+        uint8_t objectId;           // 0x00 (object loader fills this in)
+        uint8_t emitterVerticalPos; // 0x01
+        SimpleAnimationType type;   // 0x02
     };
     static_assert(sizeof(VehicleObjectSimpleAnimation) == 0x3);
 

--- a/src/OpenLoco/src/Objects/VehicleObject.h
+++ b/src/OpenLoco/src/Objects/VehicleObject.h
@@ -99,7 +99,7 @@ namespace OpenLoco
     struct VehicleObjectSimpleAnimation
     {
         uint8_t objectId;         // 0x00 (object loader fills this in)
-        uint8_t height;           // 0x01
+        uint8_t emitterVerticalPos;           // 0x01
         SimpleAnimationType type; // 0x02
     };
     static_assert(sizeof(VehicleObjectSimpleAnimation) == 0x3);
@@ -111,7 +111,7 @@ namespace OpenLoco
         uint8_t frontBogieSpriteInd; // 0x02 index of bogieSprites struct
         uint8_t backBogieSpriteInd;  // 0x03 index of bogieSprites struct
         uint8_t bodySpriteInd;       // 0x04 index of a bodySprites struct
-        uint8_t var_05;
+        uint8_t emitterHorizontalPos;
     };
     static_assert(sizeof(VehicleObjectCar) == 0x6);
 

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -582,7 +582,7 @@ namespace OpenLoco::Vehicles
         VehicleCargo primaryCargo; // 0x48
         uint8_t pad_52[0x54 - 0x52];
         uint8_t bodyIndex; // 0x54
-        int8_t var_55;
+        int8_t chuffSoundIndex;
         uint32_t creationDay; // 0x56
         uint32_t var_5A;
         uint8_t wheelSlipping; // 0x5E timeout that counts up

--- a/src/OpenLoco/src/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBody.cpp
@@ -911,7 +911,7 @@ namespace OpenLoco::Vehicles
     }
 
     // 0x004AB688, 0x004AACA5
-    void VehicleBody::steamPuffsAnimationUpdate(uint8_t num, int32_t emitterPosition)
+    void VehicleBody::steamPuffsAnimationUpdate(uint8_t num, int32_t emitterHorizontalPos)
     {
         const auto* vehicleObject = getObject();
         VehicleBogie* frontBogie = _vehicleUpdate_frontBogie;
@@ -937,7 +937,7 @@ namespace OpenLoco::Vehicles
         // Reversing
         if (has38Flags(Flags38::isReversed))
         {
-            emitterPosition = -emitterPosition;
+            emitterHorizontalPos = -emitterHorizontalPos;
             _var_44 = -_var_44;
         }
 
@@ -956,13 +956,13 @@ namespace OpenLoco::Vehicles
             }
         }
 
-        emitterPosition += 64;
+        emitterHorizontalPos += 64;
 
         auto xyFactor = Math::Trigonometry::computeXYVector(vehicleObject->animation[num].emitterVerticalPos, spritePitch, spriteYaw);
 
         auto bogieDifference = backBogie->position - frontBogie->position;
 
-        auto smokeLoc = bogieDifference * emitterPosition / 128 + frontBogie->position + World::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].emitterVerticalPos);
+        auto smokeLoc = bogieDifference * emitterHorizontalPos / 128 + frontBogie->position + World::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].emitterVerticalPos);
 
         Exhaust::create(smokeLoc, vehicleObject->animation[num].objectId | (soundCode ? 0 : 0x80));
         if (soundCode == false)

--- a/src/OpenLoco/src/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBody.cpp
@@ -1073,7 +1073,7 @@ namespace OpenLoco::Vehicles
     }
 
     // 0x004AB9DD & 0x004AAFFA
-    void VehicleBody::dieselExhaust1AnimationUpdate(uint8_t num, int32_t var_05)
+    void VehicleBody::dieselExhaust1AnimationUpdate(uint8_t num, int32_t emitterHorizontalPos)
     {
         VehicleBogie* frontBogie = _vehicleUpdate_frontBogie;
         VehicleBogie* backBogie = _vehicleUpdate_backBogie;
@@ -1095,7 +1095,7 @@ namespace OpenLoco::Vehicles
 
             if (has38Flags(Flags38::isReversed))
             {
-                var_05 = -var_05;
+                emitterHorizontalPos = -emitterHorizontalPos;
             }
 
             if (ScenarioManager::getScenarioTicks() & 3)
@@ -1103,7 +1103,7 @@ namespace OpenLoco::Vehicles
                 return;
             }
 
-            auto positionFactor = vehicleObject->bodySprites[0].halfLength * var_05 / 256;
+            auto positionFactor = vehicleObject->bodySprites[0].halfLength * emitterHorizontalPos / 256;
             auto invertedDirection = spriteYaw ^ (1 << 5);
             auto xyFactor = Math::Trigonometry::computeXYVector(positionFactor, invertedDirection) / 2;
 
@@ -1119,7 +1119,7 @@ namespace OpenLoco::Vehicles
 
             if (has38Flags(Flags38::isReversed))
             {
-                var_05 = -var_05;
+                emitterHorizontalPos = -emitterHorizontalPos;
             }
 
             if (ScenarioManager::getScenarioTicks() & 3)
@@ -1132,18 +1132,18 @@ namespace OpenLoco::Vehicles
                 return;
             }
 
-            var_05 += 64;
+            emitterHorizontalPos += 64;
             auto bogieDifference = backBogie->position - frontBogie->position;
             auto xyFactor = Math::Trigonometry::computeXYVector(vehicleObject->animation[num].emitterVerticalPos, spritePitch, spriteYaw);
 
-            auto loc = bogieDifference * var_05 / 128 + frontBogie->position + World::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].emitterVerticalPos);
+            auto loc = bogieDifference * emitterHorizontalPos / 128 + frontBogie->position + World::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].emitterVerticalPos);
 
             Exhaust::create(loc, vehicleObject->animation[num].objectId);
         }
     }
 
     // 0x004ABB5A & 0x004AB177
-    void VehicleBody::dieselExhaust2AnimationUpdate(uint8_t num, int32_t var_05)
+    void VehicleBody::dieselExhaust2AnimationUpdate(uint8_t num, int32_t emitterHorizontalPos)
     {
         VehicleBogie* frontBogie = _vehicleUpdate_frontBogie;
         VehicleBogie* backBogie = _vehicleUpdate_backBogie;
@@ -1167,7 +1167,7 @@ namespace OpenLoco::Vehicles
 
         if (has38Flags(Flags38::isReversed))
         {
-            var_05 = -var_05;
+            emitterHorizontalPos = -emitterHorizontalPos;
         }
 
         if (ScenarioManager::getScenarioTicks() & 7)
@@ -1175,12 +1175,12 @@ namespace OpenLoco::Vehicles
             return;
         }
 
-        var_05 += 64;
+        emitterHorizontalPos += 64;
 
         auto bogieDifference = backBogie->position - frontBogie->position;
         auto xyFactor = Math::Trigonometry::computeXYVector(vehicleObject->animation[num].emitterVerticalPos, spritePitch, spriteYaw);
 
-        auto loc = bogieDifference * var_05 / 128 + frontBogie->position + World::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].emitterVerticalPos);
+        auto loc = bogieDifference * emitterHorizontalPos / 128 + frontBogie->position + World::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].emitterVerticalPos);
 
         // 90 degrees C.W.
         auto yaw = (spriteYaw + 16) & 0x3F;
@@ -1199,7 +1199,7 @@ namespace OpenLoco::Vehicles
     }
 
     // 0x004ABDAD & 0x004AB3CA
-    void VehicleBody::electricSpark1AnimationUpdate(uint8_t num, int32_t var_05)
+    void VehicleBody::electricSpark1AnimationUpdate(uint8_t num, int32_t emitterHorizontalPos)
     {
         VehicleBogie* frontBogie = _vehicleUpdate_frontBogie;
         VehicleBogie* backBogie = _vehicleUpdate_backBogie;
@@ -1219,7 +1219,7 @@ namespace OpenLoco::Vehicles
         auto _var_44 = var_44;
         if (has38Flags(Flags38::isReversed))
         {
-            var_05 = -var_05;
+            emitterHorizontalPos = -emitterHorizontalPos;
             _var_44 = -var_44;
         }
 
@@ -1228,7 +1228,7 @@ namespace OpenLoco::Vehicles
             return;
         }
 
-        var_05 += 64;
+        emitterHorizontalPos += 64;
 
         if (gPrng1().randNext(std::numeric_limits<uint16_t>::max()) > 819)
         {
@@ -1238,13 +1238,13 @@ namespace OpenLoco::Vehicles
         auto bogieDifference = backBogie->position - frontBogie->position;
         auto xyFactor = Math::Trigonometry::computeXYVector(vehicleObject->animation[num].emitterVerticalPos, spritePitch, spriteYaw);
 
-        auto loc = bogieDifference * var_05 / 128 + frontBogie->position + World::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].emitterVerticalPos);
+        auto loc = bogieDifference * emitterHorizontalPos / 128 + frontBogie->position + World::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].emitterVerticalPos);
 
         Exhaust::create(loc, vehicleObject->animation[num].objectId);
     }
 
     // 0x004ABEC3 & 0x004AB4E0
-    void VehicleBody::electricSpark2AnimationUpdate(uint8_t num, int32_t var_05)
+    void VehicleBody::electricSpark2AnimationUpdate(uint8_t num, int32_t emitterHorizontalPos)
     {
         VehicleBogie* frontBogie = _vehicleUpdate_frontBogie;
         VehicleBogie* backBogie = _vehicleUpdate_backBogie;
@@ -1264,7 +1264,7 @@ namespace OpenLoco::Vehicles
         auto _var_44 = var_44;
         if (has38Flags(Flags38::isReversed))
         {
-            var_05 = -var_05;
+            emitterHorizontalPos = -emitterHorizontalPos;
             _var_44 = -var_44;
         }
 
@@ -1273,7 +1273,7 @@ namespace OpenLoco::Vehicles
             return;
         }
 
-        var_05 += 64;
+        emitterHorizontalPos += 64;
 
         if (gPrng1().randNext(std::numeric_limits<uint16_t>::max()) > 936)
         {
@@ -1283,7 +1283,7 @@ namespace OpenLoco::Vehicles
         auto bogieDifference = backBogie->position - frontBogie->position;
         auto xyFactor = Math::Trigonometry::computeXYVector(vehicleObject->animation[num].emitterVerticalPos, spritePitch, spriteYaw);
 
-        auto loc = bogieDifference * var_05 / 128 + frontBogie->position + World::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].emitterVerticalPos);
+        auto loc = bogieDifference * emitterHorizontalPos / 128 + frontBogie->position + World::Pos3(xyFactor.x, xyFactor.y, vehicleObject->animation[num].emitterVerticalPos);
 
         // 90 degrees C.W.
         auto yaw = (spriteYaw + 16) & 0x3F;


### PR DESCRIPTION
I uncovered the meaning of some flags and some unnamed variables.

I moved the return in `steamPuffsAnimationUpdate` since both paths had the same condition and did no work.