### PR TITLE
Create flags enum for _vehicleUpdate_var_1136114

### DIFF
--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -329,7 +329,7 @@ namespace OpenLoco::Vehicles
             const auto tc = World::Track::getTrackConnections(nextPos, nextRot, component.owner, component.trackType, train.head->var_53, 0);
             if (tc.hasLevelCrossing)
             {
-                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m04;
+                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::gradeCrossingSound;
             }
             bool routingFound = false;
             for (auto& connection : tc.connections)
@@ -532,7 +532,7 @@ namespace OpenLoco::Vehicles
                 auto collideResult = checkForCollisions(*component.asVehicleBogie(), intermediatePosition);
                 if (collideResult != EntityId::null)
                 {
-                    _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m02;
+                    _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::crashed;
                     _vehicleUpdate_collisionCarComponent = collideResult;
                 }
             }
@@ -592,7 +592,7 @@ namespace OpenLoco::Vehicles
                     auto collideResult = checkForCollisions(*component.asVehicleBogie(), intermediatePosition);
                     if (collideResult != EntityId::null)
                     {
-                        _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m02;
+                        _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::crashed;
                         _vehicleUpdate_collisionCarComponent = collideResult;
                     }
                 }

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -261,11 +261,11 @@ namespace OpenLoco::Vehicles
         if (routing != RoutingManager::kAllocatedButFreeRoutingStation)
         {
             Vehicle train(component.head);
-            if (_vehicleUpdate_var_1136114 & (1U << 15))
+            if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m15)
             {
                 if (train.veh1->routingHandle == component.routingHandle)
                 {
-                    _vehicleUpdate_var_1136114 |= (1U << 3);
+                    _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m03;
                     return false;
                 }
             }
@@ -285,7 +285,7 @@ namespace OpenLoco::Vehicles
             }
             if (!routingFound)
             {
-                _vehicleUpdate_var_1136114 |= (1U << 1);
+                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m01;
                 return false;
             }
             component.routingHandle = newRoutingHandle;
@@ -315,11 +315,11 @@ namespace OpenLoco::Vehicles
         if (routing != RoutingManager::kAllocatedButFreeRoutingStation)
         {
             Vehicle train(component.head);
-            if (_vehicleUpdate_var_1136114 & (1U << 15))
+            if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m15)
             {
                 if (train.veh1->routingHandle == component.routingHandle)
                 {
-                    _vehicleUpdate_var_1136114 |= (1U << 3);
+                    _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m03;
                     return false;
                 }
             }
@@ -329,7 +329,7 @@ namespace OpenLoco::Vehicles
             const auto tc = World::Track::getTrackConnections(nextPos, nextRot, component.owner, component.trackType, train.head->var_53, 0);
             if (tc.hasLevelCrossing)
             {
-                _vehicleUpdate_var_1136114 |= (1U << 4);
+                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m04;
             }
             bool routingFound = false;
             for (auto& connection : tc.connections)
@@ -342,7 +342,7 @@ namespace OpenLoco::Vehicles
             }
             if (!routingFound)
             {
-                _vehicleUpdate_var_1136114 |= (1U << 1);
+                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m01;
                 return false;
             }
             component.routingHandle = newRoutingHandle;
@@ -510,7 +510,7 @@ namespace OpenLoco::Vehicles
                 {
                     returnValue = component.remainingDistance - 0x3689;
                     component.remainingDistance = 0x3689;
-                    _vehicleUpdate_var_1136114 |= (1U << 0);
+                    _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m00;
                     break;
                 }
                 else
@@ -532,7 +532,7 @@ namespace OpenLoco::Vehicles
                 auto collideResult = checkForCollisions(*component.asVehicleBogie(), intermediatePosition);
                 if (collideResult != EntityId::null)
                 {
-                    _vehicleUpdate_var_1136114 |= (1U << 2);
+                    _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m02;
                     _vehicleUpdate_collisionCarComponent = collideResult;
                 }
             }
@@ -570,7 +570,7 @@ namespace OpenLoco::Vehicles
                     {
                         returnValue = component.remainingDistance - 0x3689;
                         component.remainingDistance = 0x3689;
-                        _vehicleUpdate_var_1136114 |= (1U << 0);
+                        _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m00;
                         break;
                     }
                     else
@@ -592,7 +592,7 @@ namespace OpenLoco::Vehicles
                     auto collideResult = checkForCollisions(*component.asVehicleBogie(), intermediatePosition);
                     if (collideResult != EntityId::null)
                     {
-                        _vehicleUpdate_var_1136114 |= (1U << 2);
+                        _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m02;
                         _vehicleUpdate_collisionCarComponent = collideResult;
                     }
                 }

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -285,7 +285,7 @@ namespace OpenLoco::Vehicles
             }
             if (!routingFound)
             {
-                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m01;
+                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::noRouteFound;
                 return false;
             }
             component.routingHandle = newRoutingHandle;
@@ -342,7 +342,7 @@ namespace OpenLoco::Vehicles
             }
             if (!routingFound)
             {
-                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m01;
+                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::noRouteFound;
                 return false;
             }
             component.routingHandle = newRoutingHandle;

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -261,11 +261,11 @@ namespace OpenLoco::Vehicles
         if (routing != RoutingManager::kAllocatedButFreeRoutingStation)
         {
             Vehicle train(component.head);
-            if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m15)
+            if (hasUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m15))
             {
                 if (train.veh1->routingHandle == component.routingHandle)
                 {
-                    _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m03;
+                    setUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m03, true);
                     return false;
                 }
             }
@@ -285,7 +285,7 @@ namespace OpenLoco::Vehicles
             }
             if (!routingFound)
             {
-                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::noRouteFound;
+                setUpdateVar1136114Flags(UpdateVar1136114Flags::noRouteFound, true);
                 return false;
             }
             component.routingHandle = newRoutingHandle;
@@ -315,11 +315,11 @@ namespace OpenLoco::Vehicles
         if (routing != RoutingManager::kAllocatedButFreeRoutingStation)
         {
             Vehicle train(component.head);
-            if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m15)
+            if (hasUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m15))
             {
                 if (train.veh1->routingHandle == component.routingHandle)
                 {
-                    _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m03;
+                    setUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m03, true);
                     return false;
                 }
             }
@@ -329,7 +329,7 @@ namespace OpenLoco::Vehicles
             const auto tc = World::Track::getTrackConnections(nextPos, nextRot, component.owner, component.trackType, train.head->var_53, 0);
             if (tc.hasLevelCrossing)
             {
-                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::approachingGradeCrossing;
+                setUpdateVar1136114Flags(UpdateVar1136114Flags::approachingGradeCrossing, true);
             }
             bool routingFound = false;
             for (auto& connection : tc.connections)
@@ -342,7 +342,7 @@ namespace OpenLoco::Vehicles
             }
             if (!routingFound)
             {
-                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::noRouteFound;
+                setUpdateVar1136114Flags(UpdateVar1136114Flags::noRouteFound, true);
                 return false;
             }
             component.routingHandle = newRoutingHandle;
@@ -510,7 +510,7 @@ namespace OpenLoco::Vehicles
                 {
                     returnValue = component.remainingDistance - 0x3689;
                     component.remainingDistance = 0x3689;
-                    _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m00;
+                    setUpdateVar1136114Flags(UpdateVar1136114Flags::crashed, true);
                     break;
                 }
                 else
@@ -532,7 +532,7 @@ namespace OpenLoco::Vehicles
                 auto collideResult = checkForCollisions(*component.asVehicleBogie(), intermediatePosition);
                 if (collideResult != EntityId::null)
                 {
-                    _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::crashed;
+                    setUpdateVar1136114Flags(UpdateVar1136114Flags::crashed, true);
                     _vehicleUpdate_collisionCarComponent = collideResult;
                 }
             }
@@ -570,7 +570,7 @@ namespace OpenLoco::Vehicles
                     {
                         returnValue = component.remainingDistance - 0x3689;
                         component.remainingDistance = 0x3689;
-                        _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::unk_m00;
+                        setUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m00, true);
                         break;
                     }
                     else
@@ -592,8 +592,8 @@ namespace OpenLoco::Vehicles
                     auto collideResult = checkForCollisions(*component.asVehicleBogie(), intermediatePosition);
                     if (collideResult != EntityId::null)
                     {
-                        _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::crashed;
-                        _vehicleUpdate_collisionCarComponent = collideResult;
+                        setUpdateVar1136114Flags(UpdateVar1136114Flags::crashed, true);
+                        _vehicleUpdate_collisionCarComponent = collideResult.value();
                     }
                 }
             }
@@ -1034,5 +1034,15 @@ namespace OpenLoco::Vehicles
                 regs.dx = nextPos.z;
                 return 0;
             });
+    }
+
+    bool hasUpdateVar1136114Flags(UpdateVar1136114Flags flags)
+    {
+        return _vehicleUpdate_var_1136114 & enumValue(flags);
+    }
+    void setUpdateVar1136114Flags(UpdateVar1136114Flags flags, bool enabled)
+    {
+        _vehicleUpdate_var_1136114 &= ~enumValue(flags);
+        _vehicleUpdate_var_1136114 |= enumValue(flags) * enabled;
     }
 }

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -329,7 +329,7 @@ namespace OpenLoco::Vehicles
             const auto tc = World::Track::getTrackConnections(nextPos, nextRot, component.owner, component.trackType, train.head->var_53, 0);
             if (tc.hasLevelCrossing)
             {
-                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::gradeCrossingSound;
+                _vehicleUpdate_var_1136114 |= UpdateVar1136114Flags::approachingGradeCrossing;
             }
             bool routingFound = false;
             for (auto& connection : tc.connections)

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -510,7 +510,7 @@ namespace OpenLoco::Vehicles
                 {
                     returnValue = component.remainingDistance - 0x3689;
                     component.remainingDistance = 0x3689;
-                    setUpdateVar1136114Flags(UpdateVar1136114Flags::crashed, true);
+                    setUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m00, true);
                     break;
                 }
                 else

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -265,7 +265,7 @@ namespace OpenLoco::Vehicles
             {
                 if (train.veh1->routingHandle == component.routingHandle)
                 {
-                    setUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m03, true);
+                    setUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m03);
                     return false;
                 }
             }
@@ -285,7 +285,7 @@ namespace OpenLoco::Vehicles
             }
             if (!routingFound)
             {
-                setUpdateVar1136114Flags(UpdateVar1136114Flags::noRouteFound, true);
+                setUpdateVar1136114Flags(UpdateVar1136114Flags::noRouteFound);
                 return false;
             }
             component.routingHandle = newRoutingHandle;
@@ -319,7 +319,7 @@ namespace OpenLoco::Vehicles
             {
                 if (train.veh1->routingHandle == component.routingHandle)
                 {
-                    setUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m03, true);
+                    setUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m03);
                     return false;
                 }
             }
@@ -329,7 +329,7 @@ namespace OpenLoco::Vehicles
             const auto tc = World::Track::getTrackConnections(nextPos, nextRot, component.owner, component.trackType, train.head->var_53, 0);
             if (tc.hasLevelCrossing)
             {
-                setUpdateVar1136114Flags(UpdateVar1136114Flags::approachingGradeCrossing, true);
+                setUpdateVar1136114Flags(UpdateVar1136114Flags::approachingGradeCrossing);
             }
             bool routingFound = false;
             for (auto& connection : tc.connections)
@@ -342,7 +342,7 @@ namespace OpenLoco::Vehicles
             }
             if (!routingFound)
             {
-                setUpdateVar1136114Flags(UpdateVar1136114Flags::noRouteFound, true);
+                setUpdateVar1136114Flags(UpdateVar1136114Flags::noRouteFound);
                 return false;
             }
             component.routingHandle = newRoutingHandle;
@@ -510,7 +510,7 @@ namespace OpenLoco::Vehicles
                 {
                     returnValue = component.remainingDistance - 0x3689;
                     component.remainingDistance = 0x3689;
-                    setUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m00, true);
+                    setUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m00);
                     break;
                 }
                 else
@@ -532,7 +532,7 @@ namespace OpenLoco::Vehicles
                 auto collideResult = checkForCollisions(*component.asVehicleBogie(), intermediatePosition);
                 if (collideResult != EntityId::null)
                 {
-                    setUpdateVar1136114Flags(UpdateVar1136114Flags::crashed, true);
+                    setUpdateVar1136114Flags(UpdateVar1136114Flags::crashed);
                     _vehicleUpdate_collisionCarComponent = collideResult;
                 }
             }
@@ -570,7 +570,7 @@ namespace OpenLoco::Vehicles
                     {
                         returnValue = component.remainingDistance - 0x3689;
                         component.remainingDistance = 0x3689;
-                        setUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m00, true);
+                        setUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m00);
                         break;
                     }
                     else
@@ -592,8 +592,8 @@ namespace OpenLoco::Vehicles
                     auto collideResult = checkForCollisions(*component.asVehicleBogie(), intermediatePosition);
                     if (collideResult != EntityId::null)
                     {
-                        setUpdateVar1136114Flags(UpdateVar1136114Flags::crashed, true);
-                        _vehicleUpdate_collisionCarComponent = collideResult.value();
+                        setUpdateVar1136114Flags(UpdateVar1136114Flags::crashed);
+                        _vehicleUpdate_collisionCarComponent = collideResult;
                     }
                 }
             }
@@ -1040,9 +1040,12 @@ namespace OpenLoco::Vehicles
     {
         return _vehicleUpdate_var_1136114 & enumValue(flags);
     }
-    void setUpdateVar1136114Flags(UpdateVar1136114Flags flags, bool enabled)
+    void setUpdateVar1136114Flags(UpdateVar1136114Flags flags)
+    {
+        _vehicleUpdate_var_1136114 |= enumValue(flags);
+    }
+    void unsetUpdateVar1136114Flags(UpdateVar1136114Flags flags)
     {
         _vehicleUpdate_var_1136114 &= ~enumValue(flags);
-        _vehicleUpdate_var_1136114 |= enumValue(flags) * enabled;
     }
 }

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -22,7 +22,7 @@ using namespace OpenLoco::Interop;
 namespace OpenLoco::Vehicles
 {
     static loco_global<uint8_t[128], 0x004F7358> _4F7358; // trackAndDirection without the direction 0x1FC
-    static loco_global<uint32_t, 0x01136114> _vehicleUpdate_var_1136114;
+    static loco_global<UpdateVar1136114Flags, 0x01136114> _vehicleUpdate_var_1136114;
     static loco_global<EntityId, 0x0113610E> _vehicleUpdate_collisionCarComponent;
 
 #pragma pack(push, 1)
@@ -1038,14 +1038,18 @@ namespace OpenLoco::Vehicles
 
     bool hasUpdateVar1136114Flags(UpdateVar1136114Flags flags)
     {
-        return _vehicleUpdate_var_1136114 & enumValue(flags);
+        return (*_vehicleUpdate_var_1136114 & flags) != UpdateVar1136114Flags::none;
+    }
+    void resetUpdateVar1136114Flags()
+    {
+        _vehicleUpdate_var_1136114 = UpdateVar1136114Flags::none;
     }
     void setUpdateVar1136114Flags(UpdateVar1136114Flags flags)
     {
-        _vehicleUpdate_var_1136114 |= enumValue(flags);
+        _vehicleUpdate_var_1136114 |= flags;
     }
     void unsetUpdateVar1136114Flags(UpdateVar1136114Flags flags)
     {
-        _vehicleUpdate_var_1136114 &= ~enumValue(flags);
+        _vehicleUpdate_var_1136114 &= ~flags;
     }
 }

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -87,8 +87,8 @@ namespace OpenLoco::Vehicles
     enum UpdateVar1136114Flags : uint32_t
     {
         unk_m00 = (1 << 0),
-        noRouteFound = (1 << 1), // no route found??
-        crashed = (1 << 2),      // crashed??
+        noRouteFound = (1 << 1),
+        crashed = (1 << 2),
         unk_m03 = (1 << 3),
         approachingGradeCrossing = (1 << 4),
         unk_m15 = (1 << 15),

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -90,7 +90,7 @@ namespace OpenLoco::Vehicles
         noRouteFound = (1 << 1), // no route found??
         crashed = (1 << 2),      // crashed??
         unk_m03 = (1 << 3),
-        gradeCrossingSound = (1 << 4),
+        approachingGradeCrossing = (1 << 4),
         unk_m15 = (1 << 15),
     };
 

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -87,8 +87,8 @@ namespace OpenLoco::Vehicles
     enum UpdateVar1136114Flags : uint32_t
     {
         unk_m00 = (1 << 0),
-        noRouteFound = (1 << 1),
-        unk_m02 = (1 << 2), // crashed??
+        noRouteFound = (1 << 1), // no route found??
+        crashed = (1 << 2), // crashed??
         unk_m03 = (1 << 3),
         gradeCrossingSound = (1 << 4),
         unk_m15 = (1 << 15),

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -84,6 +84,17 @@ namespace OpenLoco::Vehicles
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(SoundFlags);
 
+    enum class UpdateVar1136114Flags : uint32_t
+    {
+        unk_m00 = (1 << 0),
+        unk_m01 = (1 << 1), // no route??
+        unk_m02 = (1 << 2), // crashed??
+        unk_m03 = (1 << 3),
+        unk_m04 = (1 << 4), // play level crossing sound??
+        unk_m15 = (1 << 15),
+    };
+    OPENLOCO_ENABLE_ENUM_OPERATORS(SoundFlags);
+
     enum class Status : uint8_t
     {
         unk_0 = 0, // no position (not placed)

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -97,7 +97,8 @@ namespace OpenLoco::Vehicles
     OPENLOCO_ENABLE_ENUM_OPERATORS(UpdateVar1136114Flags);
 
     bool hasUpdateVar1136114Flags(UpdateVar1136114Flags flags);
-    void setUpdateVar1136114Flags(UpdateVar1136114Flags flags, bool enabled);
+    void setUpdateVar1136114Flags(UpdateVar1136114Flags flags);
+    void unsetUpdateVar1136114Flags(UpdateVar1136114Flags flags);
 
     enum class Status : uint8_t
     {

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -84,15 +84,20 @@ namespace OpenLoco::Vehicles
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(SoundFlags);
 
-    enum UpdateVar1136114Flags : uint32_t
+    enum class UpdateVar1136114Flags : uint32_t
     {
-        unk_m00 = (1 << 0),
-        noRouteFound = (1 << 1),
-        crashed = (1 << 2),
-        unk_m03 = (1 << 3),
-        approachingGradeCrossing = (1 << 4),
-        unk_m15 = (1 << 15),
+        none = 0U,
+        unk_m00 = (1U << 0),
+        noRouteFound = (1U << 1),
+        crashed = (1U << 2),
+        unk_m03 = (1U << 3),
+        approachingGradeCrossing = (1U << 4),
+        unk_m15 = (1U << 15),
     };
+    OPENLOCO_ENABLE_ENUM_OPERATORS(UpdateVar1136114Flags);
+
+    bool hasUpdateVar1136114Flags(UpdateVar1136114Flags flags);
+    void setUpdateVar1136114Flags(UpdateVar1136114Flags flags, bool enabled);
 
     enum class Status : uint8_t
     {

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -88,7 +88,7 @@ namespace OpenLoco::Vehicles
     {
         unk_m00 = (1 << 0),
         noRouteFound = (1 << 1), // no route found??
-        crashed = (1 << 2), // crashed??
+        crashed = (1 << 2),      // crashed??
         unk_m03 = (1 << 3),
         gradeCrossingSound = (1 << 4),
         unk_m15 = (1 << 15),

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -84,16 +84,15 @@ namespace OpenLoco::Vehicles
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(SoundFlags);
 
-    enum class UpdateVar1136114Flags : uint32_t
+    enum UpdateVar1136114Flags : uint32_t
     {
         unk_m00 = (1 << 0),
-        unk_m01 = (1 << 1), // no route??
+        noRouteFound = (1 << 1),
         unk_m02 = (1 << 2), // crashed??
         unk_m03 = (1 << 3),
-        unk_m04 = (1 << 4), // play level crossing sound??
+        gradeCrossingSound = (1 << 4),
         unk_m15 = (1 << 15),
     };
-    OPENLOCO_ENABLE_ENUM_OPERATORS(SoundFlags);
 
     enum class Status : uint8_t
     {

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -97,6 +97,7 @@ namespace OpenLoco::Vehicles
     OPENLOCO_ENABLE_ENUM_OPERATORS(UpdateVar1136114Flags);
 
     bool hasUpdateVar1136114Flags(UpdateVar1136114Flags flags);
+    void resetUpdateVar1136114Flags();
     void setUpdateVar1136114Flags(UpdateVar1136114Flags flags);
     void unsetUpdateVar1136114Flags(UpdateVar1136114Flags flags);
 

--- a/src/OpenLoco/src/Vehicles/Vehicle1.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle1.cpp
@@ -116,7 +116,7 @@ namespace OpenLoco::Vehicles
         distance1 = std::min(distance1, unk2);
         var_3C += distance1 - updateRoadMotion(distance1);
 
-        if (!(_vehicleUpdate_var_1136114 & (1 << 1)))
+        if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m01))
         {
             return true;
         }
@@ -227,9 +227,9 @@ namespace OpenLoco::Vehicles
         _vehicleUpdate_var_1136114 = 0;
         var_3C += distance1 - updateTrackMotion(distance1);
 
-        if (!(_vehicleUpdate_var_1136114 & (1U << 1)))
+        if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m01))
         {
-            if (_vehicleUpdate_var_1136114 & (1U << 4))
+            if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m04)
             {
                 railProduceCrossingWhistle(*train.veh2);
             }

--- a/src/OpenLoco/src/Vehicles/Vehicle1.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle1.cpp
@@ -229,7 +229,7 @@ namespace OpenLoco::Vehicles
 
         if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::noRouteFound))
         {
-            if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::gradeCrossingSound)
+            if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::approachingGradeCrossing)
             {
                 railProduceCrossingWhistle(*train.veh2);
             }

--- a/src/OpenLoco/src/Vehicles/Vehicle1.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle1.cpp
@@ -116,7 +116,7 @@ namespace OpenLoco::Vehicles
         distance1 = std::min(distance1, unk2);
         var_3C += distance1 - updateRoadMotion(distance1);
 
-        if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m01))
+        if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::noRouteFound))
         {
             return true;
         }
@@ -227,7 +227,7 @@ namespace OpenLoco::Vehicles
         _vehicleUpdate_var_1136114 = 0;
         var_3C += distance1 - updateTrackMotion(distance1);
 
-        if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m01))
+        if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::noRouteFound))
         {
             if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m04)
             {

--- a/src/OpenLoco/src/Vehicles/Vehicle1.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle1.cpp
@@ -15,7 +15,6 @@ namespace OpenLoco::Vehicles
 {
     static loco_global<int32_t, 0x0113612C> _vehicleUpdate_var_113612C; // Speed
     static loco_global<Speed32, 0x01136134> _vehicleUpdate_var_1136134; // Speed
-    static loco_global<uint32_t, 0x01136114> _vehicleUpdate_var_1136114;
 
     // If distance travelled in one tick this is the speed
     constexpr Speed32 speedFromDistanceInATick(int32_t distance)
@@ -224,7 +223,7 @@ namespace OpenLoco::Vehicles
         const auto unk2 = std::max(_vehicleUpdate_var_113612C * 4, 0xCC48);
 
         distance1 = std::min(distance1, unk2);
-        _vehicleUpdate_var_1136114 = enumValue(UpdateVar1136114Flags::none);
+        resetUpdateVar1136114Flags();
         var_3C += distance1 - updateTrackMotion(distance1);
 
         if (!hasUpdateVar1136114Flags(UpdateVar1136114Flags::noRouteFound))

--- a/src/OpenLoco/src/Vehicles/Vehicle1.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle1.cpp
@@ -116,7 +116,7 @@ namespace OpenLoco::Vehicles
         distance1 = std::min(distance1, unk2);
         var_3C += distance1 - updateRoadMotion(distance1);
 
-        if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::noRouteFound))
+        if (!hasUpdateVar1136114Flags(UpdateVar1136114Flags::noRouteFound))
         {
             return true;
         }
@@ -224,12 +224,12 @@ namespace OpenLoco::Vehicles
         const auto unk2 = std::max(_vehicleUpdate_var_113612C * 4, 0xCC48);
 
         distance1 = std::min(distance1, unk2);
-        _vehicleUpdate_var_1136114 = 0;
+        _vehicleUpdate_var_1136114 = enumValue(UpdateVar1136114Flags::none);
         var_3C += distance1 - updateTrackMotion(distance1);
 
-        if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::noRouteFound))
+        if (!hasUpdateVar1136114Flags(UpdateVar1136114Flags::noRouteFound))
         {
-            if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::approachingGradeCrossing)
+            if (hasUpdateVar1136114Flags(UpdateVar1136114Flags::approachingGradeCrossing))
             {
                 railProduceCrossingWhistle(*train.veh2);
             }

--- a/src/OpenLoco/src/Vehicles/Vehicle1.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle1.cpp
@@ -229,7 +229,7 @@ namespace OpenLoco::Vehicles
 
         if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::noRouteFound))
         {
-            if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m04)
+            if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::gradeCrossingSound)
             {
                 railProduceCrossingWhistle(*train.veh2);
             }

--- a/src/OpenLoco/src/Vehicles/Vehicle2.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle2.cpp
@@ -291,17 +291,17 @@ namespace OpenLoco::Vehicles
     bool Vehicle2::sub_4A9F20()
     {
         Vehicle train(head);
-        _vehicleUpdate_var_1136114 = UpdateVar1136114Flags::unk_m15;
+        _vehicleUpdate_var_1136114 = enumValue(UpdateVar1136114Flags::unk_m15);
         auto res = updateTrackMotion(_vehicleUpdate_var_113612C);
         _vehicleUpdate_var_113612C = _vehicleUpdate_var_113612C - res;
         _vehicleUpdate_var_1136130 = _vehicleUpdate_var_1136130 - res;
-        if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::noRouteFound)
+        if (hasUpdateVar1136114Flags(UpdateVar1136114Flags::noRouteFound))
         {
             destroyTrain();
             return false;
         }
 
-        if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m00)
+        if (hasUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m00))
         {
             if (!train.head->hasVehicleFlags(VehicleFlags::manualControl))
             {

--- a/src/OpenLoco/src/Vehicles/Vehicle2.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle2.cpp
@@ -291,17 +291,17 @@ namespace OpenLoco::Vehicles
     bool Vehicle2::sub_4A9F20()
     {
         Vehicle train(head);
-        _vehicleUpdate_var_1136114 = (1 << 15);
+        _vehicleUpdate_var_1136114 = UpdateVar1136114Flags::unk_m15;
         auto res = updateTrackMotion(_vehicleUpdate_var_113612C);
         _vehicleUpdate_var_113612C = _vehicleUpdate_var_113612C - res;
         _vehicleUpdate_var_1136130 = _vehicleUpdate_var_1136130 - res;
-        if (_vehicleUpdate_var_1136114 & (1 << 1))
+        if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m01)
         {
             destroyTrain();
             return false;
         }
 
-        if (_vehicleUpdate_var_1136114 & (1 << 0))
+        if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m00)
         {
             if (!train.head->hasVehicleFlags(VehicleFlags::manualControl))
             {

--- a/src/OpenLoco/src/Vehicles/Vehicle2.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle2.cpp
@@ -295,7 +295,7 @@ namespace OpenLoco::Vehicles
         auto res = updateTrackMotion(_vehicleUpdate_var_113612C);
         _vehicleUpdate_var_113612C = _vehicleUpdate_var_113612C - res;
         _vehicleUpdate_var_1136130 = _vehicleUpdate_var_1136130 - res;
-        if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m01)
+        if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::noRouteFound)
         {
             destroyTrain();
             return false;

--- a/src/OpenLoco/src/Vehicles/Vehicle2.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle2.cpp
@@ -12,7 +12,6 @@ using namespace OpenLoco::Literals;
 
 namespace OpenLoco::Vehicles
 {
-    static loco_global<uint32_t, 0x01136114> _vehicleUpdate_var_1136114;
     static loco_global<int32_t, 0x0113612C> _vehicleUpdate_var_113612C; // Speed
     static loco_global<int32_t, 0x01136130> _vehicleUpdate_var_1136130; // Speed
     static loco_global<Speed32, 0x01136134> _vehicleUpdate_var_1136134; // Speed
@@ -291,7 +290,9 @@ namespace OpenLoco::Vehicles
     bool Vehicle2::sub_4A9F20()
     {
         Vehicle train(head);
-        _vehicleUpdate_var_1136114 = enumValue(UpdateVar1136114Flags::unk_m15);
+
+        resetUpdateVar1136114Flags();
+        setUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m15);
         auto res = updateTrackMotion(_vehicleUpdate_var_113612C);
         _vehicleUpdate_var_113612C = _vehicleUpdate_var_113612C - res;
         _vehicleUpdate_var_1136130 = _vehicleUpdate_var_1136130 - res;

--- a/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
@@ -68,7 +68,7 @@ namespace OpenLoco::Vehicles
 
         updateRoll();
         _vehicleUpdate_var_1136130 = stash1136130;
-        if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m01)
+        if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::noRouteFound)
         {
             destroyTrain();
             return false;

--- a/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
@@ -23,8 +23,7 @@ namespace OpenLoco::Vehicles
     static loco_global<bool, 0x01136237> _vehicleUpdate_frontBogieHasMoved; // remainingDistance related?
     static loco_global<bool, 0x01136238> _vehicleUpdate_backBogieHasMoved;  // remainingDistance related?
     static loco_global<int32_t, 0x0113612C> _vehicleUpdate_var_113612C;     // Speed
-    static loco_global<uint32_t, 0x01136114> _vehicleUpdate_var_1136114;
-    static loco_global<int32_t, 0x01136130> _vehicleUpdate_var_1136130; // Speed
+    static loco_global<int32_t, 0x01136130> _vehicleUpdate_var_1136130;     // Speed
     static loco_global<EntityId, 0x0113610E> _vehicleUpdate_collisionCarComponent;
 
     template<typename T>
@@ -48,7 +47,7 @@ namespace OpenLoco::Vehicles
         }
 
         const auto oldPos = position;
-        _vehicleUpdate_var_1136114 = enumValue(UpdateVar1136114Flags::none);
+        resetUpdateVar1136114Flags();
         updateTrackMotion(_vehicleUpdate_var_113612C);
 
         const auto hasMoved = oldPos != position;
@@ -250,11 +249,11 @@ namespace OpenLoco::Vehicles
         }
         else
         {
-            _vehicleUpdate_var_1136114 = 0;
+            resetUpdateVar1136114Flags();
             if (this->mode != TransportMode::road)
             {
                 this->updateTrackMotion(_vehicleUpdate_var_113612C);
-                if ((_vehicleUpdate_var_1136114 & 0x3) != 0)
+                if (hasUpdateVar1136114Flags(UpdateVar1136114Flags::unk_m00 | UpdateVar1136114Flags::noRouteFound))
                 {
                     this->var_5A |= 1U << 31;
                 }

--- a/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
@@ -68,12 +68,12 @@ namespace OpenLoco::Vehicles
 
         updateRoll();
         _vehicleUpdate_var_1136130 = stash1136130;
-        if (_vehicleUpdate_var_1136114 & (1 << 1))
+        if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m01)
         {
             destroyTrain();
             return false;
         }
-        else if (!(_vehicleUpdate_var_1136114 & (1 << 2)))
+        else if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m02))
         {
             return true;
         }

--- a/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
@@ -73,7 +73,7 @@ namespace OpenLoco::Vehicles
             destroyTrain();
             return false;
         }
-        else if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m02))
+        else if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::crashed))
         {
             return true;
         }

--- a/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
@@ -48,7 +48,7 @@ namespace OpenLoco::Vehicles
         }
 
         const auto oldPos = position;
-        _vehicleUpdate_var_1136114 = 0;
+        _vehicleUpdate_var_1136114 = enumValue(UpdateVar1136114Flags::none);
         updateTrackMotion(_vehicleUpdate_var_113612C);
 
         const auto hasMoved = oldPos != position;
@@ -68,12 +68,12 @@ namespace OpenLoco::Vehicles
 
         updateRoll();
         _vehicleUpdate_var_1136130 = stash1136130;
-        if (_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::noRouteFound)
+        if (hasUpdateVar1136114Flags(UpdateVar1136114Flags::noRouteFound))
         {
             destroyTrain();
             return false;
         }
-        else if (!(_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::crashed))
+        else if (!hasUpdateVar1136114Flags(UpdateVar1136114Flags::crashed))
         {
             return true;
         }

--- a/src/OpenLoco/src/Vehicles/VehicleTail.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleTail.cpp
@@ -15,7 +15,6 @@ using namespace OpenLoco::World;
 namespace OpenLoco::Vehicles
 {
     static loco_global<int32_t, 0x0113612C> _vehicleUpdate_var_113612C; // Speed
-    static loco_global<uint32_t, 0x01136114> _vehicleUpdate_var_1136114;
 
     // 0x004794BC
     static void leaveLevelCrossing(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint16_t unk)
@@ -76,7 +75,7 @@ namespace OpenLoco::Vehicles
         const auto _oldRoutingHandle = routingHandle;
         const World::Pos3 _oldTilePos = World::Pos3(tileX, tileY, tileBaseZ * World::kSmallZStep);
 
-        _vehicleUpdate_var_1136114 = enumValue(UpdateVar1136114Flags::none);
+        resetUpdateVar1136114Flags();
         updateTrackMotion(*_vehicleUpdate_var_113612C);
 
         if (hasUpdateVar1136114Flags(UpdateVar1136114Flags::noRouteFound))

--- a/src/OpenLoco/src/Vehicles/VehicleTail.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleTail.cpp
@@ -79,7 +79,7 @@ namespace OpenLoco::Vehicles
         _vehicleUpdate_var_1136114 = 0;
         updateTrackMotion(*_vehicleUpdate_var_113612C);
 
-        if (*_vehicleUpdate_var_1136114 & (1 << 1))
+        if (*_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m01)
         {
             destroyTrain();
             return false;

--- a/src/OpenLoco/src/Vehicles/VehicleTail.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleTail.cpp
@@ -76,10 +76,10 @@ namespace OpenLoco::Vehicles
         const auto _oldRoutingHandle = routingHandle;
         const World::Pos3 _oldTilePos = World::Pos3(tileX, tileY, tileBaseZ * World::kSmallZStep);
 
-        _vehicleUpdate_var_1136114 = 0;
+        _vehicleUpdate_var_1136114 = enumValue(UpdateVar1136114Flags::none);
         updateTrackMotion(*_vehicleUpdate_var_113612C);
 
-        if (*_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::noRouteFound)
+        if (hasUpdateVar1136114Flags(UpdateVar1136114Flags::noRouteFound))
         {
             destroyTrain();
             return false;

--- a/src/OpenLoco/src/Vehicles/VehicleTail.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleTail.cpp
@@ -79,7 +79,7 @@ namespace OpenLoco::Vehicles
         _vehicleUpdate_var_1136114 = 0;
         updateTrackMotion(*_vehicleUpdate_var_113612C);
 
-        if (*_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::unk_m01)
+        if (*_vehicleUpdate_var_1136114 & UpdateVar1136114Flags::noRouteFound)
         {
             destroyTrain();
             return false;


### PR DESCRIPTION
I gave the unknown ones an m prefix to prevent name collisions, which slow down visual studios when renaming elements.

I named the ones I thought I knew the purpose of. In my opinion, better to name them on your hunch to get that self-documentation machine working.