### PR TITLE
Fix #2876: Screen freezes when lowering scale back to 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#2864] News messages are drawn incorrectly.
 - Fix: [#2866] Vehicles lengths with 0 in the tenths place being displayed incorrectly.
+- Fix: [#2876] Setting the UI scale back to 1.0 when using Fullscreen mode would freeze the screen.
 - Fix: [#2911] Forbidding trams/buses/trucks does not work as expected.
 - Fix: [#2917] Vehicles aren't available after adding them with the Object Selection window.
 - Fix: [#2931] Mouse movement not being frame rate independent, causing odd panning behavior.


### PR DESCRIPTION
Apparently SDL doesn't like mixing the two so we have to stick to the old way.

Close #2876