### PR TITLE
Use real tab widgets in object selection window

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -219,8 +219,6 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     // _tabObjectCounts can be integrated after implementing sub_473A95
     static loco_global<uint16_t[33], 0x00112C181> _tabObjectCounts;
 
-    // 0x0112C21C
-    static std::vector<TabPosition> _tabPositions;
     static std::vector<TabObjectEntry> _tabObjectList;
     static uint16_t _numVisibleObjectsListed;
     static bool _filterByVehicleType = false;
@@ -290,7 +288,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         Widgets::Tab({ 251, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
         Widgets::Tab({ 282, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
         Widgets::Tab({ 313, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 344, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab({ 344, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
 
         // Filter options
         makeDropdownWidgets({ 492, 20 }, { 100, 12 }, WindowColour::primary, StringIds::empty),
@@ -1194,13 +1192,16 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     {
         auto targetTab = 0;
         auto targetSubTab = 0;
-        auto targetType = kMainTabInfo[_tabPositions[0]].objectType;
+        auto targetType = ObjectType::region;
 
-        for (auto i = 0U; i < std::size(_tabPositions); i++)
+        for (auto i = 0U; i < kMaxNumPrimaryTabs; i++)
         {
-            auto mainIndex = _tabPositions[i];
-            auto& mainTabInfo = kMainTabInfo[mainIndex];
+            if (!shouldShowPrimaryTab(i, FilterLevel(self.filterLevel)))
+            {
+                continue;
+            }
 
+            auto& mainTabInfo = kMainTabInfo[i];
             if (objectType == mainTabInfo.objectType)
             {
                 targetTab = i;

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -372,18 +372,22 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     // 0x00473154
     static void assignTabPositions(Window* self)
     {
+        auto xPos = 3;
         for (auto i = 0U; i < kMainTabInfo.size(); i++)
         {
             auto widgetIndex = widx::primaryTab1 + i;
             if (shouldShowPrimaryTab(i, FilterLevel(self->filterLevel)))
             {
-                self->widgets[widgetIndex].type = WidgetType::tab;
                 self->enabledWidgets |= 1ULL << widgetIndex;
+                self->widgets[widgetIndex].type = WidgetType::tab;
+                self->widgets[widgetIndex].left = xPos;
+                self->widgets[widgetIndex].right = xPos + 31;
+                xPos = self->widgets[widgetIndex].right;
             }
             else
             {
-                self->widgets[widgetIndex].type = WidgetType::none;
                 self->enabledWidgets &= ~(1ULL << widgetIndex);
+                self->widgets[widgetIndex].type = WidgetType::none;
             }
         }
     }
@@ -565,14 +569,15 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     // 0x004733AC
     static void prepareDraw(Ui::Window& self)
     {
-        self.activatedWidgets |= (1 << widx::objectImage);
-        self.widgets[widx::closeButton].type = WidgetType::buttonWithImage;
+        self.activatedWidgets = (1 << widx::objectImage);
 
+        self.widgets[widx::closeButton].type = WidgetType::buttonWithImage;
         if (SceneManager::isEditorMode())
         {
             self.widgets[widx::closeButton].type = WidgetType::none;
         }
 
+        self.activatedWidgets |= 1ULL << (widx::primaryTab1 + self.currentTab);
         const auto& currentTab = kMainTabInfo[self.currentTab];
         const auto& subTabs = currentTab.subTabs;
         const bool showSecondaryTabs = !subTabs.empty() && FilterLevel(self.filterLevel) != FilterLevel::beginner;


### PR DESCRIPTION
This replaces the faux-tab area in the object selection window with real tab widgets, removing the need to emulate tab behaviour. This has been feasible for a while, since we split the tab strip in a primary and secondary area in #2629.