### PR TITLE
copy vehicle colours when cloning vehicle

### DIFF
--- a/src/OpenLoco/src/GameCommands/Vehicles/CloneVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/CloneVehicle.cpp
@@ -21,14 +21,7 @@ namespace OpenLoco::GameCommands
         auto* targetHead = target;
         while (sourceHead != nullptr && targetHead != nullptr)
         {
-            if (sourceHead->isBase<Vehicles::VehicleBody>())
-            {
-                targetHead->asBase<Vehicles::VehicleBody>()->colourScheme = sourceHead->asBase<Vehicles::VehicleBody>()->colourScheme;
-            }
-            if (sourceHead->isBase<Vehicles::VehicleBogie>())
-            {
-                targetHead->asBase<Vehicles::VehicleBogie>()->colourScheme = sourceHead->asBase<Vehicles::VehicleBogie>()->colourScheme;
-            }
+            targetHead->setColourScheme(sourceHead->getColourScheme());
             sourceHead = sourceHead->nextVehicleComponent();
             targetHead = targetHead->nextVehicleComponent();
         }

--- a/src/OpenLoco/src/GameCommands/Vehicles/CloneVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/CloneVehicle.cpp
@@ -15,6 +15,25 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::GameCommands
 {
+    static void copyVehicleColours(Vehicles::VehicleBase* source, Vehicles::VehicleBase* target)
+    {
+        auto* sourceHead = source;
+        auto* targetHead = target;
+        while (sourceHead != nullptr && targetHead != nullptr)
+        {
+            if (sourceHead->isBase<Vehicles::VehicleBody>())
+            {
+                targetHead->asBase<Vehicles::VehicleBody>()->colourScheme = sourceHead->asBase<Vehicles::VehicleBody>()->colourScheme;
+            }
+            if (sourceHead->isBase<Vehicles::VehicleBogie>())
+            {
+                targetHead->asBase<Vehicles::VehicleBogie>()->colourScheme = sourceHead->asBase<Vehicles::VehicleBogie>()->colourScheme;
+            }
+            sourceHead = sourceHead->nextVehicleComponent();
+            targetHead = targetHead->nextVehicleComponent();
+        }
+    }
+
     static uint32_t cloneVehicle(EntityId head, uint8_t flags)
     {
         static loco_global<EntityId, 0x0113642A> _113642A;
@@ -93,6 +112,8 @@ namespace OpenLoco::GameCommands
         {
             return FAILURE;
         }
+
+        copyVehicleColours(existingTrain.head, newHead);
 
         // Copy orders
         std::vector<std::shared_ptr<Vehicles::Order>> clonedOrders;

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -28,7 +28,7 @@ namespace OpenLoco::Vehicles
     // There are some common elements in the vehicle components at various offsets these can be accessed via VehicleBase
     struct VehicleCommon : VehicleBase
     {
-        ColourScheme colourScheme;
+        ColourScheme colourScheme;           // 0x24
         EntityId head;                       // 0x26
         int32_t remainingDistance;           // 0x28
         TrackAndDirection trackAndDirection; // 0x2C

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -28,7 +28,7 @@ namespace OpenLoco::Vehicles
     // There are some common elements in the vehicle components at various offsets these can be accessed via VehicleBase
     struct VehicleCommon : VehicleBase
     {
-        uint8_t pad_24[0x24 - 0x22];
+        ColourScheme colourScheme;
         EntityId head;                       // 0x26
         int32_t remainingDistance;           // 0x28
         TrackAndDirection trackAndDirection; // 0x2C
@@ -46,6 +46,12 @@ namespace OpenLoco::Vehicles
     };
     static_assert(sizeof(VehicleCommon) == 0x43); // Can't use offset_of change this to last field if more found
 #pragma pack(pop)
+
+    ColourScheme VehicleBase::getColourScheme()
+    {
+        auto* veh = reinterpret_cast<VehicleCommon*>(this);
+        return veh->colourScheme;
+    }
 
     VehicleBase* VehicleBase::nextVehicle()
     {

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -53,6 +53,12 @@ namespace OpenLoco::Vehicles
         return veh->colourScheme;
     }
 
+    void VehicleBase::setColourScheme(ColourScheme colourScheme)
+    {
+        auto* veh = reinterpret_cast<VehicleCommon*>(this);
+        veh->colourScheme = colourScheme;
+    }
+
     VehicleBase* VehicleBase::nextVehicle()
     {
         return EntityManager::get<VehicleBase>(nextEntityId);

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -296,6 +296,7 @@ namespace OpenLoco::Vehicles
         VehicleBase* nextVehicleComponent();
         VehicleBase* previousVehicleComponent();
         ColourScheme getColourScheme();
+        void setColourScheme(ColourScheme colourScheme);
         bool updateComponent();
         void explodeComponent();
         void sub_4AA464();

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -295,6 +295,7 @@ namespace OpenLoco::Vehicles
         VehicleBase* nextVehicle();
         VehicleBase* nextVehicleComponent();
         VehicleBase* previousVehicleComponent();
+        ColourScheme getColourScheme();
         bool updateComponent();
         void explodeComponent();
         void sub_4AA464();


### PR DESCRIPTION
Prerequisite of https://github.com/OpenLoco/OpenLoco/pull/2897

I still don't understand how trains are assembled. This was the easiest way I thought of to iterate over every component regardless of type.

![image](https://github.com/user-attachments/assets/1c6b56dc-8090-493e-a95a-e14537ab9943)

Tested with vehicles with bogies and bodies painted different colors. Works great.