### PR TITLE
Fix resize handle not being shown for some windows

### DIFF
--- a/src/OpenLoco/src/Ui/Widgets/PanelWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/PanelWidget.cpp
@@ -15,7 +15,7 @@ namespace OpenLoco::Ui::Widgets
             return;
         }
 
-        if (window->minHeight == window->maxHeight || window->minWidth == window->maxWidth)
+        if (window->minHeight == window->maxHeight && window->minWidth == window->maxWidth)
         {
             return;
         }


### PR DESCRIPTION
The resize handle was not being drawn for windows that are only resizeable on one axis.

Fixes #2927.