### PR TITLE
Use label widgets for message/news settings

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -446,10 +446,10 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             Widgets::Label({ 4, 92 }, { 230, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::competitor_minor_news),
             Widgets::dropdownWidgets({ 236, 92 }, { 124, 12 }, WindowColour::secondary),
 
-            Widgets::Label({ 4, 107 }, {2304, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::general_news),
+            Widgets::Label({ 4, 107 }, { 230, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::general_news),
             Widgets::dropdownWidgets({ 236, 107 }, { 124, 12 }, WindowColour::secondary),
 
-            Widgets::Label({ 4, 122 }, {2304, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::advice),
+            Widgets::Label({ 4, 122 }, { 230, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::advice),
             Widgets::dropdownWidgets({ 236, 122 }, { 124, 12 }, WindowColour::secondary),
 
             Widgets::Checkbox({ 4, 137 }, { 346, 12 }, WindowColour::secondary, StringIds::playNewsSoundEffects, StringIds::playNewsSoundEffectsTip)

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -27,6 +27,7 @@
 #include "Ui/Widgets/DropdownWidget.h"
 #include "Ui/Widgets/FrameWidget.h"
 #include "Ui/Widgets/ImageButtonWidget.h"
+#include "Ui/Widgets/LabelWidget.h"
 #include "Ui/Widgets/PanelWidget.h"
 #include "Ui/Widgets/ScrollViewWidget.h"
 #include "Ui/Widgets/TabWidget.h"
@@ -401,18 +402,30 @@ namespace OpenLoco::Ui::Windows::MessageWindow
 
         enum widx
         {
-            company_major_news = 6,
+            company_major_news_label = 6,
+            company_major_news,
             company_major_news_dropdown,
+
+            competitor_major_news_label,
             competitor_major_news,
             competitor_major_news_dropdown,
+
+            company_minor_news_label,
             company_minor_news,
             company_minor_news_dropdown,
+
+            competitor_minor_news_label,
             competitor_minor_news,
             competitor_minor_news_dropdown,
+
+            general_news_label,
             general_news,
             general_news_dropdown,
+
+            advice_label,
             advice,
             advice_dropdown,
+
             playSoundEffects,
         };
 
@@ -420,12 +433,25 @@ namespace OpenLoco::Ui::Windows::MessageWindow
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(366, 155, StringIds::title_messages),
+
+            Widgets::Label({ 4, 47 }, { 230, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::company_major_news),
             Widgets::dropdownWidgets({ 236, 47 }, { 124, 12 }, WindowColour::secondary),
+
+            Widgets::Label({ 4, 62 }, { 230, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::competitor_major_news),
             Widgets::dropdownWidgets({ 236, 62 }, { 124, 12 }, WindowColour::secondary),
+
+            Widgets::Label({ 4, 77 }, { 230, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::company_minor_news),
             Widgets::dropdownWidgets({ 236, 77 }, { 124, 12 }, WindowColour::secondary),
+
+            Widgets::Label({ 4, 92 }, { 230, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::competitor_minor_news),
             Widgets::dropdownWidgets({ 236, 92 }, { 124, 12 }, WindowColour::secondary),
+
+            Widgets::Label({ 4, 107 }, {2304, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::general_news),
             Widgets::dropdownWidgets({ 236, 107 }, { 124, 12 }, WindowColour::secondary),
+
+            Widgets::Label({ 4, 122 }, {2304, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::advice),
             Widgets::dropdownWidgets({ 236, 122 }, { 124, 12 }, WindowColour::secondary),
+
             Widgets::Checkbox({ 4, 137 }, { 346, 12 }, WindowColour::secondary, StringIds::playNewsSoundEffects, StringIds::playNewsSoundEffectsTip)
 
         );
@@ -541,27 +567,8 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             {
                 self.activatedWidgets &= ~(1 << widx::playSoundEffects);
             }
-        }
 
-        // 0x0042AA02
-        static void draw(Window& self, Gfx::DrawingContext& drawingCtx)
-        {
-            auto tr = Gfx::TextRenderer(drawingCtx);
-
-            self.draw(drawingCtx);
-            Common::drawTabs(&self, drawingCtx);
-            auto yPos = self.widgets[widx::company_major_news].top + self.y;
-
-            const StringId newsStringIds[] = {
-                StringIds::company_major_news,
-                StringIds::competitor_major_news,
-                StringIds::company_minor_news,
-                StringIds::competitor_minor_news,
-                StringIds::general_news,
-                StringIds::advice,
-            };
-
-            const StringId newsDropdownStringIds[] = {
+            constexpr StringId kNewsDropdownStringIds[] = {
                 StringIds::message_off,
                 StringIds::message_ticker,
                 StringIds::message_window,
@@ -569,24 +576,17 @@ namespace OpenLoco::Ui::Windows::MessageWindow
 
             for (auto i = 0; i < 6; i++)
             {
-                {
-                    auto args = FormatArguments();
-                    args.push(newsStringIds[i]);
-
-                    auto point = Point(self.x + 4, yPos);
-                    tr.drawStringLeft(point, Colour::black, StringIds::wcolour2_stringid, args);
-                }
-
-                {
-                    auto xPos = self.widgets[widx::company_major_news].left + self.x + 1;
-                    auto args = FormatArguments();
-                    args.push(newsDropdownStringIds[static_cast<uint8_t>(Config::get().old.newsSettings[i])]);
-
-                    auto point = Point(xPos, yPos);
-                    tr.drawStringLeft(point, Colour::black, StringIds::black_stringid, args);
-                }
-                yPos += 15;
+                auto widgetIndex = widx::company_major_news + (3 * i);
+                auto setting = static_cast<uint8_t>(Config::get().old.newsSettings[i]);
+                self.widgets[widgetIndex].text = kNewsDropdownStringIds[setting];
             }
+        }
+
+        // 0x0042AA02
+        static void draw(Window& self, Gfx::DrawingContext& drawingCtx)
+        {
+            self.draw(drawingCtx);
+            Common::drawTabs(&self, drawingCtx);
         }
 
         // 0x0042A7E8

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -400,6 +400,8 @@ namespace OpenLoco::Ui::Windows::MessageWindow
     {
         static constexpr Ui::Size32 kWindowSize = { 366, 155 };
 
+        static constexpr auto kNumWidgetsPerDropdown = 3;
+
         enum widx
         {
             company_major_news_label = 6,
@@ -480,25 +482,26 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             }
         }
 
+        constexpr StringId kNewsDropdownStringIds[] = {
+            StringIds::message_off,
+            StringIds::message_ticker,
+            StringIds::message_window,
+        };
+
         // 0x0042AA9F
         static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
         {
             switch (widgetIndex)
             {
-                case widx::company_major_news:
                 case widx::company_major_news_dropdown:
-                case widx::competitor_major_news:
                 case widx::competitor_major_news_dropdown:
-                case widx::company_minor_news:
                 case widx::company_minor_news_dropdown:
-                case widx::competitor_minor_news:
                 case widx::competitor_minor_news_dropdown:
-                case widx::general_news:
                 case widx::general_news_dropdown:
-                case widx::advice:
                 case widx::advice_dropdown:
                 {
-                    auto widget = self.widgets[widgetIndex - 1];
+                    auto wIndex = widgetIndex - 1;
+                    auto widget = self.widgets[wIndex];
                     auto xPos = widget.left + self.x;
                     auto yPos = widget.top + self.y;
                     auto width = widget.width() - 2;
@@ -507,13 +510,14 @@ namespace OpenLoco::Ui::Windows::MessageWindow
 
                     Dropdown::show(xPos, yPos, width, height, self.getColour(WindowColour::secondary), 3, flags);
 
-                    Dropdown::add(0, StringIds::dropdown_stringid, StringIds::message_off);
-                    Dropdown::add(1, StringIds::dropdown_stringid, StringIds::message_ticker);
-                    Dropdown::add(2, StringIds::dropdown_stringid, StringIds::message_window);
+                    for (auto i = 0U; i < std::size(kNewsDropdownStringIds); i++)
+                    {
+                        Dropdown::add(i, StringIds::dropdown_stringid, kNewsDropdownStringIds[i]);
+                    }
 
-                    auto dropdownIndex = Config::get().old.newsSettings[(widgetIndex - 7) / 2];
-
-                    Dropdown::setItemSelected(static_cast<size_t>(dropdownIndex));
+                    auto ddIndex = wIndex - widx::company_major_news;
+                    auto currentItem = Config::get().old.newsSettings[ddIndex / kNumWidgetsPerDropdown];
+                    Dropdown::setItemSelected(static_cast<size_t>(currentItem));
                     break;
                 }
             }
@@ -542,7 +546,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
                         return;
                     }
 
-                    auto dropdownIndex = (widgetIndex - 7) / 2;
+                    auto dropdownIndex = (widgetIndex - 7) / kNumWidgetsPerDropdown;
 
                     if (static_cast<Config::NewsType>(itemIndex) != Config::get().old.newsSettings[dropdownIndex])
                     {
@@ -568,15 +572,9 @@ namespace OpenLoco::Ui::Windows::MessageWindow
                 self.activatedWidgets &= ~(1 << widx::playSoundEffects);
             }
 
-            constexpr StringId kNewsDropdownStringIds[] = {
-                StringIds::message_off,
-                StringIds::message_ticker,
-                StringIds::message_window,
-            };
-
             for (auto i = 0; i < 6; i++)
             {
-                auto widgetIndex = widx::company_major_news + (3 * i);
+                auto widgetIndex = widx::company_major_news + (kNumWidgetsPerDropdown * i);
                 auto setting = static_cast<uint8_t>(Config::get().old.newsSettings[i]);
                 self.widgets[widgetIndex].text = kNewsDropdownStringIds[setting];
             }

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -528,17 +528,11 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         {
             switch (widgetIndex)
             {
-                case widx::company_major_news:
                 case widx::company_major_news_dropdown:
-                case widx::competitor_major_news:
                 case widx::competitor_major_news_dropdown:
-                case widx::company_minor_news:
                 case widx::company_minor_news_dropdown:
-                case widx::competitor_minor_news:
                 case widx::competitor_minor_news_dropdown:
-                case widx::general_news:
                 case widx::general_news_dropdown:
-                case widx::advice:
                 case widx::advice_dropdown:
                 {
                     if (itemIndex == -1)
@@ -546,11 +540,12 @@ namespace OpenLoco::Ui::Windows::MessageWindow
                         return;
                     }
 
-                    auto dropdownIndex = (widgetIndex - 7) / kNumWidgetsPerDropdown;
+                    auto dropdownIndex = (widgetIndex - widx::company_major_news) / kNumWidgetsPerDropdown;
+                    auto newValue = static_cast<Config::NewsType>(itemIndex);
 
-                    if (static_cast<Config::NewsType>(itemIndex) != Config::get().old.newsSettings[dropdownIndex])
+                    if (newValue != Config::get().old.newsSettings[dropdownIndex])
                     {
-                        Config::get().old.newsSettings[dropdownIndex] = static_cast<Config::NewsType>(itemIndex);
+                        Config::get().old.newsSettings[dropdownIndex] = newValue;
                         Config::write();
                         Gfx::invalidateScreen();
                     }


### PR DESCRIPTION
Addresses a recent regression while also improving the code slightly.

Before:
<img width="564" alt="Screenshot_2025-02-16_at_13 38 12" src="https://github.com/user-attachments/assets/1d80a11a-13f9-4ad1-b9f4-ab22a36651c4" />

After:
<img width="562" alt="Screenshot 2025-02-16 at 14 02 37" src="https://github.com/user-attachments/assets/be5ca76d-1c13-4b30-b5ca-90bf397f5f11" />
