### PR TITLE
Draw all widgets in windows relative position, also clip rt

### DIFF
--- a/src/OpenLoco/src/Ui/Dropdown.cpp
+++ b/src/OpenLoco/src/Ui/Dropdown.cpp
@@ -215,8 +215,8 @@ namespace OpenLoco::Ui::Dropdown
                 {
                     if (itemCount == _dropdownHighlightedIndex)
                     {
-                        auto x = _windowDropdownOnpaintCellX * _dropdownItemWidth + self.x + 2;
-                        auto y = _windowDropdownOnpaintCellY * _dropdownItemHeight + self.y + 2;
+                        auto x = _windowDropdownOnpaintCellX * _dropdownItemWidth + 2;
+                        auto y = _windowDropdownOnpaintCellY * _dropdownItemHeight + 2;
                         drawingCtx.drawRect(x, y, _dropdownItemWidth, _dropdownItemHeight, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
                     }
 
@@ -253,8 +253,8 @@ namespace OpenLoco::Ui::Dropdown
                                 }
                             }
 
-                            auto x = _windowDropdownOnpaintCellX * _dropdownItemWidth + self.x + 2;
-                            auto y = _windowDropdownOnpaintCellY * _dropdownItemHeight + self.y + 1;
+                            auto x = _windowDropdownOnpaintCellX * _dropdownItemWidth + 2;
+                            auto y = _windowDropdownOnpaintCellY * _dropdownItemHeight + 1;
                             auto width = self.width - 5;
                             sub_494BF6(&self, drawingCtx, dropdownItemFormat, x, y, width, colour, args);
                         }
@@ -262,8 +262,8 @@ namespace OpenLoco::Ui::Dropdown
 
                     if (dropdownItemFormat == (StringId)-2 || dropdownItemFormat == StringIds::null)
                     {
-                        auto x = _windowDropdownOnpaintCellX * _dropdownItemWidth + self.x + 2;
-                        auto y = _windowDropdownOnpaintCellY * _dropdownItemHeight + self.y + 2;
+                        auto x = _windowDropdownOnpaintCellX * _dropdownItemWidth + 2;
+                        auto y = _windowDropdownOnpaintCellY * _dropdownItemHeight + 2;
 
                         auto imageId = *(uint32_t*)&args;
                         if (dropdownItemFormat == (StringId)-2 && itemCount == _dropdownHighlightedIndex)
@@ -275,8 +275,8 @@ namespace OpenLoco::Ui::Dropdown
                 }
                 else
                 {
-                    auto x = _windowDropdownOnpaintCellX * _dropdownItemWidth + self.x + 2;
-                    auto y = _windowDropdownOnpaintCellY * _dropdownItemHeight + self.y + 1 + _dropdownItemHeight / 2;
+                    auto x = _windowDropdownOnpaintCellX * _dropdownItemWidth + 2;
+                    auto y = _windowDropdownOnpaintCellY * _dropdownItemHeight + 1 + _dropdownItemHeight / 2;
 
                     if (!self.getColour(WindowColour::primary).isTranslucent())
                     {

--- a/src/OpenLoco/src/Ui/Widget.cpp
+++ b/src/OpenLoco/src/Ui/Widget.cpp
@@ -101,8 +101,8 @@ namespace OpenLoco::Ui
         auto widget = &w->widgets[index];
 
         Ui::Point pos = {};
-        pos.x = widget->left + w->x;
-        pos.y = widget->top + w->y;
+        pos.x = widget->left;
+        pos.y = widget->top;
 
         if (w->isDisabled(index))
         {

--- a/src/OpenLoco/src/Ui/Widgets/ButtonWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ButtonWidget.cpp
@@ -11,15 +11,13 @@ namespace OpenLoco::Ui::Widgets
     // 0x004CB164
     void Button::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        const auto* window = widgetState.window;
-
         auto flags = widgetState.flags;
         if (widgetState.activated)
         {
             flags |= Gfx::RectInsetFlags::borderInset;
         }
 
-        drawingCtx.fillRectInset(window->position() + widget.position(), widget.size(), widgetState.colour, flags);
+        drawingCtx.fillRectInset(widget.position(), widget.size(), widgetState.colour, flags);
 
         Label::draw(drawingCtx, widget, widgetState);
     }

--- a/src/OpenLoco/src/Ui/Widgets/CaptionWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/CaptionWidget.cpp
@@ -12,11 +12,9 @@ namespace OpenLoco::Ui::Widgets
     // 0x004CA6AE
     static void drawBoxed(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        auto* window = widgetState.window;
-
         auto tr = Gfx::TextRenderer(drawingCtx);
 
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         const auto size = widget.size();
 
         drawingCtx.fillRectInset(
@@ -75,9 +73,7 @@ namespace OpenLoco::Ui::Widgets
 
         StringManager::formatString(&stringBuffer[1], widget.text, formatArgs);
 
-        auto* window = widgetState.window;
-
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         const auto size = widget.size();
 
         int16_t width = size.width - 4 - 14;

--- a/src/OpenLoco/src/Ui/Widgets/CheckboxWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/CheckboxWidget.cpp
@@ -12,9 +12,7 @@ namespace OpenLoco::Ui::Widgets
     // 0x004CB00B
     static void drawCheckBox(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        auto* window = widgetState.window;
-
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
 
         drawingCtx.fillRectInset(
             pos,
@@ -55,12 +53,11 @@ namespace OpenLoco::Ui::Widgets
         }
 
         auto formatArgs = FormatArguments(widget.textArgs);
-        auto* window = widgetState.window;
 
         auto tr = Gfx::TextRenderer(drawingCtx);
         tr.setCurrentFont(widget.font);
 
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         tr.drawStringLeft(pos + Point{ kCheckMarkSize.width + kLabelMarginLeft, 0 }, colour, widget.text, formatArgs);
     }
 

--- a/src/OpenLoco/src/Ui/Widgets/ColourButtonWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ColourButtonWidget.cpp
@@ -35,9 +35,7 @@ namespace OpenLoco::Ui::Widgets
             imageId = imageId.withPrimary(widgetState.colour.c());
         }
 
-        auto* window = widgetState.window;
-
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         drawingCtx.drawImage(pos, imageId);
     }
 }

--- a/src/OpenLoco/src/Ui/Widgets/DropdownWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/DropdownWidget.cpp
@@ -26,9 +26,7 @@ namespace OpenLoco::Ui::Widgets
             colour = colour.FD();
         }
 
-        auto* window = widgetStated.window;
-
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         const auto size = widget.size();
 
         auto tr = Gfx::TextRenderer(drawingCtx);
@@ -39,9 +37,7 @@ namespace OpenLoco::Ui::Widgets
     // 0x004CB164
     void ComboBox::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        const auto* window = widgetState.window;
-
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         const auto size = widget.size();
 
         const auto flags = widgetState.flags | Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillDarker;

--- a/src/OpenLoco/src/Ui/Widgets/FrameWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/FrameWidget.cpp
@@ -21,7 +21,7 @@ namespace OpenLoco::Ui::Widgets
             return;
         }
 
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         const auto size = widget.size();
 
         const auto resizeBarPos = pos + Ui::Point(size.width - 18, size.height - 18);
@@ -35,7 +35,7 @@ namespace OpenLoco::Ui::Widgets
     {
         auto* window = widgetState.window;
 
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         const auto size = widget.size();
 
         const auto& rt = drawingCtx.currentRenderTarget();

--- a/src/OpenLoco/src/Ui/Widgets/GroupBoxWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/GroupBoxWidget.cpp
@@ -8,9 +8,7 @@ namespace OpenLoco::Ui::Widgets
 {
     void GroupBox::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        auto* window = widgetState.window;
-
-        const auto position = window->position() + widget.position();
+        const auto position = widget.position();
         const auto size = widget.size();
 
         auto colour = widgetState.colour.opaque();

--- a/src/OpenLoco/src/Ui/Widgets/ImageButtonWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ImageButtonWidget.cpp
@@ -11,9 +11,7 @@ namespace OpenLoco::Ui::Widgets
     // 0x004CADE8
     static void drawImage(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        auto* window = widgetState.window;
-
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
 
         const bool isColourSet = widget.image & Widget::kImageIdColourSet;
         ImageId imageId = ImageId::fromUInt32(widget.image & ~Widget::kImageIdColourSet);
@@ -70,7 +68,7 @@ namespace OpenLoco::Ui::Widgets
     {
         auto* window = widgetState.window;
 
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         const auto size = widget.size();
 
         auto flags = widgetState.flags;
@@ -112,9 +110,7 @@ namespace OpenLoco::Ui::Widgets
             return;
         }
 
-        auto* window = widgetState.window;
-
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         const auto size = widget.size();
 
         if (widgetState.activated)

--- a/src/OpenLoco/src/Ui/Widgets/LabelWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/LabelWidget.cpp
@@ -23,8 +23,7 @@ namespace OpenLoco::Ui::Widgets
             colour = colour.inset();
         }
 
-        auto* window = widgetState.window;
-        const auto position = window->position() + widget.position();
+        const auto position = widget.position();
         const auto size = widget.size();
 
         auto formatArgs = FormatArguments(widget.textArgs);

--- a/src/OpenLoco/src/Ui/Widgets/NewsPanelWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/NewsPanelWidget.cpp
@@ -8,11 +8,9 @@
 
 namespace OpenLoco::Ui::Widgets
 {
-    void NewsPanel::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
+    void NewsPanel::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, [[maybe_unused]] const WidgetState& widgetState)
     {
-        auto* window = widgetState.window;
-
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         const auto centerPos = pos + Point(widget.width() / 2, 0);
 
         const auto style = static_cast<Style>(widget.styleData);

--- a/src/OpenLoco/src/Ui/Widgets/PanelWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/PanelWidget.cpp
@@ -20,7 +20,7 @@ namespace OpenLoco::Ui::Widgets
             return;
         }
 
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         const auto size = widget.size();
 
         const auto resizeBarPos = pos + Ui::Point(size.width - 18, size.height - 18);
@@ -34,7 +34,7 @@ namespace OpenLoco::Ui::Widgets
     {
         auto* window = widgetState.window;
 
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         const auto size = widget.size();
 
         drawingCtx.fillRectInset(

--- a/src/OpenLoco/src/Ui/Widgets/ScrollViewWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ScrollViewWidget.cpp
@@ -17,8 +17,7 @@ namespace OpenLoco::Ui::Widgets
 
     static void drawHScroll(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState, const ScrollArea& scrollArea)
     {
-        auto* window = widgetState.window;
-        const auto position = window->position() + widget.position();
+        const auto position = widget.position();
         const auto size = widget.size();
         const auto colour = widgetState.colour;
 
@@ -94,8 +93,7 @@ namespace OpenLoco::Ui::Widgets
 
     static void drawVScroll(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState, const ScrollArea& scrollArea)
     {
-        auto* window = widgetState.window;
-        const auto position = window->position() + widget.position();
+        const auto position = widget.position();
         const auto size = widget.size();
         const auto colour = widgetState.colour;
 
@@ -172,7 +170,7 @@ namespace OpenLoco::Ui::Widgets
     void ScrollView::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
         auto* window = widgetState.window;
-        const auto position = window->position() + widget.position();
+        const auto position = widget.position();
         const auto size = widget.size();
 
         auto tr = Gfx::TextRenderer(drawingCtx);

--- a/src/OpenLoco/src/Ui/Widgets/TabWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/TabWidget.cpp
@@ -9,9 +9,7 @@ namespace OpenLoco::Ui::Widgets
     // 0x004CADE8
     static void drawTabBackground(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        auto* window = widgetState.window;
-
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
 
         ImageId imageId = ImageId{ ImageIds::tab };
 
@@ -59,7 +57,7 @@ namespace OpenLoco::Ui::Widgets
     {
         auto* window = widgetState.window;
 
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
 
         if (widgetState.disabled)
         {

--- a/src/OpenLoco/src/Ui/Widgets/TextBoxWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/TextBoxWidget.cpp
@@ -23,9 +23,7 @@ namespace OpenLoco::Ui::Widgets
             colour = colour.FD();
         }
 
-        auto* window = widgetStated.window;
-
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         const auto size = widget.size();
 
         auto tr = Gfx::TextRenderer(drawingCtx);
@@ -36,9 +34,7 @@ namespace OpenLoco::Ui::Widgets
     // 0x4CB29C
     void TextBox::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        auto* window = widgetState.window;
-
-        const auto pos = window->position() + widget.position();
+        const auto pos = widget.position();
         const auto size = widget.size();
 
         const auto flags = widgetState.flags | Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillDarker;

--- a/src/OpenLoco/src/Ui/Widgets/ViewportWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ViewportWidget.cpp
@@ -24,8 +24,7 @@ namespace OpenLoco::Ui::Widgets
         }
 
         auto formatArgs = FormatArguments(widget.textArgs);
-        auto* window = widgetStated.window;
-        auto point = Point(window->x + widget.left + 1, window->y + widget.top);
+        auto point = Point(widget.left + 1, widget.top);
         int width = widget.right - widget.left - 2;
 
         auto tr = Gfx::TextRenderer(drawingCtx);

--- a/src/OpenLoco/src/Ui/Widgets/Wt3Widget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/Wt3Widget.cpp
@@ -62,10 +62,10 @@ namespace OpenLoco::Ui::Widgets
         const auto size = widget.size();
 
         int16_t t, l, b, r;
-        t = window->y + widget.top;
-        l = window->x + widget.left;
-        r = window->x + widget.right;
-        b = window->y + widget.bottom;
+        t = widget.top;
+        l = widget.left;
+        r = widget.right;
+        b = widget.bottom;
 
         auto flags = widgetState.flags;
         if (widgetState.activated)

--- a/src/OpenLoco/src/Ui/Widgets/Wt3Widget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/Wt3Widget.cpp
@@ -6,9 +6,7 @@ namespace OpenLoco::Ui::Widgets
 {
     static void sub_4CADE8(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        auto* window = widgetState.window;
-
-        const auto position = window->position() + widget.position();
+        const auto position = widget.position();
 
         const bool isColourSet = widget.image & Widget::kImageIdColourSet;
         ImageId imageId = ImageId::fromUInt32(widget.image & ~Widget::kImageIdColourSet);
@@ -60,7 +58,7 @@ namespace OpenLoco::Ui::Widgets
     {
         auto* window = widgetState.window;
 
-        const auto position = window->position() + widget.position();
+        const auto position = widget.position();
         const auto size = widget.size();
 
         int16_t t, l, b, r;

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -1281,22 +1281,6 @@ namespace OpenLoco::Ui
     // 0x004CA4DF
     void Window::draw(Gfx::DrawingContext& drawingCtx)
     {
-        // Clip render target to window rect.
-        const auto windowRect = Ui::Rect{
-            x,
-            y,
-            width,
-            height,
-        };
-
-        auto windowRT = Gfx::clipRenderTarget(drawingCtx.currentRenderTarget(), windowRect);
-        if (!windowRT.has_value())
-        {
-            return;
-        }
-
-        drawingCtx.pushRenderTarget(*windowRT);
-
         if (this->hasFlags(WindowFlags::transparent) && !this->hasFlags(WindowFlags::noBackground))
         {
             drawingCtx.fillRect(0, 0, this->width - 1, this->height - 1, enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
@@ -1347,8 +1331,6 @@ namespace OpenLoco::Ui
                 Colour::white,
                 Gfx::RectInsetFlags::fillNone);
         }
-
-        drawingCtx.popRenderTarget();
     }
 
     WidgetIndex_t Window::firstActivatedWidgetInRange(WidgetIndex_t minIndex, WidgetIndex_t maxIndex)

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -874,18 +874,6 @@ namespace OpenLoco::Ui
         this->x += dx;
         this->y += dy;
 
-        if (this->viewports[0] != nullptr)
-        {
-            this->viewports[0]->x += dx;
-            this->viewports[0]->y += dy;
-        }
-
-        if (this->viewports[1] != nullptr)
-        {
-            this->viewports[1]->x += dx;
-            this->viewports[1]->y += dy;
-        }
-
         this->invalidate();
 
         return true;
@@ -933,18 +921,6 @@ namespace OpenLoco::Ui
         this->x += offset.x;
         this->y += offset.y;
         this->invalidate();
-
-        if (this->viewports[0] != nullptr)
-        {
-            this->viewports[0]->x += offset.x;
-            this->viewports[0]->y += offset.y;
-        }
-
-        if (this->viewports[1] != nullptr)
-        {
-            this->viewports[1]->x += offset.x;
-            this->viewports[1]->y += offset.y;
-        }
     }
 
     bool Window::moveToCentre()

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -1501,16 +1501,6 @@ namespace OpenLoco::Ui::WindowManager
                 int dY = bottom + 3 - w.y;
                 w.y += dY;
                 w.invalidate();
-
-                if (w.viewports[0] != nullptr)
-                {
-                    w.viewports[0]->y += dY;
-                }
-
-                if (w.viewports[1] != nullptr)
-                {
-                    w.viewports[1]->y += dY;
-                }
             }
         }
     }

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -1426,26 +1426,11 @@ namespace OpenLoco::Ui::WindowManager
             if (extendsX || extendsY)
             {
                 // Calculate the new locations
-                int16_t oldX = w.x;
-                int16_t oldY = w.y;
                 w.x = newLocation;
                 w.y = newLocation + 28;
 
                 // Move the next new location so windows are not directly on top
                 newLocation += 8;
-
-                // Adjust the viewports if required.
-                if (w.viewports[0] != nullptr)
-                {
-                    w.viewports[0]->x -= oldX - w.x;
-                    w.viewports[0]->y -= oldY - w.y;
-                }
-
-                if (w.viewports[1] != nullptr)
-                {
-                    w.viewports[1]->x -= oldX - w.x;
-                    w.viewports[1]->y -= oldY - w.y;
-                }
             }
         }
     }

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -1320,7 +1320,21 @@ namespace OpenLoco::Ui::WindowManager
         setWindowColours(WindowColour::tertiary, w->getColour(WindowColour::tertiary).opaque());
         setWindowColours(WindowColour::quaternary, w->getColour(WindowColour::quaternary).opaque());
 
-        drawingCtx.pushRenderTarget(rt);
+        // Clip render target to window rect.
+        const auto windowRect = Ui::Rect{
+            w->x,
+            w->y,
+            w->width,
+            w->height,
+        };
+
+        auto windowRT = Gfx::clipRenderTarget(rt, windowRect);
+        if (!windowRT.has_value())
+        {
+            return;
+        }
+
+        drawingCtx.pushRenderTarget(*windowRT);
 
         w->callPrepareDraw();
         w->callDraw(drawingCtx);

--- a/src/OpenLoco/src/Ui/Windows/About.cpp
+++ b/src/OpenLoco/src/Ui/Windows/About.cpp
@@ -95,7 +95,7 @@ namespace OpenLoco::Ui::Windows::About
         window.draw(drawingCtx);
 
         // Chris Sawyer logo
-        drawingCtx.drawImage(window.x + 92, window.y + 52, ImageIds::chris_sawyer_logo_small);
+        drawingCtx.drawImage(92, 52, ImageIds::chris_sawyer_logo_small);
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -1238,7 +1238,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         strncpy(textBuffer, inputSession.buffer.c_str(), 256);
 
         auto& widget = _widgets[widx::searchBox];
-        auto clipped = Gfx::clipRenderTarget(drawingCtx.currentRenderTarget(), Ui::Rect(self.x + widget.left, widget.top + 1 + self.y, widget.width() - 2, widget.height() - 2));
+        auto clipped = Gfx::clipRenderTarget(drawingCtx.currentRenderTarget(), Ui::Rect(widget.left, widget.top + 1, widget.width() - 2, widget.height() - 2));
         if (!clipped)
         {
             return;
@@ -1293,7 +1293,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 }
             }
 
-            auto point = Point(window.x + 2, window.y + window.height - 13);
+            auto point = Point(2, window.height - 13);
             tr.drawStringLeftClipped(point, window.width - 186, Colour::black, bottomLeftMessage, args);
         }
 
@@ -1307,7 +1307,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
             args.push(cargoObj->unitInlineSprite);
 
             auto& widget = window.widgets[widx::cargoLabel];
-            auto point = Point(window.x + widget.left + 2, window.y + widget.top);
+            auto point = Point(widget.left + 2, widget.top);
             tr.drawStringLeftClipped(point, widget.width() - 15, Colour::black, StringIds::wcolour2_stringid, args);
         }
 
@@ -1432,8 +1432,8 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
 
         vehicleObj->getCargoString(buffer);
 
-        auto x = window.widgets[widx::scrollview_vehicle_selection].right + window.x + 2;
-        auto y = window.widgets[widx::scrollview_vehicle_preview].bottom + window.y + 2;
+        auto x = window.widgets[widx::scrollview_vehicle_selection].right + 2;
+        auto y = window.widgets[widx::scrollview_vehicle_preview].bottom + 2;
         tr.drawStringLeftWrapped(Point(x, y), 180, Colour::black, StringIds::buffer_1250);
     }
 
@@ -1744,14 +1744,14 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         auto skin = ObjectManager::get<InterfaceSkinObject>();
         auto companyColour = CompanyManager::getCompanyColour(CompanyId(window->number));
 
-        auto left = window->x;
-        auto top = window->y + 69;
+        auto left = 0;
+        auto top = 69;
         auto right = left + window->width - 187;
         auto bottom = top;
         drawingCtx.fillRect(left, top, right, bottom, Colours::getShade(window->getColour(WindowColour::secondary).c(), 7), Gfx::RectFlags::none);
 
-        left = window->x + window->width - 187;
-        top = window->y + 41;
+        left = window->width - 187;
+        top = 41;
         right = left;
         bottom = top + 27;
         drawingCtx.fillRect(left, top, right, bottom, Colours::getShade(window->getColour(WindowColour::secondary).c(), 7), Gfx::RectFlags::none);
@@ -1761,8 +1761,8 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
             const auto widget = window->widgets[tab + widx::tab_track_type_0];
             if (window->currentSecondaryTab == tab)
             {
-                left = widget.left + window->x + 1;
-                top = widget.top + window->y + 26;
+                left = widget.left + 1;
+                top = widget.top + 26;
                 right = left + 29;
                 bottom = top;
                 drawingCtx.fillRect(left, top, right, bottom, Colours::getShade(window->getColour(WindowColour::secondary).c(), 5), Gfx::RectFlags::none);

--- a/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
@@ -275,10 +275,10 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
 
         {
             const auto colour = Colours::getShade(self.getColour(WindowColour::secondary).c(), 0);
-            const auto l = self.x + 1 + self.widgets[widx::face_frame].left;
-            const auto t = self.y + 1 + self.widgets[widx::face_frame].top;
-            const auto r = self.x - 1 + self.widgets[widx::face_frame].right;
-            const auto b = self.y - 1 + self.widgets[widx::face_frame].bottom;
+            const auto l = self.widgets[widx::face_frame].left + 1;
+            const auto t = self.widgets[widx::face_frame].top + 1;
+            const auto r = self.widgets[widx::face_frame].right - 1;
+            const auto b = self.widgets[widx::face_frame].bottom - 1;
             drawingCtx.fillRect(l, t, r, b, colour, Gfx::RectFlags::none);
 
             const CompetitorObject* competitor = reinterpret_cast<CompetitorObject*>(ObjectManager::getTemporaryObject());
@@ -287,8 +287,8 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
         }
 
         {
-            const auto x = self.x + self.widgets[widx::face_frame].midX();
-            const auto y = self.y + self.widgets[widx::face_frame].bottom + 3;
+            const auto x = self.widgets[widx::face_frame].midX();
+            const auto y = self.widgets[widx::face_frame].bottom + 3;
             const auto width = self.width - self.widgets[widx::scrollview].right - 6;
             auto str = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
             *str++ = ControlCodes::windowColour2;

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -682,8 +682,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             self.draw(drawingCtx);
             Common::drawTabs(&self, drawingCtx);
 
-            _graphSettings.left = self.x + 4;
-            _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 4;
+            _graphSettings.left = 4;
+            _graphSettings.top = self.widgets[Common::widx::panel].top + 4;
             _graphSettings.width = self.width - kLegendWidth - kLegendMargin - 2 * kWindowPadding;
             _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
@@ -775,8 +775,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             self.draw(drawingCtx);
             Common::drawTabs(&self, drawingCtx);
 
-            _graphSettings.left = self.x + 4;
-            _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 4;
+            _graphSettings.left = 4;
+            _graphSettings.top = self.widgets[Common::widx::panel].top + 4;
             _graphSettings.width = self.width - kLegendWidth - kLegendMargin - 2 * kWindowPadding;
             _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
@@ -868,8 +868,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             self.draw(drawingCtx);
             Common::drawTabs(&self, drawingCtx);
 
-            _graphSettings.left = self.x + 4;
-            _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 4;
+            _graphSettings.left = 4;
+            _graphSettings.top = self.widgets[Common::widx::panel].top + 4;
             _graphSettings.width = self.width - kLegendWidth - kLegendMargin - 2 * kWindowPadding;
             _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
@@ -961,8 +961,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             self.draw(drawingCtx);
             Common::drawTabs(&self, drawingCtx);
 
-            _graphSettings.left = self.x + 4;
-            _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 4;
+            _graphSettings.left = 4;
+            _graphSettings.top = self.widgets[Common::widx::panel].top + 4;
             _graphSettings.width = self.width - kLegendWidth - kLegendMargin - 2 * kWindowPadding;
             _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
@@ -1131,8 +1131,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             self.draw(drawingCtx);
             Common::drawTabs(&self, drawingCtx);
 
-            _graphSettings.left = self.x + 4;
-            _graphSettings.top = self.y + self.widgets[Common::widx::panel].top + 14;
+            _graphSettings.left = 4;
+            _graphSettings.top = self.widgets[Common::widx::panel].top + 14;
             _graphSettings.width = self.width - kLegendWidth - kLegendMargin - 2 * kWindowPadding;
             _graphSettings.height = self.height - self.widgets[Common::widx::panel].top - 20 - 2 * kWindowPadding;
             _graphSettings.yOffset = 17;
@@ -1198,8 +1198,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             }
 
             {
-                auto x = self.width + self.x - kLegendWidth - kWindowPadding;
-                auto y = self.y + 52;
+                auto x = self.width - kLegendWidth - kWindowPadding;
+                auto y = 52;
 
                 drawGraphLegend(&self, drawingCtx, x, y);
             }
@@ -1208,7 +1208,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             // Chart title
             {
-                auto point = Point(self.x + canvasMidX, self.widgets[Common::widx::panel].top + self.y + 1);
+                auto point = Point(canvasMidX, self.widgets[Common::widx::panel].top + 1);
 
                 FormatArguments args{};
                 args.push<uint16_t>(100);
@@ -1219,7 +1219,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             // X axis label ("Transit time")
             {
-                auto point = Point(self.x + canvasMidX, self.height + self.y - 13);
+                auto point = Point(canvasMidX, self.height - 13);
 
                 tr.drawStringCentred(point, Colour::black, StringIds::cargo_transit_time);
             }
@@ -1335,7 +1335,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                         StringIds::water_speed_record,
                     };
 
-                    auto point = Point(self.x + 4, y);
+                    auto point = Point(4, y);
                     tr.drawStringLeft(point, Colour::black, string[i], args);
                 }
                 y += 11;
@@ -1350,11 +1350,11 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     auto imageId = competitorObj->images[enumValue(company->ownerEmotion)];
                     imageId = Gfx::recolour(imageId, company->mainColours.primary);
 
-                    auto x = self.x + 4;
+                    auto x = 4;
                     drawingCtx.drawImage(x, y, imageId);
 
                     y += 7;
-                    auto point = Point(self.x + 33, y);
+                    auto point = Point(33, y);
 
                     FormatArguments args{};
                     args.push(company->name);
@@ -1692,7 +1692,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 if (!(self->isDisabled(widx::tab_values)))
                 {
                     auto& widget = self->widgets[widx::tab_values];
-                    auto point = Point(widget.left + self->x + 28, widget.top + self->y + 14 + 1);
+                    auto point = Point(widget.left + 28, widget.top + 14 + 1);
                     tr.drawStringRight(point, Colour::black, StringIds::currency_symbol);
                 }
             }
@@ -1708,7 +1708,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 if (!(self->isDisabled(widx::tab_payment_rates)))
                 {
                     auto& widget = self->widgets[widx::tab_payment_rates];
-                    auto point = Point(widget.left + self->x + 28, widget.top + self->y + 14 + 1);
+                    auto point = Point(widget.left + 28, widget.top + 14 + 1);
                     tr.drawStringRight(point, Colour::black, StringIds::currency_symbol);
                 }
             }
@@ -1801,8 +1801,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 Ui::drawGraph(_graphSettings, self, drawingCtx);
             }
 
-            auto x = self->width + self->x - kLegendWidth - kWindowPadding;
-            auto y = self->y + 52;
+            auto x = self->width - kLegendWidth - kWindowPadding;
+            auto y = 52;
 
             Common::drawGraphLegend(self, drawingCtx, x, y);
         }

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -1316,7 +1316,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
             self.draw(drawingCtx);
             Common::drawTabs(&self, drawingCtx);
 
-            auto y = self.y + 47;
+            auto y = 47;
 
             for (auto i = 0; i < 3; i++)
             {

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -220,7 +220,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             // Draw 'owner' label
             {
                 auto& widget = self.widgets[widx::face];
-                auto point = Point(self.x + (widget.left + widget.right) / 2, self.y + widget.top - 12);
+                auto point = Point((widget.left + widget.right) / 2, widget.top - 12);
                 tr.drawStringCentred(
                     point,
                     Colour::black,
@@ -230,8 +230,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             // Draw company owner image.
             {
                 const uint32_t image = Gfx::recolour(competitor->images[enumValue(company->ownerEmotion)] + 1, company->mainColours.primary);
-                const uint16_t x = self.x + self.widgets[widx::face].left + 1;
-                const uint16_t y = self.y + self.widgets[widx::face].top + 1;
+                const uint16_t x = self.widgets[widx::face].left + 1;
+                const uint16_t y = self.widgets[widx::face].top + 1;
                 drawingCtx.drawImage(x, y, image);
             }
 
@@ -239,8 +239,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             if (company->jailStatus != 0)
             {
                 const uint32_t image = ImageIds::owner_jailed;
-                const uint16_t x = self.x + self.widgets[widx::face].left + 1;
-                const uint16_t y = self.y + self.widgets[widx::face].top + 1;
+                const uint16_t x = self.widgets[widx::face].left + 1;
+                const uint16_t y = self.widgets[widx::face].top + 1;
                 drawingCtx.drawImage(x, y, image);
             }
 
@@ -250,7 +250,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 args.push(company->ownerName);
 
                 auto& widget = self.widgets[widx::change_owner_name];
-                auto origin = Ui::Point(self.x + (widget.left + widget.right) / 2, self.y + widget.top + 5);
+                auto origin = Ui::Point((widget.left + widget.right) / 2, widget.top + 5);
                 tr.drawStringCentredWrapped(
                     origin,
                     widget.right - widget.left,
@@ -271,7 +271,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 CompanyManager::getOwnerStatus(CompanyId(self.number), args);
 
                 auto& widget = self.widgets[widx::unk_11];
-                auto point = Point(self.x + widget.left - 1, self.y + widget.top - 1);
+                auto point = Point(widget.left - 1, widget.top - 1);
                 tr.drawStringLeftClipped(
                     point,
                     widget.right - widget.left,
@@ -806,8 +806,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             Common::drawCompanySelect(&self, drawingCtx);
 
             auto company = CompanyManager::get(CompanyId(self.number));
-            auto x = self.x + 3;
-            auto y = self.y + 48;
+            auto x = 3;
+            auto y = 48;
             {
                 FormatArguments args{};
                 args.push(company->startedDate);
@@ -869,14 +869,14 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             {
                 auto& widget = self.widgets[widx::viewport];
-                auto point = Point(self.x + widget.midX(), self.y + widget.top - 12);
+                auto point = Point(widget.midX(), widget.top - 12);
                 tr.drawStringCentred(point, Colour::black, StringIds::wcolour2_headquarters);
             }
 
             if (company->headquartersX == -1)
             {
                 auto& widget = self.widgets[widx::viewport];
-                auto loc = Point(self.x + widget.midX(), self.y + widget.midY() - 5);
+                auto loc = Point(widget.midX(), widget.midY() - 5);
                 auto width = widget.width() - 2;
                 tr.drawStringCentredWrapped(loc, width, Colour::black, StringIds::not_yet_constructed);
             }
@@ -1438,7 +1438,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             Common::drawCompanySelect(&self, drawingCtx);
 
             const auto& widget = self.widgets[widx::main_colour_scheme];
-            auto point = Point(self.x + 6, self.y + widget.top + 3);
+            auto point = Point(6, widget.top + 3);
 
             // 'Main colour scheme'
             tr.drawStringLeft(
@@ -1788,7 +1788,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // Draw 'expenditure/income' label
             {
-                auto point = Point(self.x + 5, self.y + 47);
+                auto point = Point(5, 47);
                 tr.drawStringLeftUnderline(
                     point,
                     Colour::black,
@@ -1815,20 +1815,20 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 StringIds::miscellaneous,
             };
 
-            uint16_t y = self.y + 62;
+            uint16_t y = 62;
             for (uint8_t i = 0; i < static_cast<uint8_t>(std::size(ExpenditureLabels)); i++)
             {
                 // Add zebra stripes to even labels.
                 if (i % 2 == 0)
                 {
                     auto colour = Colours::getShade(self.getColour(WindowColour::secondary).c(), 6);
-                    drawingCtx.fillRect(self.x + 4, y, self.x + 129, y + 9, colour, Gfx::RectFlags::crossHatching);
+                    drawingCtx.fillRect(4, y, 129, y + 9, colour, Gfx::RectFlags::crossHatching);
                 }
 
                 FormatArguments args{};
                 args.push(ExpenditureLabels[i]);
 
-                auto point = Point(self.x + 5, y - 1);
+                auto point = Point(5, y - 1);
                 tr.drawStringLeft(
                     point,
                     Colour::black,
@@ -1840,7 +1840,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // 'Current loan' label
             {
-                auto point = Point(self.x + 7, self.y + self.widgets[widx::currentLoan].top);
+                auto point = Point(7, self.widgets[widx::currentLoan].top);
                 tr.drawStringLeft(
                     point,
                     Colour::black,
@@ -1853,7 +1853,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 args.push<uint16_t>(getGameState().loanInterestRate);
 
                 auto& widget = self.widgets[widx::currentLoan];
-                auto point = Point(self.x + widget.right + 3, self.y + widget.top + 1);
+                auto point = Point(widget.right + 3, widget.top + 1);
                 tr.drawStringLeft(
                     point,
                     Colour::black,
@@ -1877,7 +1877,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     cashFormat = StringIds::cash_negative;
                 }
 
-                auto point = Point(self.x + 7, self.y + self.widgets[widx::currentLoan].top + 13);
+                auto point = Point(7, self.widgets[widx::currentLoan].top + 13);
                 tr.drawStringLeft(
                     point,
                     Colour::black,
@@ -1891,7 +1891,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 FormatArguments args{};
                 args.push(company->companyValueHistory[0]);
 
-                auto point = Point(self.x + 7, self.y + self.widgets[widx::currentLoan].top + 26);
+                auto point = Point(7, self.widgets[widx::currentLoan].top + 26);
                 tr.drawStringLeft(
                     point,
                     Colour::black,
@@ -1905,7 +1905,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 FormatArguments args{};
                 args.push(company->vehicleProfit);
 
-                auto point = Point(self.x + 7, self.y + self.widgets[widx::currentLoan].top + 39);
+                auto point = Point(7, self.widgets[widx::currentLoan].top + 39);
                 tr.drawStringLeft(
                     point,
                     Colour::black,
@@ -2273,11 +2273,11 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self.draw(drawingCtx);
             Common::drawTabs(&self, drawingCtx);
 
-            uint16_t y = self.y + 47;
+            uint16_t y = 47;
 
             // 'Cargo delivered'
             {
-                auto point = Point(self.x + 5, y);
+                auto point = Point(5, y);
                 tr.drawStringLeft(point, Colour::black, StringIds::cargo_delivered);
             }
 
@@ -2305,7 +2305,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
                 args.push(company->cargoDelivered[i]);
 
-                auto point = Point(self.x + 10, y);
+                auto point = Point(10, y);
                 tr.drawStringLeft(point, Colour::black, StringIds::black_stringid, args);
 
                 numPrinted++;
@@ -2315,7 +2315,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             // No cargo delivered yet?
             if (numPrinted == 0)
             {
-                auto point = Point(self.x + 10, y);
+                auto point = Point(10, y);
                 tr.drawStringLeft(point, Colour::black, StringIds::cargo_delivered_none);
             }
         }
@@ -2469,7 +2469,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             char* scenarioDetailsString = getGameState().scenarioDetails;
             StringManager::locoStrcpy(buffer_2039, scenarioDetailsString);
 
-            auto point = Point(self.x + 5, self.y + 47);
+            auto point = Point(5, 47);
 
             // for example: "Provide the transport services on this little island" for "Boulder Breakers" scenario
             point = tr.drawStringLeftWrapped(point, self.width - 10, Colour::black, StringIds::buffer_2039);

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -445,7 +445,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             }
 
             auto& widget = self->widgets[widx::viewport];
-            auto origin = Ui::Point(widget.left + self->x + 1, widget.top + self->y + 1);
+            auto origin = Ui::Point(widget.left + 1, widget.top + 1);
             auto size = Ui::Size(widget.width() - 2, widget.height() - 2);
             if (view.isEntityView())
             {
@@ -1121,7 +1121,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             }
 
             auto& widget = self->widgets[widx::viewport];
-            auto origin = Ui::Point(widget.left + self->x + 1, widget.top + self->y + 1);
+            auto origin = Ui::Point(widget.left + 1, widget.top + 1);
             auto size = Ui::Size(widget.width() - 2, widget.height() - 2);
 
             ViewportManager::create(self, 0, origin, size, self->savedView.zoomLevel, view.getPos());

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -2811,8 +2811,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // Draw company owner face.
             const uint32_t image = Gfx::recolour(competitor->images[enumValue(company->ownerEmotion)], company->mainColours.primary);
-            const uint16_t x = self->x + self->widgets[Common::widx::company_select].left + 1;
-            const uint16_t y = self->y + self->widgets[Common::widx::company_select].top + 1;
+            const uint16_t x = self->widgets[Common::widx::company_select].left + 1;
+            const uint16_t y = self->widgets[Common::widx::company_select].top + 1;
             drawingCtx.drawImage(x, y, image);
         }
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -808,8 +808,8 @@ namespace OpenLoco::Ui::Windows::Construction
                 Widget::drawTab(self, drawingCtx, ImageIds::null, widx::tab_station);
                 if (!self->isDisabled(widx::tab_station))
                 {
-                    auto x = self->widgets[widx::tab_station].left + self->x + 1;
-                    auto y = self->widgets[widx::tab_station].top + self->y + 1;
+                    auto x = self->widgets[widx::tab_station].left + 1;
+                    auto y = self->widgets[widx::tab_station].top + 1;
                     auto width = 29;
                     auto height = 25;
                     if (self->currentTab == widx::tab_station - widx::tab_construction)
@@ -851,8 +851,8 @@ namespace OpenLoco::Ui::Windows::Construction
                 Widget::drawTab(self, drawingCtx, ImageIds::null, widx::tab_overhead);
                 if (!self->isDisabled(widx::tab_overhead))
                 {
-                    auto x = self->widgets[widx::tab_overhead].left + self->x + 2;
-                    auto y = self->widgets[widx::tab_overhead].top + self->y + 2;
+                    auto x = self->widgets[widx::tab_overhead].left + 2;
+                    auto y = self->widgets[widx::tab_overhead].top + 2;
 
                     for (auto i = 0; i < 2; i++)
                     {
@@ -929,8 +929,8 @@ namespace OpenLoco::Ui::Windows::Construction
                         Widget::drawTab(self, drawingCtx, ImageIds::null, widx::tab_station);
                         if (!self->isDisabled(widx::tab_station))
                         {
-                            auto x = self->widgets[widx::tab_station].left + self->x + 1;
-                            auto y = self->widgets[widx::tab_station].top + self->y + 1;
+                            auto x = self->widgets[widx::tab_station].left + 1;
+                            auto y = self->widgets[widx::tab_station].top + 1;
                             auto width = 29;
                             auto height = 25;
                             if (self->currentTab == widx::tab_station - widx::tab_construction)
@@ -975,8 +975,8 @@ namespace OpenLoco::Ui::Windows::Construction
                 Widget::drawTab(self, drawingCtx, ImageIds::null, widx::tab_signal);
                 if (!self->isDisabled(widx::tab_signal))
                 {
-                    auto x = self->widgets[widx::tab_signal].left + self->x + 1;
-                    auto y = self->widgets[widx::tab_signal].top + self->y + 1;
+                    auto x = self->widgets[widx::tab_signal].left + 1;
+                    auto y = self->widgets[widx::tab_signal].top + 1;
                     auto width = 29;
                     auto height = 25;
                     if (self->currentTab == widx::tab_station - widx::tab_construction)
@@ -1014,8 +1014,8 @@ namespace OpenLoco::Ui::Windows::Construction
                 Widget::drawTab(self, drawingCtx, ImageIds::null, widx::tab_overhead);
                 if (!self->isDisabled(widx::tab_overhead))
                 {
-                    auto x = self->widgets[widx::tab_overhead].left + self->x + 2;
-                    auto y = self->widgets[widx::tab_overhead].top + self->y + 2;
+                    auto x = self->widgets[widx::tab_overhead].left + 2;
+                    auto y = self->widgets[widx::tab_overhead].top + 2;
 
                     for (auto i = 0; i < 4; i++)
                     {

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -3010,8 +3010,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         auto tr = Gfx::TextRenderer(drawingCtx);
 
         auto x = self->widgets[widx::construct].midX();
-        x += self->x;
-        auto y = self->widgets[widx::construct].bottom + self->y - 23;
+        auto y = self->widgets[widx::construct].bottom - 23;
 
         if (_cState->constructionHover != 1)
         {

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -3106,8 +3106,8 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
                 {
                     auto company = CompanyManager::getPlayerCompany();
                     auto imageId = Gfx::recolour(bridgeObj->image, company->mainColours.primary);
-                    auto x = self.x + self.widgets[widx::bridge].left + 2;
-                    auto y = self.y + self.widgets[widx::bridge].top + 1;
+                    auto x = self.widgets[widx::bridge].left + 2;
+                    auto y = self.widgets[widx::bridge].top + 1;
 
                     drawingCtx.drawImage(x, y, imageId);
                 }
@@ -3135,8 +3135,8 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             _cState->lastSelectedTrackPieceId = road->id;
             _cState->word_1135FD6 = (_cState->lastSelectedBridge << 8) & 0x1F;
 
-            auto x = self.x + self.widgets[widx::construct].left + 1;
-            auto y = self.y + self.widgets[widx::construct].top + 1;
+            auto x = self.widgets[widx::construct].left + 1;
+            auto y = self.widgets[widx::construct].top + 1;
             auto width = self.widgets[widx::construct].width();
             auto height = self.widgets[widx::construct].height();
 
@@ -3188,8 +3188,8 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             _cState->lastSelectedTrackPieceId = track->id;
             _cState->word_1135FD6 = (_cState->lastSelectedBridge << 8) & 0x1F;
 
-            auto x = self.x + self.widgets[widx::construct].left + 1;
-            auto y = self.y + self.widgets[widx::construct].top + 1;
+            auto x = self.widgets[widx::construct].left + 1;
+            auto y = self.widgets[widx::construct].top + 1;
             auto width = self.widgets[widx::construct].width();
             auto height = self.widgets[widx::construct].height();
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/OverheadTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/OverheadTab.cpp
@@ -96,8 +96,8 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
                 uint8_t modCount = 3;
 
                 auto widget = self.widgets[widx::track];
-                auto xPos = widget.left;
-                auto yPos = widget.top;
+                auto xPos = self.x + widget.left;
+                auto yPos = self.y + widget.top;
                 auto width = widget.width() + 2;
                 auto height = widget.height();
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/OverheadTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/OverheadTab.cpp
@@ -96,8 +96,8 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
                 uint8_t modCount = 3;
 
                 auto widget = self.widgets[widx::track];
-                auto xPos = widget.left + self.x;
-                auto yPos = widget.top + self.y;
+                auto xPos = widget.left;
+                auto yPos = widget.top;
                 auto width = widget.width() + 2;
                 auto height = widget.height();
 
@@ -497,8 +497,8 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
         Common::drawTabs(&self, drawingCtx);
         if (_cState->lastSelectedMods & 0xF)
         {
-            auto xPos = self.x + self.widgets[widx::image].left + 1;
-            auto yPos = self.y + self.widgets[widx::image].top + 1;
+            auto xPos = self.widgets[widx::image].left + 1;
+            auto yPos = self.widgets[widx::image].top + 1;
             auto width = self.widgets[widx::image].width();
             auto height = self.widgets[widx::image].height();
 
@@ -545,7 +545,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
 
             auto tr = Gfx::TextRenderer(drawingCtx);
 
-            auto point = Point(self.x + 69, self.widgets[widx::image].bottom + self.y + 4);
+            auto point = Point(69, self.widgets[widx::image].bottom + 4);
             tr.drawStringCentred(point, Colour::black, StringIds::build_cost, args);
         }
     }

--- a/src/OpenLoco/src/Ui/Windows/Construction/SignalTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/SignalTab.cpp
@@ -73,8 +73,8 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
                 }
 
                 auto widget = self.widgets[widx::signal];
-                auto xPos = widget.left + self.x;
-                auto yPos = widget.top + self.y;
+                auto xPos = widget.left;
+                auto yPos = widget.top;
                 auto width = widget.width() + 2;
                 auto height = widget.height();
 
@@ -320,8 +320,8 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
 
         auto trainSignalObject = ObjectManager::get<TrainSignalObject>(_cState->lastSelectedSignal);
 
-        auto xPos = self.x + 3;
-        auto yPos = self.y + 63;
+        auto xPos = 3;
+        auto yPos = 63;
         auto width = 130;
 
         {
@@ -334,15 +334,15 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
 
         auto imageId = trainSignalObject->image;
 
-        xPos = self.widgets[widx::both_directions].midX() + self.x;
-        yPos = self.widgets[widx::both_directions].bottom + self.y - 4;
+        xPos = self.widgets[widx::both_directions].midX();
+        yPos = self.widgets[widx::both_directions].bottom - 4;
 
         drawingCtx.drawImage(xPos - 8, yPos, imageId);
 
         drawingCtx.drawImage(xPos + 8, yPos, imageId + 4);
 
-        xPos = self.widgets[widx::single_direction].midX() + self.x;
-        yPos = self.widgets[widx::single_direction].bottom + self.y - 4;
+        xPos = self.widgets[widx::single_direction].midX();
+        yPos = self.widgets[widx::single_direction].bottom - 4;
 
         drawingCtx.drawImage(xPos, yPos, imageId);
 
@@ -351,7 +351,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
             FormatArguments args{};
             args.push<uint32_t>(_cState->signalCost);
 
-            auto point = Point(self.x + 69, self.widgets[widx::single_direction].bottom + self.y + 5);
+            auto point = Point(69, self.widgets[widx::single_direction].bottom + 5);
             tr.drawStringCentred(point, Colour::black, StringIds::build_cost, args);
         }
     }

--- a/src/OpenLoco/src/Ui/Windows/Construction/SignalTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/SignalTab.cpp
@@ -73,8 +73,8 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
                 }
 
                 auto widget = self.widgets[widx::signal];
-                auto xPos = widget.left;
-                auto yPos = widget.top;
+                auto xPos = self.x + widget.left;
+                auto yPos = self.y + widget.top;
                 auto width = widget.width() + 2;
                 auto height = widget.height();
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -127,8 +127,8 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                 }
 
                 auto widget = self.widgets[widx::station];
-                auto xPos = widget.left + self.x;
-                auto yPos = widget.top + self.y;
+                auto xPos = widget.left;
+                auto yPos = widget.top;
                 auto width = widget.width() + 2;
                 auto height = widget.height();
                 Dropdown::show(xPos, yPos, width, height, self.getColour(WindowColour::secondary), stationCount, (1 << 7));
@@ -1156,8 +1156,8 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
         auto company = CompanyManager::getPlayerCompany();
         auto companyColour = company->mainColours.primary;
-        int16_t xPos = self.widgets[widx::image].left + self.x;
-        int16_t yPos = self.widgets[widx::image].top + self.y;
+        int16_t xPos = self.widgets[widx::image].left;
+        int16_t yPos = self.widgets[widx::image].top;
 
         if (_cState->byte_1136063 & (1 << 7))
         {
@@ -1207,7 +1207,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         if (_cState->stationCost != 0x80000000 && _cState->stationCost != 0)
         {
             auto& widget = self.widgets[widx::image];
-            auto point = Point(self.x + 69, widget.bottom + self.y + 4);
+            auto point = Point(69, widget.bottom + 4);
 
             FormatArguments args{};
             args.push<uint32_t>(_cState->stationCost);
@@ -1215,8 +1215,8 @@ namespace OpenLoco::Ui::Windows::Construction::Station
             tr.drawStringCentred(point, Colour::black, StringIds::build_cost, args);
         }
 
-        xPos = self.x + 3;
-        yPos = self.widgets[widx::image].bottom + self.y + 16;
+        xPos = 3;
+        yPos = self.widgets[widx::image].bottom + 16;
         auto width = self.width - 4;
         drawingCtx.drawRectInset(xPos, yPos, width, 1, self.getColour(WindowColour::secondary), Gfx::RectInsetFlags::borderInset);
 
@@ -1239,15 +1239,15 @@ namespace OpenLoco::Ui::Windows::Construction::Station
             args.push(station->town);
         }
 
-        xPos = self.x + 69;
-        yPos = self.widgets[widx::image].bottom + self.y + 18;
+        xPos = 69;
+        yPos = self.widgets[widx::image].bottom + 18;
 
         auto origin = Point(xPos, yPos);
         width = self.width - 4;
         tr.drawStringCentredClipped(origin, width, Colour::black, StringIds::new_station_buffer, args);
 
-        xPos = self.x + 2;
-        yPos = self.widgets[widx::image].bottom + self.y + 29;
+        xPos = 2;
+        yPos = self.widgets[widx::image].bottom + 29;
 
         origin = Point(xPos, yPos);
         origin = tr.drawStringLeft(origin, Colour::black, StringIds::catchment_area_accepts);
@@ -1263,7 +1263,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
             {
                 if (_cState->constructingStationAcceptedCargoTypes & (1 << i))
                 {
-                    auto xPosMax = self.x + self.width - 12;
+                    auto xPosMax = self.width - 12;
                     if (origin.x <= xPosMax)
                     {
                         auto cargoObj = ObjectManager::get<CargoObject>(i);
@@ -1275,8 +1275,8 @@ namespace OpenLoco::Ui::Windows::Construction::Station
             }
         }
 
-        xPos = self.x + 2;
-        yPos = self.widgets[widx::image].bottom + self.y + 49;
+        xPos = 2;
+        yPos = self.widgets[widx::image].bottom + 49;
         origin = Point(xPos, yPos);
 
         origin = tr.drawStringLeft(origin, Colour::black, StringIds::catchment_area_produces);
@@ -1292,7 +1292,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
             {
                 if (_cState->constructingStationProducedCargoTypes & (1 << i))
                 {
-                    auto xPosMax = self.x + self.width - 12;
+                    auto xPosMax = self.width - 12;
                     if (origin.x <= xPosMax)
                     {
                         auto cargoObj = ObjectManager::get<CargoObject>(i);

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -127,8 +127,8 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                 }
 
                 auto widget = self.widgets[widx::station];
-                auto xPos = widget.left;
-                auto yPos = widget.top;
+                auto xPos = self.x + widget.left;
+                auto yPos = self.y + widget.top;
                 auto width = widget.width() + 2;
                 auto height = widget.height();
                 Dropdown::show(xPos, yPos, width, height, self.getColour(WindowColour::secondary), stationCount, (1 << 7));

--- a/src/OpenLoco/src/Ui/Windows/DragVehiclePart.cpp
+++ b/src/OpenLoco/src/Ui/Windows/DragVehiclePart.cpp
@@ -74,25 +74,17 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
     }
 
     // 0x004B6197
-    static void draw(Ui::Window& self, Gfx::DrawingContext& drawingCtx)
+    static void draw([[maybe_unused]] Ui::Window& self, Gfx::DrawingContext& drawingCtx)
     {
-        const auto& rt = drawingCtx.currentRenderTarget();
-        auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(self.x, self.y, self.width, self.height));
-        if (clipped)
+        Vehicles::Vehicle train(_dragVehicleHead);
+        for (auto& car : train.cars)
         {
-            drawingCtx.pushRenderTarget(*clipped);
-
-            Vehicles::Vehicle train(_dragVehicleHead);
-            for (auto& car : train.cars)
+            if (car.front == _dragCarComponent)
             {
-                if (car.front == _dragCarComponent)
-                {
-                    drawVehicleInline(drawingCtx, car, { 0, 19 }, VehicleInlineMode::basic, VehiclePartsToDraw::bogies);
-                    drawVehicleInline(drawingCtx, car, { 0, 19 }, VehicleInlineMode::basic, VehiclePartsToDraw::bodies);
-                    break;
-                }
+                drawVehicleInline(drawingCtx, car, { 0, 19 }, VehicleInlineMode::basic, VehiclePartsToDraw::bogies);
+                drawVehicleInline(drawingCtx, car, { 0, 19 }, VehicleInlineMode::basic, VehiclePartsToDraw::bodies);
+                break;
             }
-            drawingCtx.popRenderTarget();
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
+++ b/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
@@ -72,7 +72,7 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
 
         FormatArguments args{};
         args.push(ShortcutManager::getName(static_cast<Shortcut>(*_editingShortcutIndex)));
-        auto point = Ui::Point(self.x + 140, self.y + 32);
+        auto point = Ui::Point(140, 32);
         tr.drawStringCentredWrapped(point, 272, Colour::black, StringIds::change_keyboard_shortcut_desc, args);
     }
 

--- a/src/OpenLoco/src/Ui/Windows/Error.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Error.cpp
@@ -225,8 +225,8 @@ namespace OpenLoco::Ui::Windows::Error
 
             if (_errorCompetitorId == CompanyId::null)
             {
-                uint16_t xPos = self.x + self.width / 2;
-                uint16_t yPos = self.y + kPadding;
+                uint16_t xPos = self.width / 2;
+                uint16_t yPos = kPadding;
 
                 tr.drawStringCentredRaw(Point(xPos, yPos), _linebreakCount, colour, &_errorText[0]);
             }
@@ -249,7 +249,7 @@ namespace OpenLoco::Ui::Windows::Error
                     drawingCtx.drawImage(xPos, yPos, ImageIds::owner_jailed);
                 }
 
-                auto point = Point(self.x + (self.width - kCompetitorSize) / 2 + kCompetitorSize + kPadding, self.y + 20);
+                auto point = Point((self.width - kCompetitorSize) / 2 + kCompetitorSize + kPadding, 20);
                 tr.drawStringCentredRaw(point, _linebreakCount, colour, &_errorText[0]);
             }
         }

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -747,7 +747,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
             if (self.var_83C == 0)
             {
-                auto point = Point(self.x + 3, self.y + self.height - 13);
+                auto point = Point(3, self.height - 13);
                 auto width = self.width - 19;
                 tr.drawStringLeftClipped(point, width, Colour::black, StringIds::no_industry_available);
                 return;
@@ -785,7 +785,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 FormatArguments args{};
                 args.push(industryCost);
 
-                auto point = Point(self.x + 3 + self.width - 19, self.y + self.height - 13);
+                auto point = Point(3 + self.width - 19, self.height - 13);
                 widthOffset = 138;
 
                 tr.drawStringRight(point, Colour::black, StringIds::build_cost, args);
@@ -795,7 +795,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 FormatArguments args{};
                 args.push(industryObj->name);
 
-                auto point = Point(self.x + 3, self.y + self.height - 13);
+                auto point = Point(3, self.height - 13);
                 auto width = self.width - 19 - widthOffset;
 
                 tr.drawStringLeftClipped(point, width, Colour::black, StringIds::black_stringid, args);

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -278,7 +278,7 @@ namespace OpenLoco::Ui::Windows::Industry
             {
                 auto widget = &self.widgets[widx::viewport];
                 auto tile = World::Pos3({ industry->x, industry->y, tileZ });
-                auto origin = Ui::Point(widget->left + self.x + 1, widget->top + self.y + 1);
+                auto origin = Ui::Point(widget->left + 1, widget->top + 1);
                 auto size = Ui::Size(widget->width() - 2, widget->height() - 2);
                 ViewportManager::create(&self, 0, origin, size, self.savedView.zoomLevel, tile);
                 self.invalidate();

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -150,7 +150,7 @@ namespace OpenLoco::Ui::Windows::Industry
             args.push(StringIds::buffer_1250);
 
             auto widget = &self.widgets[widx::status_bar];
-            auto point = Point(self.x + widget->left - 1, self.y + widget->top - 1);
+            auto point = Point(widget->left - 1, widget->top - 1);
             auto width = widget->width();
             tr.drawStringLeftClipped(point, width, Colour::black, StringIds::black_stringid, args);
         }
@@ -467,7 +467,7 @@ namespace OpenLoco::Ui::Windows::Industry
 
             auto industry = IndustryManager::get(IndustryId(self.number));
             const auto* industryObj = industry->getObject();
-            auto origin = Point(self.x + 3, self.y + 45);
+            auto origin = Point(3, 45);
 
             // Draw Last Months received cargo stats
             if (industry->canReceiveCargo())
@@ -609,21 +609,21 @@ namespace OpenLoco::Ui::Windows::Industry
                 FormatArguments args{};
                 args.push(cargoObj->unitsAndCargoName);
 
-                auto point = Point(self.x + 2, self.y - 24 + 68);
+                auto point = Point(2, 24 + 68);
                 tr.drawStringLeft(point, Colour::black, StringIds::production_graph_label, args);
             }
 
             // Draw Y label and grid lines.
-            const uint16_t graphBottom = self.y + self.height - 7;
+            const uint16_t graphBottom = self.height - 7;
             int32_t yTick = 0;
-            for (int16_t yPos = graphBottom; yPos >= self.y + 68; yPos -= 20)
+            for (int16_t yPos = graphBottom; yPos >= 68; yPos -= 20)
             {
                 FormatArguments args{};
                 args.push(yTick);
 
-                drawingCtx.drawRect(self.x + 41, yPos, 239, 1, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4), Gfx::RectFlags::none);
+                drawingCtx.drawRect(41, yPos, 239, 1, Colours::getShade(self.getColour(WindowColour::secondary).c(), 4), Gfx::RectFlags::none);
 
-                auto point = Point(self.x + 39, yPos - 6);
+                auto point = Point(39, yPos - 6);
                 tr.drawStringRight(point, Colour::black, StringIds::population_graph_people, args);
 
                 yTick += 1000;
@@ -638,8 +638,8 @@ namespace OpenLoco::Ui::Windows::Industry
             const uint8_t productionNum = productionTabWidx - widx::tab_production;
             for (uint8_t i = industry->producedCargoMonthlyHistorySize[productionNum] - 1; i > 0; i--)
             {
-                const uint16_t xPos = self.x + 41 + i;
-                const uint16_t yPos = self.y + 56;
+                const uint16_t xPos = 41 + i;
+                const uint16_t yPos = 56;
 
                 // Draw horizontal year and vertical grid lines.
                 if (month == MonthId::january)
@@ -878,8 +878,8 @@ namespace OpenLoco::Ui::Windows::Industry
                     imageId += productionTabImageIds[0];
                 }
 
-                auto xPos = widget.left + self->x;
-                auto yPos = widget.top + self->y;
+                auto xPos = widget.left;
+                auto yPos = widget.top;
                 drawingCtx.drawImage(xPos, yPos, imageId);
 
                 auto caroObj = ObjectManager::get<CargoObject>(industryObj->producedCargoType[productionTabNumber]);

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -609,7 +609,7 @@ namespace OpenLoco::Ui::Windows::Industry
                 FormatArguments args{};
                 args.push(cargoObj->unitsAndCargoName);
 
-                auto point = Point(2, 24 + 68);
+                auto point = Point(2, 44);
                 tr.drawStringLeft(point, Colour::black, StringIds::production_graph_label, args);
             }
 

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGenerationConfirm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGenerationConfirm.cpp
@@ -53,7 +53,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGenerationConfirm
             args.push(StringIds::prompt_confirm_random_landscape);
         }
 
-        auto origin = Ui::Point(window.x + (window.width / 2), window.y + 41);
+        auto origin = Ui::Point((window.width / 2), 41);
         tr.drawStringCentredWrapped(origin, window.width, Colour::black, StringIds::wcolour2_stringid, args);
     }
 

--- a/src/OpenLoco/src/Ui/Windows/MapToolTip.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapToolTip.cpp
@@ -123,16 +123,16 @@ namespace OpenLoco::Ui::Windows::MapToolTip
 
         if (_mapTooltipOwner == CompanyId::null || _mapTooltipOwner == CompanyManager::getControllingId())
         {
-            Ui::Point origin(self.x + self.width / 2, self.y + self.height / 2 - 5);
+            Ui::Point origin(self.width / 2, self.height / 2 - 5);
             tr.drawStringCentredWrapped(origin, self.width, Colour::black, StringIds::outlined_wcolour2_stringid, args);
         }
         else
         {
-            Ui::Point origin(self.x + self.width / 2 + 13, self.y + self.height / 2 - 5);
+            Ui::Point origin(self.width / 2 + 13, self.height / 2 - 5);
             auto basePoint = tr.drawStringCentredWrapped(origin, self.width - 28, Colour::black, StringIds::outlined_wcolour2_stringid, args);
 
             auto left = basePoint.x - 28;
-            auto top = self.y + self.height / 2 - 13;
+            auto top = self.height / 2 - 13;
             auto right = left + 25;
             auto bottom = top + 25;
 

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -1665,8 +1665,8 @@ namespace OpenLoco::Ui::Windows::MapWindow
         drawTabs(&self, drawingCtx);
 
         {
-            auto x = self.x + self.width - 104;
-            uint16_t y = self.y + 44;
+            auto x = self.width - 104;
+            uint16_t y = 44;
 
             switch (self.currentTab + widx::tabOverall)
             {
@@ -1718,7 +1718,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
         }
 
         auto& widget = self.widgets[widx::statusBar];
-        auto point = Point(self.x + widget.left - 1, self.y + widget.top - 1);
+        auto point = Point(widget.left - 1, widget.top - 1);
         auto width = widget.width();
 
         tr.drawStringLeftClipped(point, width, Colour::black, StringIds::black_stringid, args);

--- a/src/OpenLoco/src/Ui/Windows/NetworkStatus.cpp
+++ b/src/OpenLoco/src/Ui/Windows/NetworkStatus.cpp
@@ -108,7 +108,7 @@ namespace OpenLoco::Ui::Windows::NetworkStatus
 
         self.draw(drawingCtx);
 
-        auto origin = Point(self.x + (self.width / 2), self.y + (self.height / 2));
+        auto origin = Point((self.width / 2), (self.height / 2));
         auto width = self.width;
 
         tr.drawStringCentredClipped(origin, width, Colour::black, StringIds::buffer_1250);

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -499,8 +499,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     const auto imageIndexBase = competitorObj->images[enumValue(company->ownerEmotion)];
 
                     const ImageId imageId(imageIndexBase + 1, company->mainColours.primary);
-                    const auto x = self->x + viewWidget.midX() - 31;
-                    const auto y = self->y + viewWidget.midY() - 31;
+                    const auto x = viewWidget.midX() - 31;
+                    const auto y = viewWidget.midY() - 31;
                     drawingCtx.drawImage(Ui::Point(x, y), imageId);
 
                     if (company->jailStatus != 0)
@@ -511,8 +511,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
                 if (subjectType == SubjectType::vehicleImage && itemSubject != 0xFFFFU)
                 {
-                    const auto x = self->x + viewWidget.left;
-                    const auto y = self->y + viewWidget.top;
+                    const auto x = viewWidget.left;
+                    const auto y = viewWidget.top;
 
                     const auto& rt = drawingCtx.currentRenderTarget();
                     auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(x + 1, y + 1, viewWidget.width() - 2, viewWidget.height() - 2));
@@ -653,15 +653,13 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
             strncpy(buffer, newsString, 512);
 
-            int16_t x = (self->width / 2) + self->x;
-            int16_t y = self->y + 38;
+            int16_t x = (self->width / 2);
+            int16_t y = 38;
             Ui::Point origin = { x, y };
 
             tr.drawStringCentredWrapped(origin, 352, Colour::black, StringIds::buffer_2039);
 
-            x = self->x + 1;
-            y = self->y + 1;
-            origin = { x, y };
+            origin = { 1, 1 };
 
             auto argsBuf = FormatArgumentsBuffer{};
             auto args = FormatArguments{ argsBuf };
@@ -681,8 +679,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 {
                     if (news->itemSubjects[0] != 0xFFFF)
                     {
-                        auto x = self->widgets[Common::widx::viewport1].left + self->x;
-                        auto y = self->widgets[Common::widx::viewport1].top + self->y;
+                        auto x = self->widgets[Common::widx::viewport1].left;
+                        auto y = self->widgets[Common::widx::viewport1].top;
                         auto width = self->widgets[Common::widx::viewport1].width() + 1;
                         auto height = self->widgets[Common::widx::viewport1].height() + 1;
                         constexpr auto colour = enumValue(ExtColour::translucentGrey1);
@@ -697,8 +695,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 {
                     if (news->itemSubjects[1] != 0xFFFF)
                     {
-                        auto x = self->widgets[Common::widx::viewport2].left + self->x;
-                        auto y = self->widgets[Common::widx::viewport2].top + self->y;
+                        auto x = self->widgets[Common::widx::viewport2].left;
+                        auto y = self->widgets[Common::widx::viewport2].top;
                         auto width = self->widgets[Common::widx::viewport2].width() + 1;
                         auto height = self->widgets[Common::widx::viewport2].height() + 1;
                         constexpr auto colour = enumValue(ExtColour::translucentGrey1);
@@ -732,14 +730,14 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
             strncpy(buffer, newsString, 512);
 
-            int16_t x = (self->width / 2) + self->x;
-            int16_t y = self->y + 38;
+            int16_t x = (self->width / 2);
+            int16_t y = 38;
             Ui::Point origin = { x, y };
 
             tr.drawStringCentredWrapped(origin, 352, Colour::black, StringIds::buffer_2039);
 
-            origin.x = self->x + 4;
-            origin.y = self->y + 5;
+            origin.x = 4;
+            origin.y = 5;
 
             auto argsBuf = FormatArgumentsBuffer{};
             auto args = FormatArguments{ argsBuf };
@@ -748,15 +746,15 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
             drawNewsSubjectImages(self, drawingCtx, news);
 
-            x = self->x + 3;
-            y = self->y + 5;
+            x = 3;
+            y = 5;
             auto width = self->width - 6;
             auto height = self->height;
             auto colour = enumValue(ExtColour::translucentBrown1);
             drawingCtx.drawRect(x, y, width, height, colour, Gfx::RectFlags::transparent);
 
-            x = self->widgets[Common::widx::viewport1].left + self->x;
-            y = self->widgets[Common::widx::viewport1].top + self->y;
+            x = self->widgets[Common::widx::viewport1].left;
+            y = self->widgets[Common::widx::viewport1].top;
             width = self->widgets[Common::widx::viewport1].width();
             height = self->widgets[Common::widx::viewport1].height();
             colour = enumValue(ExtColour::translucentBrown1);
@@ -778,8 +776,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
             strncpy(buffer, newsString, 512);
 
-            int16_t x = (self->width / 2) + self->x;
-            int16_t y = self->y + 17;
+            int16_t x = (self->width / 2);
+            int16_t y = 17;
             Ui::Point origin = { x, y };
 
             tr.drawStringCentredWrapped(origin, 338, Colour::black, StringIds::buffer_2039);
@@ -791,8 +789,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 {
                     if (news->itemSubjects[0] != 0xFFFF)
                     {
-                        x = self->widgets[Common::widx::viewport1].left + self->x;
-                        y = self->widgets[Common::widx::viewport1].top + self->y;
+                        x = self->widgets[Common::widx::viewport1].left;
+                        y = self->widgets[Common::widx::viewport1].top;
                         auto width = self->widgets[Common::widx::viewport1].width();
                         auto height = self->widgets[Common::widx::viewport1].height();
                         constexpr auto colour = enumValue(ExtColour::translucentGrey1);
@@ -807,8 +805,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 {
                     if (news->itemSubjects[1] != 0xFFFF)
                     {
-                        x = self->widgets[Common::widx::viewport2].left + self->x;
-                        y = self->widgets[Common::widx::viewport2].top + self->y;
+                        x = self->widgets[Common::widx::viewport2].left;
+                        y = self->widgets[Common::widx::viewport2].top;
                         auto width = self->widgets[Common::widx::viewport2].width();
                         auto height = self->widgets[Common::widx::viewport2].height();
                         constexpr auto colour = enumValue(ExtColour::translucentGrey1);

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -187,19 +187,6 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 self.invalidate();
                 self.y += height;
                 self.x += width;
-
-                if (self.viewports[0] != nullptr)
-                {
-                    self.viewports[0]->x += width;
-                    self.viewports[0]->y += height;
-                }
-
-                if (self.viewports[1] != nullptr)
-                {
-                    self.viewports[1]->x += width;
-                    self.viewports[1]->y += height;
-                }
-
                 self.invalidate();
             }
         }
@@ -376,8 +363,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
                 if (!view.isEmpty())
                 {
-                    int16_t x = self.widgets[Common::widx::viewport1].left + 1 + self.x;
-                    int16_t y = self.widgets[Common::widx::viewport1].top + 1 + self.y;
+                    int16_t x = self.widgets[Common::widx::viewport1].left + 1;
+                    int16_t y = self.widgets[Common::widx::viewport1].top + 1;
                     Ui::Point origin = { x, y };
 
                     uint16_t viewportWidth = self.widgets[Common::widx::viewport1].width();
@@ -386,8 +373,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
                     if (mtd.hasFlag(MessageTypeFlags::unk1))
                     {
-                        x = self.widgets[Common::widx::viewport1].left + self.x;
-                        y = self.widgets[Common::widx::viewport1].top + self.y;
+                        x = self.widgets[Common::widx::viewport1].left;
+                        y = self.widgets[Common::widx::viewport1].top;
                         origin = { x, y };
 
                         viewportWidth = self.widgets[Common::widx::viewport1].width() + 2;
@@ -463,8 +450,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
                 if (!view.isEmpty())
                 {
-                    int16_t x = self.widgets[Common::widx::viewport2].left + 1 + self.x;
-                    int16_t y = self.widgets[Common::widx::viewport2].top + 1 + self.y;
+                    int16_t x = self.widgets[Common::widx::viewport2].left + 1;
+                    int16_t y = self.widgets[Common::widx::viewport2].top + 1;
                     Ui::Point origin = { x, y };
 
                     uint16_t viewportWidth = self.widgets[Common::widx::viewport2].width();
@@ -473,8 +460,8 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
                     if (mtd.hasFlag(MessageTypeFlags::unk1))
                     {
-                        x = self.widgets[Common::widx::viewport2].left + self.x;
-                        y = self.widgets[Common::widx::viewport2].top + self.y;
+                        x = self.widgets[Common::widx::viewport2].left;
+                        y = self.widgets[Common::widx::viewport2].top;
                         origin = { x, y };
 
                         viewportWidth = self.widgets[Common::widx::viewport2].width() + 2;

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -850,8 +850,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 if (news->itemSubjects[0] != 0xFFFF)
                 {
                     auto x = (self.widgets[Common::widx::viewport1Button].left + self.widgets[Common::widx::viewport1Button].right) / 2;
-                    x += self.x;
-                    auto y = self.widgets[Common::widx::viewport1Button].bottom - 7 + self.y;
+                    auto y = self.widgets[Common::widx::viewport1Button].bottom - 7;
                     auto width = self.widgets[Common::widx::viewport1Button].width() - 1;
                     auto point = Point(x, y);
 
@@ -863,8 +862,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 if (news->itemSubjects[1] != 0xFFFF)
                 {
                     auto x = (self.widgets[Common::widx::viewport2Button].left + self.widgets[Common::widx::viewport2Button].right) / 2;
-                    x += self.x;
-                    auto y = self.widgets[Common::widx::viewport2Button].bottom - 7 + self.y;
+                    auto y = self.widgets[Common::widx::viewport2Button].bottom - 7;
                     auto width = self.widgets[Common::widx::viewport2Button].width() - 1;
                     auto point = Point(x, y);
 

--- a/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
@@ -174,13 +174,11 @@ namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
 
         auto news = MessageManager::get(MessageManager::getActiveIndex());
 
-        auto x = self.x;
-        auto y = self.y;
         auto width = self.width;
         auto height = self.height;
 
         const auto& rt = drawingCtx.currentRenderTarget();
-        auto clipped = Gfx::clipRenderTarget(rt, { x, y, width, height });
+        auto clipped = Gfx::clipRenderTarget(rt, { 0, 0, width, height });
 
         if (!clipped)
         {

--- a/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
@@ -90,7 +90,7 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
         self.draw(drawingCtx);
 
         // Draw explanatory text
-        auto point = Point(self.x + 3, self.y + 19);
+        auto point = Point(3, 19);
         auto tr = Gfx::TextRenderer(drawingCtx);
         tr.drawStringLeftWrapped(point, self.width - 6, self.getColour(WindowColour::secondary), StringIds::objectErrorExplanation);
     }

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -939,7 +939,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         auto& widget = widgets[widx::textInput];
         const auto& rt = drawingCtx.currentRenderTarget();
-        auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(widget.left + 1 + self.x, widget.top + 1 + self.y, widget.width() - 2, widget.height() - 2));
+        auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(widget.left + 1, widget.top + 1, widget.width() - 2, widget.height() - 2));
         if (!clipped)
         {
             return;
@@ -974,7 +974,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     {
         auto tr = Gfx::TextRenderer(drawingCtx);
 
-        drawingCtx.fillRectInset(self.x, self.y + 20, self.x + self.width - 1, self.y + 20 + 60, self.getColour(WindowColour::primary), Gfx::RectInsetFlags::none);
+        drawingCtx.fillRectInset(0, 20, self.width - 1, 20 + 60, self.getColour(WindowColour::primary), Gfx::RectInsetFlags::none);
         self.draw(drawingCtx);
 
         drawTabs(&self, drawingCtx);
@@ -992,7 +992,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             args.push(levelStringIds[self.filterLevel]);
 
             auto& widget = self.widgets[widx::filterLabel];
-            auto point = Point(self.x + widget.left, self.y + widget.top);
+            auto point = Point(widget.left, widget.top);
 
             // Draw current level on combobox
             tr.drawStringLeftClipped(point, widget.width() - 15, Colour::black, StringIds::wcolour2_stringid, args);
@@ -1012,13 +1012,13 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         {
             auto widget = widgets[widx::objectImage];
             auto colour = Colours::getShade(self.getColour(WindowColour::secondary).c(), 5);
-            drawingCtx.drawRect(self.x + widget.left, self.y + widget.top, widget.width(), widget.height(), colour, Gfx::RectFlags::none);
+            drawingCtx.drawRect(widget.left, widget.top, widget.width(), widget.height(), colour, Gfx::RectFlags::none);
         }
         else
         {
             auto widget = widgets[widx::objectImage];
             auto colour = Colours::getShade(self.getColour(WindowColour::secondary).c(), 0);
-            drawingCtx.drawRect(self.x + widget.left + 1, self.y + widget.top + 1, widget.width() - 2, widget.height() - 2, colour, Gfx::RectFlags::none);
+            drawingCtx.drawRect(widget.left + 1, widget.top + 1, widget.width() - 2, widget.height() - 2, colour, Gfx::RectFlags::none);
         }
 
         ObjectType type{};
@@ -1037,7 +1037,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         args.push(ObjectManager::getMaxObjects(type));
 
         {
-            auto point = Point(self.x + 3, self.y + self.height - 12);
+            auto point = Point(3, self.height - 12);
             tr.drawStringLeft(point, Colour::black, StringIds::num_selected_num_max, args);
         }
 
@@ -1059,13 +1059,13 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             drawPreviewImage(
                 objectHeader,
                 drawingCtx,
-                widgets[widx::objectImage].midX() + 1 + self.x,
-                widgets[widx::objectImage].midY() + 1 + self.y,
+                widgets[widx::objectImage].midX() + 1,
+                widgets[widx::objectImage].midY() + 1,
                 *temporaryObject);
         }
 
-        auto x = self.widgets[widx::objectImage].midX() + self.x;
-        auto y = self.widgets[widx::objectImage].bottom + 3 + self.y;
+        auto x = self.widgets[widx::objectImage].midX();
+        auto y = self.widgets[widx::objectImage].bottom + 3;
         auto width = self.width - self.widgets[widx::scrollview].right - 6;
 
         {
@@ -1086,7 +1086,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 objHeader,
                 &self,
                 drawingCtx,
-                self.widgets[widx::scrollview].right + self.x + 4,
+                self.widgets[widx::scrollview].right + 4,
                 y + kDescriptionRowHeight,
                 *temporaryObject);
         }
@@ -1096,7 +1096,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 ObjectManager::getObjectInIndex(self.rowHover),
                 &self,
                 drawingCtx,
-                self.widgets[widx::scrollview].right + self.x + 4,
+                self.widgets[widx::scrollview].right + 4,
                 y + kDescriptionRowHeight);
         }
     }

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -1105,16 +1105,16 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C05F9
-        static void draw(Window& w, Gfx::DrawingContext& drawingCtx)
+        static void draw(Window& self, Gfx::DrawingContext& drawingCtx)
         {
             // Draw widgets.
-            w.draw(drawingCtx);
+            self.draw(drawingCtx);
 
             // TODO: Move this in Slider widget.
-            drawingCtx.drawImage(w.x + w.widgets[Widx::volume].left, w.y + w.widgets[Widx::volume].top, Gfx::recolour(ImageIds::volume_slider_track, w.getColour(WindowColour::secondary).c()));
+            drawingCtx.drawImage(self.widgets[Widx::volume].left, self.widgets[Widx::volume].top, Gfx::recolour(ImageIds::volume_slider_track, self.getColour(WindowColour::secondary).c()));
 
             int16_t x = 90 + (Config::get().old.volume / 32);
-            drawingCtx.drawImage(w.x + w.widgets[Widx::volume].left + x, w.y + w.widgets[Widx::volume].top, Gfx::recolour(ImageIds::volume_slider_thumb, w.getColour(WindowColour::secondary).c()));
+            drawingCtx.drawImage(self.widgets[Widx::volume].left + x, self.widgets[Widx::volume].top, Gfx::recolour(ImageIds::volume_slider_thumb, self.getColour(WindowColour::secondary).c()));
         }
 
         static void onMouseUp(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
@@ -2455,7 +2455,7 @@ namespace OpenLoco::Ui::Windows::Options
             args.push(stringId);
             args.push(value);
 
-            auto point = Point(w->x + widget.left + 1, w->y + widget.top + 1);
+            auto point = Point(widget.left + 1, widget.top + 1);
             tr.drawStringLeft(point, Colour::black, StringIds::black_stringid, args);
         }
 

--- a/src/OpenLoco/src/Ui/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PlayerInfoPanel.cpp
@@ -189,19 +189,19 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
         auto tr = Gfx::TextRenderer(drawingCtx);
 
         Widget& frame = window.widgets[Widx::outer_frame];
-        drawingCtx.drawRect(window.x + frame.left, window.y + frame.top, frame.width(), frame.height(), enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
+        drawingCtx.drawRect(frame.left, frame.top, frame.width(), frame.height(), enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
 
         // Draw widgets.
         window.draw(drawingCtx);
 
-        drawingCtx.drawRectInset(window.x + frame.left + 1, window.y + frame.top + 1, frame.width() - 2, frame.height() - 2, window.getColour(WindowColour::secondary), Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillNone);
+        drawingCtx.drawRectInset(frame.left + 1, frame.top + 1, frame.width() - 2, frame.height() - 2, window.getColour(WindowColour::secondary), Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillNone);
 
         auto playerCompany = CompanyManager::get(CompanyManager::getControllingId());
         auto competitor = ObjectManager::get<CompetitorObject>(playerCompany->competitorId);
         auto image = Gfx::recolour(competitor->images[enumValue(playerCompany->ownerEmotion)], playerCompany->mainColours.primary);
-        drawingCtx.drawImage(window.x + frame.left + 2, window.y + frame.top + 2, image);
+        drawingCtx.drawImage(frame.left + 2, frame.top + 2, image);
 
-        auto x = window.x + frame.width() / 2 + 12;
+        auto x = frame.width() / 2 + 12;
         {
             auto companyValueString = StringIds::player_info_bankrupt;
             if ((playerCompany->challengeFlags & CompanyFlags::bankrupt) == CompanyFlags::none)
@@ -225,7 +225,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
             args.push(playerCompany->cash.var_00);
             args.push(playerCompany->cash.var_04);
 
-            auto point = Point(x, window.y + frame.top + 2);
+            auto point = Point(x, frame.top + 2);
             tr.drawStringCentred(point, colour, companyValueString, args);
         }
 
@@ -250,7 +250,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
             auto args = FormatArguments();
             args.push(playerCompany->performanceIndex);
 
-            auto point = Point(x, window.y + frame.top + 14);
+            auto point = Point(x, frame.top + 14);
             tr.drawStringCentred(point, colour, performanceString, args);
         }
     }

--- a/src/OpenLoco/src/Ui/Windows/ProgressBar.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ProgressBar.cpp
@@ -104,7 +104,7 @@ namespace OpenLoco::Ui::Windows::ProgressBar
 
         self.draw(drawingCtx);
 
-        auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(self.x + 2, self.y + 17, self.width - 5, self.height - 19));
+        auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(2, 17, self.width - 5, self.height - 19));
         if (!clipped)
         {
             return;

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -421,7 +421,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         {
             auto folder = &_displayFolderBuffer[0];
             auto args = getStringPtrFormatArgs(folder);
-            auto point = Point(window.x + 3, window.y + window.widgets[widx::parent_button].top + 6);
+            auto point = Point(3, window.widgets[widx::parent_button].top + 6);
             tr.drawStringLeft(point, Colour::black, StringIds::window_browse_folder, args);
         }
 
@@ -434,8 +434,8 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                 const auto& widget = window.widgets[widx::scrollview];
 
                 auto width = window.width - widget.right - 8;
-                auto x = window.x + widget.right + 3;
-                auto y = window.y + 45;
+                auto x = widget.right + 3;
+                auto y = 45;
 
                 auto nameBuffer = selectedFile.stem().u8string();
                 nameBuffer = Localisation::convertUnicodeToLoco(nameBuffer);
@@ -472,12 +472,12 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         if (!filenameBox.hidden)
         {
             // Draw filename label
-            auto point = Point(window.x + 3, window.y + filenameBox.top + 2);
+            auto point = Point(3, filenameBox.top + 2);
             tr.drawStringLeft(point, Colour::black, StringIds::window_browse_filename);
 
             // Clip to text box
             const auto& rt = drawingCtx.currentRenderTarget();
-            auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(window.x + filenameBox.left + 1, window.y + filenameBox.top + 1, filenameBox.right - filenameBox.left - 1, filenameBox.bottom - filenameBox.top - 1));
+            auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(filenameBox.left + 1, filenameBox.top + 1, filenameBox.right - filenameBox.left - 1, filenameBox.bottom - filenameBox.top - 1));
             if (clipped)
             {
                 drawingCtx.pushRenderTarget(*clipped);

--- a/src/OpenLoco/src/Ui/Windows/PromptOkCancelWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptOkCancelWindow.cpp
@@ -136,7 +136,7 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
         FormatArguments args{};
         args.push(StringIds::buffer_2039);
 
-        auto origin = Ui::Point(self.x + self.width / 2, self.y + 41);
+        auto origin = Ui::Point(self.width / 2, 41);
         tr.drawStringCentredWrapped(origin, self.width, Colour::black, StringIds::wcolour2_stringid, args);
     }
 

--- a/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
@@ -210,7 +210,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
             Common::draw(window, drawingCtx);
 
-            auto point = Point(window.x + 5, window.y + widgets[widx::check_time_limit].bottom + 10);
+            auto point = Point(5, widgets[widx::check_time_limit].bottom + 10);
             tr.drawStringLeft(point, Colour::black, StringIds::challenge_label);
 
             FormatArguments args{};
@@ -648,19 +648,19 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
             Common::draw(window, drawingCtx);
 
-            auto point = Point(window.x + 10, window.y + widgets[widx::max_competing_companies].top + 1);
+            auto point = Point(10, widgets[widx::max_competing_companies].top + 1);
             tr.drawStringLeft(point, Colour::black, StringIds::max_competing_companies);
 
-            point.y = window.y + widgets[widx::delay_before_competing_companies_start].top + 1;
+            point.y = widgets[widx::delay_before_competing_companies_start].top + 1;
             tr.drawStringLeft(point, Colour::black, StringIds::delay_before_competing_companies_start);
 
-            point.y = window.y + widgets[widx::preferred_intelligence].top + 1;
+            point.y = widgets[widx::preferred_intelligence].top + 1;
             tr.drawStringLeft(point, Colour::black, StringIds::preferred_intelligence);
 
-            point.y = window.y + widgets[widx::preferred_aggressiveness].top + 1;
+            point.y = widgets[widx::preferred_aggressiveness].top + 1;
             tr.drawStringLeft(point, Colour::black, StringIds::preferred_aggressiveness);
 
-            point.y = window.y + widgets[widx::preferred_competitiveness].top + 1;
+            point.y = widgets[widx::preferred_competitiveness].top + 1;
             tr.drawStringLeft(point, Colour::black, StringIds::preferred_competitiveness);
         }
 
@@ -912,13 +912,13 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
             Common::draw(window, drawingCtx);
 
-            auto point = Point(window.x + 10, window.y + widgets[widx::starting_loan].top + 1);
+            auto point = Point(10, widgets[widx::starting_loan].top + 1);
             tr.drawStringLeft(point, Colour::black, StringIds::starting_loan);
 
-            point.y = window.y + widgets[widx::max_loan_size].top + 1;
+            point.y = widgets[widx::max_loan_size].top + 1;
             tr.drawStringLeft(point, Colour::black, StringIds::max_loan_size);
 
-            point.y = window.y + widgets[widx::loan_interest_rate].top + 1;
+            point.y = widgets[widx::loan_interest_rate].top + 1;
             tr.drawStringLeft(point, Colour::black, StringIds::loan_interest_rate);
         }
 
@@ -1064,8 +1064,8 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     args.push(stex->name);
                 }
 
-                const int16_t xPos = window.x + 10;
-                int16_t yPos = window.y + widgets[widx::change_name_btn].top + 1;
+                const int16_t xPos = 10;
+                int16_t yPos = widgets[widx::change_name_btn].top + 1;
                 int16_t width = widgets[widx::change_name_btn].left - 20;
 
                 auto point = Point(xPos, yPos);
@@ -1073,16 +1073,16 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             }
 
             {
-                const int16_t xPos = window.x + 10;
-                int16_t yPos = window.y + widgets[widx::scenario_group].top + 1;
+                const int16_t xPos = 10;
+                int16_t yPos = widgets[widx::scenario_group].top + 1;
 
                 auto point = Point(xPos, yPos);
                 tr.drawStringLeft(point, Colour::black, StringIds::scenario_group);
             }
 
             {
-                const int16_t xPos = window.x + 10;
-                int16_t yPos = window.y + widgets[widx::change_details_btn].top + 1;
+                const int16_t xPos = 10;
+                int16_t yPos = widgets[widx::change_details_btn].top + 1;
 
                 auto point = Point(xPos, yPos);
                 tr.drawStringLeft(point, Colour::black, StringIds::scenario_details);
@@ -1104,7 +1104,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                 }
 
                 auto& target = window.widgets[widx::change_details_btn];
-                auto point = Point(window.x + 16, window.y + 12 + target.top);
+                auto point = Point(16, 12 + target.top);
                 tr.drawStringLeftWrapped(point, target.left - 26, Colour::black, StringIds::black_stringid, args);
             }
         }

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -169,7 +169,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     {
         auto tr = Gfx::TextRenderer(drawingCtx);
 
-        drawingCtx.drawRectInset(self.x, self.y + 20, self.width, 41, self.getColour(WindowColour::primary), Gfx::RectInsetFlags::none);
+        drawingCtx.drawRectInset(0, 20, self.width, 41, self.getColour(WindowColour::primary), Gfx::RectInsetFlags::none);
 
         // Draw widgets.
         self.draw(drawingCtx);
@@ -192,7 +192,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             }
 
             const auto offset = self.currentTab == i ? 1 : 0;
-            auto origin = Ui::Point(widget.midX() + self.x, widget.midY() + self.y - 3 - offset);
+            auto origin = Ui::Point(widget.midX(), widget.midY() - 3 - offset);
             const StringId caption = scenarioGroupIds[i];
 
             auto argsBuf = FormatArgumentsBuffer{};
@@ -235,8 +235,8 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             }
         }
 
-        const int16_t baseX = self.x + self.widgets[widx::list].right + 4;
-        const int16_t baseY = self.y + self.widgets[widx::panel].top + 5;
+        const int16_t baseX = self.widgets[widx::list].right + 4;
+        const int16_t baseY = self.widgets[widx::panel].top + 5;
         const int16_t colWidth = self.widgets[widx::panel].right - self.widgets[widx::list].right - 6;
 
         int16_t x = baseX, y = baseY;

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -612,8 +612,8 @@ namespace OpenLoco::Ui::Windows::StationList
         auto company = CompanyManager::get(CompanyId(window.number));
         auto competitor = ObjectManager::get<CompetitorObject>(company->competitorId);
         uint32_t image = Gfx::recolour(competitor->images[enumValue(company->ownerEmotion)], company->mainColours.primary);
-        uint16_t x = window.x + window.widgets[widx::company_select].left + 1;
-        uint16_t y = window.y + window.widgets[widx::company_select].top + 1;
+        uint16_t x = window.widgets[widx::company_select].left + 1;
+        uint16_t y = window.widgets[widx::company_select].top + 1;
         drawingCtx.drawImage(x, y, image);
     }
 

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -267,7 +267,7 @@ namespace OpenLoco::Ui::Windows::Station
             {
                 auto widget = &self.widgets[widx::viewport];
                 auto tile = World::Pos3({ station->x, station->y, station->z });
-                auto origin = Ui::Point(widget->left + self.x + 1, widget->top + self.y + 1);
+                auto origin = Ui::Point(widget->left + 1, widget->top + 1);
                 auto size = Ui::Size(widget->width() - 2, widget->height() - 2);
                 ViewportManager::create(&self, 0, origin, size, self.savedView.zoomLevel, tile);
                 self.invalidate();

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -169,7 +169,7 @@ namespace OpenLoco::Ui::Windows::Station
 
             const auto& widget = self.widgets[widx::status_bar];
             const auto width = widget.width() - 1;
-            auto point = Point(self.x + widget.left - 1, self.y + widget.top - 1);
+            auto point = Point(widget.left - 1, widget.top - 1);
             tr.drawStringLeftClipped(point, width, Colour::black, StringIds::black_stringid, args);
         }
 
@@ -440,7 +440,7 @@ namespace OpenLoco::Ui::Windows::Station
 
             const auto& widget = self.widgets[widx::status_bar];
             const auto width = widget.width();
-            auto point = Point(self.x + widget.left - 1, self.y + widget.top - 1);
+            auto point = Point(widget.left - 1, widget.top - 1);
 
             tr.drawStringLeftClipped(point, width, Colour::black, StringIds::buffer_1250);
         }
@@ -1485,8 +1485,8 @@ namespace OpenLoco::Ui::Windows::Station
                 Widget::drawTab(self, drawingCtx, imageId, widx::tab_cargo_ratings);
 
                 auto widget = self->widgets[widx::tab_cargo_ratings];
-                auto yOffset = widget.top + self->y + 14;
-                auto xOffset = widget.left + self->x + 4;
+                auto yOffset = widget.top + 14;
+                auto xOffset = widget.left + 4;
                 auto totalRatingBars = 0;
 
                 for (const auto& cargoStats : station->cargoStats)

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -791,7 +791,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 FormatArguments args{};
                 args.push<uint32_t>(treeCost);
 
-                auto point = Point(self.x + 3 + self.width - 17, self.y + self.height - 13);
+                auto point = Point(3 + self.width - 17, self.height - 13);
                 tr.drawStringRight(point, Colour::black, StringIds::build_cost, args);
             }
 
@@ -799,7 +799,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 FormatArguments args{};
                 args.push(treeObj->name);
 
-                auto point = Point(self.x + 3, self.y + self.height - 13);
+                auto point = Point(3, self.height - 13);
                 auto width = self.width - 19 - point.x;
                 tr.drawStringLeftClipped(point, width, Colour::black, StringIds::black_stringid, args);
             }
@@ -1151,8 +1151,8 @@ namespace OpenLoco::Ui::Windows::Terraform
             // Draw as a number if we can't fit a sprite
             if (_adjustToolSize > 10)
             {
-                auto xPos = toolArea.midX() + self.x;
-                auto yPos = toolArea.midY() + self.y - 5;
+                auto xPos = toolArea.midX();
+                auto yPos = toolArea.midY() - 5;
                 auto point = Point(xPos, yPos);
 
                 FormatArguments args{};
@@ -1171,8 +1171,8 @@ namespace OpenLoco::Ui::Windows::Terraform
             }
 
             {
-                auto xPos = toolArea.midX() + self.x;
-                auto yPos = toolArea.bottom + self.y + 5;
+                auto xPos = toolArea.midX();
+                auto yPos = toolArea.bottom + 5;
                 auto point = Point(xPos, yPos);
 
                 FormatArguments args{};
@@ -1295,8 +1295,8 @@ namespace OpenLoco::Ui::Windows::Terraform
                 }
             }
 
-            auto xPos = self->widgets[widgetIndex].left + self->x;
-            auto yPos = self->widgets[widgetIndex].bottom + self->y;
+            auto xPos = self->widgets[widgetIndex].left;
+            auto yPos = self->widgets[widgetIndex].bottom;
             auto heightOffset = self->widgets[widgetIndex].height() - 18;
             auto colour = self->getColour(WindowColour::secondary).translucent();
             auto count = Dropdown::getItemsPerRow(landCount);
@@ -1798,7 +1798,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 if (isMountainMode)
                 {
                     auto areaImage = ImageId(ImageIds::tool_area);
-                    Ui::Point placeForImage(toolArea.left + self.x, toolArea.top + self.y);
+                    Ui::Point placeForImage(toolArea.left, toolArea.top);
 
                     if ((_adjustToolSize & 1) == 0)
                     {
@@ -1821,15 +1821,15 @@ namespace OpenLoco::Ui::Windows::Terraform
                 if (!isMountainMode || _adjustToolSize > 1)
                 {
                     auto areaImage = ImageId(ImageIds::tool_area).withIndexOffset(_adjustToolSize);
-                    Ui::Point placeForImage(toolArea.left + self.x, toolArea.top + self.y);
+                    Ui::Point placeForImage(toolArea.left, toolArea.top);
                     drawingCtx.drawImage(placeForImage, areaImage);
                 }
             }
             // Or draw as a number, if we can't fit a sprite
             else
             {
-                auto xPos = toolArea.midX() + self.x;
-                auto yPos = toolArea.midY() + self.y - 5;
+                auto xPos = toolArea.midX();
+                auto yPos = toolArea.midY() - 5;
                 auto point = Point(xPos, yPos);
 
                 FormatArguments args{};
@@ -1837,8 +1837,8 @@ namespace OpenLoco::Ui::Windows::Terraform
                 tr.drawStringCentred(point, Colour::black, StringIds::tile_inspector_coord, args);
             }
 
-            auto xPos = toolArea.midX() + self.x;
-            auto yPos = toolArea.bottom + self.y + 28;
+            auto xPos = toolArea.midX();
+            auto yPos = toolArea.bottom + 28;
 
             if (_raiseLandCost != 0x80000000)
             {
@@ -2174,8 +2174,8 @@ namespace OpenLoco::Ui::Windows::Terraform
             // Draw as a number if we can't fit a sprite
             if (_adjustToolSize > 10)
             {
-                auto xPos = toolArea.midX() + self.x;
-                auto yPos = toolArea.midY() + self.y - 5;
+                auto xPos = toolArea.midX();
+                auto yPos = toolArea.midY() - 5;
                 auto point = Point(xPos, yPos);
 
                 FormatArguments args{};
@@ -2183,8 +2183,8 @@ namespace OpenLoco::Ui::Windows::Terraform
                 tr.drawStringCentred(point, Colour::black, StringIds::tile_inspector_coord, args);
             }
 
-            auto xPos = toolArea.midX() + self.x;
-            auto yPos = toolArea.bottom + self.y + 5;
+            auto xPos = toolArea.midX();
+            auto yPos = toolArea.bottom + 5;
 
             if (_raiseWaterCost != 0x80000000)
             {
@@ -2654,8 +2654,8 @@ namespace OpenLoco::Ui::Windows::Terraform
             }
 
             auto wallObj = ObjectManager::get<WallObject>(wallId);
-            auto xPos = self.x + 3;
-            auto yPos = self.y + self.height - 13;
+            auto xPos = 3;
+            auto yPos = self.height - 13;
             auto width = self.width - 19;
             auto point = Point(xPos, yPos);
 

--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -243,7 +243,7 @@ namespace OpenLoco::Ui::Windows::TextInput
         tr.drawStringCentredWrapped(position, window.width - 8, Colour::black, StringIds::wcolour2_stringid, FormatArguments::common());
 
         auto widget = &_widgets[Widx::input];
-        auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(widget->left + 1 + window.x, widget->top + 1 + window.y, widget->width() - 2, widget->height() - 2));
+        auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(widget->left + 1, widget->top + 1, widget->width() - 2, widget->height() - 2));
         if (!clipped)
         {
             return;
@@ -271,7 +271,7 @@ namespace OpenLoco::Ui::Windows::TextInput
             args.push<uint16_t>(maxNumCharacters);
 
             widget = &_widgets[Widx::ok];
-            auto point = Point(window.x + widget->left - 5, window.y + widget->top + 1);
+            auto point = Point(widget->left - 5, widget->top + 1);
             tr.drawStringRight(point, Colour::black, StringIds::num_characters_left_int_int, args);
         }
 

--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -228,19 +228,19 @@ namespace OpenLoco::Ui::Windows::TextInput
      * @param window @<esi>
      * @param context @<edi>
      */
-    static void draw(Ui::Window& window, Gfx::DrawingContext& drawingCtx)
+    static void draw(Ui::Window& self, Gfx::DrawingContext& drawingCtx)
     {
         const auto& rt = drawingCtx.currentRenderTarget();
         auto tr = Gfx::TextRenderer(drawingCtx);
 
-        window.draw(drawingCtx);
+        self.draw(drawingCtx);
 
         // FIXME: This is pretty horrible.
         *((StringId*)(&_commonFormatArgs[0])) = _message;
         memcpy(&_commonFormatArgs[2], _formatArgs + 8, 8);
 
-        Ui::Point position = Point(window.x + window.width / 2, window.y + 30);
-        tr.drawStringCentredWrapped(position, window.width - 8, Colour::black, StringIds::wcolour2_stringid, FormatArguments::common());
+        Ui::Point position = Point(self.width / 2, 30);
+        tr.drawStringCentredWrapped(position, self.width - 8, Colour::black, StringIds::wcolour2_stringid, FormatArguments::common());
 
         auto widget = &_widgets[Widx::input];
         auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(widget->left + 1, widget->top + 1, widget->width() - 2, widget->height() - 2));
@@ -280,11 +280,11 @@ namespace OpenLoco::Ui::Windows::TextInput
             strncpy(drawnBuffer, inputSession.buffer.c_str(), inputSession.cursorPosition);
             drawnBuffer[inputSession.cursorPosition] = '\0';
 
-            if (Input::isFocused(window.type, window.number, Widx::input))
+            if (Input::isFocused(self.type, self.number, Widx::input))
             {
                 auto width = tr.getStringWidth(drawnBuffer);
                 auto cursorPos = Point(inputSession.xOffset + width, 1);
-                drawingCtx.fillRect(cursorPos.x, cursorPos.y, cursorPos.x, cursorPos.y + 9, Colours::getShade(window.getColour(WindowColour::secondary).c(), 9), Gfx::RectFlags::none);
+                drawingCtx.fillRect(cursorPos.x, cursorPos.y, cursorPos.x, cursorPos.y + 9, Colours::getShade(self.getColour(WindowColour::secondary).c(), 9), Gfx::RectFlags::none);
             }
         }
 

--- a/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
@@ -161,14 +161,14 @@ namespace OpenLoco::Ui::Windows::TileInspector
             FormatArguments args{};
             args.push(StringIds::tile_inspector_x_coord);
             auto& widget = self.widgets[widx::xPos];
-            auto point = Point(self.x + widget.left - 15, self.y + widget.top + 1);
+            auto point = Point(widget.left - 15, widget.top + 1);
             tr.drawStringLeft(point, Colour::black, StringIds::wcolour2_stringid, args);
         }
         {
             FormatArguments args{};
             args.push(StringIds::tile_inspector_y_coord);
             auto& widget = self.widgets[widx::yPos];
-            auto point = Point(self.x + widget.left - 15, self.y + widget.top + 1);
+            auto point = Point(widget.left - 15, widget.top + 1);
             tr.drawStringLeft(point, Colour::black, StringIds::wcolour2_stringid, args);
         }
 
@@ -177,14 +177,14 @@ namespace OpenLoco::Ui::Windows::TileInspector
             FormatArguments args{};
             args.push<int16_t>(_currentPosition.x);
             auto& widget = self.widgets[widx::xPos];
-            auto point = Point(self.x + widget.left + 2, self.y + widget.top + 1);
+            auto point = Point(widget.left + 2, widget.top + 1);
             tr.drawStringLeft(point, Colour::black, StringIds::tile_inspector_coord, args);
         }
         {
             FormatArguments args{};
             args.push<int16_t>(_currentPosition.y);
             auto& widget = self.widgets[widx::yPos];
-            auto point = Point(self.x + widget.left + 2, self.y + widget.top + 1);
+            auto point = Point(widget.left + 2, widget.top + 1);
             tr.drawStringLeft(point, Colour::black, StringIds::tile_inspector_coord, args);
         }
 
@@ -199,7 +199,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
             snprintf(&buffer[1], std::size(buffer) - 1, "Data: %02x %02x %02x %02x %02x %02x %02x %02x", data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]);
 
             auto widget = self.widgets[widx::detailsGroup];
-            auto point = Point(self.x + widget.left + 7, self.y + widget.top + 14);
+            auto point = Point(widget.left + 7, widget.top + 14);
             tr.drawString(point, Colour::black, buffer);
         }
     }

--- a/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
@@ -153,12 +153,12 @@ namespace OpenLoco::Ui::Windows::TimePanel
         auto tr = Gfx::TextRenderer(drawingCtx);
 
         Widget& frame = self.widgets[Widx::outer_frame];
-        drawingCtx.drawRect(self.x + frame.left, self.y + frame.top, frame.width(), frame.height(), enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
+        drawingCtx.drawRect(frame.left, frame.top, frame.width(), frame.height(), enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
 
         // Draw widgets.
         self.draw(drawingCtx);
 
-        drawingCtx.drawRectInset(self.x + frame.left + 1, self.y + frame.top + 1, frame.width() - 2, frame.height() - 2, self.getColour(WindowColour::secondary), Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillNone);
+        drawingCtx.drawRectInset(frame.left + 1, frame.top + 1, frame.width() - 2, frame.height() - 2, self.getColour(WindowColour::secondary), Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillNone);
 
         FormatArguments args{};
         args.push<uint32_t>(getCurrentDay());
@@ -180,12 +180,12 @@ namespace OpenLoco::Ui::Windows::TimePanel
 
         {
             auto& widget = _widgets[Widx::date_btn];
-            auto point = Point(self.x + widget.midX(), self.y + widget.top + 1);
+            auto point = Point(widget.midX(), widget.top + 1);
             tr.drawStringCentred(point, c, format, args);
         }
 
         auto skin = ObjectManager::get<InterfaceSkinObject>();
-        drawingCtx.drawImage(self.x + _widgets[Widx::map_chat_menu].left - 2, self.y + _widgets[Widx::map_chat_menu].top - 1, skin->img + map_sprites_by_rotation[WindowManager::getCurrentRotation()]);
+        drawingCtx.drawImage(_widgets[Widx::map_chat_menu].left - 2, _widgets[Widx::map_chat_menu].top - 1, skin->img + map_sprites_by_rotation[WindowManager::getCurrentRotation()]);
     }
 
     // 0x004398FB

--- a/src/OpenLoco/src/Ui/Windows/TitleExit.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleExit.cpp
@@ -68,8 +68,8 @@ namespace OpenLoco::Ui::Windows::TitleExit
         // Draw widgets.
         window.draw(drawingCtx);
 
-        int16_t x = window.x + window.width / 2;
-        int16_t y = window.y + window.widgets[Widx::exit_button].top + 8;
+        int16_t x = window.width / 2;
+        int16_t y = window.widgets[Widx::exit_button].top + 8;
         Ui::Point origin = { x, y };
         tr.drawStringCentredWrapped(origin, window.width, Colour::black, StringIds::title_exit_game);
     }

--- a/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
@@ -208,8 +208,8 @@ namespace OpenLoco::Ui::Windows::TitleMenu
 
         if (!window.widgets[Widx::scenario_list_btn].hidden)
         {
-            int16_t x = window.widgets[Widx::scenario_list_btn].left + window.x;
-            int16_t y = window.widgets[Widx::scenario_list_btn].top + window.y;
+            int16_t x = window.widgets[Widx::scenario_list_btn].left;
+            int16_t y = window.widgets[Widx::scenario_list_btn].top;
 
             uint32_t image_id = ImageIds::title_menu_globe_spin_0;
             if (Input::isHovering(WindowType::titleMenu, 0, Widx::scenario_list_btn))
@@ -223,8 +223,8 @@ namespace OpenLoco::Ui::Windows::TitleMenu
 
         if (!window.widgets[Widx::load_game_btn].hidden)
         {
-            int16_t x = window.widgets[Widx::load_game_btn].left + window.x;
-            int16_t y = window.widgets[Widx::load_game_btn].top + window.y;
+            int16_t x = window.widgets[Widx::load_game_btn].left;
+            int16_t y = window.widgets[Widx::load_game_btn].top;
 
             uint32_t image_id = ImageIds::title_menu_globe_spin_0;
             if (Input::isHovering(WindowType::titleMenu, 0, Widx::load_game_btn))
@@ -238,8 +238,8 @@ namespace OpenLoco::Ui::Windows::TitleMenu
 
         if (!window.widgets[Widx::tutorial_btn].hidden)
         {
-            int16_t x = window.widgets[Widx::tutorial_btn].left + window.x;
-            int16_t y = window.widgets[Widx::tutorial_btn].top + window.y;
+            int16_t x = window.widgets[Widx::tutorial_btn].left;
+            int16_t y = window.widgets[Widx::tutorial_btn].top;
 
             uint32_t image_id = ImageIds::title_menu_globe_spin_0;
             if (Input::isHovering(WindowType::titleMenu, 0, Widx::tutorial_btn))
@@ -255,8 +255,8 @@ namespace OpenLoco::Ui::Windows::TitleMenu
 
         if (!window.widgets[Widx::scenario_editor_btn].hidden)
         {
-            int16_t x = window.widgets[Widx::scenario_editor_btn].left + window.x;
-            int16_t y = window.widgets[Widx::scenario_editor_btn].top + window.y;
+            int16_t x = window.widgets[Widx::scenario_editor_btn].left;
+            int16_t y = window.widgets[Widx::scenario_editor_btn].top;
 
             uint32_t image_id = ImageIds::title_menu_globe_construct_24;
             if (Input::isHovering(WindowType::titleMenu, 0, Widx::scenario_editor_btn))
@@ -270,7 +270,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
         if (!window.widgets[Widx::multiplayer_toggle_btn].hidden)
         {
             auto& widget = window.widgets[Widx::multiplayer_toggle_btn];
-            auto point = Point(widget.top + 3 + window.y, window.width / 2 + window.x);
+            auto point = Point(widget.top + 3, window.width / 2);
 
             StringId string = StringIds::single_player_mode;
             FormatArguments args{};

--- a/src/OpenLoco/src/Ui/Windows/TitleOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleOptions.cpp
@@ -55,8 +55,8 @@ namespace OpenLoco::Ui::Windows::TitleOptions
         // Draw widgets.
         window.draw(drawingCtx);
 
-        int16_t x = window.x + window.width / 2;
-        int16_t y = window.y + window.widgets[Widx::options_button].top + 2;
+        int16_t x = window.width / 2;
+        int16_t y = window.widgets[Widx::options_button].top + 2;
         Ui::Point origin = { x, y };
 
         auto argsBuf = FormatArgumentsBuffer{};

--- a/src/OpenLoco/src/Ui/Windows/TitleVersion.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleVersion.cpp
@@ -26,12 +26,12 @@ namespace OpenLoco::Ui::Windows::TitleVersion
     }
 
     // 0x00439236
-    static void draw(Ui::Window& window, Gfx::DrawingContext& drawingCtx)
+    static void draw([[maybe_unused]] Ui::Window& window, Gfx::DrawingContext& drawingCtx)
     {
         auto tr = Gfx::TextRenderer(drawingCtx);
 
         auto versionInfo = getVersionInfo();
-        auto point = Point(window.x, window.y);
+        auto point = Point(0, 0);
         tr.drawString(point, AdvancedColour(Colour::white).outline(), versionInfo.c_str());
     }
 

--- a/src/OpenLoco/src/Ui/Windows/ToolTip.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolTip.cpp
@@ -173,25 +173,23 @@ namespace OpenLoco::Ui::Windows::ToolTip
     {
         auto tr = Gfx::TextRenderer(drawingCtx);
 
-        uint16_t x = window.x;
-        uint16_t y = window.y;
         uint16_t width = window.width;
         uint16_t height = window.height;
 
-        drawingCtx.drawRect(x + 1, y + 1, width - 2, height - 2, enumValue(ExtColour::unk2D), Gfx::RectFlags::transparent);
-        drawingCtx.drawRect(x + 1, y + 1, width - 2, height - 2, (enumValue(ExtColour::unk74) + enumValue(ObjectManager::get<InterfaceSkinObject>()->tooltipColour)), Gfx::RectFlags::transparent);
+        drawingCtx.drawRect(1, 1, width - 2, height - 2, enumValue(ExtColour::unk2D), Gfx::RectFlags::transparent);
+        drawingCtx.drawRect(1, 1, width - 2, height - 2, (enumValue(ExtColour::unk74) + enumValue(ObjectManager::get<InterfaceSkinObject>()->tooltipColour)), Gfx::RectFlags::transparent);
 
-        drawingCtx.drawRect(x, y + 2, 1, height - 4, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
-        drawingCtx.drawRect(x + width - 1, y + 2, 1, height - 4, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
-        drawingCtx.drawRect(x + 2, y + height - 1, width - 4, 1, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
-        drawingCtx.drawRect(x + 2, y, width - 4, 1, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
+        drawingCtx.drawRect(0, 2, 1, height - 4, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
+        drawingCtx.drawRect(0 + width - 1, 2, 1, height - 4, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
+        drawingCtx.drawRect(0 + 2, height - 1, width - 4, 1, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
+        drawingCtx.drawRect(0 + 2, 0, width - 4, 1, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
 
-        drawingCtx.drawRect(x + 1, y + 1, 1, 1, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
-        drawingCtx.drawRect(x + width - 1 - 1, y + 1, 1, 1, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
-        drawingCtx.drawRect(x + 1, y + height - 1 - 1, 1, 1, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
-        drawingCtx.drawRect(x + width - 1 - 1, y + height - 1 - 1, 1, 1, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
+        drawingCtx.drawRect(0 + 1, 1, 1, 1, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
+        drawingCtx.drawRect(0 + width - 1 - 1, 1, 1, 1, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
+        drawingCtx.drawRect(0 + 1, height - 1 - 1, 1, 1, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
+        drawingCtx.drawRect(0 + width - 1 - 1, height - 1 - 1, 1, 1, enumValue(ExtColour::unk2E), Gfx::RectFlags::transparent);
 
-        auto point = Point(((width + 1) / 2) + x - 1, y + 1);
+        auto point = Point(((width + 1) / 2) - 1, 1);
         tr.drawStringCentredRaw(point, _lineBreakCount, Colour::black, _text);
     }
 

--- a/src/OpenLoco/src/Ui/Windows/ToolbarBottomEditor.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarBottomEditor.cpp
@@ -71,24 +71,24 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
 
         if (EditorController::canGoBack())
         {
-            drawingCtx.drawRect(previous.left + self.x, previous.top + self.y, previous.width(), previous.height(), enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
+            drawingCtx.drawRect(previous.left, previous.top, previous.width(), previous.height(), enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
         }
-        drawingCtx.drawRect(next.left + self.x, next.top + self.y, next.width(), next.height(), enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
+        drawingCtx.drawRect(next.left, next.top, next.width(), next.height(), enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
 
         self.draw(drawingCtx);
 
         if (EditorController::canGoBack())
         {
-            drawingCtx.drawRectInset(previous.left + self.x + 1, previous.top + self.y + 1, previous.width() - 2, previous.height() - 2, self.getColour(WindowColour::secondary), Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillNone);
+            drawingCtx.drawRectInset(previous.left + 1, previous.top + 1, previous.width() - 2, previous.height() - 2, self.getColour(WindowColour::secondary), Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillNone);
         }
-        drawingCtx.drawRectInset(next.left + self.x + 1, next.top + self.y + 1, next.width() - 2, next.height() - 2, self.getColour(WindowColour::secondary), Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillNone);
+        drawingCtx.drawRectInset(next.left + 1, next.top + 1, next.width() - 2, next.height() - 2, self.getColour(WindowColour::secondary), Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillNone);
 
-        auto point = Point((previous.right + next.left) / 2 + self.x, self.y + self.height - 12);
+        auto point = Point((previous.right + next.left) / 2, self.height - 12);
         tr.drawStringCentred(point, self.getColour(WindowColour::tertiary).opaque().outline(), _stepNames[EditorController::getCurrentStep()]);
 
         if (EditorController::canGoBack())
         {
-            drawingCtx.drawImage(self.x + previous.left + 6, self.y + previous.top + 6, ImageIds::step_back);
+            drawingCtx.drawImage(previous.left + 6, previous.top + 6, ImageIds::step_back);
             int x = (previous.left + 30 + previous.right) / 2;
             int y = previous.top + 6;
             auto textColour = self.getColour(WindowColour::secondary).opaque();
@@ -97,13 +97,13 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
                 textColour = Colour::white;
             }
 
-            point = Point(self.x + x, self.y + y);
+            point = Point(x, y);
             tr.drawStringCentred(point, textColour, StringIds::editor_previous_step);
 
-            point = Point(self.x + x, self.y + y + 10);
+            point = Point(x, y + 10);
             tr.drawStringCentred(point, textColour, _stepNames[EditorController::getPreviousStep()]);
         }
-        drawingCtx.drawImage(self.x + next.right - 29, self.y + next.top + 4, ImageIds::step_forward);
+        drawingCtx.drawImage(next.right - 29, next.top + 4, ImageIds::step_forward);
         int x = next.left + (next.width() - 31) / 2;
         int y = next.top + 6;
         auto textColour = self.getColour(WindowColour::secondary).opaque();
@@ -112,10 +112,10 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
             textColour = Colour::white;
         }
 
-        point = Point(self.x + x, self.y + y);
+        point = Point(x, y);
         tr.drawStringCentred(point, textColour, StringIds::editor_next_step);
 
-        point = Point(self.x + x, self.y + y + 10);
+        point = Point(x, y + 10);
         tr.drawStringCentred(point, textColour, _stepNames[EditorController::getNextStep()]);
     }
 

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -827,8 +827,8 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
 
         if (!window.widgets[Common::Widx::railroad_menu].hidden)
         {
-            uint32_t x = window.widgets[Common::Widx::railroad_menu].left + window.x;
-            uint32_t y = window.widgets[Common::Widx::railroad_menu].top + window.y;
+            uint32_t x = window.widgets[Common::Widx::railroad_menu].left;
+            uint32_t y = window.widgets[Common::Widx::railroad_menu].top;
             uint32_t fg_image = 0;
 
             // Figure out what icon to show on the button face.
@@ -857,13 +857,13 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
 
             drawingCtx.drawImage(x, y, fg_image);
 
-            y = window.widgets[Common::Widx::railroad_menu].top + window.y;
+            y = window.widgets[Common::Widx::railroad_menu].top;
             drawingCtx.drawImage(x, y, bg_image);
         }
 
         {
-            uint32_t x = window.widgets[Common::Widx::vehicles_menu].left + window.x;
-            uint32_t y = window.widgets[Common::Widx::vehicles_menu].top + window.y;
+            uint32_t x = window.widgets[Common::Widx::vehicles_menu].left;
+            uint32_t y = window.widgets[Common::Widx::vehicles_menu].top;
 
             static constexpr uint32_t button_face_image_ids[] = {
                 InterfaceSkin::ImageIds::vehicle_train_frame_0,
@@ -887,13 +887,13 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
 
             drawingCtx.drawImage(x, y, fg_image);
 
-            y = window.widgets[Common::Widx::vehicles_menu].top + window.y;
+            y = window.widgets[Common::Widx::vehicles_menu].top;
             drawingCtx.drawImage(x, y, bg_image);
         }
 
         {
-            uint32_t x = window.widgets[Common::Widx::build_vehicles_menu].left + window.x;
-            uint32_t y = window.widgets[Common::Widx::build_vehicles_menu].top + window.y;
+            uint32_t x = window.widgets[Common::Widx::build_vehicles_menu].left;
+            uint32_t y = window.widgets[Common::Widx::build_vehicles_menu].top;
 
             static constexpr uint32_t kBuildVehicleImages[] = {
                 InterfaceSkin::ImageIds::toolbar_build_vehicle_train,

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
@@ -47,8 +47,8 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
 
         if (!self.widgets[Widx::road_menu].hidden && lastRoadOption != 0xFF)
         {
-            uint32_t x = self.widgets[Widx::road_menu].left + self.x;
-            uint32_t y = self.widgets[Widx::road_menu].top + self.y;
+            uint32_t x = self.widgets[Widx::road_menu].left;
+            uint32_t y = self.widgets[Widx::road_menu].top;
             uint32_t fgImage = 0;
 
             // Figure out what icon to show on the button face.
@@ -76,7 +76,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
 
             drawingCtx.drawImage(x, y, fgImage);
 
-            y = self.widgets[Widx::road_menu].top + self.y;
+            y = self.widgets[Widx::road_menu].top;
             drawingCtx.drawImage(x, y, bgImage);
         }
     }

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -698,10 +698,10 @@ namespace OpenLoco::Ui::Windows::TownList
             self.draw(drawingCtx);
             Common::drawTabs(&self, drawingCtx);
 
-            auto point = Point(self.x + 3, self.y + self.widgets[widx::current_size].top + 1);
+            auto point = Point(3, self.widgets[widx::current_size].top + 1);
             tr.drawStringLeft(point, Colour::black, StringIds::town_size_label);
 
-            point = Point(self.x + 3, self.y + self.height - 13);
+            point = Point(3, self.height - 13);
             tr.drawStringLeft(point, Colour::black, StringIds::select_town_size);
         }
 
@@ -943,7 +943,7 @@ namespace OpenLoco::Ui::Windows::TownList
             FormatArguments args{};
             args.push(buildingObj->name);
 
-            auto point = Point(self.x + 3, self.y + self.height - 13);
+            auto point = Point(3, self.height - 13);
             tr.drawStringLeftClipped(point, self.width - 19, Colour::black, StringIds::black_stringid, args);
         }
 

--- a/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
@@ -148,7 +148,7 @@ namespace OpenLoco::Ui::Windows::Town
 
             const auto& widget = self.widgets[widx::status_bar];
             const auto width = widget.width() - 1;
-            auto point = Point(self.x + widget.left - 1, self.y + widget.top - 1);
+            auto point = Point(widget.left - 1, widget.top - 1);
             tr.drawStringLeftClipped(point, width, Colour::black, StringIds::status_town_population, args);
         }
 
@@ -414,7 +414,7 @@ namespace OpenLoco::Ui::Windows::Town
             self.draw(drawingCtx);
             Common::drawTabs(&self, drawingCtx);
 
-            auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(self.x, self.y + 44, self.width, self.height - 44));
+            auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(0, 44, self.width, self.height - 44));
             if (!clipped)
             {
                 return;
@@ -556,7 +556,7 @@ namespace OpenLoco::Ui::Windows::Town
             self.draw(drawingCtx);
             Common::drawTabs(&self, drawingCtx);
 
-            auto point = Point(self.x + 4, self.y + 46);
+            auto point = Point(4, 46);
             tr.drawStringLeft(point, Colour::black, StringIds::local_authority_ratings_transport_companies);
 
             point.x += 4;

--- a/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
@@ -310,7 +310,7 @@ namespace OpenLoco::Ui::Windows::Town
             {
                 auto widget = &self.widgets[widx::viewport];
                 auto tile = World::Pos3({ town->x, town->y, tileZ });
-                auto origin = Ui::Point(widget->left + self.x + 1, widget->top + self.y + 1);
+                auto origin = Ui::Point(widget->left + 1, widget->top + 1);
                 auto size = Ui::Size(widget->width() - 2, widget->height() - 2);
                 ViewportManager::create(&self, 0, origin, size, self.savedView.zoomLevel, tile);
                 self.invalidate();

--- a/src/OpenLoco/src/Ui/Windows/Tutorial.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Tutorial.cpp
@@ -75,7 +75,7 @@ namespace OpenLoco::Ui::Windows::Tutorial
         args.push(titleStringIds[tutorialNumber]);
 
         auto& widget = self.widgets[Widx::frame];
-        auto point = Point(self.x + widget.midX(), self.y + widget.top + 4);
+        auto point = Point(widget.midX(), widget.top + 4);
         tr.drawStringCentred(point, Colour::black, StringIds::tutorial_text, args);
 
         point.y += 10;

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -368,7 +368,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             if (self.viewports[0] == nullptr)
             {
                 auto widget = &self.widgets[widx::viewport];
-                auto origin = Ui::Point(widget->left + self.x + 1, widget->top + self.y + 1);
+                auto origin = Ui::Point(widget->left + 1, widget->top + 1);
                 auto size = Ui::Size(widget->width() - 2, widget->height() - 2);
                 ViewportManager::create(&self, 0, origin, size, self.savedView.zoomLevel, targetEntity);
                 self.invalidate();

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -969,8 +969,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 if ((pickupButton.image & 0x20000000) != 0 && !self.isDisabled(widx::pickup))
                 {
                     drawingCtx.drawImage(
-                        self.x + pickupButton.left,
-                        self.y + pickupButton.top,
+                        pickupButton.left,
+                        pickupButton.top,
                         Gfx::recolour(pickupButton.image, CompanyManager::getCompanyColour(self.owner)));
                 }
             }
@@ -995,7 +995,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 }
 
                 auto& widget = self.widgets[widx::status];
-                auto point = Point(self.x + widget.left - 1, self.y + widget.top - 1);
+                auto point = Point(widget.left - 1, widget.top - 1);
                 tr.drawStringLeftClipped(point, widget.width() - 1, Colour::black, strFormat, args);
             }
 
@@ -1003,19 +1003,19 @@ namespace OpenLoco::Ui::Windows::Vehicle
             if (!speedWidget.hidden)
             {
                 drawingCtx.drawImage(
-                    self.x + speedWidget.left,
-                    self.y + speedWidget.top + 10,
+                    speedWidget.left,
+                    speedWidget.top + 10,
                     Gfx::recolour(ImageIds::speed_control_track, self.getColour(WindowColour::secondary).c()));
 
-                auto point = Point(self.x + speedWidget.midX(), self.y + speedWidget.top + 4);
+                auto point = Point(speedWidget.midX(), speedWidget.top + 4);
                 tr.drawStringCentred(point, Colour::black, StringIds::tiny_power);
 
-                point = Point(self.x + speedWidget.midX(), self.y + speedWidget.bottom - 10);
+                point = Point(speedWidget.midX(), speedWidget.bottom - 10);
                 tr.drawStringCentred(point, Colour::black, StringIds::tiny_brake);
 
                 drawingCtx.drawImage(
-                    self.x + speedWidget.left + 1,
-                    self.y + speedWidget.top + 57 - veh->manualPower,
+                    speedWidget.left + 1,
+                    speedWidget.top + 57 - veh->manualPower,
                     Gfx::recolour(ImageIds::speed_control_thumb, self.getColour(WindowColour::secondary).c()));
             }
 
@@ -1025,7 +1025,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 args.push(StringIds::getVehicleType(veh->vehicleType));
 
                 auto& button = self.widgets[widx::viewport];
-                auto origin = Point(self.x + button.midX(), self.y + button.midY());
+                auto origin = Point(button.midX(), button.midY());
                 tr.drawStringCentredWrapped(origin, button.width() - 6, Colour::black, StringIds::click_on_view_select_string_id_start, args);
             }
         }
@@ -1553,7 +1553,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 if ((self.widgets[widx::pickup].image & (1 << 29)) && !self.isDisabled(widx::pickup))
                 {
                     auto image = Gfx::recolour(self.widgets[widx::pickup].image, CompanyManager::getCompanyColour(self.owner));
-                    drawingCtx.drawImage(self.widgets[widx::pickup].left + self.x, self.widgets[widx::pickup].top + self.y, image);
+                    drawingCtx.drawImage(self.widgets[widx::pickup].left, self.widgets[widx::pickup].top, image);
                 }
             }
 
@@ -1563,7 +1563,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 return;
             }
             OpenLoco::Vehicles::Vehicle train{ *head };
-            Ui::Point pos = { static_cast<int16_t>(self.x + 3), static_cast<int16_t>(self.y + self.height - getVehicleDetailsHeight(head->getTransportMode()) + kVehicleDetailsOffset) };
+            Ui::Point pos = { 3, self.height - getVehicleDetailsHeight(head->getTransportMode()) + kVehicleDetailsOffset };
 
             {
                 FormatArguments args{};
@@ -1904,7 +1904,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 FormatArguments args = {};
                 args.push<StringId>(StringIds::buffer_1250);
 
-                auto point = Point(self.x + 3, self.y + self.height - 25);
+                auto point = Point(3, self.height - 25);
                 tr.drawStringLeftClipped(point, self.width - 15, Colour::black, StringIds::total_stringid, args);
             }
 
@@ -1916,7 +1916,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 FormatArguments args = {};
                 args.push<StringId>(StringIds::buffer_1250);
 
-                auto point = Point(self.x + 3, self.y + self.height - 13);
+                auto point = Point(3, self.height - 13);
                 tr.drawStringLeftClipped(point, self.width - 15, Colour::black, StringIds::vehicle_capacity_stringid, args);
             }
         }
@@ -2306,7 +2306,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self.draw(drawingCtx);
             Common::drawTabs(&self, drawingCtx);
 
-            auto pos = Ui::Point(self.x + 4, self.y + 46);
+            auto pos = Ui::Point(4, 46);
 
             auto head = Common::getVehicle(&self);
             if (head == nullptr)
@@ -3482,7 +3482,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             if (ToolManager::isToolActive(WindowType::vehicle, self.number))
             {
                 // Location at bottom left edge of window
-                auto loc = Point(self.x + 3, self.y + self.height - 13);
+                auto loc = Point(3, self.height - 13);
                 tr.drawStringLeftClipped(loc, self.width - 14, Colour::black, StringIds::route_click_on_waypoint);
             }
         }

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -673,8 +673,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
         auto company = CompanyManager::get(CompanyId(self.number));
         auto competitorObj = ObjectManager::get<CompetitorObject>(company->competitorId);
         uint32_t image = Gfx::recolour(competitorObj->images[enumValue(company->ownerEmotion)], company->mainColours.primary);
-        uint16_t x = self.x + self.widgets[Widx::company_select].left + 1;
-        uint16_t y = self.y + self.widgets[Widx::company_select].top + 1;
+        uint16_t x = self.widgets[Widx::company_select].left + 1;
+        uint16_t y = self.widgets[Widx::company_select].top + 1;
         drawingCtx.drawImage(x, y, image);
     }
 


### PR DESCRIPTION
All the window drawing is now clipped to the window region which means all subsequent draw calls will start at 0,0 of the window canvas rather than screen.