### PR TITLE
Use correct position for competitor image in map tooltip

### DIFF
--- a/src/OpenLoco/src/Graphics/TextRenderer.cpp
+++ b/src/OpenLoco/src/Graphics/TextRenderer.cpp
@@ -716,10 +716,12 @@ namespace OpenLoco::Gfx
 
             const char* ptr = buffer;
             uint16_t lineWidth{};
+            uint16_t maxLineWidth{};
 
             for (auto i = 0; ptr != nullptr && i < breakCount; i++)
             {
                 lineWidth = getStringWidth(drawState.font, ptr);
+                maxLineWidth = std::max(lineWidth, maxLineWidth);
 
                 auto point = basePoint;
                 point.x -= lineWidth / 2;
@@ -730,7 +732,7 @@ namespace OpenLoco::Gfx
                 basePoint.y += lineHeight;
             }
 
-            basePoint.x -= lineWidth / 2;
+            basePoint.x -= maxLineWidth / 2;
 
             return basePoint;
         }

--- a/src/OpenLoco/src/Graphics/TextRenderer.cpp
+++ b/src/OpenLoco/src/Graphics/TextRenderer.cpp
@@ -730,6 +730,8 @@ namespace OpenLoco::Gfx
                 basePoint.y += lineHeight;
             }
 
+            basePoint.x -= lineWidth / 2;
+
             return basePoint;
         }
 

--- a/src/OpenLoco/src/Ui/Windows/MapToolTip.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapToolTip.cpp
@@ -129,10 +129,10 @@ namespace OpenLoco::Ui::Windows::MapToolTip
         else
         {
             Ui::Point origin(self.x + self.width / 2 + 13, self.y + self.height / 2 - 5);
-            tr.drawStringCentredWrapped(origin, self.width - 28, Colour::black, StringIds::outlined_wcolour2_stringid, args);
+            auto basePoint = tr.drawStringCentredWrapped(origin, self.width - 28, Colour::black, StringIds::outlined_wcolour2_stringid, args);
 
-            auto left = self.width / 2 + self.x + 13 - self.width / 2 - 28;
-            auto top = self.height / 2 - 13 + self.y;
+            auto left = basePoint.x - 28;
+            auto top = self.y + self.height / 2 - 13;
             auto right = left + 25;
             auto bottom = top + 25;
 


### PR DESCRIPTION
Before:
<img width="494" alt="Screenshot 2025-02-17 at 10 06 55" src="https://github.com/user-attachments/assets/64754851-b2bf-4b3e-aa2e-77dc6dc28399" />

After:
<img width="494" alt="Screenshot 2025-02-17 at 10 05 21" src="https://github.com/user-attachments/assets/051bb416-ec28-456c-b57f-695d9bb1158c" />
