### PR TITLE
Fix incorrect error window frame size when competitor image is shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: [#2911] Forbidding trams/buses/trucks does not work as expected.
 - Fix: [#2917] Vehicles aren't available after adding them with the Object Selection window.
 - Fix: [#2931] Mouse movement not being frame rate independent, causing odd panning behavior.
+- Fix: [#2938] Error messages containing a competitor image are not laid out properly.
 
 25.01 (2025-01-30)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Ui/Windows/Error.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Error.cpp
@@ -228,8 +228,8 @@ namespace OpenLoco::Ui::Windows::Error
             }
             else
             {
-                auto xPos = self.widgets[ErrorCompetitor::widx::innerFrame].left + self.x + kPadding;
-                auto yPos = self.widgets[ErrorCompetitor::widx::innerFrame].top + self.y + kPadding;
+                auto xPos = self.widgets[ErrorCompetitor::widx::innerFrame].left + self.x;
+                auto yPos = self.widgets[ErrorCompetitor::widx::innerFrame].top + self.y;
 
                 auto company = CompanyManager::get(_errorCompetitorId);
                 auto companyObj = ObjectManager::get<CompetitorObject>(company->competitorId);

--- a/src/OpenLoco/src/Ui/Windows/Error.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Error.cpp
@@ -31,6 +31,7 @@ namespace OpenLoco::Ui::Windows::Error
     static constexpr auto kMinWidth = 70;
     static constexpr auto kMaxWidth = 250;
     static constexpr auto kPadding = 4;
+    static constexpr auto kCompetitorSize = 64;
 
     namespace Common
     {
@@ -113,17 +114,20 @@ namespace OpenLoco::Ui::Windows::Error
                 _linebreakCount = breakLineCount;
             }
 
-            // Calculate frame size
+            // Calculate window dimensions
             uint16_t width = strWidth + 2 * kPadding;
             uint16_t height = (_linebreakCount + 1) * 10 + 2 * kPadding;
-            uint16_t frameWidth = width - 1;
-            uint16_t frameHeight = height - 1;
 
+            // Add extra spacing for competitor image
             if (_errorCompetitorId != CompanyId::null)
             {
-                width = kMaxWidth;
-                height = 70;
+                width += kCompetitorSize + 22;
+                height += kCompetitorSize - 22;
             }
+
+            // Calculate frame size
+            uint16_t frameWidth = width - 1;
+            uint16_t frameHeight = height - 1;
 
             // Position error message around the cursor
             auto mousePos = Input::getMouseLocation();
@@ -245,7 +249,7 @@ namespace OpenLoco::Ui::Windows::Error
                     drawingCtx.drawImage(xPos, yPos, ImageIds::owner_jailed);
                 }
 
-                auto point = Point(self.x + 156, self.y + 20);
+                auto point = Point(self.x + (self.width - kCompetitorSize) / 2 + kCompetitorSize + kPadding, self.y + 20);
                 tr.drawStringCentredRaw(point, _linebreakCount, colour, &_errorText[0]);
             }
         }


### PR DESCRIPTION
Before:
<img width="405" alt="Screenshot 2025-02-16 at 11 53 46" src="https://github.com/user-attachments/assets/8c120022-7e25-45f6-84a4-b8dd5a9a34d5" />

After:
<img width="465" alt="Screenshot 2025-02-17 at 10 33 24" src="https://github.com/user-attachments/assets/1e1155e4-5f96-4b21-8e0a-8f44d9fb3b38" />
