### PR TITLE
Town names: fix valid index 0 not being considered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 25.01+ (???)
 ------------------------------------------------------------------------
+- Fix: [#2701] Town names are not always generated correctly.
 - Fix: [#2864] News messages are drawn incorrectly.
 - Fix: [#2866] Vehicles lengths with 0 in the tenths place being displayed incorrectly.
 - Fix: [#2876] Setting the UI scale back to 1.0 when using Fullscreen mode would freeze the screen.

--- a/src/OpenLoco/src/World/TownManager.cpp
+++ b/src/OpenLoco/src/World/TownManager.cpp
@@ -124,7 +124,7 @@ namespace OpenLoco::TownManager
             uint16_t dx = category.count + category.bias;
             int16_t index = ((ax * dx) >> 16) - category.bias;
 
-            if (index > 0)
+            if (index >= 0)
             {
                 char* strEnd = const_cast<char*>(buffer + strlen(buffer));
                 locationFlags |= copyTownNameToBuffer(namesObj, category.offset, index, strEnd);


### PR DESCRIPTION
Not convinced this will fix #2701, but it's all I can think of.