### PR TITLE
create RoutingManager::setRouting

### DIFF
--- a/src/OpenLoco/src/Vehicles/RoutingManager.cpp
+++ b/src/OpenLoco/src/Vehicles/RoutingManager.cpp
@@ -35,9 +35,9 @@ namespace OpenLoco::Vehicles::RoutingManager
         return std::nullopt;
     }
 
-    uint16_t getRouting(const RoutingHandle routing)
+    uint16_t getRouting(const RoutingHandle handle)
     {
-        return routings()[routing.getVehicleRef()][routing.getIndex()];
+        return routings()[handle.getVehicleRef()][handle.getIndex()];
     }
 
     void setRouting(const RoutingHandle handle, uint16_t routing)
@@ -45,15 +45,15 @@ namespace OpenLoco::Vehicles::RoutingManager
         routings()[handle.getVehicleRef()][handle.getIndex()] = routing;
     }
 
-    void freeRouting(const RoutingHandle routing)
+    void freeRouting(const RoutingHandle handle)
     {
-        routings()[routing.getVehicleRef()][routing.getIndex()] = kAllocatedButFreeRoutingStation;
+        routings()[handle.getVehicleRef()][handle.getIndex()] = kAllocatedButFreeRoutingStation;
     }
 
     // 0x004B1E77
-    void freeRoutingHandle(const RoutingHandle routing)
+    void freeRoutingHandle(const RoutingHandle handle)
     {
-        auto& vehRoutingArr = routings()[routing.getVehicleRef()];
+        auto& vehRoutingArr = routings()[handle.getVehicleRef()];
         std::fill(std::begin(vehRoutingArr), std::end(vehRoutingArr), kRoutingNull);
     }
 

--- a/src/OpenLoco/src/Vehicles/RoutingManager.cpp
+++ b/src/OpenLoco/src/Vehicles/RoutingManager.cpp
@@ -40,6 +40,11 @@ namespace OpenLoco::Vehicles::RoutingManager
         return routings()[routing.getVehicleRef()][routing.getIndex()];
     }
 
+    void setRouting(const RoutingHandle handle, uint16_t routing)
+    {
+        routings()[handle.getVehicleRef()][handle.getIndex()] = routing;
+    }
+
     void freeRouting(const RoutingHandle routing)
     {
         routings()[routing.getVehicleRef()][routing.getIndex()] = kAllocatedButFreeRoutingStation;

--- a/src/OpenLoco/src/Vehicles/RoutingManager.cpp
+++ b/src/OpenLoco/src/Vehicles/RoutingManager.cpp
@@ -47,7 +47,7 @@ namespace OpenLoco::Vehicles::RoutingManager
 
     void freeRouting(const RoutingHandle handle)
     {
-        routings()[handle.getVehicleRef()][handle.getIndex()] = kAllocatedButFreeRoutingStation;
+        setRouting(handle, kAllocatedButFreeRoutingStation);
     }
 
     // 0x004B1E77

--- a/src/OpenLoco/src/Vehicles/RoutingManager.h
+++ b/src/OpenLoco/src/Vehicles/RoutingManager.h
@@ -14,12 +14,12 @@ namespace OpenLoco::Vehicles::RoutingManager
     constexpr uint16_t kRoutingNull = 0xFFFFU;                    // Indicates that this array is unallocated to any vehicle.
 
     std::optional<RoutingHandle> getAndAllocateFreeRoutingHandle();
-    void freeRoutingHandle(const RoutingHandle routing);
-    uint16_t getRouting(const RoutingHandle routing);
-    void freeRouting(const RoutingHandle routing);
+    void freeRoutingHandle(const RoutingHandle handle);
+    uint16_t getRouting(const RoutingHandle handle);
+    void freeRouting(const RoutingHandle handle);
     bool isEmptyRoutingSlotAvailable();
     void resetRoutingTable();
-    void setRouting(const RoutingHandle routing, uint16_t routing2);
+    void setRouting(const RoutingHandle handle, uint16_t routing);
 
     struct RingView
     {

--- a/src/OpenLoco/src/Vehicles/RoutingManager.h
+++ b/src/OpenLoco/src/Vehicles/RoutingManager.h
@@ -16,10 +16,10 @@ namespace OpenLoco::Vehicles::RoutingManager
     std::optional<RoutingHandle> getAndAllocateFreeRoutingHandle();
     void freeRoutingHandle(const RoutingHandle handle);
     uint16_t getRouting(const RoutingHandle handle);
+    void setRouting(const RoutingHandle handle, uint16_t routing);
     void freeRouting(const RoutingHandle handle);
     bool isEmptyRoutingSlotAvailable();
     void resetRoutingTable();
-    void setRouting(const RoutingHandle handle, uint16_t routing);
 
     struct RingView
     {

--- a/src/OpenLoco/src/Vehicles/RoutingManager.h
+++ b/src/OpenLoco/src/Vehicles/RoutingManager.h
@@ -19,6 +19,7 @@ namespace OpenLoco::Vehicles::RoutingManager
     void freeRouting(const RoutingHandle routing);
     bool isEmptyRoutingSlotAvailable();
     void resetRoutingTable();
+    void setRouting(const RoutingHandle routing, uint16_t routing2);
 
     struct RingView
     {


### PR DESCRIPTION
Since RouteHandle arguments were called "routing" I renamed them to "handle" to keep the names the same between functions.