### PR TITLE
Rename dayOfOlympiad to dayOfYear

### DIFF
--- a/src/OpenLoco/src/Date.cpp
+++ b/src/OpenLoco/src/Date.cpp
@@ -8,7 +8,7 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco
 {
-    static loco_global<int32_t, 0x0112C810> _currentDayInOlympiad;
+    static loco_global<int32_t, 0x0112C810> _currentDayInYear;
 
     static std::pair<MonthId, uint8_t> getMonthDay(int32_t dayOfYear);
 
@@ -105,7 +105,7 @@ namespace OpenLoco
     {
         constexpr auto kBaseYear = 1800;
         constexpr auto kDaysInYear = 365;
-        constexpr auto kDaysInOlympiad = (365 * 4) + 1;
+        constexpr auto kDaysInOlympiad = (365 * 4) + 1; // Useful because the calendar that Loco uses (Julian) has a 4-year cycle.
         constexpr auto kFeb29 = 31 + 28;
 
         int32_t years = ((totalDays / kDaysInOlympiad) & 0xFFFF) * 4;
@@ -128,13 +128,13 @@ namespace OpenLoco
             }
         }
 
-        _currentDayInOlympiad = day;
+        _currentDayInYear = day;
 
         const auto year = kBaseYear + years;
         const auto monthDay = getMonthDay(day);
 
         auto result = Date(year, monthDay.first, monthDay.second);
-        result.dayOfOlympiad = day;
+        result.dayOfYear = day;
         return result;
     }
 

--- a/src/OpenLoco/src/Date.h
+++ b/src/OpenLoco/src/Date.h
@@ -27,7 +27,8 @@ namespace OpenLoco
         int32_t year = 0;
 
         // 0x0112C810 originally used as a return argument in calcDate
-        int32_t dayOfOlympiad = 0;
+        // Ranges from 0 (for Jan 1st) to 365 (for Dec 31st). 59 (for Feb 29th) is skipped on non-leap years.
+        int32_t dayOfYear = 0;
 
         Date() = default;
         Date(int32_t y, MonthId m, int32_t d)

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -628,7 +628,7 @@ namespace OpenLoco
                 auto yesterday = calcDate(getCurrentDay() - 1);
                 auto today = calcDate(getCurrentDay());
                 setDate(today);
-                Scenario::updateSnowLine(today.dayOfOlympiad);
+                Scenario::updateSnowLine(today.dayOfYear);
                 Ui::Windows::TimePanel::invalidateFrame();
 
                 if (today.month != yesterday.month)

--- a/src/OpenLoco/src/Scenario.cpp
+++ b/src/OpenLoco/src/Scenario.cpp
@@ -105,7 +105,7 @@ namespace OpenLoco::Scenario
     void initialiseSnowLine()
     {
         auto today = calcDate(getCurrentDay());
-        int32_t currentDayOfYear = today.dayOfOlympiad;
+        int32_t currentDayOfYear = today.dayOfYear;
 
         auto* climateObj = ObjectManager::get<ClimateObject>();
         if (climateObj == nullptr)


### PR DESCRIPTION
Old name was incorrect, as by following the logic of the code that sets its value, and by using a tracepoint, the value of dayOfOlympiad clearly only ranges from 0 to 365. It is also clearly not intended to actually store the day of the current Olympiad (4 year period), as that would in theory cause a bug where each Winter (or Summer in Australia) would last for an additional 3 years.