### PR TITLE
Add CMake preset for vcpkg linux static

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -116,6 +116,65 @@
                     "value": false
                 }
             }
+        },
+        {
+            "name": "linux-vcpkg-static",
+            "displayName": "Linux-vcpkg-static",
+            "description": "Ninja configure environment for linux (static linkage)",
+            "generator": "Ninja Multi-Config",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+            "vendor": {"microsoft.com/VisualStudioSettings/CMake/1.0": {"intelliSenseMode": "linux-gcc-x86"}},
+            "condition": {
+                "type": "not",
+                "condition": {
+                    "type": "equals",
+                    "lhs": "${hostSystemName}",
+                    "rhs": "Windows"
+                }
+            },
+            "cacheVariables": {
+                "OPENLOCO_HEADER_CHECK": {
+                    "type": "BOOL",
+                    "value": true
+                },
+                "OPENLOCO_USE_CCACHE": {
+                    "type": "BOOL",
+                    "value": false
+                },
+                "VCPKG_ROOT": {
+                    "type": "PATH",
+                    "value": "$env{VCPKG_ROOT}"
+                },
+                "VCPKG_TARGET_TRIPLET": {
+                    "type": "STRING",
+                    "value": "x86-linux"
+                },
+                "VCPKG_LIBRARY_LINKAGE": {
+                    "type": "STRING",
+                    "value": "static"
+                },
+                "CMAKE_C_FLAGS": {
+                    "type": "STRING",
+                    "value": "-m32"
+                },
+                "CMAKE_CXX_FLAGS": {
+                    "type": "STRING",
+                    "value": "-m32"
+                },
+                "CMAKE_SYSTEM_PROCESSOR": {
+                    "type": "STRING",
+                    "value": "i686"
+                },
+                "CMAKE_FIND_ROOT_PATH_MODE_LIBRARY": {
+                    "type": "STRING",
+                    "value": "ONLY"
+                },
+                "CMAKE_FIND_ROOT_PATH_MODE_PACKAGE": {
+                    "type": "STRING",
+                    "value": "ONLY"
+                }
+            }
         }
     ],
     "buildPresets": [
@@ -160,6 +219,22 @@
             "configurePreset": "linux",
             "displayName": "Release",
             "description": "Build Release Ninja Configurations",
+            "configuration": "Release",
+            "nativeToolOptions": [ "-k0" ]
+        },
+        {
+            "name": "linux-debug-static",
+            "configurePreset": "linux-vcpkg-static",
+            "displayName": "Debug",
+            "description": "Build Debug Ninja Configurations (static linkage)",
+            "configuration": "Debug",
+            "nativeToolOptions": [ "-k0" ]
+        },
+        {
+            "name": "linux-release-static",
+            "configurePreset": "linux-vcpkg-static",
+            "displayName": "Release",
+            "description": "Build Release Ninja Configurations (static linkage)",
             "configuration": "Release",
             "nativeToolOptions": [ "-k0" ]
         },

--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -811,6 +811,9 @@ else ()
         PRIVATE
             DEBUG=${DEBUG_LEVEL}
             _NO_LOCO_WIN32_=1)
+
+    target_link_libraries(OpenLoco
+        ZLIB::ZLIB) # This shouldn't be required but vcpkg seems to not map the dependencies correctly for png static
 endif()
 
 if (APPLE AND FALSE) # TODO: This is broken after moving resources into src/Resources

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,12 +1,28 @@
 {
-    "name": "openloco",
-    "version-string": "22.02",
-    "dependencies": [
-        "benchmark",
-        "breakpad",
-        "gtest",
-        "libpng",
-        "openal-soft",
-        "sdl2"
-    ]
+  "name": "openloco",
+  "version-string": "22.02",
+  "dependencies": [
+    "benchmark",
+    {
+      "name": "breakpad",
+      "platform": "windows"
+    },
+    "gtest",
+    "libpng",
+    "openal-soft",
+    {
+      "name": "sdl2",
+      "default-features": false,
+      "features": [
+        "x11"
+      ]
+    }
+  ],
+  "builtin-baseline": "300239058e33420acd153135b3f6e6b187828992",
+  "overrides": [
+    {
+        "name": "openal-soft",
+        "version": "1.24.1"
+    }
+]
 }


### PR DESCRIPTION
Adds a new CMake preset for Linux builds which uses the vcpkg toolchain to produce a "mostly" static linked binary on Linux, similar to a Windows build.

## Why?
I know statically linking your dependencies is a bit of a holy war in some Linux spaces, so if this is in any way unacceptable to any Linux maintainer of OpenLoco, I'm happy if the PR is just immediately closed, end of discussion.

The reasons I think this might be useful:
- I've specifically tested the resulting binary works in the Steam Runtime (scout). This makes it run well when adding as a Non-Steam game and setting the compatibility tool, which ensures that any built (and possibly distributed) binary will continue working for a very long time, even if glibc and whatnot change on the host system. Would be doubly good if sometime in the very distant future OpenLoco is listed on Steam proper, like OpenTTD is.
  - Steam Runtime doesn't necessarily _need_ static linking, dynamic linking works fine as long as the requisite libraries are already bundled in the Steam runtime. However, the best way to achieve this typically is to build your program using the Steam Runtime OCI container, but since it's based on a positively ancient Ubuntu base, the provided CMake, compilers, etc. are also positively ancient, and no longer supported by OpenLoco (nor should they be).
- The 32-bit requirement is making it increasingly difficult to build, especially on rolling release distros like Arch, where more and more 32-bit libs are moving to the AUR. Even the SDL2 requirement makes it somewhat of a pain. This configuration makes building on Arch pretty painless if you already have vcpkg.

## Usage
Ensure `VCPKG_ROOT` is set in your environment, and that you have all the necessary build tools installed on your host (e.g. on Arch vcpkg seems to need `python-jinja`). Then building should be as simple as:

```sh
cmake --preset linux-vcpkg-static
cmake --build --preset linux-vcpkg-static
```

You should get a _mostly_ statically linked binary out the other end:

```
$ ldd build/linux-vcpkg-static/Release/OpenLoco
        linux-gate.so.1 (0xe9acd000)
        libatomic.so.1 => /usr/lib32/libatomic.so.1 (0xe9a89000)
        libstdc++.so.6 => /usr/lib32/libstdc++.so.6 (0xe9811000)
        libm.so.6 => /usr/lib32/libm.so.6 (0xe972d000)
        libgcc_s.so.1 => /usr/lib32/libgcc_s.so.1 (0xe96f8000)
        libc.so.6 => /usr/lib32/libc.so.6 (0xe94c5000)
        /lib/ld-linux.so.2 => /usr/lib/ld-linux.so.2 (0xe9acf000)
```

Probably possible to move even more of those to link statically, but for my purposes (running in Steam Runtime) this already works OK.

Apologies in advance for any crimes committed in the code. I'm _very_ green at C++ and CMake especially.