### PR TITLE
Pass the WidgetId to all event functions

### DIFF
--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -467,7 +467,8 @@ namespace OpenLoco::Input
                         auto tool = WindowManager::find(ToolManager::getToolWindowType(), ToolManager::getToolWindowNumber());
                         if (tool != nullptr)
                         {
-                            tool->callToolDragContinue(ToolManager::getToolWidgetIndex(), x, y);
+                            // TODO: Handle widget id properly for tools.
+                            tool->callToolDragContinue(ToolManager::getToolWidgetIndex(), WidgetId::none, x, y);
                         }
                     }
                 }
@@ -488,7 +489,8 @@ namespace OpenLoco::Input
                     auto tool = WindowManager::find(ToolManager::getToolWindowType(), ToolManager::getToolWindowNumber());
                     if (tool != nullptr)
                     {
-                        tool->callToolDragEnd(ToolManager::getToolWidgetIndex());
+                        // TODO: Handle widget id properly for tools.
+                        tool->callToolDragEnd(ToolManager::getToolWidgetIndex(), WidgetId::none);
                     }
                 }
                 else if (!hasFlag(Flags::leftMousePressed))
@@ -884,7 +886,7 @@ namespace OpenLoco::Input
                             auto pressedWidget = &dragWindow->widgets[_pressedWidgetIndex];
 
                             Audio::playSound(Audio::SoundId::clickPress, dragWindow->x + pressedWidget->midX());
-                            dragWindow->callOnMouseUp(_pressedWidgetIndex);
+                            dragWindow->callOnMouseUp(_pressedWidgetIndex, pressedWidget->id);
                         }
                     }
                 }
@@ -924,7 +926,7 @@ namespace OpenLoco::Input
 
         if (WindowManager::getCurrentModalType() == Ui::WindowType::undefined || WindowManager::getCurrentModalType() == window->type)
         {
-            window->callOnDropdown(_pressedWidgetIndex, item);
+            window->callOnDropdown(_pressedWidgetIndex, window->widgets[_pressedWidgetIndex].id, item);
         }
     }
 
@@ -1047,7 +1049,7 @@ namespace OpenLoco::Input
                         // Handle click repeat
                         if (window->isHoldable(widgetIndex) && _clickRepeatTicks >= 16 && (_clickRepeatTicks % 4) == 0)
                         {
-                            window->callOnMouseDown(widgetIndex);
+                            window->callOnMouseDown(widgetIndex, window->widgets[widgetIndex].id);
                         }
 
                         bool flagSet = Input::hasFlag(Flags::widgetPressed);
@@ -1147,7 +1149,7 @@ namespace OpenLoco::Input
             if (window != nullptr && window->type == *_pressedWindowType && window->number == _pressedWindowNumber && widgetIndex == _pressedWidgetIndex && !window->isDisabled(widgetIndex))
             {
                 WindowManager::invalidateWidget(_pressedWindowType, _pressedWindowNumber, _pressedWidgetIndex);
-                window->callOnMouseUp(widgetIndex);
+                window->callOnMouseUp(widgetIndex, window->widgets[widgetIndex].id);
                 return;
             }
         }
@@ -1223,7 +1225,7 @@ namespace OpenLoco::Input
         {
             if (!window->isDisabled(widgetIndex))
             {
-                window->call_3(widgetIndex);
+                window->call_3(widgetIndex, window->widgets[widgetIndex].id);
             }
         }
 
@@ -1374,7 +1376,8 @@ namespace OpenLoco::Input
                     auto w = WindowManager::find(ToolManager::getToolWindowType(), ToolManager::getToolWindowNumber());
                     if (w != nullptr)
                     {
-                        w->callToolDown(ToolManager::getToolWidgetIndex(), x, y);
+                        // TODO: Handle the WidgetId properly for tools.
+                        w->callToolDown(ToolManager::getToolWidgetIndex(), WidgetId::none, x, y);
                         setFlag(Flags::leftMousePressed);
                     }
                 }
@@ -1404,7 +1407,7 @@ namespace OpenLoco::Input
                     _clickRepeatTicks = 1;
 
                     WindowManager::invalidateWidget(window->type, window->number, widgetIndex);
-                    window->callOnMouseDown(widgetIndex);
+                    window->callOnMouseDown(widgetIndex, window->widgets[widgetIndex].id);
                 }
 
                 break;
@@ -1629,7 +1632,7 @@ namespace OpenLoco::Input
                     default:
                         _scrollLast->x = x;
                         _scrollLast->y = y;
-                        cursorId = window->callCursor(widgetIdx, x, y, cursorId);
+                        cursorId = window->callCursor(widgetIdx, window->widgets[widgetIdx].id, x, y, cursorId);
                         break;
 
                     case Ui::WidgetType::scrollview:
@@ -1645,7 +1648,7 @@ namespace OpenLoco::Input
 
                         if (res.area == Ui::ScrollPart::view)
                         {
-                            cursorId = window->callCursor(widgetIdx, res.scrollviewLoc.x, res.scrollviewLoc.y, cursorId);
+                            cursorId = window->callCursor(widgetIdx, window->widgets[widgetIdx].id, res.scrollviewLoc.x, res.scrollviewLoc.y, cursorId);
                         }
                         break;
                     }

--- a/src/OpenLoco/src/Ui.cpp
+++ b/src/OpenLoco/src/Ui.cpp
@@ -818,7 +818,8 @@ namespace OpenLoco::Ui
         auto toolWindow = WindowManager::find(ToolManager::getToolWindowType(), ToolManager::getToolWindowNumber());
         if (toolWindow != nullptr)
         {
-            toolWindow->callToolUpdate(ToolManager::getToolWidgetIndex(), x, y);
+            // TODO: Use widget ids properly for tools.
+            toolWindow->callToolUpdate(ToolManager::getToolWidgetIndex(), WidgetId::none, x, y);
         }
         else
         {

--- a/src/OpenLoco/src/Ui/ToolManager.cpp
+++ b/src/OpenLoco/src/Ui/ToolManager.cpp
@@ -105,7 +105,8 @@ namespace OpenLoco::ToolManager
                 Window* w = Ui::WindowManager::find(ToolManager::getToolWindowType(), ToolManager::getToolWindowNumber());
                 if (w != nullptr)
                 {
-                    w->callToolAbort(ToolManager::getToolWidgetIndex());
+                    // TODO: Handle widget ids properly for tools.
+                    w->callToolAbort(ToolManager::getToolWidgetIndex(), WidgetId::none);
                 }
             }
         }

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -1060,54 +1060,54 @@ namespace OpenLoco::Ui
         eventHandlers->event_09(*this);
     }
 
-    void Window::callToolUpdate(WidgetIndex_t widgetIndex, int16_t xPos, int16_t yPos)
+    void Window::callToolUpdate(WidgetIndex_t widgetIndex, const WidgetId id, int16_t xPos, int16_t yPos)
     {
         if (eventHandlers->onToolUpdate == nullptr)
         {
             return;
         }
 
-        eventHandlers->onToolUpdate(*this, widgetIndex, xPos, yPos);
+        eventHandlers->onToolUpdate(*this, widgetIndex, id, xPos, yPos);
     }
 
-    void Window::callToolDown(WidgetIndex_t widgetIndex, int16_t xPos, int16_t yPos)
+    void Window::callToolDown(WidgetIndex_t widgetIndex, const WidgetId id, int16_t xPos, int16_t yPos)
     {
         if (eventHandlers->onToolDown == nullptr)
         {
             return;
         }
 
-        eventHandlers->onToolDown(*this, widgetIndex, xPos, yPos);
+        eventHandlers->onToolDown(*this, widgetIndex, id, xPos, yPos);
     }
 
-    void Window::callToolDragContinue(const WidgetIndex_t widgetIndex, const int16_t xPos, const int16_t yPos)
+    void Window::callToolDragContinue(const WidgetIndex_t widgetIndex, const WidgetId id, const int16_t xPos, const int16_t yPos)
     {
         if (eventHandlers->toolDragContinue == nullptr)
         {
             return;
         }
 
-        eventHandlers->toolDragContinue(*this, widgetIndex, xPos, yPos);
+        eventHandlers->toolDragContinue(*this, widgetIndex, id, xPos, yPos);
     }
 
-    void Window::callToolDragEnd(const WidgetIndex_t widgetIndex)
+    void Window::callToolDragEnd(const WidgetIndex_t widgetIndex, const WidgetId id)
     {
         if (eventHandlers->toolDragEnd == nullptr)
         {
             return;
         }
 
-        eventHandlers->toolDragEnd(*this, widgetIndex);
+        eventHandlers->toolDragEnd(*this, widgetIndex, id);
     }
 
-    void Window::callToolAbort(WidgetIndex_t widgetIndex)
+    void Window::callToolAbort(WidgetIndex_t widgetIndex, const WidgetId id)
     {
         if (eventHandlers->onToolAbort == nullptr)
         {
             return;
         }
 
-        eventHandlers->onToolAbort(*this, widgetIndex);
+        eventHandlers->onToolAbort(*this, widgetIndex, id);
     }
 
     Ui::CursorId Window::callToolCursor(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out)
@@ -1120,24 +1120,24 @@ namespace OpenLoco::Ui
         return eventHandlers->toolCursor(*this, xPos, yPos, fallback, *out);
     }
 
-    Ui::CursorId Window::callCursor(WidgetIndex_t widgetIdx, int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+    Ui::CursorId Window::callCursor(WidgetIndex_t widgetIdx, const WidgetId id, int16_t xPos, int16_t yPos, Ui::CursorId fallback)
     {
         if (eventHandlers->cursor == nullptr)
         {
             return fallback;
         }
 
-        return eventHandlers->cursor(*this, widgetIdx, xPos, yPos, fallback);
+        return eventHandlers->cursor(*this, widgetIdx, id, xPos, yPos, fallback);
     }
 
-    void Window::callOnMouseUp(WidgetIndex_t widgetIndex)
+    void Window::callOnMouseUp(WidgetIndex_t widgetIndex, const WidgetId id)
     {
         if (eventHandlers->onMouseUp == nullptr)
         {
             return;
         }
 
-        eventHandlers->onMouseUp(*this, widgetIndex);
+        eventHandlers->onMouseUp(*this, widgetIndex, id);
     }
 
     Ui::Window* Window::callOnResize()
@@ -1151,34 +1151,34 @@ namespace OpenLoco::Ui
         return this;
     }
 
-    void Window::call_3(WidgetIndex_t widgetIndex)
+    void Window::call_3(WidgetIndex_t widgetIndex, const WidgetId id)
     {
         if (eventHandlers->event_03 == nullptr)
         {
             return;
         }
 
-        eventHandlers->event_03(*this, widgetIndex);
+        eventHandlers->event_03(*this, widgetIndex, id);
     }
 
-    void Window::callOnMouseDown(WidgetIndex_t widgetIndex)
+    void Window::callOnMouseDown(WidgetIndex_t widgetIndex, const WidgetId id)
     {
         if (eventHandlers->onMouseDown == nullptr)
         {
             return;
         }
 
-        eventHandlers->onMouseDown(*this, widgetIndex);
+        eventHandlers->onMouseDown(*this, widgetIndex, id);
     }
 
-    void Window::callOnDropdown(WidgetIndex_t widgetIndex, int16_t itemIndex)
+    void Window::callOnDropdown(WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
         if (eventHandlers->onDropdown == nullptr)
         {
             return;
         }
 
-        eventHandlers->onDropdown(*this, widgetIndex, itemIndex);
+        eventHandlers->onDropdown(*this, widgetIndex, id, itemIndex);
     }
 
     void Window::callGetScrollSize(uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
@@ -1221,14 +1221,14 @@ namespace OpenLoco::Ui
         this->eventHandlers->scrollMouseOver(*this, xPos, yPos, scrollIndex);
     }
 
-    void Window::callTextInput(WidgetIndex_t caller, const char* buffer)
+    void Window::callTextInput(WidgetIndex_t caller, const WidgetId id, const char* buffer)
     {
         if (eventHandlers->textInput == nullptr)
         {
             return;
         }
 
-        this->eventHandlers->textInput(*this, caller, buffer);
+        this->eventHandlers->textInput(*this, caller, id, buffer);
     }
 
     void Window::callViewportRotate()
@@ -1241,7 +1241,7 @@ namespace OpenLoco::Ui
         this->eventHandlers->viewportRotate(*this);
     }
 
-    std::optional<FormatArguments> Window::callTooltip(WidgetIndex_t widgetIndex)
+    std::optional<FormatArguments> Window::callTooltip(WidgetIndex_t widgetIndex, const WidgetId id)
     {
         // We only return std::nullopt when required by the tooltip function
         if (eventHandlers->tooltip == nullptr)
@@ -1249,7 +1249,7 @@ namespace OpenLoco::Ui
             return FormatArguments();
         }
 
-        return eventHandlers->tooltip(*this, widgetIndex);
+        return eventHandlers->tooltip(*this, widgetIndex, id);
     }
 
     void Window::callOnMove(int16_t xPos, int16_t yPos)

--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -69,30 +69,30 @@ namespace OpenLoco::Ui
     struct WindowEventList
     {
         void (*onClose)(Window&) = nullptr;
-        void (*onMouseUp)(Window&, WidgetIndex_t) = nullptr;
+        void (*onMouseUp)(Window&, WidgetIndex_t, WidgetId) = nullptr;
         void (*onResize)(Window&) = nullptr;
-        void (*event_03)(Window&, WidgetIndex_t) = nullptr; // mouse_over?
-        void (*onMouseDown)(Window&, WidgetIndex_t) = nullptr;
-        void (*onDropdown)(Window&, WidgetIndex_t, int16_t) = nullptr;
+        void (*event_03)(Window&, WidgetIndex_t, WidgetId) = nullptr; // mouse_over?
+        void (*onMouseDown)(Window&, WidgetIndex_t, WidgetId) = nullptr;
+        void (*onDropdown)(Window&, WidgetIndex_t, WidgetId, int16_t) = nullptr;
         void (*onPeriodicUpdate)(Window&) = nullptr;
         void (*onUpdate)(Window&) = nullptr;
         void (*event_08)(Window&) = nullptr;
         void (*event_09)(Window&) = nullptr;
-        void (*onToolUpdate)(Window&, const WidgetIndex_t, const int16_t, const int16_t) = nullptr;
-        void (*onToolDown)(Window&, const WidgetIndex_t, const int16_t, const int16_t) = nullptr;
-        void (*toolDragContinue)(Window&, const WidgetIndex_t, const int16_t, const int16_t) = nullptr;
-        void (*toolDragEnd)(Window&, const WidgetIndex_t) = nullptr;
-        void (*onToolAbort)(Window&, const WidgetIndex_t) = nullptr;
+        void (*onToolUpdate)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
+        void (*onToolDown)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
+        void (*toolDragContinue)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
+        void (*toolDragEnd)(Window&, const WidgetIndex_t, WidgetId) = nullptr;
+        void (*onToolAbort)(Window&, const WidgetIndex_t, WidgetId) = nullptr;
         Ui::CursorId (*toolCursor)(Window&, const int16_t x, const int16_t y, const Ui::CursorId, bool&) = nullptr;
         void (*getScrollSize)(Window&, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight) = nullptr;
         void (*scrollMouseDown)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
         void (*scrollMouseDrag)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
         void (*scrollMouseOver)(Ui::Window& window, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
-        void (*textInput)(Window&, WidgetIndex_t, const char*) = nullptr;
+        void (*textInput)(Window&, WidgetIndex_t, WidgetId, const char*) = nullptr;
         void (*viewportRotate)(Window&) = nullptr;
         uint32_t event_22{};
-        std::optional<FormatArguments> (*tooltip)(Window&, WidgetIndex_t) = nullptr;
-        Ui::CursorId (*cursor)(Window&, WidgetIndex_t, int16_t, int16_t, Ui::CursorId) = nullptr;
+        std::optional<FormatArguments> (*tooltip)(Window&, WidgetIndex_t, WidgetId) = nullptr;
+        Ui::CursorId (*cursor)(Window&, WidgetIndex_t, WidgetId, int16_t, int16_t, Ui::CursorId) = nullptr;
         void (*onMove)(Window&, const int16_t x, const int16_t y) = nullptr;
         void (*prepareDraw)(Window&) = nullptr;
         void (*draw)(Window&, Gfx::DrawingContext&) = nullptr;
@@ -373,35 +373,35 @@ namespace OpenLoco::Ui
         WidgetIndex_t findWidgetAt(int16_t xPos, int16_t yPos);
         void draw(Gfx::DrawingContext& drawingCtx);
 
-        void callClose();                                                                                    // 0
-        void callOnMouseUp(WidgetIndex_t widgetIndex);                                                       // 1
-        Ui::Window* callOnResize();                                                                          // 2
-        void call_3(WidgetIndex_t widgetIndex);                                                              // 3
-        void callOnMouseDown(WidgetIndex_t widgetIndex);                                                     // 4
-        void callOnDropdown(WidgetIndex_t widgetIndex, int16_t itemIndex);                                   // 5
-        void callOnPeriodicUpdate();                                                                         // 6
-        void callUpdate();                                                                                   // 7
-        void call_8();                                                                                       // 8
-        void call_9();                                                                                       // 9
-        void callToolUpdate(WidgetIndex_t widgetIndex, int16_t xPos, int16_t yPos);                          // 10
-        void callToolDown(WidgetIndex_t widgetIndex, int16_t xPos, int16_t yPos);                            // 11
-        void callToolDragContinue(WidgetIndex_t widgetIndex, const int16_t xPos, const int16_t yPos);        // 12
-        void callToolDragEnd(WidgetIndex_t widgetIndex);                                                     // 13
-        void callToolAbort(WidgetIndex_t widgetIndex);                                                       // 14
-        Ui::CursorId callToolCursor(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out);           // 15
-        void callGetScrollSize(uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);         // 16
-        void callScrollMouseDown(int16_t x, int16_t y, uint8_t scrollIndex);                                 // 17
-        void callScrollMouseDrag(int16_t x, int16_t y, uint8_t scrollIndex);                                 // 18
-        void callScrollMouseOver(int16_t x, int16_t y, uint8_t scrollIndex);                                 // 19
-        void callTextInput(WidgetIndex_t caller, const char* buffer);                                        // 20
-        void callViewportRotate();                                                                           // 21
-        std::optional<FormatArguments> callTooltip(WidgetIndex_t widgetIndex);                               // 23
-        Ui::CursorId callCursor(WidgetIndex_t widgetIdx, int16_t xPos, int16_t yPos, Ui::CursorId fallback); // 24
-        void callOnMove(int16_t xPos, int16_t yPos);                                                         // 25
-        void callPrepareDraw();                                                                              // 26
-        void callDraw(Gfx::DrawingContext& ctx);                                                             // 27
-        void callDrawScroll(Gfx::DrawingContext& drawingCtx, uint32_t scrollIndex);                          // 28
-        bool callKeyUp(uint32_t charCode, uint32_t keyCode);                                                 // 29
+        void callClose();                                                                                                 // 0
+        void callOnMouseUp(WidgetIndex_t widgetIndex, WidgetId id);                                                       // 1
+        Ui::Window* callOnResize();                                                                                       // 2
+        void call_3(WidgetIndex_t widgetIndex, WidgetId id);                                                              // 3
+        void callOnMouseDown(WidgetIndex_t widgetIndex, WidgetId id);                                                     // 4
+        void callOnDropdown(WidgetIndex_t widgetIndex, WidgetId id, int16_t itemIndex);                                   // 5
+        void callOnPeriodicUpdate();                                                                                      // 6
+        void callUpdate();                                                                                                // 7
+        void call_8();                                                                                                    // 8
+        void call_9();                                                                                                    // 9
+        void callToolUpdate(WidgetIndex_t widgetIndex, WidgetId id, int16_t xPos, int16_t yPos);                          // 10
+        void callToolDown(WidgetIndex_t widgetIndex, WidgetId id, int16_t xPos, int16_t yPos);                            // 11
+        void callToolDragContinue(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);        // 12
+        void callToolDragEnd(WidgetIndex_t widgetIndex, WidgetId id);                                                     // 13
+        void callToolAbort(WidgetIndex_t widgetIndex, WidgetId id);                                                       // 14
+        Ui::CursorId callToolCursor(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out);                        // 15
+        void callGetScrollSize(uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);                      // 16
+        void callScrollMouseDown(int16_t x, int16_t y, uint8_t scrollIndex);                                              // 17
+        void callScrollMouseDrag(int16_t x, int16_t y, uint8_t scrollIndex);                                              // 18
+        void callScrollMouseOver(int16_t x, int16_t y, uint8_t scrollIndex);                                              // 19
+        void callTextInput(WidgetIndex_t caller, WidgetId id, const char* buffer);                                        // 20
+        void callViewportRotate();                                                                                        // 21
+        std::optional<FormatArguments> callTooltip(WidgetIndex_t widgetIndex, WidgetId id);                               // 23
+        Ui::CursorId callCursor(WidgetIndex_t widgetIdx, WidgetId id, int16_t xPos, int16_t yPos, Ui::CursorId fallback); // 24
+        void callOnMove(int16_t xPos, int16_t yPos);                                                                      // 25
+        void callPrepareDraw();                                                                                           // 26
+        void callDraw(Gfx::DrawingContext& ctx);                                                                          // 27
+        void callDrawScroll(Gfx::DrawingContext& drawingCtx, uint32_t scrollIndex);                                       // 28
+        bool callKeyUp(uint32_t charCode, uint32_t keyCode);                                                              // 29
 
         WidgetIndex_t firstActivatedWidgetInRange(WidgetIndex_t minIndex, WidgetIndex_t maxIndex);
         WidgetIndex_t prevAvailableWidgetInRange(WidgetIndex_t minIndex, WidgetIndex_t maxIndex);

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -1693,7 +1693,7 @@ namespace OpenLoco::Ui::WindowManager
             return false;
         }
 
-        w.callOnMouseDown(targetWidgetIndex);
+        w.callOnMouseDown(targetWidgetIndex, w.widgets[targetWidgetIndex].id);
         return true;
     }
 

--- a/src/OpenLoco/src/Ui/Windows/About.cpp
+++ b/src/OpenLoco/src/Ui/Windows/About.cpp
@@ -63,7 +63,7 @@ namespace OpenLoco::Ui::Windows::About
     }
 
     // 0x0043B4AF
-    static void onMouseUp(Ui::Window& window, const WidgetIndex_t widgetIndex)
+    static void onMouseUp(Ui::Window& window, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {

--- a/src/OpenLoco/src/Ui/Windows/AboutMusic.cpp
+++ b/src/OpenLoco/src/Ui/Windows/AboutMusic.cpp
@@ -68,7 +68,7 @@ namespace OpenLoco::Ui::Windows::AboutMusic
     }
 
     // 0x0043BFB0
-    static void onMouseUp(Ui::Window& window, const WidgetIndex_t widgetIndex)
+    static void onMouseUp(Ui::Window& window, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -85,7 +85,7 @@ namespace OpenLoco::Ui::Windows::AboutMusic
     }
 
     // 0x0043BFC0
-    static std::optional<FormatArguments> tooltip(Ui::Window&, WidgetIndex_t)
+    static std::optional<FormatArguments> tooltip(Ui::Window&, WidgetIndex_t, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_credits_list);

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -351,7 +351,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 // Not a vehicle but a type
                 tab += vehicle;
             }
-            window->callOnMouseUp(tab);
+            window->callOnMouseUp(tab, window->widgets[tab].id);
 
             if (tabMode)
             {
@@ -436,7 +436,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
             }
         }
 
-        window->callOnMouseUp(widgetIndex);
+        window->callOnMouseUp(widgetIndex, window->widgets[widgetIndex].id);
         return window;
     }
 
@@ -718,7 +718,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     }
 
     // 0x4C3576
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -819,7 +819,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         }
     }
 
-    static void onMouseDown(Window& self, const WidgetIndex_t widgetIndex)
+    static void onMouseDown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         if (widgetIndex == widx::filterDropdown)
         {
@@ -915,7 +915,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         }
     }
 
-    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
     {
         if (itemIndex < 0)
         {
@@ -1106,7 +1106,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     }
 
     // 0x4C370C
-    static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         if (widgetIndex < widx::tab_track_type_0 || widgetIndex >= widx::scrollview_vehicle_selection)
@@ -1149,7 +1149,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     }
 
     // 0x4C37CB
-    static Ui::CursorId cursor(Window& window, WidgetIndex_t widgetIdx, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId cursor(Window& window, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
     {
         if (widgetIdx != widx::scrollview_vehicle_selection)
         {

--- a/src/OpenLoco/src/Ui/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Cheats.cpp
@@ -352,7 +352,7 @@ namespace OpenLoco::Ui::Windows::Cheats
             }
         }
 
-        static void onMouseUp(Ui::Window& self, const WidgetIndex_t widgetIndex)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -408,7 +408,7 @@ namespace OpenLoco::Ui::Windows::Cheats
             return std::max<int32_t>(0, std::min<int32_t>(getMonthTotalDay(date.year, date.month) - 1, date.day));
         }
 
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             currency32_t cashStepSize{};
             int32_t timeStepSize{};
@@ -576,7 +576,7 @@ namespace OpenLoco::Ui::Windows::Cheats
             Common::drawTabs(&self, drawingCtx);
         }
 
-        static void onMouseUp(Ui::Window& self, const WidgetIndex_t widgetIndex)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -648,7 +648,7 @@ namespace OpenLoco::Ui::Windows::Cheats
             }
         }
 
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex == Widx::target_company_dropdown_btn)
             {
@@ -656,7 +656,7 @@ namespace OpenLoco::Ui::Windows::Cheats
             }
         }
 
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (itemIndex == -1)
             {
@@ -754,7 +754,7 @@ namespace OpenLoco::Ui::Windows::Cheats
             Common::drawTabs(&self, drawingCtx);
         }
 
-        static void onMouseUp(Ui::Window& self, const WidgetIndex_t widgetIndex)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -887,7 +887,7 @@ namespace OpenLoco::Ui::Windows::Cheats
             Common::drawTabs(&self, drawingCtx);
         }
 
-        static void onMouseUp(Ui::Window& self, const WidgetIndex_t widgetIndex)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {

--- a/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
@@ -139,7 +139,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x435299
-    static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -239,7 +239,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x4352B1
-    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, const WidgetIndex_t)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, const WidgetIndex_t, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_list);

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -78,7 +78,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                 Widgets::Tab({ 189, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_speed_records));
         }
 
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex);
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id);
         static void onUpdate(Window& self);
         static void prepareDraw(Window& self);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
@@ -123,7 +123,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         };
 
         // 0x004360A2
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -384,7 +384,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x004362B6
-        static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_company_list);
@@ -392,7 +392,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x0043632C
-        static Ui::CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
         {
             if (widgetIdx != widx::scrollview)
             {
@@ -667,7 +667,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
     void openPerformanceIndexes()
     {
         auto window = open();
-        window->callOnMouseUp(Common::widx::tab_performance);
+        window->callOnMouseUp(Common::widx::tab_performance, window->widgets[Common::widx::tab_performance].id);
     }
 
     namespace CompanyPerformance
@@ -1427,7 +1427,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // clang-format on
 
         // 0x0043667B
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -286,7 +286,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432244
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -325,7 +325,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432283
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex == Common::widx::company_select)
             {
@@ -334,7 +334,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x0043228E
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (widgetIndex == Common::widx::company_select)
             {
@@ -397,7 +397,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x004322F6
-        static void textInput(Window& self, WidgetIndex_t callingWidget, const char* input)
+        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
         {
             if (callingWidget == Common::widx::caption)
             {
@@ -675,7 +675,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         // Allow setting company owner name if no preferred owner name has been set.
         if (!Config::get().usePreferredOwnerName)
         {
-            Status::onMouseUp(*self, Status::widx::change_owner_name);
+            Status::onMouseUp(*self, Status::widx::change_owner_name, WidgetId::none);
         }
 
         return self;
@@ -890,7 +890,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432BDD
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -918,7 +918,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432C08
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -934,7 +934,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432C19
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (widgetIndex == Common::widx::company_select)
             {
@@ -953,7 +953,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432C24
-        static void textInput(Window& self, WidgetIndex_t callingWidget, const char* input)
+        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
         {
             if (callingWidget == Common::widx::caption)
             {
@@ -1031,7 +1031,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432CA1
-        static void onToolUpdate([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             World::mapInvalidateSelectionRect();
             World::resetMapSelectionFlag(World::MapSelectionFlags::enable);
@@ -1070,7 +1070,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         // regs.dx = widgetIndex;
         // regs.ax = mouseX;
         // regs.bx = mouseY;
-        static void onToolDown([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t mouseX, const int16_t mouseY)
+        static void onToolDown([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t mouseX, const int16_t mouseY)
         {
             removeHeadquarterGhost();
 
@@ -1090,7 +1090,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432D7A
-        static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex)
+        static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             removeHeadquarterGhost();
             Ui::Windows::Main::hideGridlines();
@@ -1464,7 +1464,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433032
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -1516,7 +1516,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433067
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -1585,7 +1585,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433092
-        static void textInput(Window& self, WidgetIndex_t callingWidget, const char* input)
+        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
         {
             if (callingWidget == Common::widx::caption)
             {
@@ -1594,7 +1594,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x0043309D
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             switch (widgetIndex)
             {
@@ -2040,7 +2040,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433819
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -2076,7 +2076,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x0043383E
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -2113,7 +2113,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x0043385D
-        static void textInput(Window& self, WidgetIndex_t callingWidget, const char* input)
+        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
         {
             if (callingWidget == Common::widx::caption)
             {
@@ -2147,7 +2147,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433868
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (widgetIndex == Common::widx::company_select)
             {
@@ -2165,7 +2165,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433887
-        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_list);
@@ -2335,7 +2335,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433BE6
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -2359,7 +2359,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433C0B
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex == Common::widx::company_select)
             {
@@ -2368,7 +2368,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433C16
-        static void textInput(Window& self, WidgetIndex_t callingWidget, const char* input)
+        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
         {
             if (callingWidget == Common::widx::caption)
             {
@@ -2377,7 +2377,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433C21
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (widgetIndex == Common::widx::company_select)
             {
@@ -2560,7 +2560,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433FFE
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -2584,7 +2584,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00434023
-        static void textInput(Window& self, WidgetIndex_t callingWidget, const char* input)
+        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
         {
             if (callingWidget == Common::widx::caption)
             {

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -50,7 +50,7 @@ namespace OpenLoco::Ui::Windows::Construction
 
         if (window != nullptr)
         {
-            window->callOnMouseUp(Common::widx::tab_station);
+            window->callOnMouseUp(Common::widx::tab_station, window->widgets[Common::widx::tab_station].id);
         }
         return window;
     }
@@ -69,7 +69,7 @@ namespace OpenLoco::Ui::Windows::Construction
 
         if (window != nullptr)
         {
-            window->callOnMouseUp(Construction::widx::rotate_90);
+            window->callOnMouseUp(Construction::widx::rotate_90, window->widgets[Construction::widx::rotate_90].id);
         }
 
         return window;
@@ -535,7 +535,7 @@ namespace OpenLoco::Ui::Windows::Construction
             }
             else
             {
-                window->callOnMouseUp(Common::widx::tab_construction);
+                window->callOnMouseUp(Common::widx::tab_construction, window->widgets[Common::widx::tab_construction].id);
             }
         }
     }
@@ -1244,7 +1244,7 @@ namespace OpenLoco::Ui::Windows::Construction
             WidgetIndex_t prev = self->prevAvailableWidgetInRange(widx::tab_construction, widx::tab_overhead);
             if (prev != -1)
             {
-                self->callOnMouseUp(prev);
+                self->callOnMouseUp(prev, self->widgets[prev].id);
             }
         }
 
@@ -1253,7 +1253,7 @@ namespace OpenLoco::Ui::Windows::Construction
             WidgetIndex_t next = self->nextAvailableWidgetInRange(widx::tab_construction, widx::tab_overhead);
             if (next != -1)
             {
-                self->callOnMouseUp(next);
+                self->callOnMouseUp(next, self->widgets[next].id);
             }
         }
     }
@@ -1265,7 +1265,7 @@ namespace OpenLoco::Ui::Windows::Construction
             case Common::widx::tab_construction - Common::widx::tab_construction:
                 if (_cState->constructionHover == 1)
                 {
-                    self.callOnMouseUp(Construction::widx::rotate_90);
+                    self.callOnMouseUp(Construction::widx::rotate_90, self.widgets[Construction::widx::rotate_90].id);
                     removeConstructionGhosts();
                     return true;
                 }
@@ -1274,7 +1274,7 @@ namespace OpenLoco::Ui::Windows::Construction
             case Common::widx::tab_station - Common::widx::tab_construction:
                 if (!self.widgets[Station::widx::rotate].hidden)
                 {
-                    self.callOnMouseUp(Station::widx::rotate);
+                    self.callOnMouseUp(Station::widx::rotate, self.widgets[Station::widx::rotate].id);
                     return true;
                 }
                 break;

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -504,7 +504,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049D3F6
-    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -1742,7 +1742,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049D42F
-    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -1883,7 +1883,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049D4EA
-    static void onDropdown([[maybe_unused]] Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void onDropdown([[maybe_unused]] Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
     {
         if (widgetIndex == widx::bridge_dropdown)
         {
@@ -2092,7 +2092,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
             // Attempt to place track piece -- in silent
             _suppressErrorSound = true;
-            onMouseUp(*window, widx::construct);
+            onMouseUp(*window, widx::construct, WidgetId::none);
             _suppressErrorSound = false;
 
             if (_cState->dword_1135F42 != 0x80000000)
@@ -2120,7 +2120,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             }
 
             // Failed to place track piece -- rotate and make error sound
-            onMouseUp(*window, widx::rotate_90);
+            onMouseUp(*window, widx::rotate_90, WidgetId::none);
             Audio::playSound(Audio::SoundId::error, int32_t(Input::getMouseLocation().x));
             return;
         }
@@ -2536,7 +2536,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049DC8C
-    static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::construct)
         {
@@ -2623,7 +2623,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049DC97
-    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::construct)
         {
@@ -2641,7 +2641,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049D4F5
-    static Ui::CursorId cursor([[maybe_unused]] Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId cursor([[maybe_unused]] Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
     {
         if (widgetIndex == widx::bridge || widgetIndex == widx::bridge_dropdown)
         {
@@ -2669,7 +2669,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         Common::repositionTabs(&self);
     }
 
-    static std::optional<FormatArguments> tooltip(Ui::Window&, WidgetIndex_t)
+    static std::optional<FormatArguments> tooltip(Ui::Window&, WidgetIndex_t, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         args.skip(2);
@@ -3121,7 +3121,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         {
             _cState->constructionHover = 0;
             _cState->byte_113607E = 1;
-            self->callOnMouseUp(widx::rotate_90);
+            self->callOnMouseUp(widx::rotate_90, self->widgets[widx::rotate_90].id);
         }
     }
 
@@ -3150,7 +3150,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         WidgetIndex_t prev = self->prevAvailableWidgetInRange(widx::left_hand_curve_very_small, widx::s_bend_dual_track_right);
         if (prev != -1)
         {
-            self->callOnMouseDown(prev);
+            self->callOnMouseDown(prev, self->widgets[prev].id);
         }
     }
 
@@ -3159,7 +3159,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         WidgetIndex_t next = self->nextAvailableWidgetInRange(widx::left_hand_curve_very_small, widx::s_bend_dual_track_right);
         if (next != -1)
         {
-            self->callOnMouseDown(next);
+            self->callOnMouseDown(next, self->widgets[next].id);
         }
     }
 
@@ -3168,7 +3168,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         WidgetIndex_t prev = self->prevAvailableWidgetInRange(widx::steep_slope_down, widx::steep_slope_up);
         if (prev != -1)
         {
-            self->callOnMouseDown(prev);
+            self->callOnMouseDown(prev, self->widgets[prev].id);
         }
     }
 
@@ -3177,7 +3177,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         WidgetIndex_t next = self->nextAvailableWidgetInRange(widx::steep_slope_down, widx::steep_slope_up);
         if (next != -1)
         {
-            self->callOnMouseDown(next);
+            self->callOnMouseDown(next, self->widgets[next].id);
         }
     }
 
@@ -3190,7 +3190,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
         if (_cState->constructionHover == 0)
         {
-            self->callOnMouseUp(widx::construct);
+            self->callOnMouseUp(widx::construct, self->widgets[widx::construct].id);
         }
     }
 
@@ -3198,7 +3198,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     {
         if (self->currentTab == Common::widx::tab_construction - Common::widx::tab_construction)
         {
-            self->callOnMouseUp(widx::remove);
+            self->callOnMouseUp(widx::remove, self->widgets[widx::remove].id);
         }
     }
 
@@ -3211,7 +3211,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
         if (_cState->constructionHover == 0)
         {
-            self->callOnMouseUp(widx::rotate_90);
+            self->callOnMouseUp(widx::rotate_90, self->widgets[widx::rotate_90].id);
         }
     }
 }

--- a/src/OpenLoco/src/Ui/Windows/Construction/OverheadTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/OverheadTab.cpp
@@ -53,7 +53,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
     WindowEventList events;
 
     // 0x0049EBD1
-    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -87,7 +87,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
     }
 
     // 0x0049EBFC
-    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -121,7 +121,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
     }
 
     // 0x0049EC09
-    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
     {
         if (widgetIndex != widx::track_dropdown)
         {
@@ -263,7 +263,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
     }
 
     // 0x0049EC15
-    static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::image)
         {
@@ -343,7 +343,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
     }
 
     // 0x0049EC20
-    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::image)
         {
@@ -552,7 +552,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
 
     void tabReset(Window* self)
     {
-        self->callOnMouseDown(Overhead::widx::image);
+        self->callOnMouseDown(Overhead::widx::image, self->widgets[Overhead::widx::image].id);
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/Construction/SignalTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/SignalTab.cpp
@@ -42,7 +42,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
     WindowEventList events;
 
     // 0x0049E64E
-    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -60,7 +60,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
     }
 
     // 0x0049E669
-    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -114,7 +114,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
     }
 
     // 0x0049E67C
-    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
     {
         if (widgetIndex != widx::signal_dropdown)
         {
@@ -217,7 +217,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
     }
 
     // 0x0049E745
-    static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::single_direction && widgetIndex != widx::both_directions)
         {
@@ -262,7 +262,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
     }
 
     // 0x0049E75A
-    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::single_direction && widgetIndex != widx::both_directions)
         {
@@ -358,7 +358,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
 
     void tabReset(Window* self)
     {
-        self->callOnMouseDown(Signal::widx::both_directions);
+        self->callOnMouseDown(Signal::widx::both_directions, self->widgets[Signal::widx::both_directions].id);
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -67,7 +67,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     WindowEventList events;
 
     // 0x0049E228
-    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -108,7 +108,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     }
 
     // 0x0049E249
-    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -155,7 +155,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     }
 
     // 0x0049E256
-    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
     {
         if (widgetIndex == widx::station_dropdown)
         {
@@ -531,7 +531,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     }
 
     // 0x0049E421
-    static void onToolUpdate(Window&, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolUpdate(Window&, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::image)
         {
@@ -855,7 +855,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     }
 
     // 0x0049E42C
-    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::image)
         {
@@ -1094,7 +1094,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
     void tabReset(Window* self)
     {
-        self->callOnMouseDown(Station::widx::image);
+        self->callOnMouseDown(Station::widx::image, self->widgets[Station::widx::image].id);
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/DebugWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/DebugWindow.cpp
@@ -101,7 +101,7 @@ namespace OpenLoco::Ui::Windows::Debug
     }
 
     // 0x0043B4AF
-    static void onMouseUp(Ui::Window& window, const WidgetIndex_t widgetIndex)
+    static void onMouseUp(Ui::Window& window, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         const auto& widget = window.widgets[widgetIndex];
         switch (widget.id)

--- a/src/OpenLoco/src/Ui/Windows/DragVehiclePart.cpp
+++ b/src/OpenLoco/src/Ui/Windows/DragVehiclePart.cpp
@@ -52,7 +52,7 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
     }
 
     // 0x004B62FE
-    static Ui::CursorId cursor(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIdx, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y, [[maybe_unused]] const Ui::CursorId fallback)
+    static Ui::CursorId cursor(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y, [[maybe_unused]] const Ui::CursorId fallback)
     {
         self.height = 0; // Set to zero so that skipped in window find
         Vehicle::Details::scrollDrag(Input::getScrollLastLocation());

--- a/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
+++ b/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
@@ -78,7 +78,7 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
     }
 
     // 0x004BE821
-    static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -177,7 +177,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00457EC4
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -447,7 +447,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00457EE8
-        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_industry_list);
@@ -546,7 +546,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458113
-        static Ui::CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
         {
             if (widgetIdx != widx::scrollview)
             {
@@ -627,7 +627,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         auto window = WindowManager::bringToFront(WindowType::industryList, 0);
         if (window != nullptr)
         {
-            window->callOnMouseUp(Common::widx::tab_industry_list);
+            window->callOnMouseUp(Common::widx::tab_industry_list, window->widgets[Common::widx::tab_industry_list].id);
         }
         else
         {
@@ -814,7 +814,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x0045843A
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -1005,7 +1005,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458455
-        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_new_industry_list);
@@ -1161,7 +1161,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x0045848A
-        static void onToolUpdate(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, int16_t x, const int16_t y)
+        static void onToolUpdate(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t x, const int16_t y)
         {
             World::mapInvalidateSelectionRect();
             World::resetMapSelectionFlag(World::MapSelectionFlags::enable);
@@ -1198,7 +1198,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x0045851F
-        static void onToolDown([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, int16_t x, const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t x, const int16_t y)
         {
             removeIndustryGhost();
             auto placementArgs = getIndustryPlacementArgsFromCursor(x, y);
@@ -1216,7 +1216,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x004585AD
-        static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex)
+        static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             removeIndustryGhost();
             Ui::Windows::Main::hideGridlines();

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -68,14 +68,14 @@ namespace OpenLoco::Ui::Windows::Industry
 
         // Defined at the bottom of this file.
         static void prepareDraw(Window& self);
-        static void textInput(Window& self, WidgetIndex_t callingWidget, const char* input);
+        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input);
         static void update(Window& self);
         static void renameIndustryPrompt(Window* self, WidgetIndex_t widgetIndex);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
         static void drawTabs(Window* self, Gfx::DrawingContext& drawingCtx);
         static void setDisabledWidgets(Window* self);
         static void draw(Window& self, Gfx::DrawingContext& drawingCtx);
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex);
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id);
     }
 
     namespace Industry
@@ -160,7 +160,7 @@ namespace OpenLoco::Ui::Windows::Industry
         }
 
         // 0x00455C86
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -698,7 +698,7 @@ namespace OpenLoco::Ui::Windows::Industry
         }
 
         // 0x004565B5, 0x00456505
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -746,7 +746,7 @@ namespace OpenLoco::Ui::Windows::Industry
         }
 
         // 0x00455CBC
-        static void textInput(Window& self, WidgetIndex_t callingWidget, const char* input)
+        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
         {
             if (callingWidget != Common::widx::caption)
             {

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -207,7 +207,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     }
 
     // 0x004BE821
-    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -229,7 +229,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     }
 
     // 0x004BE844
-    static std::optional<FormatArguments> tooltip(Window&, WidgetIndex_t)
+    static std::optional<FormatArguments> tooltip(Window&, WidgetIndex_t, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_list);

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -110,7 +110,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             }
         }
 
-        static void onMouseUp(Window& window, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -460,7 +460,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E1BA
-        static void onDropdown(Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             switch (widgetIndex)
             {
@@ -475,7 +475,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043DC83
-        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             auto& options = Scenario::getOptions();
 
@@ -524,7 +524,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043DC58
-        static void onMouseUp(Window& window, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -558,7 +558,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                 }
 
                 default:
-                    Common::onMouseUp(window, widgetIndex);
+                    Common::onMouseUp(window, widgetIndex, id);
             }
         }
 
@@ -779,7 +779,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         };
 
         // 0x0043E1BA
-        static void onDropdown(Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             switch (widgetIndex)
             {
@@ -802,7 +802,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E173
-        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             auto& options = Scenario::getOptions();
 
@@ -848,7 +848,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E14E
-        static void onMouseUp(Window& window, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -858,7 +858,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     break;
 
                 default:
-                    Common::onMouseUp(window, widgetIndex);
+                    Common::onMouseUp(window, widgetIndex, id);
             }
         }
 
@@ -944,7 +944,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E2A2
-        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_list);
@@ -1085,7 +1085,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E173
-        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             auto& gameState = getGameState();
             auto& options = Scenario::getOptions();
@@ -1300,7 +1300,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E670
-        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             auto& options = Scenario::getOptions();
 
@@ -1543,7 +1543,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         };
 
         // 0x0043EA28
-        static void onDropdown(Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (widgetIndex != widx::max_town_size_btn || itemIndex == -1)
             {
@@ -1555,7 +1555,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043EA0D
-        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             auto& options = Scenario::getOptions();
 
@@ -1668,7 +1668,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         };
 
         // 0x0043EBF8
-        static void onDropdown(Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (widgetIndex != widx::num_industries_btn || itemIndex == -1)
             {
@@ -1680,7 +1680,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043EBF1
-        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGenerationConfirm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGenerationConfirm.cpp
@@ -58,7 +58,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGenerationConfirm
     }
 
     // 0x004C18E4
-    static void onMouseUp(Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -184,7 +184,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046B8CF
-    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -1150,7 +1150,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046B946
-    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_map);

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -87,7 +87,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         );
 
         // 0x0042A6F5
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -205,7 +205,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042A70C
-        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_message_list);
@@ -459,7 +459,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         );
 
         // 0x0042AA84
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -489,7 +489,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         };
 
         // 0x0042AA9F
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -524,7 +524,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042AAAC
-        static void onDropdown([[maybe_unused]] Window& self, Ui::WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown([[maybe_unused]] Window& self, Ui::WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             switch (widgetIndex)
             {

--- a/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
@@ -152,7 +152,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     }
 
     // 0x004C1757
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -219,7 +219,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     }
 
     // 0x004C1762
-    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_list);

--- a/src/OpenLoco/src/Ui/Windows/NetworkStatus.cpp
+++ b/src/OpenLoco/src/Ui/Windows/NetworkStatus.cpp
@@ -89,7 +89,7 @@ namespace OpenLoco::Ui::Windows::NetworkStatus
         }
     }
 
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {

--- a/src/OpenLoco/src/Ui/Windows/News/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/Common.cpp
@@ -187,6 +187,6 @@ namespace OpenLoco::Ui::Windows::NewsWindow
     void close(Window* self)
     {
         // Only affects the newspaper view; the ticker ignores this widget
-        self->callOnMouseUp(1);
+        self->callOnMouseUp(Common::close_button, self->widgets[Common::close_button].id);
     }
 }

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -65,7 +65,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
     namespace Common
     {
         // 0x00429BB7
-        static void onMouseUp([[maybe_unused]] Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp([[maybe_unused]] Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {

--- a/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
@@ -26,7 +26,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
     }
 
     // 0x00429EA2
-    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         if (widgetIndex != 0)
         {

--- a/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
@@ -249,7 +249,7 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
         *scrollHeight = kRowHeight * window.rowCount;
     }
 
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -271,7 +271,7 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
         window.invalidate();
     }
 
-    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_object_list);

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -1329,7 +1329,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x004737BA
-    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -1394,7 +1394,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         }
     }
 
-    static void onMouseDown(Window& self, const WidgetIndex_t widgetIndex)
+    static void onMouseDown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         if (widgetIndex == widx::filterDropdown)
         {
@@ -1432,7 +1432,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         }
     }
 
-    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
     {
         if (widgetIndex != widx::filterDropdown)
         {
@@ -1492,7 +1492,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x00473900
-    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_object_list);

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -330,7 +330,7 @@ namespace OpenLoco::Ui::Windows::Options
             | (1ULL << Display::Widx::display_scale_down_btn);
 
         // 0x004BFB8C
-        static void onMouseUp(Window& w, WidgetIndex_t wi)
+        static void onMouseUp(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             switch (wi)
             {
@@ -607,7 +607,7 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004BFBB7
-        static void onMouseDown(Window& w, WidgetIndex_t wi)
+        static void onMouseDown(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             switch (wi)
             {
@@ -636,7 +636,7 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004BFBE8
-        static void onDropdown(Window& w, WidgetIndex_t wi, int16_t item_index)
+        static void onDropdown(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id, int16_t item_index)
         {
             switch (wi)
             {
@@ -912,7 +912,7 @@ namespace OpenLoco::Ui::Windows::Options
             Common::drawTabs(&w, drawingCtx);
         }
 
-        static void onMouseUp(Window& w, WidgetIndex_t wi)
+        static void onMouseUp(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             switch (wi)
             {
@@ -936,7 +936,7 @@ namespace OpenLoco::Ui::Windows::Options
             }
         }
 
-        static void onMouseDown(Window& w, WidgetIndex_t wi)
+        static void onMouseDown(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             switch (wi)
             {
@@ -946,7 +946,7 @@ namespace OpenLoco::Ui::Windows::Options
             }
         }
 
-        static void onDropdown(Ui::Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             switch (widgetIndex)
             {
@@ -1168,7 +1168,7 @@ namespace OpenLoco::Ui::Windows::Options
             drawingCtx.drawImage(w.x + w.widgets[Widx::volume].left + x, w.y + w.widgets[Widx::volume].top, Gfx::recolour(ImageIds::volume_slider_thumb, w.getColour(WindowColour::secondary).c()));
         }
 
-        static void onMouseUp(Window& w, WidgetIndex_t wi)
+        static void onMouseUp(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             switch (wi)
             {
@@ -1205,7 +1205,7 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C06F2
-        static void onMouseDown(Window& w, WidgetIndex_t wi)
+        static void onMouseDown(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             switch (wi)
             {
@@ -1222,7 +1222,7 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C070D
-        static void onDropdown(Ui::Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             switch (widgetIndex)
             {
@@ -1574,7 +1574,7 @@ namespace OpenLoco::Ui::Windows::Options
             Common::drawTabs(&w, drawingCtx);
         }
 
-        static void onMouseUp(Window& w, WidgetIndex_t wi)
+        static void onMouseUp(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             switch (wi)
             {
@@ -1603,7 +1603,7 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004BFBB7
-        static void onMouseDown(Window& w, WidgetIndex_t wi)
+        static void onMouseDown(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             switch (wi)
             {
@@ -1626,7 +1626,7 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C0C4A
-        static void onDropdown(Ui::Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             switch (widgetIndex)
             {
@@ -2002,7 +2002,7 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C114A
-        static void onMouseUp(Window& w, WidgetIndex_t wi)
+        static void onMouseUp(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             switch (wi)
             {
@@ -2305,7 +2305,7 @@ namespace OpenLoco::Ui::Windows::Options
             }
         }
 
-        static void onMouseUp(Window& w, WidgetIndex_t wi)
+        static void onMouseUp(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             switch (wi)
             {
@@ -2357,7 +2357,7 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C1304
-        static void textInput(Window& w, WidgetIndex_t i, const char* str)
+        static void textInput(Window& w, WidgetIndex_t i, [[maybe_unused]] const WidgetId id, const char* str)
         {
             switch (i)
             {
@@ -2693,7 +2693,7 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C12D2
-        static void onMouseUp(Window& w, WidgetIndex_t wi)
+        static void onMouseUp(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             switch (wi)
             {
@@ -2747,7 +2747,7 @@ namespace OpenLoco::Ui::Windows::Options
             }
         }
 
-        static void onMouseDown(Window& w, WidgetIndex_t wi)
+        static void onMouseDown(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             switch (wi)
             {
@@ -2763,7 +2763,7 @@ namespace OpenLoco::Ui::Windows::Options
             }
         }
 
-        static void onDropdown(Window& w, WidgetIndex_t wi, int16_t item_index)
+        static void onDropdown(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id, int16_t item_index)
         {
             switch (wi)
             {
@@ -2942,7 +2942,7 @@ namespace OpenLoco::Ui::Windows::Options
     {
         auto window = open();
 
-        window->callOnMouseUp(Common::Widx::tab_music);
+        window->callOnMouseUp(Common::Widx::tab_music, window->widgets[Common::Widx::tab_music].id);
 
         return window;
     }

--- a/src/OpenLoco/src/Ui/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PlayerInfoPanel.cpp
@@ -257,7 +257,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     }
 
     // 0x004395A4
-    static void onMouseUp([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -271,7 +271,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     }
 
     // 0x004395B1
-    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -282,7 +282,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     }
 
     // 0x004395BC
-    static void onDropdown([[maybe_unused]] Window& w, WidgetIndex_t widgetIndex, int16_t item_index)
+    static void onDropdown([[maybe_unused]] Window& w, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t item_index)
     {
         switch (widgetIndex)
         {
@@ -305,7 +305,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     }
 
     // 0x004395DE
-    static Ui::CursorId onCursor([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId onCursor([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
     {
         switch (widgetIndex)
         {
@@ -318,7 +318,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     }
 
     // 0x004395F5
-    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         switch (widgetIndex)

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -205,7 +205,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x00446465
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -308,7 +308,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x004467D7
-    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_list);
@@ -693,12 +693,12 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     {
         if (keyCode == SDLK_RETURN)
         {
-            w.callOnMouseUp(widx::ok_button);
+            w.callOnMouseUp(widx::ok_button, w.widgets[widx::ok_button].id);
             return true;
         }
         else if (keyCode == SDLK_ESCAPE)
         {
-            w.callOnMouseUp(widx::close_button);
+            w.callOnMouseUp(widx::close_button, w.widgets[widx::close_button].id);
             return true;
         }
         else if (!Input::isFocused(w.type, w.number, widx::text_filename) || !inputSession.handleInput(charCode, keyCode))

--- a/src/OpenLoco/src/Ui/Windows/PromptOkCancelWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptOkCancelWindow.cpp
@@ -96,7 +96,7 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
     {
         if (keyCode == SDLK_ESCAPE)
         {
-            w.callOnMouseUp(widx::closeButton);
+            w.callOnMouseUp(widx::closeButton, w.widgets[widx::closeButton].id);
             return true;
         }
         return false;
@@ -111,7 +111,7 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
     }
 
     // 0x004470FD
-    static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {

--- a/src/OpenLoco/src/Ui/Windows/PromptSaveWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptSaveWindow.cpp
@@ -117,7 +117,7 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
     }
 
     // 0x0043C3F4
-    static void onMouseUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex)
+    static void onMouseUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {

--- a/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
@@ -234,7 +234,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         static int16_t cargoByDropdownIndex[kMaxCargoObjects] = { -1 };
 
         // 0x0043FD51
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (itemIndex == -1)
             {
@@ -257,7 +257,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043FD14
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -421,7 +421,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043FCED
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -678,7 +678,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         };
 
         // 0x0043F67C
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (itemIndex == -1)
             {
@@ -706,7 +706,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043F639
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             auto& state = getGameState();
 
@@ -777,7 +777,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043F60C
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             auto& state = getGameState();
 
@@ -929,7 +929,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             tr.drawStringLeft(point, Colour::black, StringIds::loan_interest_rate);
         }
 
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             auto& state = getGameState();
 
@@ -971,7 +971,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             self.invalidate();
         }
 
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -1134,7 +1134,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         };
 
         // 0x0043F14B
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (widgetIndex == widx::scenario_group_btn && itemIndex != -1)
             {
@@ -1144,7 +1144,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043F140
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex == widx::scenario_group_btn)
             {
@@ -1161,7 +1161,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043F11F
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -1219,7 +1219,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043F156
-        static void textInput(Window& self, WidgetIndex_t callingWidget, const char* input)
+        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
         {
             switch (callingWidget)
             {

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -446,7 +446,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     }
 
     // 0x00443E9B
-    static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -457,7 +457,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     }
 
     // 0x00443EA6
-    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -554,7 +554,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     }
 
     // 0x00444001
-    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_scenario_list);

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -365,13 +365,13 @@ namespace OpenLoco::Ui::Windows::StationList
 
         Window* stationList = open(companyId);
         widx target = tabInformationByType[type].widgetIndex;
-        stationList->callOnMouseUp(target);
+        stationList->callOnMouseUp(target, stationList->widgets[target].id);
 
         return stationList;
     }
 
     // 0x004919A4
-    static Ui::CursorId cursor(Window& window, WidgetIndex_t widgetIdx, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId cursor(Window& window, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
     {
         if (widgetIdx != widx::scrollview)
         {
@@ -623,7 +623,7 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x004917BB
-    static void onDropdown(Ui::Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void onDropdown(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
     {
         if (widgetIndex != widx::company_select)
         {
@@ -668,7 +668,7 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x004917B0
-    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         if (widgetIndex == widx::company_select)
         {
@@ -677,7 +677,7 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x00491785
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -796,7 +796,7 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x00491841
-    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_station_list);

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -74,7 +74,7 @@ namespace OpenLoco::Ui::Windows::Station
 
         // Defined at the bottom of this file.
         static void prepareDraw(Window& self);
-        static void textInput(Window& self, WidgetIndex_t callingWidget, const char* input);
+        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input);
         static void update(Window& self);
         static void renameStationPrompt(Window* self, WidgetIndex_t widgetIndex);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
@@ -146,7 +146,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048E4D4
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -425,7 +425,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EB0B
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -484,7 +484,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EB4F
-        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_cargo_list);
@@ -656,7 +656,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EE1A
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -699,7 +699,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EE73
-        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_ratings_list);
@@ -894,7 +894,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048E5DF
-        static void textInput(Window& self, WidgetIndex_t callingWidget, const char* input)
+        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
         {
             if (callingWidget != Common::widx::caption)
             {

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -97,7 +97,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void prepareDraw(Window& self);
         static void onUpdate(Window& self);
         static void onResize(Window& self, uint8_t height);
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex);
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id);
         static void sub_4A69DD();
 
         enum class GhostPlacedFlags : uint8_t
@@ -277,7 +277,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBAB5
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -344,7 +344,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBAEA
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex == widx::object_colour && self.rowHover != -1)
             {
@@ -354,7 +354,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBAF5
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (widgetIndex != widx::object_colour)
             {
@@ -524,7 +524,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBB15
-        static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -563,7 +563,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBB20
-        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -694,7 +694,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBB00
-        static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_trees_list);
@@ -908,7 +908,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         auto window = WindowManager::bringToFront(WindowType::terraform, 0);
         if (window != nullptr)
         {
-            window->callOnMouseUp(Common::widx::tab_plant_trees);
+            window->callOnMouseUp(Common::widx::tab_plant_trees, window->widgets[Common::widx::tab_plant_trees].id);
         }
         else
         {
@@ -1012,7 +1012,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC65C
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -1043,7 +1043,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC677
-        static void onToolUpdate([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             World::mapInvalidateSelectionRect();
             World::resetMapSelectionFlag(World::MapSelectionFlags::enable);
@@ -1090,7 +1090,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC689
-        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -1100,7 +1100,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC682
-        static void toolDragContinue([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
+        static void toolDragContinue([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -1115,7 +1115,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC701
-        static void toolDragEnd([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex)
+        static void toolDragEnd([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex == Common::widx::panel)
             {
@@ -1334,7 +1334,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC9A7
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -1370,7 +1370,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             }
         }
 
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -1407,7 +1407,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC9C6
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (widgetIndex != widx::land_material)
             {
@@ -1596,7 +1596,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC9D7
-        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             switch (widgetIndex)
             {
@@ -1631,7 +1631,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC9ED
-        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
         {
             switch (widgetIndex)
             {
@@ -1654,7 +1654,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC9E2
-        static void toolDragContinue([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void toolDragContinue([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             switch (widgetIndex)
             {
@@ -1728,7 +1728,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCA5D
-        static void toolDragEnd([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex)
+        static void toolDragEnd([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -1937,7 +1937,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCD9D
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -1987,7 +1987,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static uint32_t lowerWater(uint8_t flags);
 
         // 0x004BCDB4
-        static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -2031,7 +2031,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCDCA
-        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -2076,7 +2076,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCDBF
-        static void toolDragContinue([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void toolDragContinue([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -2138,7 +2138,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCDE8
-        static void toolDragEnd([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex)
+        static void toolDragEnd([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex == Common::widx::panel)
             {
@@ -2508,7 +2508,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC227
-        static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -2543,7 +2543,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC232
-        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -2625,7 +2625,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC212
-        static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_walls_list);
@@ -2796,7 +2796,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCD82
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -2953,35 +2953,35 @@ namespace OpenLoco::Ui::Windows::Terraform
     void openClearArea()
     {
         auto terraformWindow = open();
-        terraformWindow->callOnMouseUp(Common::widx::tab_clear_area);
+        terraformWindow->callOnMouseUp(Common::widx::tab_clear_area, terraformWindow->widgets[Common::widx::tab_clear_area].id);
     }
 
     // 0x004BB546
     void openAdjustLand()
     {
         auto terraformWindow = open();
-        terraformWindow->callOnMouseUp(Common::widx::tab_adjust_land);
+        terraformWindow->callOnMouseUp(Common::widx::tab_adjust_land, terraformWindow->widgets[Common::widx::tab_adjust_land].id);
     }
 
     // 0x004BB556
     void openAdjustWater()
     {
         auto terraformWindow = open();
-        terraformWindow->callOnMouseUp(Common::widx::tab_adjust_water);
+        terraformWindow->callOnMouseUp(Common::widx::tab_adjust_water, terraformWindow->widgets[Common::widx::tab_adjust_water].id);
     }
 
     // 0x004BB4A3
     void openPlantTrees()
     {
         auto terraformWindow = open();
-        terraformWindow->callOnMouseUp(Common::widx::tab_plant_trees);
+        terraformWindow->callOnMouseUp(Common::widx::tab_plant_trees, terraformWindow->widgets[Common::widx::tab_plant_trees].id);
     }
 
     // 0x004BB576
     void openBuildWalls()
     {
         auto terraformWindow = open();
-        terraformWindow->callOnMouseUp(Common::widx::tab_build_walls);
+        terraformWindow->callOnMouseUp(Common::widx::tab_build_walls, terraformWindow->widgets[Common::widx::tab_build_walls].id);
     }
 
     bool rotate(Window& self)
@@ -2992,7 +2992,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             {
                 if (!self.widgets[PlantTrees::widx::rotate_object].hidden)
                 {
-                    self.callOnMouseUp(PlantTrees::widx::rotate_object);
+                    self.callOnMouseUp(PlantTrees::widx::rotate_object, self.widgets[PlantTrees::widx::rotate_object].id);
                     return true;
                 }
             }

--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -294,7 +294,7 @@ namespace OpenLoco::Ui::Windows::TextInput
     }
 
     // 0x004CE8B6
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -306,7 +306,7 @@ namespace OpenLoco::Ui::Windows::TextInput
                 auto caller = WindowManager::find(_callingWindowType, _callingWindowNumber);
                 if (caller != nullptr)
                 {
-                    caller->callTextInput(_callingWidget, inputSession.buffer.c_str());
+                    caller->callTextInput(_callingWidget, caller->widgets[_callingWidget].id, inputSession.buffer.c_str());
                 }
                 WindowManager::close(&window);
                 break;
@@ -328,12 +328,12 @@ namespace OpenLoco::Ui::Windows::TextInput
     {
         if (charCode == SDLK_RETURN)
         {
-            w.callOnMouseUp(Widx::ok);
+            w.callOnMouseUp(Widx::ok, w.widgets[Widx::ok].id);
             return true;
         }
         else if (charCode == SDLK_ESCAPE)
         {
-            w.callOnMouseUp(Widx::close);
+            w.callOnMouseUp(Widx::close, w.widgets[Widx::close].id);
             return true;
         }
         else if (!Input::isFocused(w.type, w.number, Widx::input) || !inputSession.handleInput(charCode, keyCode))

--- a/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
@@ -478,7 +478,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         }
     }
 
-    static void onMouseUp(Ui::Window& self, const WidgetIndex_t widgetIndex)
+    static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -492,7 +492,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         }
     }
 
-    static void onMouseDown(Ui::Window& self, const WidgetIndex_t widgetIndex)
+    static void onMouseDown(Ui::Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -529,7 +529,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         *scrollHeight = self.rowCount * self.rowHeight;
     }
 
-    static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::panel)
         {
@@ -545,7 +545,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         }
     }
 
-    static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+    static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::panel || !World::hasMapSelectionFlag(World::MapSelectionFlags::enable))
         {

--- a/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
@@ -190,7 +190,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x004398FB
-    static void onMouseUp([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -274,7 +274,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x043992E
-    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -285,7 +285,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x439939
-    static void onDropdown(Window& w, WidgetIndex_t widgetIndex, int16_t item_index)
+    static void onDropdown(Window& w, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t item_index)
     {
         switch (widgetIndex)
         {
@@ -296,7 +296,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x00439944
-    static Ui::CursorId onCursor([[maybe_unused]] Ui::Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId onCursor([[maybe_unused]] Ui::Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
     {
         switch (widgetIdx)
         {
@@ -309,7 +309,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x00439955
-    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         switch (widgetIndex)
@@ -362,7 +362,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x00439A15
-    static void textInput([[maybe_unused]] Window& w, WidgetIndex_t widgetIndex, const char* str)
+    static void textInput([[maybe_unused]] Window& w, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const char* str)
     {
         switch (widgetIndex)
         {

--- a/src/OpenLoco/src/Ui/Windows/TitleExit.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleExit.cpp
@@ -77,7 +77,7 @@ namespace OpenLoco::Ui::Windows::TitleExit
     }
 
     // 0x00439268
-    static void onMouseUp([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         if (Intro::isActive())
         {

--- a/src/OpenLoco/src/Ui/Windows/TitleLogo.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleLogo.cpp
@@ -52,7 +52,7 @@ namespace OpenLoco::Ui::Windows::TitleLogo
     }
 
     // 0x004392AD
-    static void onMouseUp([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {

--- a/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
@@ -295,7 +295,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     }
 
     // 0x00439094
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         if (Intro::isActive())
         {
@@ -326,7 +326,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     }
 
     // 0x004390D1
-    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         sub_46E328();
         switch (widgetIndex)
@@ -338,7 +338,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     }
 
     // 0x004390DD
-    static void onDropdown([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void onDropdown([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
     {
         sub_46E328();
         switch (widgetIndex)
@@ -350,7 +350,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     }
 
     // 0x004390ED
-    static void onTextInput([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex, const char* input)
+    static void onTextInput([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const char* input)
     {
         switch (widgetIndex)
         {
@@ -364,7 +364,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     }
 
     // 0x004390f8
-    static Ui::CursorId onCursor([[maybe_unused]] Window& window, [[maybe_unused]] WidgetIndex_t widgetIdx, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId onCursor([[maybe_unused]] Window& window, [[maybe_unused]] WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
     {
         // Reset tooltip timeout to keep tooltips open.
         addr<0x0052338A, uint16_t>() = 2000;

--- a/src/OpenLoco/src/Ui/Windows/TitleOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleOptions.cpp
@@ -68,7 +68,7 @@ namespace OpenLoco::Ui::Windows::TitleOptions
         tr.drawStringCentredWrapped(origin, window.width, Colour::white, StringIds::outlined_wcolour2_stringid, args);
     }
 
-    static void onMouseUp([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseUp([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         if (Intro::isActive())
         {

--- a/src/OpenLoco/src/Ui/Windows/ToolTip.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolTip.cpp
@@ -125,7 +125,7 @@ namespace OpenLoco::Ui::Windows::ToolTip
         _tooltipWindowNumber = window->number;
         _tooltipWidgetIndex = widgetIndex;
 
-        auto toolArgs = window->callTooltip(widgetIndex);
+        auto toolArgs = window->callTooltip(widgetIndex, window->widgets[widgetIndex].id);
         if (!toolArgs)
         {
             return;
@@ -151,7 +151,7 @@ namespace OpenLoco::Ui::Windows::ToolTip
         _tooltipWindowNumber = window->number;
         _tooltipWidgetIndex = widgetIndex;
 
-        auto toolArgs = window->callTooltip(widgetIndex);
+        auto toolArgs = window->callTooltip(widgetIndex, window->widgets[widgetIndex].id);
         if (!toolArgs)
         {
             return;

--- a/src/OpenLoco/src/Ui/Windows/ToolbarBottomEditor.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarBottomEditor.cpp
@@ -120,7 +120,7 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
     }
 
     // 0x0043D0ED
-    static void onMouseUp(Window&, WidgetIndex_t i)
+    static void onMouseUp(Window&, WidgetIndex_t i, [[maybe_unused]] const WidgetId id)
     {
         switch (i)
         {

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -735,7 +735,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     }
 
     // 0x0043A071
-    static void onMouseDown(Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -777,7 +777,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         }
     }
 
-    static void onDropdown(Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void onDropdown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
     {
         switch (widgetIndex)
         {

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
@@ -246,7 +246,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
     }
 
     // 0x0043D541
-    static void onMouseDown(Window& window, WidgetIndex_t widgetIndex)
+    static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -269,7 +269,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
     }
 
     // 0x0043D5A6
-    static void onDropdown(Window& window, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void onDropdown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
     {
         switch (widgetIndex)
         {

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -255,7 +255,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A27F
-        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -505,7 +505,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x00491841
-        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_town_list);
@@ -513,7 +513,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x004919A4
-        static Ui::CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
         {
             if (widgetIdx != widx::scrollview)
             {
@@ -571,7 +571,7 @@ namespace OpenLoco::Ui::Windows::TownList
         auto window = WindowManager::bringToFront(WindowType::townList, 0);
         if (window != nullptr)
         {
-            window->callOnMouseUp(Common::widx::tab_town_list);
+            window->callOnMouseUp(Common::widx::tab_town_list, window->widgets[Common::widx::tab_town_list].id);
         }
         else
         {
@@ -716,7 +716,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A675
-        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -746,7 +746,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A697
-        static void onDropdown(Window& self, Ui::WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& self, Ui::WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (widgetIndex != widx::select_size)
             {
@@ -761,13 +761,13 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A7C1
-        static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex)
+        static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             Ui::Windows::Main::hideGridlines();
         }
 
         // 0x0049A710
-        static void onToolUpdate([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             World::mapInvalidateSelectionRect();
             World::resetMapSelectionFlag(World::MapSelectionFlags::enable);
@@ -783,7 +783,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A75E
-        static void onToolDown([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             auto mapPos = Ui::ViewportInteraction::getSurfaceOrWaterLocFromUi({ x, y });
             if (mapPos)
@@ -815,7 +815,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A690
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex == widx::select_size)
             {
@@ -960,7 +960,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AB31
-        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -1060,7 +1060,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AB59
-        static void onDropdown(Window& self, Ui::WidgetIndex_t widgetIndex, int16_t itemIndex)
+        static void onDropdown(Window& self, Ui::WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
             if (widgetIndex != widx::object_colour)
             {
@@ -1088,7 +1088,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AD46
-        static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex)
+        static void onToolAbort([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             removeBuildingGhost();
             Ui::Windows::Main::hideGridlines();
@@ -1160,7 +1160,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049ABF0
-        static void onToolUpdate(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             World::mapInvalidateSelectionRect();
             World::resetMapSelectionFlag(World::MapSelectionFlags::enable);
@@ -1199,7 +1199,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049ACBD
-        static void onToolDown(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             removeBuildingGhost();
             auto placementArgs = getBuildingPlacementArgsFromCursor(x, y);
@@ -1223,7 +1223,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AB52
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex == widx::object_colour)
             {
@@ -1285,7 +1285,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049ABBB
-        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex)
+        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_building_list);
@@ -1584,7 +1584,7 @@ namespace OpenLoco::Ui::Windows::TownList
             {
                 if (!self.widgets[BuildBuildings::widx::rotate_object].hidden)
                 {
-                    self.callOnMouseUp(BuildBuildings::widx::rotate_object);
+                    self.callOnMouseUp(BuildBuildings::widx::rotate_object, self.widgets[BuildBuildings::widx::rotate_object].id);
                     return true;
                 }
             }

--- a/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
@@ -68,7 +68,7 @@ namespace OpenLoco::Ui::Windows::Town
 
         // Defined at the bottom of this file.
         static void prepareDraw(Window& self);
-        static void textInput(Window& self, WidgetIndex_t callingWidget, const char* input);
+        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input);
         static void update(Window& self);
         static void renameTownPrompt(Window* self, WidgetIndex_t widgetIndex);
         static void switchTab(Window* self, WidgetIndex_t widgetIndex);
@@ -157,7 +157,7 @@ namespace OpenLoco::Ui::Windows::Town
         }
 
         // 0x00499079
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -497,7 +497,7 @@ namespace OpenLoco::Ui::Windows::Town
         }
 
         // 0x004996AC
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -610,7 +610,7 @@ namespace OpenLoco::Ui::Windows::Town
         }
 
         // 0x004998E7
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -696,7 +696,7 @@ namespace OpenLoco::Ui::Windows::Town
         }
 
         // 0x00499287
-        static void textInput(Window& self, WidgetIndex_t callingWidget, const char* input)
+        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
         {
             if (callingWidget != Common::widx::caption)
             {

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -132,7 +132,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
         static void onClose(Window& self);
         static void setActiveTabs(Window* const self);
-        static void textInput(Window& self, const WidgetIndex_t callingWidget, const char* const input);
+        static void textInput(Window& self, const WidgetIndex_t callingWidget, const WidgetId id, const char* const input);
         static void renameVehicle(Window* const self, const WidgetIndex_t widgetIndex);
         static void switchTab(Window* const self, const WidgetIndex_t widgetIndex);
         static void setCaptionEnableState(Window* const self);
@@ -501,7 +501,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B24D1
-        static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -677,7 +677,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B251A
-        static void onMouseDown(Window& self, const WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -753,7 +753,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B253A
-        static void onDropdown(Window& self, const WidgetIndex_t widgetIndex, const int16_t itemIndex)
+        static void onDropdown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t itemIndex)
         {
             switch (widgetIndex)
             {
@@ -767,7 +767,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B2545
-        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             if (widgetIndex != widx::pickup)
             {
@@ -777,7 +777,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B2550
-        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             if (widgetIndex != widx::pickup)
             {
@@ -787,7 +787,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B255B
-        static void onToolAbort(Window& self, const WidgetIndex_t widgetIndex)
+        static void onToolAbort(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex != widx::pickup)
             {
@@ -797,7 +797,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B31F2
-        static std::optional<FormatArguments> tooltip(Ui::Window& self, WidgetIndex_t)
+        static std::optional<FormatArguments> tooltip(Ui::Window& self, WidgetIndex_t, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
 
@@ -1070,7 +1070,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             auto self = Main::open(vehicle);
             if (self != nullptr)
             {
-                self->callOnMouseUp(Common::widx::tabDetails);
+                self->callOnMouseUp(Common::widx::tabDetails, self->widgets[Common::widx::tabDetails].id);
             }
             return self;
         }
@@ -1100,7 +1100,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B3823
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -1149,7 +1149,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self.setSize(kMinWindowSize, kMaxWindowSize);
         }
 
-        static void onMouseDown(Window& self, const WidgetIndex_t widgetIndex)
+        static void onMouseDown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex != widx::buildNew)
             {
@@ -1174,7 +1174,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B253A
-        static void onDropdown(Window& self, const WidgetIndex_t widgetIndex, const int16_t itemIndex)
+        static void onDropdown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t itemIndex)
         {
             if (widgetIndex != widx::buildNew)
             {
@@ -1249,7 +1249,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B385F
-        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolUpdate(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             if (widgetIndex != widx::pickup)
             {
@@ -1259,7 +1259,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B386A
-        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             if (widgetIndex != widx::pickup)
             {
@@ -1269,7 +1269,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B3875
-        static void onToolAbort(Window& self, const WidgetIndex_t widgetIndex)
+        static void onToolAbort(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex != widx::pickup)
             {
@@ -1416,7 +1416,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B3880 TODO: common across 3 tabs
-        static std::optional<FormatArguments> tooltip(Ui::Window& self, WidgetIndex_t)
+        static std::optional<FormatArguments> tooltip(Ui::Window& self, WidgetIndex_t, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_vehicle_list);
@@ -1431,7 +1431,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B3B18
-        static Ui::CursorId cursor(Window& self, const WidgetIndex_t widgetIdx, [[maybe_unused]] const int16_t x, const int16_t y, const Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, const WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, const int16_t y, const Ui::CursorId fallback)
         {
             if (widgetIdx != widx::carList)
             {
@@ -1833,7 +1833,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
     namespace Cargo
     {
-        static void onRefitButton(Window* const self, const WidgetIndex_t wi);
+        static void onRefitButton(Window* const self, const WidgetIndex_t wi, const WidgetId id);
 
         static bool canRefit(Vehicles::VehicleHead* headVehicle)
         {
@@ -2017,7 +2017,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B41BD
-        static void onMouseUp(Window& self, const WidgetIndex_t i)
+        static void onMouseUp(Window& self, const WidgetIndex_t i, [[maybe_unused]] const WidgetId id)
         {
             switch (i)
             {
@@ -2040,18 +2040,18 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B41E2
-        static void onMouseDown(Window& self, const WidgetIndex_t i)
+        static void onMouseDown(Window& self, const WidgetIndex_t i, [[maybe_unused]] const WidgetId id)
         {
             switch (i)
             {
                 case widx::refit:
-                    onRefitButton(&self, i);
+                    onRefitButton(&self, i, id);
                     break;
             }
         }
 
         // 0x004B41E9
-        static void onDropdown(Window& self, const WidgetIndex_t i, const int16_t dropdownIndex)
+        static void onDropdown(Window& self, const WidgetIndex_t i, [[maybe_unused]] const WidgetId id, const int16_t dropdownIndex)
         {
             switch (i)
             {
@@ -2073,7 +2073,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
         }
 
-        static void onRefitButton(Window* const self, const WidgetIndex_t wi)
+        static void onRefitButton(Window* const self, const WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             auto* head = Common::getVehicle(self);
             if (head == nullptr)
@@ -2127,7 +2127,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4339
-        static std::optional<FormatArguments> tooltip(Ui::Window& self, WidgetIndex_t)
+        static std::optional<FormatArguments> tooltip(Ui::Window& self, WidgetIndex_t, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_vehicle_list);
@@ -2407,7 +2407,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B5945
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -2428,7 +2428,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B5977
-        static std::optional<FormatArguments> tooltip(Ui::Window& self, WidgetIndex_t)
+        static std::optional<FormatArguments> tooltip(Ui::Window& self, WidgetIndex_t, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             auto veh0 = Common::getVehicle(&self);
@@ -2592,7 +2592,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4B43
-        static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex)
+        static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             auto* head = Common::getVehicle(&self);
             if (head == nullptr)
@@ -2750,7 +2750,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4B8C
-        static void onMouseDown(Window& self, const WidgetIndex_t i)
+        static void onMouseDown(Window& self, const WidgetIndex_t i, [[maybe_unused]] const WidgetId id)
         {
             switch (i)
             {
@@ -2809,7 +2809,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4BAC
-        static void onDropdown(Window& self, const WidgetIndex_t i, const int16_t dropdownIndex)
+        static void onDropdown(Window& self, const WidgetIndex_t i, [[maybe_unused]] const WidgetId id, const int16_t dropdownIndex)
         {
             auto item = dropdownIndex == -1 ? Dropdown::getHighlightedItem() : dropdownIndex;
             if (item == -1)
@@ -2867,7 +2867,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4D74
-        static std::optional<FormatArguments> tooltip(Ui::Window& self, WidgetIndex_t)
+        static std::optional<FormatArguments> tooltip(Ui::Window& self, WidgetIndex_t, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
             args.push(StringIds::tooltip_scroll_orders_list);
@@ -3131,14 +3131,14 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B5088
-        static void toolCancel(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIdx)
+        static void toolCancel(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id)
         {
             self.invalidate();
             World::resetMapSelectionFlag(World::MapSelectionFlags::unk_04);
             Gfx::invalidateScreen();
         }
 
-        static void onToolDown(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const int16_t x, const int16_t y)
+        static void onToolDown(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             const auto args = getRouteInteractionFromCursor(self, x, y);
             switch (args.type)
@@ -3356,7 +3356,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B5339
-        static Ui::CursorId cursor(Window& self, const WidgetIndex_t widgetIdx, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y, const Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, const WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y, const Ui::CursorId fallback)
         {
             if (widgetIdx != widx::routeList)
             {
@@ -3796,7 +3796,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B26C0
-        static void textInput(Window& self, const WidgetIndex_t callingWidget, const char* const input)
+        static void textInput(Window& self, const WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* const input)
         {
             if (callingWidget != widx::caption)
             {
@@ -4375,7 +4375,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
 
             ToolManager::toolCancel();
-            self.callOnMouseUp(Common::widx::tabMain);
+            self.callOnMouseUp(Common::widx::tabMain, self.widgets[Common::widx::tabMain].id);
         }
 
         // 0x004B2E18
@@ -4679,7 +4679,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
             if (success)
             {
-                self->callOnMouseUp(widx::tabDetails);
+                self->callOnMouseUp(widx::tabDetails, self->widgets[widx::tabDetails].id);
             }
         }
 
@@ -4831,12 +4831,12 @@ namespace OpenLoco::Ui::Windows::Vehicle
             auto* w = WindowManager::find(WindowType::vehicle, ToolManager::getToolWindowNumber());
             if (w->currentTab == (Common::widx::tabMain - Common::widx::tabMain))
             {
-                w->callOnMouseUp(Common::widx::tabDetails);
+                w->callOnMouseUp(Common::widx::tabDetails, w->widgets[Common::widx::tabDetails].id);
                 return true;
             }
             else if (w->currentTab == (Common::widx::tabRoute - Common::widx::tabMain))
             {
-                w->callOnMouseUp(Common::widx::tabMain);
+                w->callOnMouseUp(Common::widx::tabMain, w->widgets[Common::widx::tabMain].id);
                 return true;
             }
         }

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -506,7 +506,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
         Window* self = WindowManager::bringToFront(WindowType::vehicleList, enumValue(companyId));
         if (self != nullptr)
         {
-            self->callOnMouseUp(VehicleList::getTabFromType(type));
+            const auto tabWidx = getTabFromType(type);
+            self->callOnMouseUp(tabWidx, self->widgets[tabWidx].id);
             return self;
         }
 
@@ -914,7 +915,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C2409
-    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         switch (widgetIndex)
         {
@@ -954,7 +955,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C2434
-    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex)
+    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         if (widgetIndex == Widx::company_select)
         {
@@ -1047,7 +1048,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         self->invalidate();
     }
 
-    static void onDropdown(Ui::Window& self, WidgetIndex_t widgetIndex, int16_t itemIndex)
+    static void onDropdown(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
     {
         if (widgetIndex == Widx::company_select)
         {
@@ -1070,7 +1071,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C24CA
-    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         FormatArguments args{};
         args.push(StringIds::tooltip_scroll_vehicle_list);
@@ -1115,7 +1116,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C266D
-    static CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] int16_t xPos, int16_t yPos, CursorId fallback)
+    static CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, CursorId fallback)
     {
         if (widgetIdx != Widx::scrollview)
         {


### PR DESCRIPTION
Some of the indirection might seem a bit silly but this way we don't have to update all the definitions all at once.