### PR TITLE
Simplify enabled/disabled widget state

### DIFF
--- a/src/OpenLoco/src/Ui/Widget.cpp
+++ b/src/OpenLoco/src/Ui/Widget.cpp
@@ -77,9 +77,8 @@ namespace OpenLoco::Ui
         widgetState.flags = widgetFlags;
         widgetState.colour = window->getColour(windowColour);
 
-        widgetState.enabled = enabled | ((window->enabledWidgets & (1ULL << widgetIndex)) != 0);
-        widgetState.disabled = disabled | ((window->disabledWidgets & (1ULL << widgetIndex)) != 0);
-        widgetState.activated = activated | ((window->activatedWidgets & (1ULL << widgetIndex)) != 0);
+        widgetState.disabled = disabled || ((window->disabledWidgets & (1ULL << widgetIndex)) != 0);
+        widgetState.activated = activated || ((window->activatedWidgets & (1ULL << widgetIndex)) != 0);
         widgetState.activated |= (pressedWidgets & (1ULL << widgetIndex)) != 0;
         widgetState.activated |= (toolWidgets & (1ULL << widgetIndex)) != 0;
 

--- a/src/OpenLoco/src/Ui/Widget.h
+++ b/src/OpenLoco/src/Ui/Widget.h
@@ -118,14 +118,13 @@ namespace OpenLoco::Ui
 
     struct WidgetState
     {
-        Window* window;
-        Gfx::RectInsetFlags flags;
-        AdvancedColour colour;
-        bool enabled;
-        bool disabled;
-        bool activated;
-        bool hovered;
-        int scrollviewIndex;
+        Window* window{};
+        Gfx::RectInsetFlags flags{};
+        AdvancedColour colour{};
+        bool disabled{};
+        bool activated{};
+        bool hovered{};
+        int scrollviewIndex{};
     };
 
     struct Widget;
@@ -200,7 +199,6 @@ namespace OpenLoco::Ui
         uint32_t styleData{};
 
         // Widget state.
-        bool enabled : 1 {};
         bool disabled : 1 {};
         bool activated : 1 {};
         bool hidden : 1 {};

--- a/src/OpenLoco/src/Ui/Widgets/CheckboxWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/CheckboxWidget.cpp
@@ -10,29 +10,31 @@ namespace OpenLoco::Ui::Widgets
     static constexpr auto kLabelMarginLeft = 4;
 
     // 0x004CB00B
-    static void drawCheckMark(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
+    static void drawCheckBox(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
         auto* window = widgetState.window;
 
         const auto pos = window->position() + widget.position();
 
-        if (!widgetState.disabled)
-        {
-            drawingCtx.fillRectInset(
-                pos,
-                kCheckMarkSize,
-                widgetState.colour,
-                widgetState.flags | Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillDarker);
-        }
+        drawingCtx.fillRectInset(
+            pos,
+            kCheckMarkSize,
+            widgetState.colour,
+            widgetState.flags | Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillDarker);
 
         if (widgetState.activated)
         {
             auto tr = Gfx::TextRenderer(drawingCtx);
             static constexpr char strCheckmark[] = "\xAC";
 
-            auto color = widgetState.colour;
+            auto colour = widgetState.colour;
+            if (widgetState.disabled)
+            {
+                colour = colour.inset();
+            }
+
             tr.setCurrentFont(widget.font);
-            tr.drawString(pos, color.opaque(), strCheckmark);
+            tr.drawString(pos, colour.opaque(), strCheckmark);
         }
     }
 
@@ -64,7 +66,7 @@ namespace OpenLoco::Ui::Widgets
 
     void Checkbox::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        drawCheckMark(drawingCtx, widget, widgetState);
+        drawCheckBox(drawingCtx, widget, widgetState);
         drawLabel(drawingCtx, widget, widgetState);
     }
 }

--- a/src/OpenLoco/src/Ui/Widgets/CheckboxWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/CheckboxWidget.cpp
@@ -16,7 +16,7 @@ namespace OpenLoco::Ui::Widgets
 
         const auto pos = window->position() + widget.position();
 
-        if (widgetState.enabled)
+        if (!widgetState.disabled)
         {
             drawingCtx.fillRectInset(
                 pos,

--- a/src/OpenLoco/src/Ui/Widgets/ColourButtonWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ColourButtonWidget.cpp
@@ -19,12 +19,12 @@ namespace OpenLoco::Ui::Widgets
         // TODO: Remove addition
         ImageId imageId = ImageId::fromUInt32(widget.image & ~Widget::kImageIdColourSet);
 
-        if (widgetState.enabled && widgetState.activated && widgetState.hovered)
+        if (!widgetState.disabled && widgetState.activated && widgetState.hovered)
         {
             // TODO: Remove addition
             imageId = imageId.withIndexOffset(2);
         }
-        else if (widgetState.enabled && !widgetState.activated && widgetState.hovered)
+        else if (!widgetState.disabled && !widgetState.activated && widgetState.hovered)
         {
             // TODO: Remove addition
             imageId = imageId.withIndexOffset(1);

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -89,7 +89,7 @@ namespace OpenLoco::Ui
 
     bool Window::isEnabled(WidgetIndex_t widgetIndex)
     {
-        return (this->enabledWidgets & (1ULL << widgetIndex)) != 0;
+        return (this->disabledWidgets & (1ULL << widgetIndex)) == 0;
     }
 
     bool Window::isDisabled(WidgetIndex_t widgetIndex)

--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -183,7 +183,6 @@ namespace OpenLoco::Ui
 
         sfl::small_vector<Widget, 16> widgets;
         const WindowEventList* eventHandlers;
-        uint64_t enabledWidgets = 0;
         uint64_t disabledWidgets = 0;
         uint64_t activatedWidgets = 0;
         uint64_t holdableWidgets = 0;

--- a/src/OpenLoco/src/Ui/Windows/About.cpp
+++ b/src/OpenLoco/src/Ui/Windows/About.cpp
@@ -54,7 +54,6 @@ namespace OpenLoco::Ui::Windows::About
             getEvents());
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = (1 << widx::close) | (1 << widx::music_acknowledgements_btn);
         window->initScrollWidgets();
 
         const auto interface = ObjectManager::get<InterfaceSkinObject>();

--- a/src/OpenLoco/src/Ui/Windows/AboutMusic.cpp
+++ b/src/OpenLoco/src/Ui/Windows/AboutMusic.cpp
@@ -59,7 +59,6 @@ namespace OpenLoco::Ui::Windows::AboutMusic
             getEvents());
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = 1 << Widx::close;
         window->initScrollWidgets();
 
         const auto interface = ObjectManager::get<InterfaceSkinObject>();

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -315,7 +315,6 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         auto window = WindowManager::createWindow(WindowType::buildVehicle, kWindowSize, WindowFlags::flag_11, getEvents());
         window->setWidgets(_widgets);
         window->number = enumValue(company);
-        window->enabledWidgets = (1ULL << widx::close_button) | (1ULL << widx::tab_build_new_trains) | (1ULL << widx::tab_build_new_buses) | (1ULL << widx::tab_build_new_trucks) | (1ULL << widx::tab_build_new_trams) | (1ULL << widx::tab_build_new_aircraft) | (1ULL << widx::tab_build_new_ships) | (1ULL << widx::tab_track_type_0) | (1ULL << widx::tab_track_type_1) | (1ULL << widx::tab_track_type_2) | (1ULL << widx::tab_track_type_3) | (1ULL << widx::tab_track_type_4) | (1ULL << widx::tab_track_type_5) | (1ULL << widx::tab_track_type_6) | (1ULL << widx::tab_track_type_7) | (1ULL << widx::searchClearButton) | (1ULL << widx::filterLabel) | (1ULL << widx::filterDropdown) | (1ULL << widx::cargoLabel) | (1ULL << widx::cargoDropdown) | (1ULL << widx::scrollview_vehicle_selection);
         window->owner = CompanyManager::getControllingId();
         window->frameNo = 0;
         auto skin = OpenLoco::ObjectManager::get<InterfaceSkinObject>();
@@ -390,7 +389,6 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
             window->rowHover = -1;
             window->invalidate();
             window->setWidgets(_widgets);
-            window->enabledWidgets = (1ULL << widx::close_button) | (1ULL << widx::tab_build_new_trains) | (1ULL << widx::tab_build_new_buses) | (1ULL << widx::tab_build_new_trucks) | (1ULL << widx::tab_build_new_trams) | (1ULL << widx::tab_build_new_aircraft) | (1ULL << widx::tab_build_new_ships) | (1ULL << widx::tab_track_type_0) | (1ULL << widx::tab_track_type_1) | (1ULL << widx::tab_track_type_2) | (1ULL << widx::tab_track_type_3) | (1ULL << widx::tab_track_type_4) | (1ULL << widx::tab_track_type_5) | (1ULL << widx::tab_track_type_6) | (1ULL << widx::tab_track_type_7) | (1ULL << widx::searchClearButton) | (1ULL << widx::filterLabel) | (1ULL << widx::filterDropdown) | (1ULL << widx::cargoLabel) | (1ULL << widx::cargoDropdown) | (1ULL << widx::scrollview_vehicle_selection);
             window->holdableWidgets = 0;
             window->eventHandlers = &getEvents();
             window->activatedWidgets = 0;
@@ -757,7 +755,6 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                     curViewport->width = 0;
                 }
 
-                window.enabledWidgets = (1 << widx::close_button) | (1 << widx::tab_build_new_trains) | (1 << widx::tab_build_new_buses) | (1 << widx::tab_build_new_trucks) | (1 << widx::tab_build_new_trams) | (1 << widx::tab_build_new_aircraft) | (1 << widx::tab_build_new_ships) | (1 << widx::tab_track_type_0) | (1 << widx::tab_track_type_1) | (1 << widx::tab_track_type_2) | (1 << widx::tab_track_type_3) | (1 << widx::tab_track_type_4) | (1 << widx::tab_track_type_5) | (1 << widx::tab_track_type_6) | (1 << widx::tab_track_type_7) | (1ULL << widx::searchClearButton) | (1ULL << widx::filterLabel) | (1ULL << widx::filterDropdown) | (1ULL << widx::cargoLabel) | (1ULL << widx::cargoDropdown) | (1 << widx::scrollview_vehicle_selection);
                 window.holdableWidgets = 0;
                 window.eventHandlers = &getEvents();
                 window.setWidgets(_widgets);

--- a/src/OpenLoco/src/Ui/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Cheats.cpp
@@ -68,8 +68,6 @@ namespace OpenLoco::Ui::Windows::Cheats
                 Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab));
         }
 
-        constexpr uint64_t enabledWidgets = (1 << Widx::close_button) | (1 << Widx::tab_finances) | (1 << Widx::tab_companies) | (1 << Widx::tab_vehicles) | (1 << Widx::tab_towns);
-
         static void drawTabs(Ui::Window* const self, Gfx::DrawingContext& drawingCtx)
         {
             auto skin = ObjectManager::get<InterfaceSkinObject>();
@@ -203,20 +201,6 @@ namespace OpenLoco::Ui::Windows::Cheats
             Widgets::Button({ 10, 186 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_date_change_apply)
 
         );
-
-        static uint64_t enabledWidgets
-            = Common::enabledWidgets
-            | (1 << Widx::loan_clear)
-            | (1 << Widx::cash_step_decrease)
-            | (1 << Widx::cash_step_increase)
-            | (1 << Widx::cash_step_apply)
-            | (1 << Widx::year_step_decrease)
-            | (1 << Widx::year_step_increase)
-            | (1 << Widx::month_step_decrease)
-            | (1 << Widx::month_step_increase)
-            | (1 << Widx::day_step_decrease)
-            | (1 << Widx::day_step_increase)
-            | (1 << Widx::date_change_apply);
 
         const uint64_t holdableWidgets
             = (1 << Widx::cash_step_decrease)
@@ -535,8 +519,6 @@ namespace OpenLoco::Ui::Windows::Cheats
 
         );
 
-        static uint64_t enabledWidgets = Common::enabledWidgets | (1 << Widx::target_company_dropdown) | (1 << Widx::target_company_dropdown_btn) | (1 << Widx::switch_company_button) | (1 << Widx::acquire_company_assets_button) | (1 << Widx::toggle_bankruptcy_button) | (1 << Widx::toggle_jail_status_button) | (1 << Widx::complete_challenge_button);
-
         static CompanyId _targetCompanyId{};
 
         static void prepareDraw(Window& self)
@@ -720,8 +702,6 @@ namespace OpenLoco::Ui::Windows::Cheats
 
         );
 
-        static uint64_t enabledWidgets = Common::enabledWidgets | (1 << Widx::reliablity_all_to_zero) | (1 << Widx::reliablity_all_to_hundred) | (1 << Widx::checkbox_display_locked_vehicles) | (1 << Widx::checkbox_build_locked_vehicles);
-
         static void prepareDraw(Window& self)
         {
             self.activatedWidgets = (1 << Common::Widx::tab_vehicles);
@@ -873,8 +853,6 @@ namespace OpenLoco::Ui::Windows::Cheats
 
         );
 
-        static uint64_t enabledWidgets = Common::enabledWidgets | (1 << Widx::ratings_all_min_10pct) | (1 << Widx::ratings_all_plus_10pct) | (1 << Widx::ratings_all_to_min) | (1 << Widx::ratings_all_to_max);
-
         static void prepareDraw(Window& self)
         {
             self.activatedWidgets = (1 << Common::Widx::tab_towns);
@@ -1007,17 +985,16 @@ namespace OpenLoco::Ui::Windows::Cheats
             std::span<const Widget> widgets;
             WidgetIndex_t widgetIndex;
             const WindowEventList& events;
-            const uint64_t* enabledWidgets;
             const uint64_t* holdableWidgets;
             Ui::Size32 kWindowSize;
         };
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { Finances::_widgets,  Widx::tab_finances,  Finances::getEvents(),  &Finances::enabledWidgets,  &Finances::holdableWidgets, Finances::kWindowSize  },
-            { Companies::_widgets, Widx::tab_companies, Companies::getEvents(), &Companies::enabledWidgets, nullptr,                    Companies::kWindowSize },
-            { Vehicles::_widgets,  Widx::tab_vehicles,  Vehicles::getEvents(),  &Vehicles::enabledWidgets,  nullptr,                    Vehicles::kWindowSize  },
-            { Towns::_widgets,     Widx::tab_towns,     Towns::getEvents(),     &Towns::enabledWidgets,     nullptr,                    Towns::kWindowSize     },
+            { Finances::_widgets,  Widx::tab_finances,  Finances::getEvents(),  &Finances::holdableWidgets, Finances::kWindowSize  },
+            { Companies::_widgets, Widx::tab_companies, Companies::getEvents(), nullptr,                    Companies::kWindowSize },
+            { Vehicles::_widgets,  Widx::tab_vehicles,  Vehicles::getEvents(),  nullptr,                    Vehicles::kWindowSize  },
+            { Towns::_widgets,     Widx::tab_towns,     Towns::getEvents(),     nullptr,                    Towns::kWindowSize     },
         };
         // clang-format on
 

--- a/src/OpenLoco/src/Ui/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Cheats.cpp
@@ -990,7 +990,6 @@ namespace OpenLoco::Ui::Windows::Cheats
 
         window->setWidgets(Finances::_widgets);
         window->currentTab = Common::Widx::tab_finances - Common::Widx::tab_finances;
-        window->enabledWidgets = Finances::enabledWidgets;
         window->holdableWidgets = Finances::holdableWidgets;
         window->initScrollWidgets();
 
@@ -1029,7 +1028,6 @@ namespace OpenLoco::Ui::Windows::Cheats
 
             auto tabInfo = tabInformationByTabOffset[self->currentTab];
 
-            self->enabledWidgets = *tabInfo.enabledWidgets;
             self->holdableWidgets = tabInfo.holdableWidgets != nullptr ? *tabInfo.holdableWidgets : 0;
             self->eventHandlers = &tabInfo.events;
             self->activatedWidgets = 0;

--- a/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
@@ -88,7 +88,6 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
         {
             self = WindowManager::createWindow(WindowType::companyFaceSelection, kWindowSize, WindowFlags::none, getEvents());
             self->setWidgets(widgets);
-            self->enabledWidgets = (1 << widx::close_button);
             self->initScrollWidgets();
             _9C68F2 = id;
             self->owner = id;

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -60,8 +60,6 @@ namespace OpenLoco::Ui::Windows::CompanyList
             tab_speed_records,
         };
 
-        const uint64_t enabledWidgets = (1 << widx::close_button) | (1 << widx::tab_company_list) | (1 << widx::tab_performance) | (1 << widx::tab_cargo_units) | (1 << widx::tab_cargo_distance) | (1 << widx::tab_values) | (1 << widx::tab_payment_rates) | (1 << widx::tab_speed_records);
-
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
@@ -101,8 +99,6 @@ namespace OpenLoco::Ui::Windows::CompanyList
             sort_value,
             scrollview,
         };
-
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << sort_name) | (1 << sort_status) | (1 << sort_performance) | (1 << sort_value) | (1 << scrollview);
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(640, 272, StringIds::title_company_list),
@@ -638,7 +634,6 @@ namespace OpenLoco::Ui::Windows::CompanyList
         window->invalidate();
 
         window->setWidgets(CompanyList::widgets);
-        window->enabledWidgets = CompanyList::enabledWidgets;
         window->holdableWidgets = 0;
         window->eventHandlers = &CompanyList::getEvents();
         window->activatedWidgets = 0;
@@ -673,8 +668,6 @@ namespace OpenLoco::Ui::Windows::CompanyList
     namespace CompanyPerformance
     {
         static constexpr Ui::Size32 kWindowSize = { 635, 322 };
-
-        const uint64_t enabledWidgets = Common::enabledWidgets;
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(635, 322, StringIds::title_company_performance)
@@ -769,8 +762,6 @@ namespace OpenLoco::Ui::Windows::CompanyList
     {
         static constexpr Ui::Size32 kWindowSize = { 640, 272 };
 
-        const uint64_t enabledWidgets = Common::enabledWidgets;
-
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(635, 322, StringIds::title_company_cargo_units)
 
@@ -863,8 +854,6 @@ namespace OpenLoco::Ui::Windows::CompanyList
     namespace CargoDistance
     {
         static constexpr Ui::Size32 kWindowSize = { 660, 272 };
-
-        const uint64_t enabledWidgets = Common::enabledWidgets;
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(635, 322, StringIds::title_cargo_distance_graphs)
@@ -959,8 +948,6 @@ namespace OpenLoco::Ui::Windows::CompanyList
     {
         static constexpr Ui::Size32 kWindowSize = { 685, 322 };
 
-        const uint64_t enabledWidgets = Common::enabledWidgets;
-
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(685, 322, StringIds::title_company_values)
 
@@ -1053,8 +1040,6 @@ namespace OpenLoco::Ui::Windows::CompanyList
     namespace CargoPaymentRates
     {
         static constexpr Ui::Size32 kWindowSize = { 495, 342 };
-
-        const uint64_t enabledWidgets = Common::enabledWidgets;
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(495, 342, StringIds::title_cargo_payment_rates)
@@ -1316,8 +1301,6 @@ namespace OpenLoco::Ui::Windows::CompanyList
     {
         static constexpr Ui::Size32 kWindowSize = { 495, 169 };
 
-        const uint64_t enabledWidgets = Common::enabledWidgets;
-
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(495, 169, StringIds::title_speed_records)
 
@@ -1411,18 +1394,17 @@ namespace OpenLoco::Ui::Windows::CompanyList
             std::span<const Widget> widgets;
             const widx widgetIndex;
             const WindowEventList& events;
-            const uint64_t enabledWidgets;
         };
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { CompanyList::widgets,         widx::tab_company_list,   CompanyList::getEvents(),         CompanyList::enabledWidgets },
-            { CompanyPerformance::widgets,  widx::tab_performance,    CompanyPerformance::getEvents(),  CompanyPerformance::enabledWidgets },
-            { CargoUnits::widgets,          widx::tab_cargo_units,    CargoUnits::getEvents(),          CargoUnits::enabledWidgets },
-            { CargoDistance::widgets,       widx::tab_cargo_distance, CargoDistance::getEvents(),       CargoDistance::enabledWidgets },
-            { CompanyValues::widgets,       widx::tab_values,         CompanyValues::getEvents(),       CompanyValues::enabledWidgets },
-            { CargoPaymentRates::widgets,   widx::tab_payment_rates,  CargoPaymentRates::getEvents(),   CargoPaymentRates::enabledWidgets },
-            { CompanySpeedRecords::widgets, widx::tab_speed_records,  CompanySpeedRecords::getEvents(), CompanySpeedRecords::enabledWidgets },
+            { CompanyList::widgets,         widx::tab_company_list,   CompanyList::getEvents()         },
+            { CompanyPerformance::widgets,  widx::tab_performance,    CompanyPerformance::getEvents()  },
+            { CargoUnits::widgets,          widx::tab_cargo_units,    CargoUnits::getEvents()          },
+            { CargoDistance::widgets,       widx::tab_cargo_distance, CargoDistance::getEvents()       },
+            { CompanyValues::widgets,       widx::tab_values,         CompanyValues::getEvents()       },
+            { CargoPaymentRates::widgets,   widx::tab_payment_rates,  CargoPaymentRates::getEvents()   },
+            { CompanySpeedRecords::widgets, widx::tab_speed_records,  CompanySpeedRecords::getEvents() },
         };
         // clang-format on
 
@@ -1549,7 +1531,6 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
             const auto& tabInfo = tabInformationByTabOffset[widgetIndex - widx::tab_company_list];
 
-            self->enabledWidgets = tabInfo.enabledWidgets;
             self->holdableWidgets = 0;
             self->eventHandlers = &tabInfo.events;
             self->activatedWidgets = 0;

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -106,11 +106,11 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         {
             if (SceneManager::isEditorMode() || CompanyId(self->number) == CompanyManager::getControllingId())
             {
-                self->enabledWidgets |= (1 << caption);
+                self->disabledWidgets &= ~(1ULL << caption);
             }
             else
             {
-                self->enabledWidgets &= ~(1 << caption);
+                self->disabledWidgets |= (1ULL << caption);
             }
         }
 
@@ -654,7 +654,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         window->invalidate();
 
         window->setWidgets(Status::widgets);
-        window->enabledWidgets = Status::enabledWidgets;
         window->holdableWidgets = 0;
         window->eventHandlers = &Status::getEvents();
         window->activatedWidgets = 0;
@@ -1429,11 +1428,11 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             if (CompanyId(self.number) == CompanyManager::getControllingId())
             {
-                self.enabledWidgets |= allColourChecks | allMainColours | allSecondaryColours;
+                self.disabledWidgets &= ~(allColourChecks | allMainColours | allSecondaryColours);
             }
             else
             {
-                self.enabledWidgets &= ~(allColourChecks | allMainColours | allSecondaryColours);
+                self.disabledWidgets |= (allColourChecks | allMainColours | allSecondaryColours);
             }
         }
 
@@ -2231,7 +2230,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         window->invalidate();
 
         window->setWidgets(Finances::widgets);
-        window->enabledWidgets = Finances::enabledWidgets;
         window->holdableWidgets = Finances::holdableWidgets;
         window->eventHandlers = &Finances::getEvents();
         window->activatedWidgets = 0;
@@ -2645,7 +2643,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         window->invalidate();
 
         window->setWidgets(Challenge::widgets);
-        window->enabledWidgets = Challenge::enabledWidgets;
         window->holdableWidgets = 0;
         window->eventHandlers = &Challenge::getEvents();
         window->activatedWidgets = 0;
@@ -2758,7 +2755,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             auto tabIndex = widgetIndex - widx::tab_status;
             auto tabInfo = tabInformationByTabOffset[tabIndex];
 
-            self->enabledWidgets = *tabInfo.enabledWidgets;
             self->holdableWidgets = 0;
             self->eventHandlers = &tabInfo.events;
             self->activatedWidgets = 0;

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -73,8 +73,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             company_select,
         };
 
-        constexpr uint64_t enabledWidgets = (1 << widx::caption) | (1 << widx::close_button) | (1 << widx::tab_status) | (1 << widx::tab_details) | (1 << widx::tab_colour_scheme) | (1 << widx::tab_finances) | (1 << widx::tab_cargo_delivered) | (1 << widx::tab_challenge);
-
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
@@ -146,8 +144,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             Widgets::ImageButton({ 154, 124 }, { 112, 22 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_change_owner_name)
 
         );
-
-        constexpr uint64_t enabledWidgets = Common::enabledWidgets | (1 << Common::widx::company_select) | (1 << widx::centre_on_viewport) | (1 << widx::face) | (1 << widx::change_owner_name);
 
         // 0x00431EBB
         static void prepareDraw(Window& self)
@@ -706,8 +702,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this)
 
         );
-
-        constexpr uint64_t enabledWidgets = Common::enabledWidgets | (1 << Common::widx::company_select) | (1 << build_hq) | (1 << centre_on_viewport);
 
         // 0x004327CF
         static void prepareDraw(Window& self)
@@ -1347,8 +1341,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
         );
 
-        constexpr uint64_t enabledWidgets = Common::enabledWidgets | (1 << Common::widx::company_select) | allMainColours | allSecondaryColours | allColourChecks;
-
         // 0x00432E0F
         static void prepareDraw(Window& self)
         {
@@ -1726,8 +1718,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             Widgets::Checkbox({ 320, 264 }, { 204, 12 }, WindowColour::secondary, StringIds::loan_autopay, StringIds::tooltip_loan_autopay) // loan_autopay
 
         );
-
-        constexpr uint64_t enabledWidgets = Common::enabledWidgets | (1 << Common::widx::company_select) | (1 << widx::loan_decrease) | (1 << widx::loan_increase) | (1 << widx::loan_autopay);
 
         const uint64_t holdableWidgets = (1 << widx::loan_decrease) | (1 << widx::loan_increase);
 
@@ -2251,8 +2241,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
         );
 
-        constexpr uint64_t enabledWidgets = Common::enabledWidgets | (1 << Common::widx::company_select);
-
         // 0x00433A22
         static void prepareDraw(Window& self)
         {
@@ -2439,8 +2427,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             Common::makeCommonWidgets(320, 182, StringIds::title_company_challenge)
 
         );
-
-        constexpr uint64_t enabledWidgets = Common::enabledWidgets;
 
         // 0x00433D39
         static void prepareDraw(Window& self)
@@ -2661,18 +2647,17 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             std::span<const Widget> widgets;
             const widx widgetIndex;
             const WindowEventList& events;
-            const uint64_t* enabledWidgets;
             const Ui::Size32* kWindowSize;
         };
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { Status::widgets,         widx::tab_status,          Status::getEvents(),         &Status::enabledWidgets,         &Status::kWindowSize },
-            { Details::widgets,        widx::tab_details,         Details::getEvents(),        &Details::enabledWidgets,        &Details::kWindowSize },
-            { ColourScheme::widgets,   widx::tab_colour_scheme,   ColourScheme::getEvents(),   &ColourScheme::enabledWidgets,   &ColourScheme::kWindowSize },
-            { Finances::widgets,       widx::tab_finances,        Finances::getEvents(),       &Finances::enabledWidgets,       &Finances::kWindowSize },
-            { CargoDelivered::widgets, widx::tab_cargo_delivered, CargoDelivered::getEvents(), &CargoDelivered::enabledWidgets, &CargoDelivered::kWindowSize },
-            { Challenge::widgets,      widx::tab_challenge,       Challenge::getEvents(),      &Challenge::enabledWidgets,      &Challenge::kWindowSize }
+            { Status::widgets,         widx::tab_status,          Status::getEvents(),         &Status::kWindowSize },
+            { Details::widgets,        widx::tab_details,         Details::getEvents(),        &Details::kWindowSize },
+            { ColourScheme::widgets,   widx::tab_colour_scheme,   ColourScheme::getEvents(),   &ColourScheme::kWindowSize },
+            { Finances::widgets,       widx::tab_finances,        Finances::getEvents(),       &Finances::kWindowSize },
+            { CargoDelivered::widgets, widx::tab_cargo_delivered, CargoDelivered::getEvents(), &CargoDelivered::kWindowSize },
+            { Challenge::widgets,      widx::tab_challenge,       Challenge::getEvents(),      &Challenge::kWindowSize }
         };
         // clang-format on
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -615,16 +615,15 @@ namespace OpenLoco::Ui::Windows::Construction
             std::span<const Widget> widgets;
             const widx widgetIndex;
             const WindowEventList& events;
-            const uint64_t enabledWidgets;
             void (*tabReset)(Window*);
         };
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { Construction::getWidgets(), widx::tab_construction, Construction::getEvents(), Construction::enabledWidgets, &Construction::tabReset },
-            { Station::getWidgets(),      widx::tab_station,      Station::getEvents(),      Station::enabledWidgets,      &Station::tabReset },
-            { Signal::getWidgets(),       widx::tab_signal,       Signal::getEvents(),       Signal::enabledWidgets,       &Signal::tabReset },
-            { Overhead::getWidgets(),     widx::tab_overhead,     Overhead::getEvents(),     Overhead::enabledWidgets,     &Overhead::tabReset },
+            { Construction::getWidgets(), widx::tab_construction, Construction::getEvents(), &Construction::tabReset },
+            { Station::getWidgets(),      widx::tab_station,      Station::getEvents(),      &Station::tabReset },
+            { Signal::getWidgets(),       widx::tab_signal,       Signal::getEvents(),       &Signal::tabReset },
+            { Overhead::getWidgets(),     widx::tab_overhead,     Overhead::getEvents(),     &Overhead::tabReset },
         };
         // clang-format on
 
@@ -642,7 +641,6 @@ namespace OpenLoco::Ui::Windows::Construction
 
             const auto& tabInfo = tabInformationByTabOffset[tabWidgetIndex - widx::tab_construction];
 
-            self.enabledWidgets = tabInfo.enabledWidgets;
             self.eventHandlers = &tabInfo.events;
             self.activatedWidgets = 0;
             self.setWidgets(tabInfo.widgets);
@@ -753,7 +751,6 @@ namespace OpenLoco::Ui::Windows::Construction
 
             auto tabInfo = tabInformationByTabOffset[widgetIndex - widx::tab_construction];
 
-            self->enabledWidgets = tabInfo.enabledWidgets;
             self->eventHandlers = &tabInfo.events;
             self->activatedWidgets = 0;
             self->setWidgets(tabInfo.widgets);
@@ -1179,7 +1176,6 @@ namespace OpenLoco::Ui::Windows::Construction
 
             window->setWidgets(Construction::getWidgets());
             window->currentTab = 0;
-            window->enabledWidgets = Construction::enabledWidgets;
             window->activatedWidgets = 0;
 
             setDisabledWidgets(window);

--- a/src/OpenLoco/src/Ui/Windows/Construction/Construction.h
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Construction.h
@@ -162,8 +162,6 @@ namespace OpenLoco::Ui::Windows::Construction
                 Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_electrification_construction));
         }
 
-        constexpr uint64_t enabledWidgets = (1 << widx::caption) | (1 << widx::close_button) | (1 << widx::tab_construction) | (1 << widx::tab_station) | (1 << widx::tab_signal) | (1 << widx::tab_overhead);
-
         void prepareDraw(Window* self);
         void resetWindow(Window& self, WidgetIndex_t tabWidgetIndex);
         void switchTab(Window* self, WidgetIndex_t widgetIndex);
@@ -256,8 +254,6 @@ namespace OpenLoco::Ui::Windows::Construction
 
         std::span<const Widget> getWidgets();
 
-        constexpr uint64_t enabledWidgets = Common::enabledWidgets | allConstruction;
-
         void reset();
         void activateSelectedConstructionWidgets();
         void tabReset(Window* self);
@@ -286,8 +282,6 @@ namespace OpenLoco::Ui::Windows::Construction
 
         std::span<const Widget> getWidgets();
 
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << station) | (1 << station_dropdown) | (1 << image) | (1 << rotate);
-
         void tabReset(Window* self);
         void removeStationGhost();
         const WindowEventList& getEvents();
@@ -304,8 +298,6 @@ namespace OpenLoco::Ui::Windows::Construction
         };
 
         std::span<const Widget> getWidgets();
-
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << signal) | (1 << signal_dropdown) | (1 << both_directions) | (1 << single_direction);
 
         void tabReset(Window* self);
         void removeSignalGhost();
@@ -326,8 +318,6 @@ namespace OpenLoco::Ui::Windows::Construction
         };
 
         std::span<const Widget> getWidgets();
-
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << checkbox_1) | (1 << checkbox_2) | (1 << checkbox_3) | (1 << checkbox_4) | (1 << image) | (1 << track) | (1 << track_dropdown);
 
         void tabReset(Window* self);
         void removeTrackModsGhost();

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -1575,11 +1575,11 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     // 0x0049DAA5
     static void onResize(Window& self)
     {
-        self.enabledWidgets &= ~(1 << widx::construct);
+        self.disabledWidgets |= (1ULL << widx::construct);
 
         if (_cState->constructionHover != 1)
         {
-            self.enabledWidgets |= (1 << widx::construct);
+            self.disabledWidgets &= ~(1ULL << widx::construct);
         }
 
         auto disabledWidgets = self.disabledWidgets;

--- a/src/OpenLoco/src/Ui/Windows/DebugWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/DebugWindow.cpp
@@ -89,7 +89,6 @@ namespace OpenLoco::Ui::Windows::Debug
             getEvents());
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = ~0ULL;
         // window->disabledWidgets = 1U << widx::tab_3;
         window->initScrollWidgets();
 

--- a/src/OpenLoco/src/Ui/Windows/DebugWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/DebugWindow.cpp
@@ -9,6 +9,7 @@
 #include "Ui/Widget.h"
 #include "Ui/Widgets/ButtonWidget.h"
 #include "Ui/Widgets/CaptionWidget.h"
+#include "Ui/Widgets/CheckboxWidget.h"
 #include "Ui/Widgets/FrameWidget.h"
 #include "Ui/Widgets/ImageButtonWidget.h"
 #include "Ui/Widgets/LabelWidget.h"
@@ -44,6 +45,12 @@ namespace OpenLoco::Ui::Windows::Debug
         constexpr auto tab_1 = WidgetId("tab_1");
         constexpr auto tab_2 = WidgetId("tab_2");
         constexpr auto tab_3 = WidgetId("tab_3");
+
+        constexpr auto checkbox_1 = WidgetId("checkbox_1");
+        constexpr auto checkbox_2 = WidgetId("checkbox_2");
+        constexpr auto checkbox_3 = WidgetId("checkbox_3");
+        constexpr auto checkbox_4 = WidgetId("checkbox_4");
+
         // constexpr auto tab_4 = WidgetId("tab_4");
     }
 
@@ -67,9 +74,14 @@ namespace OpenLoco::Ui::Windows::Debug
             Label(widx::label_2, { kMargin, kTitlebarHeight + kMargin + (3 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, ContentAlign::center, StringIds::openloco),
             Label(widx::label_3, { kMargin, kTitlebarHeight + kMargin + (4 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, ContentAlign::right, StringIds::openloco),
 
-            Tab(widx::tab_1, { kMargin + ((kTabWidth + kMargin) * 0), kTitlebarHeight + kMargin + (5 * (kRowSize + kMargin)) }, { kTabWidth, kTabHeight }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town),
-            Tab(widx::tab_2, { kMargin + ((kTabWidth + kMargin) * 1), kTitlebarHeight + kMargin + (5 * (kRowSize + kMargin)) }, { kTabWidth, kTabHeight }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_population_graph),
-            Tab(widx::tab_3, { kMargin + ((kTabWidth + kMargin) * 2), kTitlebarHeight + kMargin + (5 * (kRowSize + kMargin)) }, { kTabWidth, kTabHeight }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town_ratings_each_company)
+            Checkbox(widx::checkbox_1, { kMargin, kTitlebarHeight + kMargin + (5 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, StringIds::openloco),
+            Checkbox(widx::checkbox_2, { kMargin, kTitlebarHeight + kMargin + (6 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, StringIds::openloco),
+            Checkbox(widx::checkbox_3, { kMargin, kTitlebarHeight + kMargin + (7 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, StringIds::openloco),
+            Checkbox(widx::checkbox_4, { kMargin, kTitlebarHeight + kMargin + (8 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, StringIds::openloco),
+
+            Tab(widx::tab_1, { kMargin + ((kTabWidth + kMargin) * 0), kTitlebarHeight + kMargin + (9 * (kRowSize + kMargin)) }, { kTabWidth, kTabHeight }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town),
+            Tab(widx::tab_2, { kMargin + ((kTabWidth + kMargin) * 1), kTitlebarHeight + kMargin + (9 * (kRowSize + kMargin)) }, { kTabWidth, kTabHeight }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_population_graph),
+            Tab(widx::tab_3, { kMargin + ((kTabWidth + kMargin) * 2), kTitlebarHeight + kMargin + (9 * (kRowSize + kMargin)) }, { kTabWidth, kTabHeight }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town_ratings_each_company)
             //
         );
     }
@@ -91,6 +103,28 @@ namespace OpenLoco::Ui::Windows::Debug
         window->setWidgets(_widgets);
         // window->disabledWidgets = 1U << widx::tab_3;
         window->initScrollWidgets();
+
+        auto getWidgetById = [&](Window& window, const WidgetId id) -> Widget& {
+            for (auto& widget : window.widgets)
+            {
+                if (widget.id == id)
+                {
+                    return widget;
+                }
+            }
+            throw std::runtime_error("Widget not found");
+        };
+
+        auto& chkbox2 = getWidgetById(*window, widx::checkbox_2);
+        chkbox2.activated = true;
+
+        auto& chkbox3 = getWidgetById(*window, widx::checkbox_3);
+        chkbox3.activated = false;
+        chkbox3.disabled = true;
+
+        auto& chkbox4 = getWidgetById(*window, widx::checkbox_4);
+        chkbox4.activated = true;
+        chkbox4.disabled = true;
 
         const auto interface = ObjectManager::get<InterfaceSkinObject>();
         window->setColour(WindowColour::primary, interface->windowTitlebarColour);

--- a/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
+++ b/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
@@ -54,7 +54,6 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
         auto window = WindowManager::createWindow(WindowType::editKeyboardShortcut, kWindowSize, WindowFlags::none, getEvents());
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = 1 << Widx::close;
         window->initScrollWidgets();
 
         const auto skin = ObjectManager::get<InterfaceSkinObject>();

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -670,8 +670,6 @@ namespace OpenLoco::Ui::Windows::IndustryList
             window->invalidate();
 
             window->setWidgets(IndustryList::widgets);
-            window->enabledWidgets = IndustryList::enabledWidgets;
-
             window->activatedWidgets = 0;
             window->holdableWidgets = 0;
 
@@ -1425,7 +1423,6 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
             const auto& tabInfo = tabInformationByTabOffset[widgetIndex - widx::tab_industry_list];
 
-            self->enabledWidgets = tabInfo.enabledWidgets;
             self->holdableWidgets = 0;
             self->eventHandlers = &tabInfo.events;
             self->activatedWidgets = 0;

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -61,8 +61,6 @@ namespace OpenLoco::Ui::Windows::IndustryList
             tab_new_industry,
         };
 
-        const uint64_t enabledWidgets = (1 << widx::close_button) | (1 << widx::tab_industry_list) | (1 << widx::tab_new_industry);
-
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
@@ -96,8 +94,6 @@ namespace OpenLoco::Ui::Windows::IndustryList
             sort_industry_production_last_month,
             scrollview,
         };
-
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << sort_industry_name) | (1 << sort_industry_status) | (1 << sort_industry_production_transported) | (1 << sort_industry_production_last_month) | (1 << scrollview);
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(600, 197, StringIds::title_industries),
@@ -717,8 +713,6 @@ namespace OpenLoco::Ui::Windows::IndustryList
         {
             scrollview = 6,
         };
-
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << scrollview);
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(577, 171, StringIds::title_fund_new_industries),
@@ -1380,12 +1374,11 @@ namespace OpenLoco::Ui::Windows::IndustryList
             std::span<const Widget> widgets;
             const widx widgetIndex;
             const WindowEventList& events;
-            const uint64_t enabledWidgets;
         };
 
         static TabInformation tabInformationByTabOffset[] = {
-            { IndustryList::widgets, widx::tab_industry_list, IndustryList::getEvents(), IndustryList::enabledWidgets },
-            { NewIndustries::widgets, widx::tab_new_industry, NewIndustries::getEvents(), NewIndustries::enabledWidgets },
+            { IndustryList::widgets, widx::tab_industry_list, IndustryList::getEvents() },
+            { NewIndustries::widgets, widx::tab_new_industry, NewIndustries::getEvents() },
         };
 
         // 0x00457B94

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -352,7 +352,6 @@ namespace OpenLoco::Ui::Windows::Industry
         window->invalidate();
 
         window->setWidgets(Industry::widgets);
-        window->enabledWidgets = Industry::enabledWidgets;
         window->holdableWidgets = 0;
         window->eventHandlers = &Industry::getEvents();
         window->activatedWidgets = 0;
@@ -827,7 +826,6 @@ namespace OpenLoco::Ui::Windows::Industry
 
             auto tabInfo = tabInformationByTabOffset[widgetIndex - widx::tab_industry];
 
-            self->enabledWidgets = *tabInfo.enabledWidgets;
             self->holdableWidgets = 0;
             self->eventHandlers = &tabInfo.events;
             self->activatedWidgets = 0;

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -51,8 +51,6 @@ namespace OpenLoco::Ui::Windows::Industry
             tab_transported,
         };
 
-        const uint64_t enabledWidgets = (1 << widx::caption) | (1 << widx::close_button) | (1 << widx::tab_industry) | (1 << widx::tab_production) | (1 << widx::tab_production_2) | (1 << widx::tab_transported);
-
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
@@ -102,8 +100,6 @@ namespace OpenLoco::Ui::Windows::Industry
             Widgets::ImageButton({ 198, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::rubbish_bin, StringIds::demolish_this_industry)
 
         );
-
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << centre_on_viewport) | (1 << demolish_industry);
 
         // 0x00455ADD
         static void prepareDraw(Window& self)
@@ -569,14 +565,13 @@ namespace OpenLoco::Ui::Windows::Industry
             std::span<const Widget> widgets;
             const widx widgetIndex;
             const WindowEventList& events;
-            const uint64_t* enabledWidgets;
         };
 
         static TabInformation tabInformationByTabOffset[] = {
-            { Industry::widgets, widx::tab_industry, Industry::getEvents(), &Industry::enabledWidgets },
-            { Production2::widgets, widx::tab_production, Production::getEvents(), &Common::enabledWidgets },
-            { Production2::widgets, widx::tab_production_2, Production2::getEvents(), &Common::enabledWidgets },
-            { Transported::widgets, widx::tab_transported, Transported::getEvents(), &Common::enabledWidgets }
+            { Industry::widgets, widx::tab_industry, Industry::getEvents() },
+            { Production2::widgets, widx::tab_production, Production::getEvents() },
+            { Production2::widgets, widx::tab_production_2, Production2::getEvents() },
+            { Transported::widgets, widx::tab_transported, Transported::getEvents() }
         };
 
         static void setDisabledWidgets(Window* self)

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -68,7 +68,6 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
         window = WindowManager::createWindowCentred(WindowType::keyboardShortcuts, { 360, 238 }, WindowFlags::none, getEvents());
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = (1 << Widx::close_button) | (1 << Widx::reset_keys_btn);
         window->initScrollWidgets();
 
         auto skin = ObjectManager::get<InterfaceSkinObject>();

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -67,8 +67,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             generate_now,
         };
 
-        const uint64_t enabled_widgets = (1 << widx::close_button) | (1 << tab_options) | (1 << tab_land) | (1 << tab_water) | (1 << tab_forests) | (1 << tab_towns) | (1 << tab_industries) | (1 << generate_now);
-
         static constexpr auto makeCommonWidgets(int32_t frame_height, StringId window_caption_id)
         {
             return makeWidgets(
@@ -276,16 +274,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             (1 << widx::start_year_down) |
             (1 << widx::terrainSmoothingNumUp) |
             (1 << widx::terrainSmoothingNumDown);
-
-        const uint64_t enabled_widgets = Common::enabled_widgets |
-            (1 << widx::start_year_up) |
-            (1 << widx::start_year_down) |
-            (1 << widx::heightMapBox) |
-            (1 << widx::heightMapDropdown) |
-            (1 << widx::change_heightmap_btn) |
-            (1 << widx::terrainSmoothingNumUp) |
-            (1 << widx::terrainSmoothingNumDown) |
-            (1 << widx::generate_when_game_starts);
         // clang-format on
 
         static constexpr auto widgets = makeWidgets(
@@ -402,9 +390,9 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             {
                 case Scenario::LandGeneratorType::Original:
                 {
-                    self.enabledWidgets |= (1 << widx::change_heightmap_btn);
-                    self.enabledWidgets &= ~((1 << widx::terrainSmoothingNum) | (1 << widx::terrainSmoothingNumUp) | (1 << widx::terrainSmoothingNumDown));
-                    self.enabledWidgets &= ~(1 << widx::browseHeightmapFile);
+                    self.disabledWidgets &= ~(1 << widx::change_heightmap_btn);
+                    self.disabledWidgets |= ((1 << widx::terrainSmoothingNum) | (1 << widx::terrainSmoothingNumUp) | (1 << widx::terrainSmoothingNumDown));
+                    self.disabledWidgets |= (1 << widx::browseHeightmapFile);
 
                     self.widgets[widx::change_heightmap_btn].hidden = false;
                     self.widgets[widx::terrainSmoothingNum].hidden = true;
@@ -416,9 +404,9 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
                 case Scenario::LandGeneratorType::Simplex:
                 {
-                    self.enabledWidgets &= ~(1 << widx::change_heightmap_btn);
-                    self.enabledWidgets |= ((1 << widx::terrainSmoothingNum) | (1 << widx::terrainSmoothingNumUp) | (1 << widx::terrainSmoothingNumDown));
-                    self.enabledWidgets &= ~(1 << widx::browseHeightmapFile);
+                    self.disabledWidgets |= (1 << widx::change_heightmap_btn);
+                    self.disabledWidgets &= ~((1 << widx::terrainSmoothingNum) | (1 << widx::terrainSmoothingNumUp) | (1 << widx::terrainSmoothingNumDown));
+                    self.disabledWidgets |= (1 << widx::browseHeightmapFile);
 
                     self.widgets[widx::change_heightmap_btn].hidden = true;
                     self.widgets[widx::terrainSmoothingNum].hidden = false;
@@ -430,9 +418,9 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
                 case Scenario::LandGeneratorType::PngHeightMap:
                 {
-                    self.enabledWidgets &= ~(1 << widx::change_heightmap_btn);
-                    self.enabledWidgets &= ~((1 << widx::terrainSmoothingNum) | (1 << widx::terrainSmoothingNumUp) | (1 << widx::terrainSmoothingNumDown));
-                    self.enabledWidgets |= (1 << widx::browseHeightmapFile);
+                    self.disabledWidgets |= (1 << widx::change_heightmap_btn);
+                    self.disabledWidgets |= ((1 << widx::terrainSmoothingNum) | (1 << widx::terrainSmoothingNumUp) | (1 << widx::terrainSmoothingNumDown));
+                    self.disabledWidgets &= ~(1 << widx::browseHeightmapFile);
 
                     self.widgets[widx::change_heightmap_btn].hidden = true;
                     self.widgets[widx::terrainSmoothingNum].hidden = true;
@@ -596,7 +584,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         {
             window = WindowManager::createWindowCentred(WindowType::landscapeGeneration, kWindowSize, WindowFlags::none, Options::getEvents());
             window->setWidgets(Options::widgets);
-            window->enabledWidgets = Options::enabled_widgets;
             window->number = 0;
             window->currentTab = 0;
             window->frameNo = 0;
@@ -639,7 +626,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             scrollview,
         };
 
-        const uint64_t enabled_widgets = Common::enabled_widgets | (1 << widx::min_land_height_up) | (1 << widx::min_land_height_down) | (1 << widx::topography_style) | (1 << widx::topography_style_btn) | (1 << widx::hill_density_up) | (1 << widx::hill_density_down) | (1 << widx::hillsEdgeOfMap);
         const uint64_t holdable_widgets = (1 << widx::min_land_height_up) | (1 << widx::min_land_height_down) | (1 << widx::hill_density_up) | (1 << widx::hill_density_down);
 
         static constexpr auto widgets = makeWidgets(
@@ -1013,14 +999,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         };
 
         // clang-format off
-        const uint64_t enabled_widgets = Common::enabled_widgets |
-            (1 << widx::sea_level_down) | (1 << widx::sea_level_up) |
-            (1 << widx::num_riverbeds_down) | (1 << widx::num_riverbeds_up) |
-            (1 << widx::min_river_width_down) | (1 << widx::min_river_width_up) |
-            (1 << widx::max_river_width_down) | (1 << widx::max_river_width_up) |
-            (1 << widx::riverbank_width_down) | (1 << widx::riverbank_width_up) |
-            (1 << widx::meander_rate_down) | (1 << widx::meander_rate_up);
-
         const uint64_t holdable_widgets = (1 << widx::sea_level_up) | (1 << widx::sea_level_down) |
             (1 << widx::num_riverbeds_down) | (1 << widx::num_riverbeds_up) |
             (1 << widx::min_river_width_down) | (1 << widx::min_river_width_up) |
@@ -1227,7 +1205,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             max_altitude_for_trees_up,
         };
 
-        const uint64_t enabled_widgets = Common::enabled_widgets | (1ULL << widx::number_of_forests_up) | (1ULL << widx::number_of_forests_down) | (1ULL << widx::min_forest_radius_up) | (1ULL << widx::min_forest_radius_down) | (1ULL << widx::max_forest_radius_up) | (1ULL << widx::max_forest_radius_down) | (1ULL << widx::min_forest_density_up) | (1ULL << widx::min_forest_density_down) | (1 << widx::max_forest_density_up) | (1ULL << widx::max_forest_density_down) | (1ULL << widx::number_random_trees_up) | (1ULL << widx::number_random_trees_down) | (1ULL << widx::min_altitude_for_trees_up) | (1ULL << widx::min_altitude_for_trees_down) | (1ULL << widx::max_altitude_for_trees_down) | (1ULL << widx::max_altitude_for_trees_up);
         const uint64_t holdable_widgets = (1ULL << widx::number_of_forests_up) | (1ULL << widx::number_of_forests_down) | (1ULL << widx::min_forest_radius_up) | (1ULL << widx::min_forest_radius_down) | (1ULL << widx::max_forest_radius_up) | (1ULL << widx::max_forest_radius_down) | (1ULL << widx::min_forest_density_up) | (1ULL << widx::min_forest_density_down) | (1ULL << widx::max_forest_density_up) | (1 << widx::max_forest_density_down) | (1ULL << widx::number_random_trees_up) | (1ULL << widx::number_random_trees_down) | (1ULL << widx::min_altitude_for_trees_up) | (1ULL << widx::min_altitude_for_trees_down) | (1ULL << widx::max_altitude_for_trees_down) | (1ULL << widx::max_altitude_for_trees_up);
 
         static constexpr auto widgets = makeWidgets(
@@ -1501,7 +1478,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             max_town_size_btn,
         };
 
-        const uint64_t enabled_widgets = Common::enabled_widgets | (1 << widx::number_of_towns_up) | (1 << widx::number_of_towns_down) | (1 << widx::max_town_size) | (1 << widx::max_town_size_btn);
         const uint64_t holdable_widgets = (1 << widx::number_of_towns_up) | (1 << widx::number_of_towns_down);
 
         static constexpr auto widgets = makeWidgets(
@@ -1636,7 +1612,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             check_allow_industries_start_up,
         };
 
-        const uint64_t enabled_widgets = Common::enabled_widgets | (1 << widx::num_industries) | (1 << widx::num_industries_btn) | (1 << widx::check_allow_industries_close_down) | (1 << widx::check_allow_industries_start_up);
         const uint64_t holdable_widgets = 0;
 
         static constexpr auto widgets = makeWidgets(
@@ -1787,17 +1762,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             window->frameNo = 0;
             window->flags &= ~(WindowFlags::flag_16);
             window->disabledWidgets = 0;
-
-            static const uint64_t* enabledWidgetsByTab[] = {
-                &Options::enabled_widgets,
-                &Land::enabled_widgets,
-                &Water::enabled_widgets,
-                &Forests::enabled_widgets,
-                &Towns::enabled_widgets,
-                &Industries::enabled_widgets,
-            };
-
-            window->enabledWidgets = *enabledWidgetsByTab[window->currentTab];
 
             static const uint64_t* holdableWidgetsByTab[] = {
                 &Options::holdable_widgets,

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGenerationConfirm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGenerationConfirm.cpp
@@ -101,7 +101,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGenerationConfirm
         {
             window = WindowManager::createWindowCentred(WindowType::landscapeGenerationConfirm, kWindowSize, WindowFlags::none, getEvents());
             window->setWidgets(widgets);
-            window->enabledWidgets = (1 << widx::close_button) | (1 << widx::button_ok) | (1 << widx::button_cancel);
             window->initScrollWidgets();
             window->setColour(WindowColour::primary, AdvancedColour(Colour::mutedDarkRed).translucent());
             window->setColour(WindowColour::secondary, AdvancedColour(Colour::mutedDarkRed).translucent());

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -103,8 +103,6 @@ namespace OpenLoco::Ui::Windows::MapWindow
         statusBar,
     };
 
-    const uint64_t enabledWidgets = (1 << closeButton) | (1 << tabOverall) | (1 << tabVehicles) | (1 << tabIndustries) | (1 << tabRoutes) | (1 << tabOwnership);
-
     static constexpr auto widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, { 350, 272 }, WindowColour::primary),
         Widgets::Caption({ 1, 1 }, { 348, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::title_map),

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -2421,8 +2421,6 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
         window = WindowManager::createWindow(WindowType::map, size, WindowFlags::none, getEvents());
         window->setWidgets(widgets);
-        window->enabledWidgets |= enabledWidgets;
-
         window->initScrollWidgets();
         window->frameNo = 0;
 

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -48,8 +48,6 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             tab_settings,
         };
 
-        const uint64_t enabledWidgets = (1 << widx::close_button) | (1 << widx::tab_messages) | (1 << widx::tab_settings);
-
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
@@ -77,8 +75,6 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         {
             scrollview = 6,
         };
-
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << scrollview);
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(366, 217, StringIds::title_messages),
@@ -429,8 +425,6 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             playSoundEffects,
         };
 
-        static constexpr uint64_t enabledWidgets = Common::enabledWidgets | (1 << widx::company_major_news) | (1 << widx::company_major_news_dropdown) | (1 << widx::competitor_major_news) | (1 << widx::competitor_major_news_dropdown) | (1 << widx::company_minor_news) | (1 << widx::company_minor_news_dropdown) | (1 << widx::competitor_minor_news) | (1 << widx::competitor_minor_news_dropdown) | (1 << widx::general_news) | (1 << widx::general_news_dropdown) | (1 << widx::advice) | (1 << widx::advice_dropdown) | (1 << widx::playSoundEffects);
-
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(366, 155, StringIds::title_messages),
 
@@ -613,12 +607,11 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             std::span<const Widget> widgets;
             const widx widgetIndex;
             const WindowEventList& events;
-            const uint64_t enabledWidgets;
         };
 
         static TabInformation tabInformationByTabOffset[] = {
-            { Messages::widgets, widx::tab_messages, Messages::getEvents(), Messages::enabledWidgets },
-            { Settings::widgets, widx::tab_settings, Settings::getEvents(), Settings::enabledWidgets },
+            { Messages::widgets, widx::tab_messages, Messages::getEvents() },
+            { Settings::widgets, widx::tab_settings, Settings::getEvents() },
         };
 
         static void prepareDraw(Window& self)

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -345,7 +345,6 @@ namespace OpenLoco::Ui::Windows::MessageWindow
                 WindowFlags::flag_11,
                 Messages::getEvents());
 
-            window->enabledWidgets = Messages::enabledWidgets;
             window->number = 0;
             window->currentTab = 0;
             window->frameNo = 0;
@@ -372,7 +371,6 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         window->invalidate();
 
         window->setWidgets(Messages::widgets);
-        window->enabledWidgets = Messages::enabledWidgets;
         window->holdableWidgets = 0;
         window->eventHandlers = &Messages::getEvents();
         window->disabledWidgets = 0;
@@ -657,7 +655,6 @@ namespace OpenLoco::Ui::Windows::MessageWindow
 
             const auto& tabInfo = tabInformationByTabOffset[widgetIndex - widx::tab_messages];
 
-            self->enabledWidgets = tabInfo.enabledWidgets;
             self->holdableWidgets = 0;
             self->eventHandlers = &tabInfo.events;
             self->activatedWidgets = 0;

--- a/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
@@ -61,7 +61,6 @@ namespace OpenLoco::Ui::Windows::MusicSelection
             getEvents());
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = 1 << widx::close;
         window->initScrollWidgets();
 
         auto interface = ObjectManager::get<InterfaceSkinObject>();

--- a/src/OpenLoco/src/Ui/Windows/NetworkStatus.cpp
+++ b/src/OpenLoco/src/Ui/Windows/NetworkStatus.cpp
@@ -53,8 +53,6 @@ namespace OpenLoco::Ui::Windows::NetworkStatus
             getEvents());
 
         window->setWidgets(widgets);
-        window->enabledWidgets = (1 << Widx::closeBtn);
-
         window->initScrollWidgets();
         window->setColour(WindowColour::primary, Colour::black);
         window->setColour(WindowColour::secondary, Colour::black);

--- a/src/OpenLoco/src/Ui/Windows/News/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/Common.cpp
@@ -36,8 +36,6 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             Common::getEvents());
 
         window->setWidgets(widgets);
-        window->enabledWidgets = Common::enabledWidgets;
-
         window->initScrollWidgets();
         window->setColour(WindowColour::primary, colour);
 
@@ -107,8 +105,6 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     Ticker::getEvents());
 
                 window->setWidgets(Ticker::getWidgets());
-                window->enabledWidgets = Ticker::enabledWidgets;
-
                 window->initScrollWidgets();
 
                 auto skin = ObjectManager::get<InterfaceSkinObject>();

--- a/src/OpenLoco/src/Ui/Windows/News/News.h
+++ b/src/OpenLoco/src/Ui/Windows/News/News.h
@@ -36,8 +36,6 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             viewport2Button,
         };
 
-        constexpr uint64_t enabledWidgets = (1 << close_button) | (1 << viewport1Button) | (1 << viewport2Button);
-
         template<typename TFrameWidget>
         constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight)
         {
@@ -76,7 +74,6 @@ namespace OpenLoco::Ui::Windows::NewsWindow
         {
             frame,
         };
-        constexpr uint64_t enabledWidgets = (1 << widx::frame);
 
         std::span<const Widget> getWidgets();
 

--- a/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
@@ -72,7 +72,6 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
             getEvents());
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = 1 << Widx::close;
         window->initScrollWidgets();
 
         auto interface = ObjectManager::get<InterfaceSkinObject>();

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -380,7 +380,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             auto widgetIndex = widx::primaryTab1 + i;
             if (shouldShowPrimaryTab(i, FilterLevel(self->filterLevel)))
             {
-                self->enabledWidgets |= 1ULL << widgetIndex;
+                self->disabledWidgets &= ~(1ULL << widgetIndex);
                 self->widgets[widgetIndex].hidden = false;
                 self->widgets[widgetIndex].left = xPos;
                 self->widgets[widgetIndex].right = xPos + 31;
@@ -388,7 +388,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             }
             else
             {
-                self->enabledWidgets &= ~(1ULL << widgetIndex);
+                self->disabledWidgets |= (1ULL << widgetIndex);
                 self->widgets[widgetIndex].hidden = true;
             }
         }
@@ -523,7 +523,6 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         window = WindowManager::createWindowCentred(WindowType::objectSelection, { kWindowSize }, WindowFlags::none, getEvents());
         window->setWidgets(widgets);
-        window->enabledWidgets = (1ULL << widx::closeButton) | (1ULL << widx::filterLabel) | (1ULL << widx::filterDropdown) | (1ULL << widx::clearButton);
         window->initScrollWidgets();
         window->frameNo = 0;
         window->rowHover = -1;
@@ -601,22 +600,13 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             const auto widgetIndex = i + widx::secondaryTab1;
 
             const bool subTabIsVisible = showSecondaryTabs && i < subTabs.size() && shouldShowSubTab(subTabs, i, FilterLevel(self.filterLevel));
-            if (!subTabIsVisible)
-            {
-                self.disabledWidgets |= 1ULL << widgetIndex;
-            }
-            else
+            if (subTabIsVisible)
             {
                 self.disabledWidgets &= ~(1ULL << widgetIndex);
             }
-
-            if (subTabIsVisible)
-            {
-                self.enabledWidgets |= 1ULL << widgetIndex;
-            }
             else
             {
-                self.enabledWidgets &= ~(1ULL << widgetIndex);
+                self.disabledWidgets |= (1ULL << widgetIndex);
             }
 
             if (self.currentSecondaryTab == i)

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -240,7 +240,6 @@ namespace OpenLoco::Ui::Windows::Options
             | (1ULL << Widx::tab_company)
             | (1ULL << Widx::tab_miscellaneous);
 
-        static constexpr int enabledWidgets = (1ULL << Widx::close_button) | tabWidgets;
     }
 
     namespace Display
@@ -312,22 +311,6 @@ namespace OpenLoco::Ui::Windows::Options
             Widgets::Checkbox({ 10, 243 }, { 346, 12 }, WindowColour::secondary, StringIds::cash_popup_rendering, StringIds::tooltip_cash_popup_rendering)
 
         );
-
-        static constexpr uint64_t enabledWidgets = Common::enabledWidgets
-            | (1ULL << Widx::show_fps)
-            | (1ULL << Widx::uncap_fps)
-            | (1ULL << Widx::screen_mode_label)
-            | (1ULL << Widx::cash_popup_rendering)
-            | (1ULL << Display::Widx::landscape_smoothing)
-            | (1ULL << Display::Widx::gridlines_on_landscape)
-            | (1ULL << Display::Widx::vehicles_min_scale)
-            | (1ULL << Display::Widx::vehicles_min_scale_btn)
-            | (1ULL << Display::Widx::station_names_min_scale)
-            | (1ULL << Display::Widx::station_names_min_scale_btn)
-            | (1ULL << Display::Widx::construction_marker)
-            | (1ULL << Display::Widx::construction_marker_btn)
-            | (1ULL << Display::Widx::display_scale_up_btn)
-            | (1ULL << Display::Widx::display_scale_down_btn);
 
         // 0x004BFB8C
         static void onMouseUp(Window& w, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
@@ -525,12 +508,12 @@ namespace OpenLoco::Ui::Windows::Options
         {
             if (Config::get().display.mode == Config::ScreenMode::fullscreen)
             {
-                w->enabledWidgets |= (1ULL << Widx::display_resolution) | (1ULL << Widx::display_resolution_btn);
+                w->disabledWidgets &= ~(1ULL << Widx::display_resolution) | (1ULL << Widx::display_resolution_btn);
                 w->disabledWidgets &= ~((1ULL << Widx::display_resolution) | (1ULL << Widx::display_resolution_btn));
             }
             else
             {
-                w->enabledWidgets &= ~((1ULL << Widx::display_resolution) | (1ULL << Widx::display_resolution_btn));
+                w->disabledWidgets |= ((1ULL << Widx::display_resolution) | (1ULL << Widx::display_resolution_btn));
                 w->disabledWidgets |= (1ULL << Widx::display_resolution) | (1ULL << Widx::display_resolution_btn);
             }
         }
@@ -806,7 +789,6 @@ namespace OpenLoco::Ui::Windows::Options
             }
 
 #if !(defined(__APPLE__) && defined(__MACH__))
-            w->enabledWidgets |= (1ULL << Display::Widx::screen_mode) | (1ULL << Display::Widx::screen_mode_btn);
             Display::screenModeToggleEnabled(w);
 #else
             w->disabledWidgets |= (1ULL << Display::Widx::screen_mode)
@@ -845,11 +827,6 @@ namespace OpenLoco::Ui::Windows::Options
                 play_title_music,
             };
         }
-
-        static constexpr uint64_t enabledWidgets = Common::enabledWidgets
-            | (1ULL << Sound::Widx::audio_device)
-            | (1ULL << Sound::Widx::audio_device_btn)
-            | (1ULL << Sound::Widx::play_title_music);
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_sound),
@@ -1059,17 +1036,6 @@ namespace OpenLoco::Ui::Windows::Options
                 edit_selection
             };
         }
-
-        static constexpr uint64_t enabledWidgets = Common::enabledWidgets
-            | (1ULL << Music::Widx::currently_playing)
-            | (1ULL << Music::Widx::currently_playing_btn)
-            | (1ULL << Music::Widx::music_controls_stop)
-            | (1ULL << Music::Widx::music_controls_play)
-            | (1ULL << Music::Widx::music_controls_next)
-            | (1ULL << Music::Widx::volume)
-            | (1ULL << Music::Widx::music_playlist)
-            | (1ULL << Music::Widx::music_playlist_btn)
-            | (1ULL << Music::Widx::edit_selection);
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_music),
@@ -1429,20 +1395,6 @@ namespace OpenLoco::Ui::Windows::Options
                 preferred_currency_always
             };
         }
-
-        static constexpr uint64_t enabledWidgets = Common::enabledWidgets
-            | (1ULL << Regional::Widx::language)
-            | (1ULL << Regional::Widx::language_btn)
-            | (1ULL << Regional::Widx::distance_speed)
-            | (1ULL << Regional::Widx::distance_speed_btn)
-            | (1ULL << Regional::Widx::heights)
-            | (1ULL << Regional::Widx::heights_btn)
-            | (1ULL << Regional::Widx::currency)
-            | (1ULL << Regional::Widx::currency_btn)
-            | (1ULL << Regional::Widx::preferred_currency)
-            | (1ULL << Regional::Widx::preferred_currency_btn)
-            | (1ULL << Regional::Widx::preferred_currency_for_new_games)
-            | (1ULL << Regional::Widx::preferred_currency_always);
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_regional),
@@ -1940,12 +1892,6 @@ namespace OpenLoco::Ui::Windows::Options
             };
         }
 
-        static constexpr uint64_t enabledWidgets = Common::enabledWidgets
-            | (1ULL << Controls::Widx::edge_scrolling)
-            | (1ULL << Controls::Widx::customize_keys)
-            | (1ULL << Controls::Widx::zoom_to_cursor)
-            | (1ULL << Controls::Widx::invertRightMouseViewPan);
-
         static constexpr Ui::Size32 kWindowSize = { 366, 114 };
 
         static constexpr auto _widgets = makeWidgets(
@@ -2115,15 +2061,6 @@ namespace OpenLoco::Ui::Windows::Options
                 ownerFacePreview,
             };
         }
-
-        // clang-format off
-        static constexpr uint64_t enabledWidgets = Common::enabledWidgets |
-            (1ULL << Widx::usePreferredOwnerFace) |
-            (1ULL << Widx::changeOwnerFaceBtn) |
-            (1ULL << Widx::usePreferredOwnerName) |
-            (1ULL << Widx::changeOwnerNameBtn) |
-            (1ULL << Widx::ownerFacePreview);
-        // clang-format on
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_company),
@@ -2420,20 +2357,6 @@ namespace OpenLoco::Ui::Windows::Options
                 export_plugin_objects,
             };
         }
-
-        static constexpr uint64_t enabledWidgets = Common::enabledWidgets
-            | (1ULL << Widx::enableCheatsToolbarButton)
-            | (1ULL << Widx::disableAICompanies)
-            | (1ULL << Widx::disableTownExpansion)
-            | (1ULL << Widx::disable_vehicle_breakdowns)
-            | (1ULL << Widx::disable_vehicle_load_penalty)
-            | (1ULL << Widx::disableStationSizeLimit)
-            | (1ULL << Widx::trainsReverseAtSignals)
-            | (1ULL << Widx::autosave_amount)
-            | (1ULL << Widx::autosave_amount_down_btn)
-            | (1ULL << Widx::autosave_amount_up_btn)
-            | (1ULL << Widx::autosave_frequency_btn)
-            | (1ULL << Widx::export_plugin_objects);
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_miscellaneous),
@@ -2923,7 +2846,6 @@ namespace OpenLoco::Ui::Windows::Options
         populateAvailableCurrencies();
         setPreferredCurrencyNameBuffer();
 
-        window->enabledWidgets = Display::enabledWidgets;
         Display::applyScreenModeRestrictions(window);
 
         window->holdableWidgets = 0;
@@ -2952,18 +2874,17 @@ namespace OpenLoco::Ui::Windows::Options
         std::span<const Widget> widgets;
         const WindowEventList& events;
         Ui::Size32 kWindowSize;
-        const uint64_t* enabledWidgets;
     };
 
     // clang-format off
     static TabInformation tabInformationByTabOffset[] = {
-        { Display::_widgets,  Display::getEvents(),  Display::kWindowSize,  &Display::enabledWidgets },
-        { Sound::_widgets,    Sound::getEvents(),    Sound::kWindowSize,    &Sound::enabledWidgets },
-        { Music::_widgets,    Music::getEvents(),    Music::kWindowSize,    &Music::enabledWidgets },
-        { Regional::_widgets, Regional::getEvents(), Regional::kWindowSize, &Regional::enabledWidgets },
-        { Controls::_widgets, Controls::getEvents(), Controls::kWindowSize, &Controls::enabledWidgets },
-        { Company::_widgets,  Company::getEvents(),  Company::kWindowSize,  &Company::enabledWidgets },
-        { Misc::_widgets,     Misc::getEvents(),     Misc::kWindowSize,     &Misc::enabledWidgets },
+        { Display::_widgets,  Display::getEvents(),  Display::kWindowSize  },
+        { Sound::_widgets,    Sound::getEvents(),    Sound::kWindowSize    },
+        { Music::_widgets,    Music::getEvents(),    Music::kWindowSize    },
+        { Regional::_widgets, Regional::getEvents(), Regional::kWindowSize },
+        { Controls::_widgets, Controls::getEvents(), Controls::kWindowSize },
+        { Company::_widgets,  Company::getEvents(),  Company::kWindowSize  },
+        { Misc::_widgets,     Misc::getEvents(),     Misc::kWindowSize     },
     };
     // clang-format on
 
@@ -2983,7 +2904,6 @@ namespace OpenLoco::Ui::Windows::Options
         w->viewportRemove(0);
 
         auto& tabInfo = tabInformationByTabOffset[w->currentTab];
-        w->enabledWidgets = *tabInfo.enabledWidgets;
         w->eventHandlers = &tabInfo.events;
         w->setWidgets(tabInfo.widgets);
         w->invalidate();

--- a/src/OpenLoco/src/Ui/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PlayerInfoPanel.cpp
@@ -164,7 +164,6 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
             Ui::WindowFlags::stickToFront | Ui::WindowFlags::transparent | Ui::WindowFlags::noBackground,
             getEvents());
         window->setWidgets(_widgets);
-        window->enabledWidgets = (1 << Widx::player) | (1 << Widx::company_value) | (1 << Widx::performanceIndex);
         window->var_854 = 0;
         window->initScrollWidgets();
 

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -148,8 +148,6 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         {
             window->setWidgets(widgets);
             window->widgets[widx::caption].text = titleId;
-
-            window->enabledWidgets = (1 << widx::close_button) | (1 << widx::parent_button) | (1 << widx::ok_button);
             window->initScrollWidgets();
 
             window->rowHeight = 11;

--- a/src/OpenLoco/src/Ui/Windows/PromptOkCancelWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptOkCancelWindow.cpp
@@ -65,7 +65,6 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
         // Prepare description buffer for drawing
         StringManager::formatString(_descriptionBuffer, descriptionId, descriptionArgs);
 
-        window->enabledWidgets = (1 << widx::closeButton) | (1 << widx::okButton) | (1 << widx::cancelButton);
         window->initScrollWidgets();
         window->setColour(WindowColour::primary, AdvancedColour(Colour::mutedDarkRed).translucent());
         window->setColour(WindowColour::secondary, AdvancedColour(Colour::mutedDarkRed).translucent());

--- a/src/OpenLoco/src/Ui/Windows/PromptSaveWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptSaveWindow.cpp
@@ -66,7 +66,6 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
             }
 
             window->setWidgets(_widgets);
-            window->enabledWidgets = (1 << widx::closeButton) | (1 << widx::saveButton) | (1 << widx::dontSaveButton) | (1 << widx::cancelButton);
             window->initScrollWidgets();
             window->setColour(WindowColour::primary, AdvancedColour(Colour::mutedDarkRed).translucent());
             window->flags |= Ui::WindowFlags::transparent;

--- a/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
@@ -51,8 +51,6 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             tab_scenario,
         };
 
-        const uint64_t enabledWidgets = (1 << widx::close_button) | (1 << widx::tab_challenge) | (1 << widx::tab_companies) | (1 << widx::tab_finances) | (1 << widx::tab_scenario);
-
         static constexpr auto makeCommonWidgets(int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
@@ -191,7 +189,6 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             time_limit_value_up,
         };
 
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << widx::objective_type) | (1 << widx::objective_type_btn) | (1 << widx::objective_value_down) | (1 << widx::objective_value_up) | (1 << widx::objective_cargo) | (1 << widx::objective_cargo_btn) | (1 << widx::check_be_top_company) | (1 << widx::check_be_within_top_three_companies) | (1 << widx::check_time_limit) | (1 << widx::time_limit_value_down) | (1 << widx::time_limit_value_up);
         const uint64_t holdableWidgets = (1 << widx::objective_value_down) | (1 << widx::objective_value_up) | (1 << widx::time_limit_value_down) | (1 << widx::time_limit_value_up);
 
         static constexpr auto widgets = makeWidgets(
@@ -553,7 +550,6 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             // 0x0043EEFF start
             window = WindowManager::createWindowCentred(WindowType::scenarioOptions, kOtherWindowSize, WindowFlags::none, Challenge::getEvents());
             window->setWidgets(Challenge::widgets);
-            window->enabledWidgets = Challenge::enabledWidgets;
             window->number = 0;
             window->currentTab = 0;
             window->frameNo = 0;
@@ -574,7 +570,6 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         window->invalidate();
 
         window->setWidgets(Challenge::widgets);
-        window->enabledWidgets = Challenge::enabledWidgets;
         window->holdableWidgets = Challenge::holdableWidgets;
         window->eventHandlers = &Challenge::getEvents();
         window->activatedWidgets = 0;
@@ -644,7 +639,6 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
         );
 
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1ULL << widx::max_competing_companies_down) | (1ULL << widx::max_competing_companies_up) | (1ULL << widx::delay_before_competing_companies_start_down) | (1ULL << widx::delay_before_competing_companies_start_up) | (1ULL << widx::preferred_intelligence) | (1ULL << widx::preferred_intelligence_btn) | (1ULL << widx::preferred_aggressiveness) | (1ULL << widx::preferred_aggressiveness_btn) | (1ULL << widx::preferred_competitiveness) | (1ULL << widx::preferred_competitiveness_btn) | (1ULL << widx::competitor_forbid_trains) | (1ULL << widx::competitor_forbid_buses) | (1ULL << widx::competitor_forbid_trucks) | (1ULL << widx::competitor_forbid_trams) | (1ULL << widx::competitor_forbid_aircraft) | (1ULL << widx::competitor_forbid_ships) | (1ULL << widx::player_forbid_trains) | (1ULL << widx::player_forbid_buses) | (1ULL << widx::player_forbid_trucks) | (1ULL << widx::player_forbid_trams) | (1ULL << widx::player_forbid_aircraft) | (1ULL << widx::player_forbid_ships);
         const uint64_t holdableWidgets = (1ULL << widx::max_competing_companies_down) | (1ULL << widx::max_competing_companies_up) | (1ULL << widx::delay_before_competing_companies_start_down) | (1ULL << widx::delay_before_competing_companies_start_up);
 
         // 0x0043F4EB
@@ -909,7 +903,6 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
         );
 
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << widx::starting_loan_down) | (1 << widx::starting_loan_up) | (1 << widx::max_loan_size_down) | (1 << widx::max_loan_size_up) | (1 << widx::loan_interest_rate_down) | (1 << widx::loan_interest_rate_up);
         const uint64_t holdableWidgets = (1 << widx::starting_loan_down) | (1 << widx::starting_loan_up) | (1 << widx::max_loan_size_down) | (1 << widx::max_loan_size_up) | (1 << widx::loan_interest_rate_down) | (1 << widx::loan_interest_rate_up);
 
         // 0x0043F97D
@@ -1055,7 +1048,6 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
         );
 
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << widx::change_name_btn) | (1 << widx::scenario_group) | (1 << widx::scenario_group_btn) | (1 << widx::change_details_btn);
         const uint64_t holdableWidgets = 0;
 
         // 0x0043F004
@@ -1266,16 +1258,15 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             std::span<const Widget> widgets;
             const widx widgetIndex;
             const WindowEventList& events;
-            const uint64_t* enabledWidgets;
             const uint64_t* holdableWidgets;
         };
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { Challenge::widgets,   widx::tab_challenge,  Challenge::getEvents(),   &Challenge::enabledWidgets,   &Challenge::holdableWidgets },
-            { Companies::widgets,   widx::tab_companies,  Companies::getEvents(),   &Companies::enabledWidgets,   &Companies::holdableWidgets },
-            { Finances::widgets,    widx::tab_finances,   Finances::getEvents(),    &Finances::enabledWidgets,    &Finances::holdableWidgets },
-            { ScenarioTab::widgets, widx::tab_scenario,   ScenarioTab::getEvents(), &ScenarioTab::enabledWidgets, &ScenarioTab::holdableWidgets }
+            { Challenge::widgets,   widx::tab_challenge,  Challenge::getEvents(),   &Challenge::holdableWidgets },
+            { Companies::widgets,   widx::tab_companies,  Companies::getEvents(),   &Companies::holdableWidgets },
+            { Finances::widgets,    widx::tab_finances,   Finances::getEvents(),    &Finances::holdableWidgets },
+            { ScenarioTab::widgets, widx::tab_scenario,   ScenarioTab::getEvents(), &ScenarioTab::holdableWidgets }
         };
         // clang-format on
 
@@ -1317,7 +1308,6 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
             auto tabInfo = tabInformationByTabOffset[widgetIndex - widx::tab_challenge];
 
-            self->enabledWidgets = *tabInfo.enabledWidgets;
             self->holdableWidgets = *tabInfo.holdableWidgets;
             self->eventHandlers = &tabInfo.events;
             self->activatedWidgets = 0;

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -125,7 +125,6 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             getEvents());
 
         self->setWidgets(_widgets);
-        self->enabledWidgets = (1 << widx::close) | (1 << widx::tab0) | (1 << widx::tab1) | (1 << widx::tab2) | (1 << widx::tab3) | (1 << widx::tab4);
         self->initScrollWidgets();
 
         self->setColour(WindowColour::primary, Colour::black);

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -344,8 +344,6 @@ namespace OpenLoco::Ui::Windows::StationList
         window->invalidate();
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = (1 << close_button) | (1 << tab_all_stations) | (1 << tab_rail_stations) | (1 << tab_road_stations) | (1 << tab_airports) | (1 << tab_ship_ports) | (1 << company_select) | (1 << sort_name) | (1 << sort_status) | (1 << sort_total_waiting) | (1 << sort_accepts) | (1 << scrollview);
-
         window->activatedWidgets = 0;
         window->holdableWidgets = 0;
 

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -58,8 +58,6 @@ namespace OpenLoco::Ui::Windows::Station
             tab_cargo_ratings,
         };
 
-        const uint64_t enabledWidgets = (1 << widx::caption) | (1 << widx::close_button) | (1 << widx::tab_station) | (1 << widx::tab_cargo) | (1 << widx::tab_cargo_ratings);
-
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight)
         {
             return makeWidgets(
@@ -101,8 +99,6 @@ namespace OpenLoco::Ui::Windows::Station
             Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this)
 
         );
-
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << centre_on_viewport);
 
         // 0x0048E352
         static void prepareDraw(Window& self)
@@ -320,7 +316,6 @@ namespace OpenLoco::Ui::Windows::Station
         window->invalidate();
 
         window->setWidgets(Station::widgets);
-        window->enabledWidgets = Station::enabledWidgets;
         window->holdableWidgets = 0;
         window->eventHandlers = &Station::getEvents();
         window->activatedWidgets = 0;
@@ -352,8 +347,6 @@ namespace OpenLoco::Ui::Windows::Station
             Widgets::ImageButton({ 198, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::show_station_catchment, StringIds::station_catchment)
 
         );
-
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << station_catchment);
 
         // 0x0048E7C0
         static void prepareDraw(Window& self)
@@ -853,14 +846,13 @@ namespace OpenLoco::Ui::Windows::Station
             std::span<const Widget> widgets;
             const widx widgetIndex;
             const WindowEventList& events;
-            const uint64_t* enabledWidgets;
         };
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { Station::widgets,      widx::tab_station,       Station::getEvents(),      &Station::enabledWidgets },
-            { Cargo::widgets,        widx::tab_cargo,         Cargo::getEvents(),        &Cargo::enabledWidgets },
-            { CargoRatings::widgets, widx::tab_cargo_ratings, CargoRatings::getEvents(), &Common::enabledWidgets }
+            { Station::widgets,      widx::tab_station,       Station::getEvents()      },
+            { Cargo::widgets,        widx::tab_cargo,         Cargo::getEvents()        },
+            { CargoRatings::widgets, widx::tab_cargo_ratings, CargoRatings::getEvents() }
         };
         // clang-format on
 
@@ -967,7 +959,6 @@ namespace OpenLoco::Ui::Windows::Station
 
             auto tabInfo = tabInformationByTabOffset[widgetIndex - widx::tab_station];
 
-            self->enabledWidgets = *tabInfo.enabledWidgets;
             self->holdableWidgets = 0;
             self->eventHandlers = &tabInfo.events;
             self->activatedWidgets = 0;
@@ -1069,11 +1060,11 @@ namespace OpenLoco::Ui::Windows::Station
             {
                 if (CompanyManager::isPlayerCompany(station->owner))
                 {
-                    self->enabledWidgets |= (1 << Common::widx::caption);
+                    self->disabledWidgets &= ~(1 << Common::widx::caption);
                 }
                 else
                 {
-                    self->enabledWidgets &= ~(1 << Common::widx::caption);
+                    self->disabledWidgets |= (1 << Common::widx::caption);
                 }
             }
         }

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -76,8 +76,6 @@ namespace OpenLoco::Ui::Windows::Terraform
             tab_build_walls,
         };
 
-        const uint64_t enabledWidgets = (1 << widx::close_button) | (1 << widx::tab_adjust_land) | (1 << widx::tab_adjust_water) | (1 << widx::tab_build_walls) | (1 << widx::tab_clear_area) | (1 << widx::tab_plant_trees);
-
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
@@ -151,7 +149,6 @@ namespace OpenLoco::Ui::Windows::Terraform
             plant_cluster_random,
         };
 
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << scrollview) | (1 << rotate_object) | (1 << object_colour) | (1 << plant_cluster_selected) | (1 << plant_cluster_random);
         const uint64_t holdableWidgets = 0;
 
         static constexpr auto widgets = makeWidgets(
@@ -948,7 +945,6 @@ namespace OpenLoco::Ui::Windows::Terraform
             window->invalidate();
 
             window->setWidgets(PlantTrees::widgets);
-            window->enabledWidgets = PlantTrees::enabledWidgets;
             window->holdableWidgets = 0;
             window->activatedWidgets = 0;
 
@@ -979,7 +975,6 @@ namespace OpenLoco::Ui::Windows::Terraform
             increase_area,
         };
 
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << tool_area) | (1 << decrease_area) | (1 << increase_area);
         const uint64_t holdableWidgets = (1 << decrease_area) | (1 << increase_area);
 
         static constexpr auto widgets = makeWidgets(
@@ -1219,7 +1214,6 @@ namespace OpenLoco::Ui::Windows::Terraform
             land_material
         };
 
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << tool_area) | (1 << decrease_area) | (1 << increase_area) | (1 << land_material) | (1 << mountain_mode) | (1 << paint_mode);
         const uint64_t holdableWidgets = (1 << decrease_area) | (1 << increase_area);
         static bool isMountainMode = false;
         static bool isPaintMode = false;
@@ -1903,7 +1897,6 @@ namespace OpenLoco::Ui::Windows::Terraform
             increase_area,
         };
 
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << tool_area) | (1 << decrease_area) | (1 << increase_area);
         const uint64_t holdableWidgets = (1 << decrease_area) | (1 << increase_area);
 
         static constexpr auto widgets = makeWidgets(
@@ -2251,7 +2244,6 @@ namespace OpenLoco::Ui::Windows::Terraform
             scrollview = 9,
         };
 
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << scrollview);
         const uint64_t holdableWidgets = 0;
 
         static constexpr auto widgets = makeWidgets(
@@ -2749,17 +2741,16 @@ namespace OpenLoco::Ui::Windows::Terraform
             std::span<const Widget> widgets;
             const widx widgetIndex;
             const WindowEventList& events;
-            const uint64_t enabledWidgets;
             const uint64_t holdableWidgets;
         };
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { ClearArea::widgets,   widx::tab_clear_area,   ClearArea::getEvents(),   ClearArea::enabledWidgets,   ClearArea::holdableWidgets },
-            { AdjustLand::widgets,  widx::tab_adjust_land,  AdjustLand::getEvents(),  AdjustLand::enabledWidgets,  AdjustLand::holdableWidgets },
-            { AdjustWater::widgets, widx::tab_adjust_water, AdjustWater::getEvents(), AdjustWater::enabledWidgets, AdjustWater::holdableWidgets },
-            { PlantTrees::widgets,  widx::tab_plant_trees,  PlantTrees::getEvents(),  PlantTrees::enabledWidgets,  PlantTrees::holdableWidgets },
-            { BuildWalls::widgets,  widx::tab_build_walls,  BuildWalls::getEvents(),  BuildWalls::enabledWidgets,  BuildWalls::holdableWidgets },
+            { ClearArea::widgets,   widx::tab_clear_area,   ClearArea::getEvents(),   ClearArea::holdableWidgets },
+            { AdjustLand::widgets,  widx::tab_adjust_land,  AdjustLand::getEvents(),  AdjustLand::holdableWidgets },
+            { AdjustWater::widgets, widx::tab_adjust_water, AdjustWater::getEvents(), AdjustWater::holdableWidgets },
+            { PlantTrees::widgets,  widx::tab_plant_trees,  PlantTrees::getEvents(),  PlantTrees::holdableWidgets },
+            { BuildWalls::widgets,  widx::tab_build_walls,  BuildWalls::getEvents(),  BuildWalls::holdableWidgets },
         };
         // clang-format on
 
@@ -2893,7 +2884,6 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             const auto& tabInfo = tabInformationByTabOffset[widgetIndex - widx::tab_clear_area];
 
-            self->enabledWidgets = tabInfo.enabledWidgets;
             self->holdableWidgets = tabInfo.holdableWidgets;
             self->eventHandlers = &tabInfo.events;
             self->activatedWidgets = 0;

--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -120,8 +120,6 @@ namespace OpenLoco::Ui::Windows::TextInput
             WindowFlags::stickToFront | WindowFlags::flag_12,
             getEvents());
         window->setWidgets(_widgets);
-        window->enabledWidgets |= 1ULL << Widx::close;
-        window->enabledWidgets |= 1ULL << Widx::ok;
         window->initScrollWidgets();
 
         memcpy(_formatArgs, _commonFormatArgs, 16);

--- a/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
@@ -124,7 +124,6 @@ namespace OpenLoco::Ui::Windows::TileInspector
             getEvents());
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = (1 << widx::close) | (1 << widx::select) | (1 << widx::xPosDecrease) | (1 << widx::xPosIncrease) | (1 << widx::yPosDecrease) | (1 << widx::yPosIncrease);
         window->rowCount = 0;
         window->rowHeight = 10;
         window->selectedTileIndex = -1;

--- a/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
@@ -73,7 +73,6 @@ namespace OpenLoco::Ui::Windows::TimePanel
             Ui::WindowFlags::stickToFront | Ui::WindowFlags::transparent | Ui::WindowFlags::noBackground,
             getEvents());
         window->setWidgets(_widgets);
-        window->enabledWidgets = (1 << Widx::map_chat_menu) | (1 << Widx::date_btn) | (1 << Widx::pause_btn) | (1 << Widx::normal_speed_btn) | (1 << Widx::fast_forward_btn) | (1 << Widx::extra_fast_forward_btn);
         window->var_854 = 0;
         window->numTicksVisible = 0;
         window->initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/TitleExit.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleExit.cpp
@@ -43,8 +43,6 @@ namespace OpenLoco::Ui::Windows::TitleExit
             getEvents());
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = (1 << Widx::exit_button);
-
         window->initScrollWidgets();
 
         window->setColour(WindowColour::primary, AdvancedColour(Colour::mutedSeaGreen).translucent());

--- a/src/OpenLoco/src/Ui/Windows/TitleLogo.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleLogo.cpp
@@ -35,8 +35,6 @@ namespace OpenLoco::Ui::Windows::TitleLogo
             getEvents());
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = 1 << Widx::logo;
-
         window->initScrollWidgets();
 
         window->setColour(WindowColour::primary, AdvancedColour(Colour::grey).translucent());

--- a/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
@@ -152,8 +152,6 @@ namespace OpenLoco::Ui::Windows::TitleMenu
             getEvents());
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = (1 << Widx::scenario_list_btn) | (1 << Widx::load_game_btn) | (1 << Widx::tutorial_btn) | (1 << Widx::scenario_editor_btn) | (1 << Widx::chat_btn) | (1 << Widx::multiplayer_toggle_btn);
-
         window->initScrollWidgets();
 
         window->setColour(WindowColour::primary, AdvancedColour(Colour::mutedSeaGreen).translucent());

--- a/src/OpenLoco/src/Ui/Windows/TitleOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleOptions.cpp
@@ -40,8 +40,6 @@ namespace OpenLoco::Ui::Windows::TitleOptions
             getEvents());
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = (1U << Widx::options_button);
-
         window->initScrollWidgets();
 
         window->setColour(WindowColour::primary, AdvancedColour(Colour::mutedSeaGreen).translucent());

--- a/src/OpenLoco/src/Ui/Windows/ToolbarBottomEditor.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarBottomEditor.cpp
@@ -159,7 +159,6 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
             getEvents());
 
         window->setWidgets(_widgets);
-        window->enabledWidgets = 1 << widx::previous_button | 1 << widx::previous_frame | 1 << widx::next_frame | 1 << widx::next_button;
         window->var_854 = 0;
         window->initScrollWidgets();
         window->setColour(WindowColour::primary, AdvancedColour(Colour::mutedSeaGreen).translucent());

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -106,7 +106,6 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             WindowFlags::stickToFront | WindowFlags::transparent | WindowFlags::noBackground,
             getEvents());
         window->setWidgets(_widgets);
-        window->enabledWidgets = (1 << Common::Widx::loadsave_menu) | (1 << Common::Widx::audio_menu) | (1 << Common::Widx::zoom_menu) | (1 << Common::Widx::rotate_menu) | (1 << Common::Widx::view_menu) | (1 << Common::Widx::terraform_menu) | (1 << Common::Widx::railroad_menu) | (1 << Common::Widx::road_menu) | (1 << Common::Widx::port_menu) | (1 << Common::Widx::build_vehicles_menu) | (1 << Common::Widx::vehicles_menu) | (1 << Common::Widx::stations_menu) | (1 << Common::Widx::towns_menu);
         window->initScrollWidgets();
 
         auto skin = ObjectManager::get<InterfaceSkinObject>();

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
@@ -77,7 +77,6 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
             WindowFlags::stickToFront | WindowFlags::transparent | WindowFlags::noBackground,
             getEvents());
         window->setWidgets(_widgets);
-        window->enabledWidgets = (1 << Common::Widx::loadsave_menu) | (1 << Common::Widx::audio_menu) | (1 << Common::Widx::zoom_menu) | (1 << Common::Widx::rotate_menu) | (1 << Common::Widx::view_menu) | (1 << Common::Widx::terraform_menu) | (1 << Widx::map_generation_menu) | (1 << Common::Widx::road_menu) | (1 << Common::Widx::towns_menu);
         window->initScrollWidgets();
         window->setColour(WindowColour::primary, Colour::grey);
         window->setColour(WindowColour::secondary, Colour::grey);

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -69,8 +69,6 @@ namespace OpenLoco::Ui::Windows::TownList
             tab_build_misc_buildings,
         };
 
-        const uint64_t enabledWidgets = (1 << widx::close_button) | (1 << widx::tab_town_list) | (1 << widx::tab_build_town) | (1 << widx::tab_build_buildings) | (1 << widx::tab_build_misc_buildings);
-
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
@@ -106,8 +104,6 @@ namespace OpenLoco::Ui::Windows::TownList
             sort_town_stations,
             scrollview,
         };
-
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << sort_town_name) | (1 << sort_town_type) | (1 << sort_town_population) | (1 << sort_town_stations) | (1 << scrollview);
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(600, 197, StringIds::title_towns),
@@ -613,7 +609,6 @@ namespace OpenLoco::Ui::Windows::TownList
             window->invalidate();
 
             window->setWidgets(TownList::widgets);
-            window->enabledWidgets = TownList::enabledWidgets;
 
             if (SceneManager::isEditorMode() || SceneManager::isSandboxMode())
             {
@@ -670,8 +665,6 @@ namespace OpenLoco::Ui::Windows::TownList
             current_size = 8,
             select_size,
         };
-
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << current_size) | (1 << select_size);
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(220, 87, StringIds::title_build_new_towns),
@@ -884,8 +877,6 @@ namespace OpenLoco::Ui::Windows::TownList
             rotate_object,
             object_colour,
         };
-
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << scrollview) | (1 << rotate_object) | (1 << object_colour);
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(640, 172, StringIds::title_build_new_buildings),
@@ -1600,15 +1591,14 @@ namespace OpenLoco::Ui::Windows::TownList
             std::span<const Widget> widgets;
             const widx widgetIndex;
             const WindowEventList& events;
-            const uint64_t enabledWidgets;
         };
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { TownList::widgets,       widx::tab_town_list,            TownList::getEvents(),       TownList::enabledWidgets },
-            { BuildTowns::widgets,     widx::tab_build_town,           BuildTowns::getEvents(),     BuildTowns::enabledWidgets },
-            { BuildBuildings::widgets, widx::tab_build_buildings,      BuildBuildings::getEvents(), BuildBuildings::enabledWidgets },
-            { BuildBuildings::widgets, widx::tab_build_misc_buildings, BuildBuildings::getEvents(), BuildBuildings::enabledWidgets },
+            { TownList::widgets,       widx::tab_town_list,            TownList::getEvents()       },
+            { BuildTowns::widgets,     widx::tab_build_town,           BuildTowns::getEvents()     },
+            { BuildBuildings::widgets, widx::tab_build_buildings,      BuildBuildings::getEvents() },
+            { BuildBuildings::widgets, widx::tab_build_misc_buildings, BuildBuildings::getEvents() },
         };
         // clang-format on
 
@@ -1759,7 +1749,6 @@ namespace OpenLoco::Ui::Windows::TownList
 
             const auto& tabInfo = tabInformationByTabOffset[widgetIndex - widx::tab_town_list];
 
-            self->enabledWidgets = tabInfo.enabledWidgets;
             self->holdableWidgets = 0;
             self->eventHandlers = &tabInfo.events;
             self->activatedWidgets = 0;

--- a/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
@@ -52,8 +52,6 @@ namespace OpenLoco::Ui::Windows::Town
             tab_company_ratings,
         };
 
-        const uint64_t enabledWidgets = (1 << widx::caption) | (1 << widx::close_button) | (1 << widx::tab_town) | (1 << widx::tab_population) | (1 << widx::tab_company_ratings);
-
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
@@ -95,8 +93,6 @@ namespace OpenLoco::Ui::Windows::Town
             Widgets::ImageButton({ 198, 68 }, { 24, 24 }, WindowColour::secondary, ImageIds::rubbish_bin, StringIds::demolish_this_town)
 
         );
-
-        const uint64_t enabledWidgets = Common::enabledWidgets | (1 << centre_on_viewport) | (1 << expand_town) | (1 << demolish_town);
 
         // 0x00498EAF
         static void prepareDraw(Window& self)
@@ -385,7 +381,6 @@ namespace OpenLoco::Ui::Windows::Town
         window->invalidate();
 
         window->setWidgets(Town::widgets);
-        window->enabledWidgets = Town::enabledWidgets;
         window->holdableWidgets = 0;
         window->eventHandlers = &Town::getEvents();
         window->activatedWidgets = 0;
@@ -660,14 +655,13 @@ namespace OpenLoco::Ui::Windows::Town
             std::span<const Widget> widgets;
             const widx widgetIndex;
             const WindowEventList& events;
-            const uint64_t* enabledWidgets;
         };
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { Town::widgets,           widx::tab_town,            Town::getEvents(),           &Town::enabledWidgets },
-            { Population::widgets,     widx::tab_population,      Population::getEvents(),     &Common::enabledWidgets },
-            { CompanyRatings::widgets, widx::tab_company_ratings, CompanyRatings::getEvents(), &Common::enabledWidgets }
+            { Town::widgets,           widx::tab_town,            Town::getEvents()           },
+            { Population::widgets,     widx::tab_population,      Population::getEvents()     },
+            { CompanyRatings::widgets, widx::tab_company_ratings, CompanyRatings::getEvents() }
         };
         // clang-format on
 
@@ -765,7 +759,6 @@ namespace OpenLoco::Ui::Windows::Town
 
             auto tabInfo = tabInformationByTabOffset[widgetIndex - widx::tab_town];
 
-            self->enabledWidgets = *tabInfo.enabledWidgets;
             self->holdableWidgets = 0;
             self->eventHandlers = &tabInfo.events;
             self->activatedWidgets = 0;

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -117,8 +117,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 Widgets::Tab({ 158, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicle_tab_route));
         }
 
-        constexpr uint64_t enabledWidgets = (1 << closeButton) | (1 << tabMain) | (1 << tabDetails) | (1 << tabCargo) | (1 << tabFinances) | (1 << tabRoute);
-
         static Vehicles::VehicleHead* getVehicle(const Window* self)
         {
             auto* veh = EntityManager::get<Vehicles::VehicleHead>(EntityId(self->number));
@@ -162,7 +160,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
             carList
         };
 
-        constexpr uint64_t enabledWidgets = (1 << widx::buildNew) | (1 << widx::pickup) | (1 << widx::remove) | (1 << widx::carList) | Common::enabledWidgets;
         constexpr uint64_t holdableWidgets = 0;
 
         static constexpr auto widgets = makeWidgets(
@@ -186,7 +183,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
             cargoList = 10,
         };
 
-        constexpr uint64_t enabledWidgets = (1 << widx::refit) | (1 << widx::cargoList) | Common::enabledWidgets;
         constexpr uint64_t holdableWidgets = 0;
 
         static constexpr auto widgets = makeWidgets(
@@ -202,7 +198,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static constexpr Ui::Size32 kMinWindowSize = { 400, 202 };
         static constexpr Ui::Size32 kMaxWindowSize = kMinWindowSize;
 
-        constexpr uint64_t enabledWidgets = Common::enabledWidgets;
         constexpr uint64_t holdableWidgets = 0;
 
         // 0x00522470
@@ -232,7 +227,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
             orderReverse
         };
 
-        constexpr uint64_t enabledWidgets = (1ULL << widx::routeList) | (1ULL << widx::orderForceUnload) | (1ULL << widx::orderWait) | (1ULL << widx::orderSkip) | (1ULL << widx::orderDelete) | (1ULL << widx::orderUp) | (1ULL << widx::orderDown) | (1ULL << widx::orderReverse) | Common::enabledWidgets;
         constexpr uint64_t holdableWidgets = 0;
         constexpr auto lineHeight = 10;
 
@@ -294,7 +288,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
         );
 
         constexpr uint64_t interactiveWidgets = (1 << widx::stopStart) | (1 << widx::pickup) | (1 << widx::passSignal) | (1 << widx::changeDirection) | (1 << widx::centreViewport);
-        constexpr uint64_t enabledWidgets = Common::enabledWidgets | (1 << widx::speedControl) | interactiveWidgets;
         constexpr uint64_t holdableWidgets = 1 << widx::speedControl;
 
         // 0x004B5D82
@@ -406,7 +399,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
         {
             auto* const self = WindowManager::createWindow(WindowType::vehicle, kWindowSize, WindowFlags::flag_11 | WindowFlags::flag_8 | WindowFlags::resizable, Main::getEvents());
             self->setWidgets(widgets);
-            self->enabledWidgets = enabledWidgets;
             self->number = enumValue(head);
             const auto* vehicle = Common::getVehicle(self);
             if (vehicle == nullptr)
@@ -457,7 +449,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self->currentTab = 0;
             self->invalidate();
             self->setWidgets(widgets);
-            self->enabledWidgets = enabledWidgets;
             self->holdableWidgets = holdableWidgets;
             self->eventHandlers = &getEvents();
             self->activatedWidgets = 0;
@@ -3461,11 +3452,11 @@ namespace OpenLoco::Ui::Windows::Vehicle
             if (isControllingCompany)
             {
                 self.widgets[widx::routeList].right += 22;
-                self.enabledWidgets &= ~(1 << widx::expressMode | 1 << widx::localMode);
+                self.disabledWidgets |= (1 << widx::expressMode | 1 << widx::localMode);
             }
             else
             {
-                self.enabledWidgets |= (1 << widx::expressMode | 1 << widx::localMode);
+                self.disabledWidgets &= ~(1 << widx::expressMode | 1 << widx::localMode);
             }
 
             self.widgets[widx::expressMode].right = self.widgets[widx::routeList].right;
@@ -3728,17 +3719,16 @@ namespace OpenLoco::Ui::Windows::Vehicle
             const widx widgetIndex;
             std::span<const Widget> widgets;
             const WindowEventList& events;
-            const uint64_t* enabledWidgets;
             const uint64_t* holdableWidgets;
         };
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { widx::tabMain,     Main::widgets,     Main::getEvents(),     &Main::enabledWidgets,     &Main::holdableWidgets },
-            { widx::tabDetails,  Details::widgets,  Details::getEvents(),  &Details::enabledWidgets,  &Details::holdableWidgets },
-            { widx::tabCargo,    Cargo::widgets,    Cargo::getEvents(),    &Cargo::enabledWidgets,    &Cargo::holdableWidgets },
-            { widx::tabFinances, Finances::widgets, Finances::getEvents(), &Finances::enabledWidgets, &Finances::holdableWidgets },
-            { widx::tabRoute,    Route::widgets,    Route::getEvents(),    &Route::enabledWidgets,    &Route::holdableWidgets }
+            { widx::tabMain,     Main::widgets,     Main::getEvents(),     &Main::holdableWidgets },
+            { widx::tabDetails,  Details::widgets,  Details::getEvents(),  &Details::holdableWidgets },
+            { widx::tabCargo,    Cargo::widgets,    Cargo::getEvents(),    &Cargo::holdableWidgets },
+            { widx::tabFinances, Finances::widgets, Finances::getEvents(), &Finances::holdableWidgets },
+            { widx::tabRoute,    Route::widgets,    Route::getEvents(),    &Route::holdableWidgets }
         };
         // clang-format on
 
@@ -4574,9 +4564,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             auto tabInfo = tabInformationByTabOffset[widgetIndex - widx::tabMain];
 
-            self->enabledWidgets = *tabInfo.enabledWidgets;
             self->holdableWidgets = *tabInfo.holdableWidgets;
-
             self->eventHandlers = &tabInfo.events;
             self->activatedWidgets = 0;
             self->setWidgets(tabInfo.widgets);
@@ -4595,7 +4583,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         // 0x004B1E94
         static void setCaptionEnableState(Window* const self)
         {
-            self->enabledWidgets |= 1 << widx::caption;
+            self->disabledWidgets &= ~(1ULL << widx::caption);
             auto head = getVehicle(self);
             if (head == nullptr)
             {
@@ -4603,7 +4591,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
             if (head->owner != CompanyManager::getControllingId())
             {
-                self->enabledWidgets &= ~static_cast<uint64_t>(1 << widx::caption);
+                self->disabledWidgets |= (1ULL << widx::caption);
             }
         }
 

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -92,9 +92,6 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
     // clang-format off
     constexpr uint16_t _tabWidgets = (1 << Widx::tab_trains) | (1 << Widx::tab_buses) | (1 << Widx::tab_trucks) | (1 << Widx::tab_trams) | (1 << Widx::tab_aircraft) | (1 << Widx::tab_ships);
-    constexpr uint64_t _enabledWidgets = (1ULL << Widx::close_button) | _tabWidgets | (1ULL << Widx::company_select) |
-        (1ULL << Widx::sort_name) | (1ULL << Widx::sort_profit) | (1ULL << Widx::sort_age) | (1ULL << Widx::sort_reliability) |
-        (1ULL << Widx::scrollview) | (1ULL << Widx::filter_type) | (1ULL << Widx::filter_type_btn) | (1ULL << Widx::cargo_type) | (1ULL << Widx::cargo_type_btn);
     // clang-format on
 
     enum SortMode : uint16_t
@@ -487,7 +484,6 @@ namespace OpenLoco::Ui::Windows::VehicleList
             getEvents());
 
         self->setWidgets(_widgets);
-        self->enabledWidgets = _enabledWidgets;
         self->number = enumValue(companyId);
         self->owner = companyId;
         self->frameNo = 0;


### PR DESCRIPTION
Instead of always telling it what is enabled and disabled I decided to just have disabled and enabled is the opposite of disabled so we have all widgets implicitly enabled. I'm not sure what the idea was behind having two states like that. Now we have explicit state about enabled/disabled, visible/hidden, pressed/activated

Will have to rebase, depends on #3014