### PR TITLE
Fix mouse getting stuck on edges of monitor when right mouse dragging scrollviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 25.07+ (???)
 ------------------------------------------------------------------------
 - Change: [#3104] Landscape generation confirmation prompts now prevent you from clicking other windows until a choice is made.
+- Fix: [#3019] Mouse getting stuck on edges of monitor when right mouse dragging scroll views.
 - Fix: [#3167] Dropdown for terrain type selection is displayed at the wrong position.
 - Fix: [#3171] Background of station labels have a visible gap due to being off by one pixel.
 - Fix: [#3184] The minimum size of the map window is miscalculated when it is dragged past a certain point.


### PR DESCRIPTION
Mainly to change stateScrollRight() to use getNextDragOffset() (like stateViewportRight() already does) instead of the x, y from handleMouse().
   - Fixes #3019

Also a couple new unrelated code comments and a minor code style change in the same file.