### PR TITLE
Use SDL relative mouse mode for right click dragging where available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Feature: [#1438] Add basic blueprint feature for copy, paste and rotate railroad track.
 - Feature: [#3591] Cheat to keep cargo when picking up a vehicle or modifying a vehicle's components.
 - Feature: [#3639] The Locomotion title screen music can now be listened to during scenario play.
+- Change: [#3022] use relative mouse mode for right mouse dragging where available.
 - Change: [#3594] More sorting options when building vehicles.
 - Change: [#3702, #3703, #3704, #3705] Improved performance for vehicle, industry, town, station, and company lists.
 - Change: [#3707] The music jukebox has been moved from the options window to its own, with an optional keyboard shortcut.

--- a/src/OpenLoco/src/Input.cpp
+++ b/src/OpenLoco/src/Input.cpp
@@ -6,6 +6,7 @@
 #include "Ui/ScrollView.h"
 #include "Ui/Window.h"
 #include <SDL3/SDL.h>
+#include <SDL_mouse.h>
 #include <map>
 
 namespace OpenLoco::Input
@@ -55,7 +56,17 @@ namespace OpenLoco::Input
             _cursorDragState = 1;
             auto cursor = Ui::getCursorPos();
             _cursorDragStart = cursor;
-            Ui::hideCursor();
+
+            auto result = SDL_SetRelativeMouseMode(SDL_TRUE);
+            if (result == 0)
+            {
+                // Consume the mouse delta x and y of SDL centering the mouse cursor
+                SDL_GetRelativeMouseState(nullptr, nullptr);
+            }
+            else
+            {
+                Ui::hideCursor();
+            }
         }
     }
 
@@ -66,23 +77,42 @@ namespace OpenLoco::Input
         {
             _cursorDragState = 0;
             Ui::setCursorPos(_cursorDragStart.x, _cursorDragStart.y);
+            SDL_SetRelativeMouseMode(SDL_FALSE);
             Ui::showCursor();
         }
     }
 
+    // Returns how far the mouse cursor has moved since this function was last called,
+    // and resets its position (if not using relative mouse mode).
     Ui::Point getNextDragOffset()
     {
-        auto current = Ui::getCursorPos();
+        auto deltaX = 0;
+        auto deltaY = 0;
 
-        auto delta = current - _cursorDragStart;
+        if (SDL_GetRelativeMouseMode())
+        {
+            // get the mouse deltas since the last call to SDL_GetRelativeMouseState() or since event initialization.
+            SDL_GetRelativeMouseState(&deltaX, &deltaY);
+        }
+        else
+        {
+            // Fallback for if relative mode could not be enabled
 
-        Ui::setCursorPos(_cursorDragStart.x, _cursorDragStart.y);
+            const auto oldCursorPos = Ui::getCursorPos();
 
-        auto scale = Config::get().scaleFactor;
-        delta.x /= scale;
-        delta.y /= scale;
+            // TODO: midX, midY would ideally be the center of the screen to minimise the cursor getting stopped by the edges of the monitor, in theory
+            const auto midX = _cursorDragStart.x;
+            const auto midY = _cursorDragStart.y;
 
-        return { static_cast<int16_t>(delta.x), static_cast<int16_t>(delta.y) };
+            deltaX = (oldCursorPos.x - midX);
+            deltaY = (oldCursorPos.y - midY);
+
+            Ui::setCursorPos(midX, midY); // Moves the mouse cursor
+        }
+
+        const auto scale = Config::get().scaleFactor;
+
+        return { static_cast<int16_t>(deltaX / scale), static_cast<int16_t>(deltaY / scale) };
     }
 
     // 0x004072EC


### PR DESCRIPTION
The benefit of this is that the mouse is not able to get stopped by the edges of the monitor when using relative mode, thus slightly improving the user experience: Now right mouse dragging will work as expected even when you start from the edge of the screen.