### PR TITLE
Fix sfl not being downloaded

### DIFF
--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -86,7 +86,6 @@ if ( NOT sfl_FOUND )
         sfl
         GIT_REPOSITORY      https://github.com/slavenf/sfl-library
         GIT_TAG             d331ddb219ea2f7438fa6dca1248551622156f72
-        GIT_SHALLOW         ON
     )
     FetchContent_MakeAvailable(sfl)
     


### PR DESCRIPTION
Just removing GIT_SHALLOW does the trick, at first I thought commits were force pushed but I was wrong.