### PR TITLE
Add "One second per year" game speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 25.02+ (???)
 ------------------------------------------------------------------------
+- Feature: [#3026] "Game speed: One second per year" keyboard shortcut.
 - Change: [#2457] Right mouse dragging in ScrollViews now respects "Invert right mouse dragging" option.
 - Fix: [#2972] More vehicle-related messages not using the correct vehicle name string.
 - Fix: [#2984] Areas of forbid trams checkboxes covering forbidding trucks checkboxes.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2410,3 +2410,4 @@ strings:
   2355: "{COLOUR WINDOW_2}Riverbank width:"
   2356: "{COLOUR WINDOW_2}Meander rate:"
   2357: "OpenLoco"
+  2358: "Game speed: One second per year"

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -673,6 +673,11 @@ namespace OpenLoco::Input::Shortcuts
         GameCommands::doCommand(GameCommands::SetGameSpeedArgs{ GameSpeed::ExtraFastForward }, GameCommands::Flags::apply);
     }
 
+    static void gameSpeedOneSecondPerYear()
+    {
+        GameCommands::doCommand(GameCommands::SetGameSpeedArgs{ GameSpeed::OneSecondPerYear }, GameCommands::Flags::apply);
+    }
+
     static void openDebugWindow()
     {
         Windows::Debug::open();
@@ -733,6 +738,7 @@ namespace OpenLoco::Input::Shortcuts
         ShortcutManager::add(Shortcut::gameSpeedNormal,                 StringIds::shortcut_game_speed_normal,                  gameSpeedNormal,                "gameSpeedNormal",                  "");
         ShortcutManager::add(Shortcut::gameSpeedFastForward,            StringIds::shortcut_game_speed_fast_forward,            gameSpeedFastForward,           "gameSpeedFastForward",             "");
         ShortcutManager::add(Shortcut::gameSpeedExtraFastForward,       StringIds::shortcut_game_speed_extra_fast_forward,      gameSpeedExtraFastForward,      "gameSpeedExtraFastForward",        "");
+        ShortcutManager::add(Shortcut::gameSpeedOneSecondPerYear,       StringIds::shortcut_game_speed_one_second_per_year,     gameSpeedOneSecondPerYear,      "gameSpeedOneSecondPerYear",        "");
         ShortcutManager::add(Shortcut::openDebugWindow,                 StringIds::empty,                                       openDebugWindow,                "openDebugWindow",                  "F10");
         // clang-format on
     }

--- a/src/OpenLoco/src/Input/Shortcuts.h
+++ b/src/OpenLoco/src/Input/Shortcuts.h
@@ -58,6 +58,7 @@ namespace OpenLoco::Input
         gameSpeedNormal,
         gameSpeedFastForward,
         gameSpeedExtraFastForward,
+        gameSpeedOneSecondPerYear,
         openDebugWindow,
     };
 

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1994,6 +1994,7 @@ namespace OpenLoco::StringIds
     constexpr StringId riverbank_width = 2355;
     constexpr StringId meander_rate = 2356;
     constexpr StringId objSelectionFilterOpenLoco = 2357;
+    constexpr StringId shortcut_game_speed_one_second_per_year = 2358;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -395,14 +395,29 @@ namespace OpenLoco
                     }
                     uint16_t var_F253A0 = std::max<uint16_t>(1, numUpdates);
                     SceneManager::setSceneAge(std::min(0xFFFF, (int32_t)SceneManager::getSceneAge() + var_F253A0));
-                    if (SceneManager::getGameSpeed() != GameSpeed::Normal)
+
+                    auto speed = 1;
+                    switch (SceneManager::getGameSpeed())
                     {
-                        numUpdates *= 3;
-                        if (SceneManager::getGameSpeed() != GameSpeed::FastForward)
-                        {
-                            numUpdates *= 3;
-                        }
+                        case GameSpeed::Normal:
+                            break;
+
+                        case GameSpeed::FastForward:
+                            speed = 3;
+                            break;
+
+                        case GameSpeed::ExtraFastForward:
+                            speed = 9;
+                            break;
+
+                        case GameSpeed::OneSecondPerYear:
+                            speed = 900; // Roughly one second per Julian year 
+                            break;
+
+                        default:
+                            assert(false);
                     }
+                    numUpdates *= speed;
 
                     // Catch up to server (usually after we have just joined the game)
                     auto numTicksBehind = Network::getServerTick() - ScenarioManager::getScenarioTicks();

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -411,7 +411,7 @@ namespace OpenLoco
                             break;
 
                         case GameSpeed::OneSecondPerYear:
-                            speed = 900; // Roughly one second per Julian year 
+                            speed = 900; // Roughly one second per Julian year
                             break;
 
                         default:

--- a/src/OpenLoco/src/SceneManager.h
+++ b/src/OpenLoco/src/SceneManager.h
@@ -10,7 +10,8 @@ namespace OpenLoco
         Normal = 0,
         FastForward = 1,
         ExtraFastForward = 2,
-        MAX = ExtraFastForward,
+        OneSecondPerYear, // Approximate
+        MAX = OneSecondPerYear,
     };
 
     namespace SceneManager


### PR DESCRIPTION
Adds the ability to speed up the game to approximately (if my calculations are correct) one second per in-game Julian year via a new keyboard shortcut.

Closes #3026

![image](https://github.com/user-attachments/assets/8c4b414d-a19f-4a3f-a6c8-1250491e894c)
