### PR TITLE
Refactor more music functionality to Jukebox.cpp and remove music rel…

### DIFF
--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -52,11 +52,7 @@ namespace OpenLoco::Audio
     [[maybe_unused]] constexpr int32_t kPlayAtLocation = 0x8001;
     [[maybe_unused]] constexpr int32_t kNumSoundChannels = 16;
 
-    static constexpr Jukebox::MusicId kNoSong = 0xFF;
-
     static loco_global<uint32_t, 0x0050D1EC> _audioInitialised;
-    static loco_global<uint8_t, 0x0050D434> _currentSong;
-    static loco_global<uint8_t, 0x0050D435> _lastSong;
     static loco_global<bool, 0x0050D554> _audioIsPaused;
     static loco_global<bool, 0x0050D555> _audioIsEnabled;
     // 0x0050D5B0
@@ -1004,7 +1000,9 @@ namespace OpenLoco::Audio
         using MusicPlaylistType = Config::MusicPlaylistType;
         const auto& cfg = Config::get().old;
 
-        if (_currentSong == kNoSong)
+        const auto currentTrack = Jukebox::getCurrentTrack();
+
+        if (currentTrack == Jukebox::kNoSong)
         {
             return;
         }
@@ -1015,7 +1013,7 @@ namespace OpenLoco::Audio
             case MusicPlaylistType::currentEra:
             {
                 auto currentYear = getCurrentYear();
-                const auto& info = Jukebox::getMusicInfo(_currentSong);
+                const auto& info = Jukebox::getMusicInfo(currentTrack);
                 if (currentYear < info.startYear || currentYear > info.endYear)
                 {
                     trackStillApplies = false;
@@ -1027,7 +1025,7 @@ namespace OpenLoco::Audio
                 return;
 
             case MusicPlaylistType::custom:
-                if (!cfg.enabledMusic[_currentSong])
+                if (!cfg.enabledMusic[currentTrack])
                 {
                     trackStillApplies = false;
                 }
@@ -1037,8 +1035,7 @@ namespace OpenLoco::Audio
         if (!trackStillApplies)
         {
             stopMusic();
-            _currentSong = kNoSong;
-            _lastSong = kNoSong;
+            Jukebox::resetJukebox();
         }
     }
 
@@ -1059,23 +1056,9 @@ namespace OpenLoco::Audio
 
         if (!channel->isPlaying())
         {
-            // Not playing, but the 'current song' is last song? It's been requested manually!
-            bool requestedSong = _lastSong != kNoSong && _lastSong == _currentSong;
+            // Set the next song to play and load its info
+            const auto& mi = Jukebox::changeTrack();
 
-            // Choose a track to play, unless we have requested one track in particular.
-            if (_currentSong == kNoSong || !requestedSong)
-            {
-                _lastSong = _currentSong;
-                _currentSong = Jukebox::chooseNextMusicTrack(_lastSong);
-            }
-            else
-            {
-                // We're choosing this one, but the next one should be decided automatically again.
-                _lastSong = kNoSong;
-            }
-
-            // Load info on the song to play.
-            const auto& mi = Jukebox::getMusicInfo(_currentSong);
             playMusic(mi.pathId, cfg.volume, false);
 
             WindowManager::invalidate(WindowType::options);
@@ -1106,8 +1089,7 @@ namespace OpenLoco::Audio
     void resetMusic()
     {
         stopMusic();
-        _currentSong = kNoSong;
-        _lastSong = kNoSong;
+        Jukebox::resetJukebox();
     }
 
     // 0x0048AAE8
@@ -1156,7 +1138,7 @@ namespace OpenLoco::Audio
         {
             return;
         }
-        if (_audioInitialised && _currentSong != kNoSong)
+        if (_audioInitialised && Jukebox::getCurrentTrack() != Jukebox::kNoSong)
         {
             channel->setVolume(volume);
         }

--- a/src/OpenLoco/src/Jukebox.h
+++ b/src/OpenLoco/src/Jukebox.h
@@ -22,7 +22,18 @@ namespace OpenLoco::Jukebox
         uint16_t endYear;
     };
 
-    std::vector<MusicId> makeSelectedPlaylist();
-    MusicId chooseNextMusicTrack(MusicId lastSong);
+    static constexpr MusicId kNoSong = 0xFF;
+
     const MusicInfo& getMusicInfo(MusicId track);
+    bool isMusicPlaying();
+    MusicId getRequestedTrack();
+    MusicId getCurrentTrack();
+    StringId getCurrentTrackTitleId();
+
+    std::vector<MusicId> makeSelectedPlaylist();
+    const MusicInfo& changeTrack();
+    bool changeTrackTo(MusicId toTrack);
+    bool skipCurrentTrack();
+    bool stopMusic();
+    void resetJukebox();
 }

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -50,10 +50,6 @@ namespace OpenLoco::Ui::Windows::Options
     static void sub_4C13BE(Window* w);
     static void setPreferredCurrencyNameBuffer();
 
-    static loco_global<uint32_t, 0x0050D430> _songProgress;
-    static loco_global<int8_t, 0x0050D434> _currentSong;
-    static loco_global<uint8_t, 0x0050D435> _lastSong;
-
     // Pointer to an array of SelectedObjectsFlags
     static loco_global<ObjectManager::SelectedObjectsFlags*, 0x011364A0> __11364A0;
     static loco_global<uint16_t, 0x0112C185> _112C185;
@@ -1076,11 +1072,7 @@ namespace OpenLoco::Ui::Windows::Options
             w.widgets[Common::Widx::close_button].right = w.width - 15 + 12;
 
             {
-                StringId songName = StringIds::music_none;
-                if (_currentSong != -1)
-                {
-                    songName = Jukebox::getMusicInfo(_currentSong).titleId;
-                }
+                StringId songName = Jukebox::getCurrentTrackTitleId();
 
                 auto args = FormatArguments(w.widgets[Widx::currently_playing].textArgs);
                 args.push(songName);
@@ -1101,13 +1093,10 @@ namespace OpenLoco::Ui::Windows::Options
 
             w.activatedWidgets &= ~((1ULL << Widx::music_controls_stop) | (1ULL << Widx::music_controls_play));
             w.activatedWidgets |= (1ULL << Widx::music_controls_stop);
-            if (_currentSong != -1)
+            if (Jukebox::isMusicPlaying())
             {
-                if (Config::get().old.musicPlaying)
-                {
-                    w.activatedWidgets &= ~((1ULL << Widx::music_controls_stop) | (1ULL << Widx::music_controls_play));
-                    w.activatedWidgets |= (1ULL << Widx::music_controls_play);
-                }
+                w.activatedWidgets &= ~((1ULL << Widx::music_controls_stop) | (1ULL << Widx::music_controls_play));
+                w.activatedWidgets |= (1ULL << Widx::music_controls_play);
             }
 
             w.disabledWidgets |= (1ULL << Widx::edit_selection);
@@ -1218,31 +1207,22 @@ namespace OpenLoco::Ui::Windows::Options
         // 0x004C0778
         static void stopMusic(Window* w)
         {
-            if (Config::get().old.musicPlaying == 0)
+            if (Jukebox::stopMusic())
             {
-                return;
+                w->invalidate();
             }
-
-            auto& cfg = Config::get().old;
-            cfg.musicPlaying = 0;
-            Config::write();
-
-            Audio::stopMusic();
-
-            _currentSong = -1;
-
-            w->invalidate();
         }
 
         // 0x004C07A4
         static void playMusic(Window* w)
         {
-            if (Config::get().old.musicPlaying != 0)
+            auto& cfg = Config::get().old;
+
+            if (cfg.musicPlaying != 0)
             {
                 return;
             }
 
-            auto& cfg = Config::get().old;
             cfg.musicPlaying = 1;
             Config::write();
 
@@ -1252,16 +1232,10 @@ namespace OpenLoco::Ui::Windows::Options
         // 0x004C07C4
         static void playNextSong(Window* w)
         {
-            if (Config::get().old.musicPlaying == 0)
+            if (Jukebox::skipCurrentTrack())
             {
-                return;
+                w->invalidate();
             }
-
-            Audio::stopMusic();
-
-            _currentSong = -1;
-
-            w->invalidate();
         }
 
 #pragma mark - Widget 17
@@ -1313,7 +1287,7 @@ namespace OpenLoco::Ui::Windows::Options
             {
                 index++;
                 Dropdown::add(index, StringIds::dropdown_stringid, Jukebox::getMusicInfo(track).titleId);
-                if (track == _currentSong)
+                if (track == Jukebox::getCurrentTrack())
                 {
                     Dropdown::setItemSelected(index);
                 }
@@ -1328,20 +1302,11 @@ namespace OpenLoco::Ui::Windows::Options
                 return;
             }
 
-            auto tracks = Jukebox::makeSelectedPlaylist();
-            int track = tracks.at(ax);
-            if (track == _currentSong)
+            auto track = Jukebox::makeSelectedPlaylist().at(ax);
+            if (Jukebox::changeTrackTo(track))
             {
-                return;
+                w->invalidate();
             }
-
-            Audio::stopMusic();
-
-            _currentSong = track;
-            _lastSong = track;
-            _songProgress = 0;
-
-            w->invalidate();
         }
 
         // 0x004C0A37


### PR DESCRIPTION
Pretty substantial music refactor.
- Moves more of the music functionality from Options.cpp and Audio.cpp to Jukebox.cpp
- Removes three loco globals:
    - 0x0050D430 _songProgress
    - 0x0050D434 _currentSong
    - 0x0050D435 _lastSong
- Supersedes my previous PR #2794 by fixing the same minor issues that it fixed:
    - Fixes #2703
    - Fixes #2704