### PR TITLE
LandscapeGeneration: turn text labels into widgets

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -253,9 +253,11 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         enum widx
         {
             groupGeneral = Common::widx::generate_now + 1,
+            start_year_label,
             start_year,
             start_year_down,
             start_year_up,
+            heightMapBoxLabel,
             heightMapBox,
             heightMapDropdown,
 
@@ -282,7 +284,9 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
             // General options
             Widgets::GroupBox({ 4, 50 }, { 358, 50 }, WindowColour::secondary, StringIds::landscapeOptionsGroupGeneral),
+            Widgets::Label({ 10, 65 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::start_year),
             Widgets::stepperWidgets({ 256, 65 }, { 100, 12 }, WindowColour::secondary, StringIds::start_year_value),
+            Widgets::Label({ 10, 81 }, { 160, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::height_map_source),
             Widgets::dropdownWidgets({ 176, 81 }, { 180, 12 }, WindowColour::secondary),
 
             // Generator options
@@ -302,18 +306,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             auto tr = Gfx::TextRenderer(drawingCtx);
 
             Common::draw(window, drawingCtx);
-
-            auto point = Point(window.x + 10, window.y + window.widgets[widx::start_year].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::start_year);
-
-            point = Point(window.x + 10, window.y + window.widgets[widx::heightMapBox].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::height_map_source);
 
             auto& options = Scenario::getOptions();
             switch (options.generator)

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -1128,27 +1128,35 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
     {
         enum widx
         {
-            number_of_forests = Common::widx::generate_now + 1,
+            number_of_forests_label = Common::widx::generate_now + 1,
+            number_of_forests,
             number_of_forests_down,
             number_of_forests_up,
+            minForestRadiusLabel,
             minForestRadius,
             min_forest_radius_down,
             min_forest_radius_up,
+            maxForestRadiusLabel,
             maxForestRadius,
             max_forest_radius_down,
             max_forest_radius_up,
+            minForestDensityLabel,
             minForestDensity,
             min_forest_density_down,
             min_forest_density_up,
+            maxForestDensityLabel,
             maxForestDensity,
             max_forest_density_down,
             max_forest_density_up,
+            number_random_trees_label,
             number_random_trees,
             number_random_trees_down,
             number_random_trees_up,
+            min_altitude_for_trees_label,
             min_altitude_for_trees,
             min_altitude_for_trees_down,
             min_altitude_for_trees_up,
+            max_altitude_for_trees_label,
             max_altitude_for_trees,
             max_altitude_for_trees_down,
             max_altitude_for_trees_up,
@@ -1158,72 +1166,24 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(217, StringIds::title_landscape_generation_forests),
+            Widgets::Label({ 10, 52 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::number_of_forests),
             Widgets::stepperWidgets({ 256, 52 }, { 100, 12 }, WindowColour::secondary, StringIds::number_of_forests_value),
+            Widgets::Label({ 10, 67 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::min_forest_radius),
             Widgets::stepperWidgets({ 256, 67 }, { 100, 12 }, WindowColour::secondary, StringIds::min_forest_radius_blocks),
+            Widgets::Label({ 10, 82 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::max_forest_radius),
             Widgets::stepperWidgets({ 256, 82 }, { 100, 12 }, WindowColour::secondary, StringIds::max_forest_radius_blocks),
+            Widgets::Label({ 10, 97 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::min_forest_density),
             Widgets::stepperWidgets({ 256, 97 }, { 100, 12 }, WindowColour::secondary, StringIds::min_forest_density_percent),
+            Widgets::Label({ 10, 112 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::max_forest_density),
             Widgets::stepperWidgets({ 256, 112 }, { 100, 12 }, WindowColour::secondary, StringIds::max_forest_density_percent),
+            Widgets::Label({ 10, 127 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::number_random_trees),
             Widgets::stepperWidgets({ 256, 127 }, { 100, 12 }, WindowColour::secondary, StringIds::number_random_trees_value),
+            Widgets::Label({ 10, 142 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::min_altitude_for_trees),
             Widgets::stepperWidgets({ 256, 142 }, { 100, 12 }, WindowColour::secondary, StringIds::min_altitude_for_trees_height),
+            Widgets::Label({ 10, 157 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::max_altitude_for_trees),
             Widgets::stepperWidgets({ 256, 157 }, { 100, 12 }, WindowColour::secondary, StringIds::max_altitude_for_trees_height)
 
         );
-
-        // 0x0043E53A
-        static void draw(Window& window, Gfx::DrawingContext& drawingCtx)
-        {
-            auto tr = Gfx::TextRenderer(drawingCtx);
-
-            Common::draw(window, drawingCtx);
-
-            auto point = Point(window.x + 10, window.y + window.widgets[widx::number_of_forests].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::number_of_forests);
-
-            point = Point(window.x + 10, window.y + window.widgets[widx::minForestRadius].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::min_forest_radius);
-
-            point = Point(window.x + 10, window.y + window.widgets[widx::maxForestRadius].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::max_forest_radius);
-
-            point = Point(window.x + 10, window.y + window.widgets[widx::minForestDensity].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::min_forest_density);
-
-            point = Point(window.x + 10, window.y + window.widgets[widx::maxForestDensity].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::max_forest_density);
-
-            point = Point(window.x + 10, window.y + window.widgets[widx::number_random_trees].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::number_random_trees);
-
-            point = Point(window.x + 10, window.y + window.widgets[widx::min_altitude_for_trees].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::min_altitude_for_trees);
-
-            point = Point(window.x + 10, window.y + window.widgets[widx::max_altitude_for_trees].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::max_altitude_for_trees);
-        }
 
         // 0x0043E670
         static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
@@ -1407,7 +1367,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             .onMouseDown = onMouseDown,
             .onUpdate = Common::update,
             .prepareDraw = prepareDraw,
-            .draw = draw,
+            .draw = Common::draw,
         };
 
         static const WindowEventList& getEvents()

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -1499,7 +1499,8 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
     {
         enum widx
         {
-            num_industries = Common::widx::generate_now + 1,
+            num_industries_label = Common::widx::generate_now + 1,
+            num_industries,
             num_industries_btn,
             check_allow_industries_close_down,
             check_allow_industries_start_up,
@@ -1509,25 +1510,12 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(217, StringIds::title_landscape_generation_industries),
+            Widgets::Label({ 10, 52 }, { 160, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::number_of_industries),
             Widgets::dropdownWidgets({ 176, 52 }, { 180, 12 }, WindowColour::secondary),
             Widgets::Checkbox({ 10, 68 }, { 346, 12 }, WindowColour::secondary, StringIds::allow_industries_to_close_down_during_game),
             Widgets::Checkbox({ 10, 83 }, { 346, 12 }, WindowColour::secondary, StringIds::allow_new_industries_to_start_up_during_game)
 
         );
-
-        // 0x0043EB9D
-        static void draw(Window& window, Gfx::DrawingContext& drawingCtx)
-        {
-            auto tr = Gfx::TextRenderer(drawingCtx);
-
-            Common::draw(window, drawingCtx);
-
-            auto point = Point(window.x + 10, window.y + window.widgets[widx::num_industries].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::number_of_industries);
-        }
 
         static constexpr StringId numIndustriesLabels[] = {
             StringIds::industry_size_low,
@@ -1601,7 +1589,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             .onDropdown = onDropdown,
             .onUpdate = Common::update,
             .prepareDraw = prepareDraw,
-            .draw = draw,
+            .draw = Common::draw,
         };
 
         static const WindowEventList& getEvents()

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -28,6 +28,7 @@
 #include "Ui/Widgets/FrameWidget.h"
 #include "Ui/Widgets/GroupBoxWidget.h"
 #include "Ui/Widgets/ImageButtonWidget.h"
+#include "Ui/Widgets/LabelWidget.h"
 #include "Ui/Widgets/PanelWidget.h"
 #include "Ui/Widgets/ScrollViewWidget.h"
 #include "Ui/Widgets/StepperWidget.h"
@@ -614,11 +615,14 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
     {
         enum widx
         {
-            topography_style = Common::widx::generate_now + 1,
+            topography_style_label = Common::widx::generate_now + 1,
+            topography_style,
             topography_style_btn,
+            min_land_height_label,
             min_land_height,
             min_land_height_down,
             min_land_height_up,
+            hill_density_label,
             hill_density,
             hill_density_down,
             hill_density_up,
@@ -630,39 +634,16 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(252, StringIds::title_landscape_generation_land),
+            Widgets::Label({ 10, 52 }, { 160, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::topography_style),
             Widgets::dropdownWidgets({ 176, 52 }, { 180, 12 }, WindowColour::secondary),
+            Widgets::Label({ 10, 68 }, { 250, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::min_land_height),
             Widgets::stepperWidgets({ 256, 68 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units),
+            Widgets::Label({ 10, 84 }, { 250, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::hill_density),
             Widgets::stepperWidgets({ 256, 84 }, { 100, 12 }, WindowColour::secondary, StringIds::hill_density_percent),
             Widgets::Checkbox({ 10, 100 }, { 346, 12 }, WindowColour::secondary, StringIds::create_hills_right_up_to_edge_of_map),
             Widgets::ScrollView({ 4, 116 }, { 358, 112 }, WindowColour::secondary, Scrollbars::vertical)
 
         );
-
-        // 0x0043DF89
-        static void draw(Window& window, Gfx::DrawingContext& drawingCtx)
-        {
-            auto tr = Gfx::TextRenderer(drawingCtx);
-
-            Common::draw(window, drawingCtx);
-
-            auto point = Point(window.x + 10, window.y + window.widgets[widx::min_land_height].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::min_land_height);
-
-            point.y = window.y + window.widgets[widx::topography_style].top;
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::topography_style);
-
-            point.y = window.y + window.widgets[widx::hill_density].top;
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::hill_density);
-        }
 
         static constexpr StringId landDistributionLabelIds[] = {
             StringIds::land_distribution_everywhere,
@@ -959,7 +940,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             .scrollMouseDown = scrollMouseDown,
             .tooltip = tooltip,
             .prepareDraw = prepareDraw,
-            .draw = draw,
+            .draw = Common::draw,
             .drawScroll = drawScroll,
         };
 

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -1380,9 +1380,11 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
     {
         enum widx
         {
-            number_of_towns = Common::widx::generate_now + 1,
+            number_of_towns_label = Common::widx::generate_now + 1,
+            number_of_towns,
             number_of_towns_down,
             number_of_towns_up,
+            max_town_size_label,
             max_town_size,
             max_town_size_btn,
         };
@@ -1391,30 +1393,12 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(217, StringIds::title_landscape_generation_towns),
+            Widgets::Label({ 10, 52 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::number_of_towns),
             Widgets::stepperWidgets({ 256, 52 }, { 100, 12 }, WindowColour::secondary, StringIds::number_of_towns_value),
+            Widgets::Label({ 10, 67 }, { 160, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::max_town_size),
             Widgets::dropdownWidgets({ 176, 67 }, { 180, 12 }, WindowColour::secondary)
 
         );
-
-        // 0x0043E9A3
-        static void draw(Window& window, Gfx::DrawingContext& drawingCtx)
-        {
-            auto tr = Gfx::TextRenderer(drawingCtx);
-
-            Common::draw(window, drawingCtx);
-
-            auto point = Point(window.x + 10, window.y + window.widgets[widx::number_of_towns].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::number_of_towns);
-
-            point = Point(window.x + 10, window.y + window.widgets[widx::max_town_size].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::max_town_size);
-        }
 
         static constexpr StringId townSizeLabels[] = {
             StringIds::town_size_1,
@@ -1502,7 +1486,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             .onDropdown = onDropdown,
             .onUpdate = Common::update,
             .prepareDraw = prepareDraw,
-            .draw = draw,
+            .draw = Common::draw,
         };
 
         static const WindowEventList& getEvents()

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -954,94 +954,62 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
     {
         enum widx
         {
-            sea_level = Common::widx::generate_now + 1,
+            sea_level_label = Common::widx::generate_now + 1,
+            sea_level,
             sea_level_down,
             sea_level_up,
 
+            num_riverbeds_label,
             num_riverbeds,
             num_riverbeds_down,
             num_riverbeds_up,
 
+            min_river_width_label,
             min_river_width,
             min_river_width_down,
             min_river_width_up,
 
+            max_river_width_label,
             max_river_width,
             max_river_width_down,
             max_river_width_up,
 
+            riverbank_width_label,
             riverbank_width,
             riverbank_width_down,
             riverbank_width_up,
 
+            meander_rate_label,
             meander_rate,
             meander_rate_down,
             meander_rate_up,
         };
 
         // clang-format off
-        const uint64_t holdable_widgets = (1 << widx::sea_level_up) | (1 << widx::sea_level_down) |
-            (1 << widx::num_riverbeds_down) | (1 << widx::num_riverbeds_up) |
-            (1 << widx::min_river_width_down) | (1 << widx::min_river_width_up) |
-            (1 << widx::max_river_width_down) | (1 << widx::max_river_width_up) |
-            (1 << widx::riverbank_width_down) | (1 << widx::riverbank_width_up) |
-            (1 << widx::meander_rate_down) | (1 << widx::meander_rate_up);
+        const uint64_t holdable_widgets = (1ULL << widx::sea_level_up) | (1ULL << widx::sea_level_down) |
+            (1ULL << widx::num_riverbeds_down) | (1ULL << widx::num_riverbeds_up) |
+            (1ULL << widx::min_river_width_down) | (1ULL << widx::min_river_width_up) |
+            (1ULL << widx::max_river_width_down) | (1ULL << widx::max_river_width_up) |
+            (1ULL << widx::riverbank_width_down) | (1ULL << widx::riverbank_width_up) |
+            (1ULL << widx::meander_rate_down) | (1ULL << widx::meander_rate_up);
         // clang-format on
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(217, StringIds::title_landscape_generation_water),
+            Widgets::Label({ 10, 52 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::sea_level),
             Widgets::stepperWidgets({ 256, 52 }, { 100, 12 }, WindowColour::secondary, StringIds::sea_level_units),
+            Widgets::Label({ 10, 68 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::number_riverbeds),
             Widgets::stepperWidgets({ 256, 68 }, { 100, 12 }, WindowColour::secondary, StringIds::uint16_raw),
+            Widgets::Label({ 10, 84 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::minimum_river_width),
             Widgets::stepperWidgets({ 256, 84 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units),
+            Widgets::Label({ 10, 100 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::maximum_river_width),
             Widgets::stepperWidgets({ 256, 100 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units),
+            Widgets::Label({ 10, 116 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::riverbank_width),
             Widgets::stepperWidgets({ 256, 116 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units),
+            Widgets::Label({ 10, 132 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::meander_rate),
             Widgets::stepperWidgets({ 256, 132 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units)
 
         );
-
-        // 0x0043DF89
-        static void draw(Window& window, Gfx::DrawingContext& drawingCtx)
-        {
-            auto tr = Gfx::TextRenderer(drawingCtx);
-
-            Common::draw(window, drawingCtx);
-
-            auto point = Point(window.x + 10, window.y + window.widgets[widx::sea_level].top);
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::sea_level);
-
-            point.y = window.y + window.widgets[widx::num_riverbeds].top;
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::number_riverbeds);
-
-            point.y = window.y + window.widgets[widx::min_river_width].top;
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::minimum_river_width);
-
-            point.y = window.y + window.widgets[widx::max_river_width].top;
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::maximum_river_width);
-
-            point.y = window.y + window.widgets[widx::riverbank_width].top;
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::riverbank_width);
-
-            point.y = window.y + window.widgets[widx::meander_rate].top;
-            tr.drawStringLeft(
-                point,
-                Colour::black,
-                StringIds::meander_rate);
-        }
 
         // 0x0043E173
         static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
@@ -1147,7 +1115,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             .onMouseDown = onMouseDown,
             .onUpdate = Common::update,
             .prepareDraw = prepareDraw,
-            .draw = draw,
+            .draw = Common::draw,
         };
 
         static const WindowEventList& getEvents()

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -322,6 +322,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
             auto& options = Scenario::getOptions();
 
+            // Start year info
             {
                 auto args = FormatArguments(self.widgets[widx::start_year].textArgs);
                 args.push<uint16_t>(options.scenarioStartYear);
@@ -329,95 +330,74 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
             self.widgets[widx::heightMapBox].text = generatorIds[enumValue(options.generator)];
 
-            switch (options.generator)
+            bool isOriginal = options.generator == Scenario::LandGeneratorType::Original;
+            bool isSimplex = options.generator == Scenario::LandGeneratorType::Simplex;
+            bool isPngFile = options.generator == Scenario::LandGeneratorType::PngHeightMap;
+
+            // Hide widgets depending on active generator
+            self.widgets[widx::hillObjectLabel].hidden = !isOriginal;
+            self.widgets[widx::change_heightmap_btn].hidden = !isOriginal;
+
+            self.widgets[widx::terrainSmoothingLabel].hidden = !isSimplex;
+            self.widgets[widx::terrainSmoothingNum].hidden = !isSimplex;
+            self.widgets[widx::terrainSmoothingNumUp].hidden = !isSimplex;
+            self.widgets[widx::terrainSmoothingNumDown].hidden = !isSimplex;
+
+            self.widgets[widx::heightmapFileLabel].hidden = !isPngFile;
+            self.widgets[widx::browseHeightmapFile].hidden = !isPngFile;
+
+            if (isOriginal)
             {
-                case Scenario::LandGeneratorType::Original:
-                {
-                    // Prepare object name
-                    auto& widget = self.widgets[widx::hillObjectLabel];
-                    FormatArguments args{ widget.textArgs };
-                    auto* obj = ObjectManager::get<HillShapesObject>();
-                    args.push(obj->name);
+                // Prepare object name
+                auto& widget = self.widgets[widx::hillObjectLabel];
+                FormatArguments args{ widget.textArgs };
+                auto* obj = ObjectManager::get<HillShapesObject>();
+                args.push(obj->name);
 
-                    self.disabledWidgets &= ~(1 << widx::change_heightmap_btn);
-                    self.disabledWidgets |= ((1 << widx::terrainSmoothingNum) | (1 << widx::terrainSmoothingNumUp) | (1 << widx::terrainSmoothingNumDown));
-                    self.disabledWidgets |= (1 << widx::browseHeightmapFile);
-
-                    self.widgets[widx::hillObjectLabel].hidden = false;
-                    self.widgets[widx::terrainSmoothingLabel].hidden = true;
-                    self.widgets[widx::heightmapFileLabel].hidden = true;
-
-                    self.widgets[widx::change_heightmap_btn].hidden = false;
-                    self.widgets[widx::terrainSmoothingNum].hidden = true;
-                    self.widgets[widx::terrainSmoothingNumUp].hidden = true;
-                    self.widgets[widx::terrainSmoothingNumDown].hidden = true;
-                    self.widgets[widx::browseHeightmapFile].hidden = true;
-                    break;
-                }
-
-                case Scenario::LandGeneratorType::Simplex:
-                {
-                    // Prepare value
-                    auto& widget = self.widgets[widx::terrainSmoothingNum];
-                    FormatArguments args{ widget.textArgs };
-                    args.push<uint16_t>(options.numTerrainSmoothingPasses);
-
-                    self.disabledWidgets |= (1 << widx::change_heightmap_btn);
-                    self.disabledWidgets &= ~((1 << widx::terrainSmoothingNum) | (1 << widx::terrainSmoothingNumUp) | (1 << widx::terrainSmoothingNumDown));
-                    self.disabledWidgets |= (1 << widx::browseHeightmapFile);
-
-                    self.widgets[widx::hillObjectLabel].hidden = true;
-                    self.widgets[widx::terrainSmoothingLabel].hidden = false;
-                    self.widgets[widx::heightmapFileLabel].hidden = true;
-
-                    self.widgets[widx::change_heightmap_btn].hidden = true;
-                    self.widgets[widx::terrainSmoothingNum].hidden = false;
-                    self.widgets[widx::terrainSmoothingNumUp].hidden = false;
-                    self.widgets[widx::terrainSmoothingNumDown].hidden = false;
-                    self.widgets[widx::browseHeightmapFile].hidden = true;
-                    break;
-                }
-
-                case Scenario::LandGeneratorType::PngHeightMap:
-                {
-                    // Prepare filename label
-                    auto path = World::MapGenerator::getPngHeightmapPath();
-                    auto filename = path.filename().make_preferred().u8string();
-                    auto& widget = self.widgets[widx::heightmapFileLabel];
-                    FormatArguments args{ widget.textArgs };
-                    if (!filename.empty())
-                    {
-                        _pngFilename = Localisation::convertUnicodeToLoco(filename);
-                        args.push(_pngFilename.c_str());
-                    }
-                    else
-                    {
-                        args.push(StringManager::getString(StringIds::noneSelected));
-                    }
-
-                    self.disabledWidgets |= (1 << widx::change_heightmap_btn);
-                    self.disabledWidgets |= ((1 << widx::terrainSmoothingNum) | (1 << widx::terrainSmoothingNumUp) | (1 << widx::terrainSmoothingNumDown));
-                    self.disabledWidgets &= ~(1 << widx::browseHeightmapFile);
-
-                    self.widgets[widx::hillObjectLabel].hidden = true;
-                    self.widgets[widx::terrainSmoothingLabel].hidden = true;
-                    self.widgets[widx::heightmapFileLabel].hidden = false;
-
-                    self.widgets[widx::change_heightmap_btn].hidden = true;
-                    self.widgets[widx::terrainSmoothingNum].hidden = true;
-                    self.widgets[widx::terrainSmoothingNumUp].hidden = true;
-                    self.widgets[widx::terrainSmoothingNumDown].hidden = true;
-                    self.widgets[widx::browseHeightmapFile].hidden = false;
-                    break;
-                }
+                self.disabledWidgets &= ~(1 << widx::change_heightmap_btn);
+                self.disabledWidgets |= ((1 << widx::terrainSmoothingNum) | (1 << widx::terrainSmoothingNumUp) | (1 << widx::terrainSmoothingNumDown));
+                self.disabledWidgets |= (1 << widx::browseHeightmapFile);
             }
 
-            if (options.generator == Scenario::LandGeneratorType::PngHeightMap)
+            else if (isSimplex)
             {
+                // Prepare value
+                auto& widget = self.widgets[widx::terrainSmoothingNum];
+                FormatArguments args{ widget.textArgs };
+                args.push<uint16_t>(options.numTerrainSmoothingPasses);
+
+                self.disabledWidgets |= (1 << widx::change_heightmap_btn);
+                self.disabledWidgets &= ~((1 << widx::terrainSmoothingNum) | (1 << widx::terrainSmoothingNumUp) | (1 << widx::terrainSmoothingNumDown));
+                self.disabledWidgets |= (1 << widx::browseHeightmapFile);
+            }
+
+            else if (isPngFile)
+            {
+                // Prepare filename label
+                auto path = World::MapGenerator::getPngHeightmapPath();
+                auto filename = path.filename().make_preferred().u8string();
+                auto& widget = self.widgets[widx::heightmapFileLabel];
+                FormatArguments args{ widget.textArgs };
+                if (!filename.empty())
+                {
+                    _pngFilename = Localisation::convertUnicodeToLoco(filename);
+                    args.push(_pngFilename.c_str());
+                }
+                else
+                {
+                    args.push(StringManager::getString(StringIds::noneSelected));
+                }
+
+                self.disabledWidgets |= (1 << widx::change_heightmap_btn);
+                self.disabledWidgets |= ((1 << widx::terrainSmoothingNum) | (1 << widx::terrainSmoothingNumUp) | (1 << widx::terrainSmoothingNumDown));
+                self.disabledWidgets &= ~(1 << widx::browseHeightmapFile);
+
                 self.activatedWidgets &= ~(1 << widx::generate_when_game_starts);
                 self.disabledWidgets |= (1 << widx::generate_when_game_starts);
             }
-            else if ((options.scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) == Scenario::ScenarioFlags::none)
+
+            // Enable/disable the 'generate when game starts' checkbox
+            if ((options.scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) == Scenario::ScenarioFlags::none)
             {
                 self.activatedWidgets |= (1 << widx::generate_when_game_starts);
                 self.disabledWidgets &= ~(1 << widx::generate_when_game_starts);


### PR DESCRIPTION
This is mostly done, but I've noticed LandscapeGeneration::Options::draw can be simplified further. I'd like to tackle that in this PR, still.

Part of #2951