### PR TITLE
Avoid the use of pointers for the Industry object

### DIFF
--- a/src/OpenLoco/src/GameCommands/Industries/CreateIndustry.cpp
+++ b/src/OpenLoco/src/GameCommands/Industries/CreateIndustry.cpp
@@ -477,9 +477,10 @@ namespace OpenLoco::GameCommands
 
         // 0x00454552
         const auto numBuildings = (((indObj->maxNumBuildings - indObj->minNumBuildings + 1) * randVal) / 256) + indObj->minNumBuildings;
+        const auto buildings = indObj->getBuildings();
         for (auto i = 0U; i < numBuildings; ++i)
         {
-            const auto building = indObj->buildings[i];
+            const auto building = buildings[i];
             // 0x00E0C3D2 (bit 0)
             const bool isMultiTile = indObj->buildingSizeFlags & (1ULL << building);
 

--- a/src/OpenLoco/src/GameCommands/Industries/CreateIndustry.cpp
+++ b/src/OpenLoco/src/GameCommands/Industries/CreateIndustry.cpp
@@ -165,11 +165,12 @@ namespace OpenLoco::GameCommands
 
         // Workout clearance height of building (including scaffolding if required)
         const auto buildingParts = indObj->getBuildingParts(buildingType);
+        const auto partHeights = indObj->getBuildingPartHeights();
         // 0x00E0C3BC (note this is bigZ and does not include the base height)
         auto clearHeight = 0;
         for (auto part : buildingParts)
         {
-            clearHeight += indObj->buildingPartHeights[part];
+            clearHeight += partHeights[part];
         }
         if (!buildImmediate && indObj->scaffoldingSegmentType != 0xFF)
         {

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -175,9 +175,10 @@ namespace OpenLoco::World
         if (isConstructed())
         {
             bool hasAZeroFrame = false;
+            const auto buildingPartAnims = indObj->getBuildingPartAnimations();
             for (auto& part : indObj->getBuildingParts(type))
             {
-                const auto animFrames = indObj->buildingPartAnimations[part].numFrames;
+                const auto animFrames = buildingPartAnims[part].numFrames;
                 if (animFrames == 0)
                 {
                     hasAZeroFrame = true;
@@ -259,12 +260,13 @@ namespace OpenLoco::World
 
             auto* industry = elIndustry->industry();
             const auto* indObj = industry->getObject();
-            auto buildingParts = indObj->getBuildingParts(elIndustry->buildingType());
+            const auto buildingParts = indObj->getBuildingParts(elIndustry->buildingType());
+            const auto buildingPartAnims = indObj->getBuildingPartAnimations();
             bool hasAnimation = false;
             uint8_t animSpeed = std::numeric_limits<uint8_t>::max();
             for (auto& part : buildingParts)
             {
-                auto& partAnim = indObj->buildingPartAnimations[part];
+                auto& partAnim = buildingPartAnims[part];
                 if (partAnim.numFrames > 1)
                 {
                     hasAnimation = true;
@@ -308,14 +310,15 @@ namespace OpenLoco::World
             auto* industry = elIndustry->industry();
             const auto* indObj = industry->getObject();
             const auto type = elIndustry->buildingType();
-            auto buildingParts = indObj->getBuildingParts(type);
+            const auto buildingParts = indObj->getBuildingParts(type);
+            const auto buildingPartAnims = indObj->getBuildingPartAnimations();
             // Guaranteed power of 2
             auto animLength = indObj->getAnimationSequence(elIndustry->var_6_003F() & 0x3).size();
             const auto isMultiTile = indObj->buildingSizeFlags & (1 << type);
 
             for (auto& part : buildingParts)
             {
-                auto& partAnim = indObj->buildingPartAnimations[part];
+                auto& partAnim = buildingPartAnims[part];
                 if (partAnim.numFrames == 0)
                 {
                     const auto animSpeed = partAnim.animationSpeed & ~(1 << 7);

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -125,7 +125,8 @@ namespace OpenLoco::World
             if (progress == 0x7)
             {
                 const size_t numSections = var_6_003F();
-                auto parts = indObj->getBuildingParts(type);
+                const auto parts = indObj->getBuildingParts(type);
+                const auto heights = indObj->getBuildingPartHeights();
                 if (parts.size() <= numSections + 1)
                 {
                     ind->under_construction++;
@@ -136,7 +137,7 @@ namespace OpenLoco::World
                         Ui::WindowManager::invalidate(Ui::WindowType::industryList);
                     }
 
-                    const auto height = std::accumulate(parts.begin(), parts.end(), 0, [partHeights = indObj->buildingPartHeights](int32_t total, uint8_t part) {
+                    const auto height = std::accumulate(parts.begin(), parts.end(), 0, [partHeights = heights](int32_t total, uint8_t part) {
                         return total + partHeights[part];
                     });
 

--- a/src/OpenLoco/src/Objects/IndustryObject.cpp
+++ b/src/OpenLoco/src/Objects/IndustryObject.cpp
@@ -111,11 +111,12 @@ namespace OpenLoco
                                      : Colour::black;
         ImageId baseImage(buildingImageIds, c);
         Ui::Point pos{ x, y };
+        const auto partHeights = getBuildingPartHeights();
         for (const auto part : getBuildingParts(0))
         {
             auto image = baseImage.withIndexOffset(part * 4 + 1);
             drawingCtx.drawImage(pos, image);
-            pos.y -= buildingPartHeights[part];
+            pos.y -= partHeights[part];
         }
     }
 
@@ -205,7 +206,7 @@ namespace OpenLoco
 
         // LOAD BUILDING VARIATION PARTS Start
         // Load variation heights
-        buildingPartHeights = reinterpret_cast<const uint8_t*>(remainingData.data());
+        buildingPartHeightsOffset = remainingData.data() - data.data();
         remainingData = remainingData.subspan(numBuildingParts * sizeof(uint8_t));
 
         // Load Part Animations
@@ -370,7 +371,7 @@ namespace OpenLoco
         buildingImageIds = 0;
         fieldImageIds = 0;
         numImagesPerFieldGrowthStage = 0;
-        buildingPartHeights = nullptr;
+        buildingPartHeightsOffset = 0;
         buildingPartAnimations = nullptr;
         std::fill(std::begin(animationSequences), std::end(animationSequences), nullptr);
         var_38 = nullptr;
@@ -401,6 +402,12 @@ namespace OpenLoco
         const auto* sequencePointer = animationSequences[unk];
         const auto size = *sequencePointer++;
         return std::span<const std::uint8_t>(sequencePointer, size);
+    }
+
+    std::span<const std::uint8_t> IndustryObject::getBuildingPartHeights() const
+    {
+        const auto* base = reinterpret_cast<const uint8_t*>(this);
+        return std::span<const std::uint8_t>(base + buildingPartHeightsOffset, numBuildingParts);
     }
 
     std::span<const IndustryObjectUnk38> OpenLoco::IndustryObject::getUnk38() const

--- a/src/OpenLoco/src/Objects/IndustryObject.cpp
+++ b/src/OpenLoco/src/Objects/IndustryObject.cpp
@@ -222,7 +222,8 @@ namespace OpenLoco
         }
 
         // Load unk Animation Related Structure
-        var_38 = reinterpret_cast<const IndustryObjectUnk38*>(remainingData.data());
+        // var_38 = reinterpret_cast<const IndustryObjectUnk38*>(remainingData.data());
+        var_38_Offset = remainingData.data() - data.data();
         while (*remainingData.data() != static_cast<std::byte>(0xFF))
         {
             remainingData = remainingData.subspan(sizeof(IndustryObjectUnk38));
@@ -373,7 +374,7 @@ namespace OpenLoco
         buildingPartHeightsOffset = 0;
         buildingPartAnimations = nullptr;
         std::fill(std::begin(animationSequences), std::end(animationSequences), nullptr);
-        var_38 = nullptr;
+        var_38_Offset = 0;
         std::fill(std::begin(buildingVariationPartOffsets), std::end(buildingVariationPartOffsets), 0);
         buildings = nullptr;
         std::fill(std::begin(producedCargoType), std::end(producedCargoType), 0);
@@ -413,7 +414,8 @@ namespace OpenLoco
 
     std::span<const IndustryObjectUnk38> OpenLoco::IndustryObject::getUnk38() const
     {
-        const auto* unkPointer = var_38;
+        const auto* base = reinterpret_cast<const std::uint8_t*>(this);
+        const auto* unkPointer = reinterpret_cast<const IndustryObjectUnk38*>(base + var_38_Offset);
         auto* end = unkPointer;
         while (end->var_00 != 0xFF)
         {

--- a/src/OpenLoco/src/Objects/IndustryObject.cpp
+++ b/src/OpenLoco/src/Objects/IndustryObject.cpp
@@ -232,8 +232,7 @@ namespace OpenLoco
         // Load Parts
         for (auto i = 0; i < numBuildingVariations; ++i)
         {
-            auto& part = buildingVariationParts[i];
-            part = reinterpret_cast<const uint8_t*>(remainingData.data());
+            buildingVariationPartOffsets[i] = remainingData.data() - data.data();
             while (*remainingData.data() != static_cast<std::byte>(0xFF))
             {
                 remainingData = remainingData.subspan(1);
@@ -375,7 +374,7 @@ namespace OpenLoco
         buildingPartAnimations = nullptr;
         std::fill(std::begin(animationSequences), std::end(animationSequences), nullptr);
         var_38 = nullptr;
-        std::fill(std::begin(buildingVariationParts), std::end(buildingVariationParts), nullptr);
+        std::fill(std::begin(buildingVariationPartOffsets), std::end(buildingVariationPartOffsets), 0);
         buildings = nullptr;
         std::fill(std::begin(producedCargoType), std::end(producedCargoType), 0);
         std::fill(std::begin(requiredCargoType), std::end(requiredCargoType), 0);
@@ -386,7 +385,9 @@ namespace OpenLoco
 
     std::span<const std::uint8_t> IndustryObject::getBuildingParts(const uint8_t buildingType) const
     {
-        const auto* partsPointer = buildingVariationParts[buildingType];
+        const auto offset = buildingVariationPartOffsets[buildingType];
+
+        const auto* partsPointer = reinterpret_cast<const std::uint8_t*>(this) + offset;
         auto* end = partsPointer;
         while (*end != 0xFF)
         {

--- a/src/OpenLoco/src/Objects/IndustryObject.cpp
+++ b/src/OpenLoco/src/Objects/IndustryObject.cpp
@@ -210,7 +210,8 @@ namespace OpenLoco
         remainingData = remainingData.subspan(numBuildingParts * sizeof(uint8_t));
 
         // Load Part Animations
-        buildingPartAnimations = reinterpret_cast<const BuildingPartAnimation*>(remainingData.data());
+        //buildingPartAnimations = reinterpret_cast<const BuildingPartAnimation*>(remainingData.data());
+        buildingPartAnimationsOffset = remainingData.data() - data.data();
         remainingData = remainingData.subspan(numBuildingParts * sizeof(BuildingPartAnimation));
 
         // Load Animations
@@ -372,7 +373,7 @@ namespace OpenLoco
         fieldImageIds = 0;
         numImagesPerFieldGrowthStage = 0;
         buildingPartHeightsOffset = 0;
-        buildingPartAnimations = nullptr;
+        buildingPartAnimationsOffset = 0;
         std::fill(std::begin(animationSequences), std::end(animationSequences), nullptr);
         var_38_Offset = 0;
         std::fill(std::begin(buildingVariationPartOffsets), std::end(buildingVariationPartOffsets), 0);
@@ -410,6 +411,13 @@ namespace OpenLoco
     {
         const auto* base = reinterpret_cast<const uint8_t*>(this);
         return std::span<const std::uint8_t>(base + buildingPartHeightsOffset, numBuildingParts);
+    }
+
+    std::span<const BuildingPartAnimation> IndustryObject::getBuildingPartAnimations() const
+    {
+        const auto* base = reinterpret_cast<const uint8_t*>(this);
+        const auto* ptr = reinterpret_cast<const BuildingPartAnimation*>(base + buildingPartAnimationsOffset);
+        return std::span<const BuildingPartAnimation>(ptr, numBuildingParts);
     }
 
     std::span<const IndustryObjectUnk38> OpenLoco::IndustryObject::getUnk38() const

--- a/src/OpenLoco/src/Objects/IndustryObject.cpp
+++ b/src/OpenLoco/src/Objects/IndustryObject.cpp
@@ -215,11 +215,12 @@ namespace OpenLoco
         remainingData = remainingData.subspan(numBuildingParts * sizeof(BuildingPartAnimation));
 
         // Load Animations
-        for (auto& animSeq : animationSequences)
+        for (auto& animSeqOffset : animationSequenceOffsets)
         {
-            animSeq = reinterpret_cast<const uint8_t*>(remainingData.data());
+            animSeqOffset = remainingData.data() - data.data();
             // animationSequences comprises of a size then data. Size will always be a power of 2
-            remainingData = remainingData.subspan(*animSeq * sizeof(uint8_t) + 1);
+            const auto* ptr = reinterpret_cast<const uint8_t*>(remainingData.data());
+            remainingData = remainingData.subspan(*ptr * sizeof(uint8_t) + 1);
         }
 
         // Load unk Animation Related Structure
@@ -374,7 +375,7 @@ namespace OpenLoco
         numImagesPerFieldGrowthStage = 0;
         buildingPartHeightsOffset = 0;
         buildingPartAnimationsOffset = 0;
-        std::fill(std::begin(animationSequences), std::end(animationSequences), nullptr);
+        std::fill(std::begin(animationSequenceOffsets), std::end(animationSequenceOffsets), 0);
         var_38_Offset = 0;
         std::fill(std::begin(buildingVariationPartOffsets), std::end(buildingVariationPartOffsets), 0);
         buildings = nullptr;
@@ -402,7 +403,8 @@ namespace OpenLoco
     std::span<const std::uint8_t> IndustryObject::getAnimationSequence(const uint8_t unk) const
     {
         // animationSequences comprises of a size then data. Size will always be a power of 2
-        const auto* sequencePointer = animationSequences[unk];
+        const auto* base = reinterpret_cast<const std::uint8_t*>(this);
+        const auto* sequencePointer = base + animationSequenceOffsets[unk];
         const auto size = *sequencePointer++;
         return std::span<const std::uint8_t>(sequencePointer, size);
     }

--- a/src/OpenLoco/src/Objects/IndustryObject.cpp
+++ b/src/OpenLoco/src/Objects/IndustryObject.cpp
@@ -245,7 +245,8 @@ namespace OpenLoco
         // LOAD BUILDING PARTS End
 
         // Load unk?
-        buildings = reinterpret_cast<const uint8_t*>(remainingData.data());
+        //buildings = reinterpret_cast<const uint8_t*>(remainingData.data());
+        buildingsOffset = remainingData.data() - data.data();
         remainingData = remainingData.subspan(maxNumBuildings * sizeof(uint8_t));
 
         // Load Produced Cargo
@@ -378,7 +379,7 @@ namespace OpenLoco
         std::fill(std::begin(animationSequenceOffsets), std::end(animationSequenceOffsets), 0);
         var_38_Offset = 0;
         std::fill(std::begin(buildingVariationPartOffsets), std::end(buildingVariationPartOffsets), 0);
-        buildings = nullptr;
+        buildingsOffset = 0;
         std::fill(std::begin(producedCargoType), std::end(producedCargoType), 0);
         std::fill(std::begin(requiredCargoType), std::end(requiredCargoType), 0);
         std::fill(std::begin(wallTypes), std::end(wallTypes), 0);
@@ -420,6 +421,12 @@ namespace OpenLoco
         const auto* base = reinterpret_cast<const uint8_t*>(this);
         const auto* ptr = reinterpret_cast<const BuildingPartAnimation*>(base + buildingPartAnimationsOffset);
         return std::span<const BuildingPartAnimation>(ptr, numBuildingParts);
+    }
+
+    std::span<const std::uint8_t> IndustryObject::getBuildings() const
+    {
+        const auto* base = reinterpret_cast<const std::uint8_t*>(this);
+        return std::span<const std::uint8_t>(base + buildingsOffset, maxNumBuildings);
     }
 
     std::span<const IndustryObjectUnk38> OpenLoco::IndustryObject::getUnk38() const

--- a/src/OpenLoco/src/Objects/IndustryObject.cpp
+++ b/src/OpenLoco/src/Objects/IndustryObject.cpp
@@ -210,7 +210,6 @@ namespace OpenLoco
         remainingData = remainingData.subspan(numBuildingParts * sizeof(uint8_t));
 
         // Load Part Animations
-        //buildingPartAnimations = reinterpret_cast<const BuildingPartAnimation*>(remainingData.data());
         buildingPartAnimationsOffset = remainingData.data() - data.data();
         remainingData = remainingData.subspan(numBuildingParts * sizeof(BuildingPartAnimation));
 
@@ -224,7 +223,6 @@ namespace OpenLoco
         }
 
         // Load unk Animation Related Structure
-        // var_38 = reinterpret_cast<const IndustryObjectUnk38*>(remainingData.data());
         var_38_Offset = remainingData.data() - data.data();
         while (*remainingData.data() != static_cast<std::byte>(0xFF))
         {
@@ -245,7 +243,6 @@ namespace OpenLoco
         // LOAD BUILDING PARTS End
 
         // Load unk?
-        //buildings = reinterpret_cast<const uint8_t*>(remainingData.data());
         buildingsOffset = remainingData.data() - data.data();
         remainingData = remainingData.subspan(maxNumBuildings * sizeof(uint8_t));
 

--- a/src/OpenLoco/src/Objects/IndustryObject.h
+++ b/src/OpenLoco/src/Objects/IndustryObject.h
@@ -90,7 +90,7 @@ namespace OpenLoco
         uint32_t buildingVariationPartOffsets[32]; // 0x3C Access with getBuildingParts helper method
         uint8_t minNumBuildings;                   // 0xBC
         uint8_t maxNumBuildings;                   // 0xBD
-        const uint8_t* buildings;                  // 0xBE
+        uint32_t buildingsOffset;                  // 0xBE
         uint32_t availableColours;                 // 0xC2 bitset
         uint32_t buildingSizeFlags;                // 0xC6 flags indicating the building types size 1:large4x4, 0:small1x1
         uint16_t designedYear;                     // 0xCA start year
@@ -135,6 +135,7 @@ namespace OpenLoco
         std::span<const std::uint8_t> getBuildingPartHeights() const;
         std::span<const IndustryObjectUnk38> getUnk38() const;
         std::span<const BuildingPartAnimation> getBuildingPartAnimations() const;
+        std::span<const std::uint8_t> getBuildings() const;
 
         constexpr bool hasFlags(IndustryObjectFlags flagsToTest) const
         {

--- a/src/OpenLoco/src/Objects/IndustryObject.h
+++ b/src/OpenLoco/src/Objects/IndustryObject.h
@@ -83,7 +83,7 @@ namespace OpenLoco
         uint32_t numImagesPerFieldGrowthStage;               // 0x1A
         uint8_t numBuildingParts;                            // 0x1E
         uint8_t numBuildingVariations;                       // 0x1F
-        const uint8_t* buildingPartHeights;                  // 0x20 This is the height of a building image
+        uint32_t buildingPartHeightsOffset;                  // 0x20 This is the height of a building image
         const BuildingPartAnimation* buildingPartAnimations; // 0x24
         const uint8_t* animationSequences[4];                // 0x28 Access with getAnimationSequence helper method
         const IndustryObjectUnk38* var_38;                   // 0x38 Access with getUnk38 helper method
@@ -132,6 +132,7 @@ namespace OpenLoco
         void unload();
         std::span<const std::uint8_t> getBuildingParts(const uint8_t buildingType) const;
         std::span<const std::uint8_t> getAnimationSequence(const uint8_t unk) const;
+        std::span<const std::uint8_t> getBuildingPartHeights() const;
         std::span<const IndustryObjectUnk38> getUnk38() const;
 
         constexpr bool hasFlags(IndustryObjectFlags flagsToTest) const

--- a/src/OpenLoco/src/Objects/IndustryObject.h
+++ b/src/OpenLoco/src/Objects/IndustryObject.h
@@ -70,31 +70,31 @@ namespace OpenLoco
     {
         static constexpr auto kObjectType = ObjectType::industry;
 
-        StringId name;                                       // 0x0
-        StringId var_02;                                     // 0x2
-        StringId nameClosingDown;                            // 0x4
-        StringId nameUpProduction;                           // 0x6
-        StringId nameDownProduction;                         // 0x8
-        StringId nameSingular;                               // 0x0A
-        StringId namePlural;                                 // 0x0C
-        uint32_t shadowImageIds;                             // 0x0E shadows image id base
-        uint32_t buildingImageIds;                           // 0x12 Base image id for building 0
-        uint32_t fieldImageIds;                              // 0x16 Base image for field sprites
-        uint32_t numImagesPerFieldGrowthStage;               // 0x1A
-        uint8_t numBuildingParts;                            // 0x1E
-        uint8_t numBuildingVariations;                       // 0x1F
-        uint32_t buildingPartHeightsOffset;                  // 0x20 This is the height of a building image
-        const BuildingPartAnimation* buildingPartAnimations; // 0x24
-        const uint8_t* animationSequences[4];                // 0x28 Access with getAnimationSequence helper method
-        uint32_t var_38_Offset;                              // 0x38 Access with getUnk38 helper method
-        uint32_t buildingVariationPartOffsets[32];           // 0x3C Access with getBuildingParts helper method
-        uint8_t minNumBuildings;                             // 0xBC
-        uint8_t maxNumBuildings;                             // 0xBD
-        const uint8_t* buildings;                            // 0xBE
-        uint32_t availableColours;                           // 0xC2 bitset
-        uint32_t buildingSizeFlags;                          // 0xC6 flags indicating the building types size 1:large4x4, 0:small1x1
-        uint16_t designedYear;                               // 0xCA start year
-        uint16_t obsoleteYear;                               // 0xCC end year
+        StringId name;                             // 0x0
+        StringId var_02;                           // 0x2
+        StringId nameClosingDown;                  // 0x4
+        StringId nameUpProduction;                 // 0x6
+        StringId nameDownProduction;               // 0x8
+        StringId nameSingular;                     // 0x0A
+        StringId namePlural;                       // 0x0C
+        uint32_t shadowImageIds;                   // 0x0E shadows image id base
+        uint32_t buildingImageIds;                 // 0x12 Base image id for building 0
+        uint32_t fieldImageIds;                    // 0x16 Base image for field sprites
+        uint32_t numImagesPerFieldGrowthStage;     // 0x1A
+        uint8_t numBuildingParts;                  // 0x1E
+        uint8_t numBuildingVariations;             // 0x1F
+        uint32_t buildingPartHeightsOffset;        // 0x20 This is the height of a building image
+        uint32_t buildingPartAnimationsOffset;     // 0x24
+        const uint8_t* animationSequences[4];      // 0x28 Access with getAnimationSequence helper method
+        uint32_t var_38_Offset;                    // 0x38 Access with getUnk38 helper method
+        uint32_t buildingVariationPartOffsets[32]; // 0x3C Access with getBuildingParts helper method
+        uint8_t minNumBuildings;                   // 0xBC
+        uint8_t maxNumBuildings;                   // 0xBD
+        const uint8_t* buildings;                  // 0xBE
+        uint32_t availableColours;                 // 0xC2 bitset
+        uint32_t buildingSizeFlags;                // 0xC6 flags indicating the building types size 1:large4x4, 0:small1x1
+        uint16_t designedYear;                     // 0xCA start year
+        uint16_t obsoleteYear;                     // 0xCC end year
         // Total industries of this type that can be created in a scenario
         // Note: this is not directly comparable to total industries and varies based
         // on scenario total industries cap settings. At low industries cap this value is ~3x the
@@ -134,6 +134,7 @@ namespace OpenLoco
         std::span<const std::uint8_t> getAnimationSequence(const uint8_t unk) const;
         std::span<const std::uint8_t> getBuildingPartHeights() const;
         std::span<const IndustryObjectUnk38> getUnk38() const;
+        std::span<const BuildingPartAnimation> getBuildingPartAnimations() const;
 
         constexpr bool hasFlags(IndustryObjectFlags flagsToTest) const
         {

--- a/src/OpenLoco/src/Objects/IndustryObject.h
+++ b/src/OpenLoco/src/Objects/IndustryObject.h
@@ -85,7 +85,7 @@ namespace OpenLoco
         uint8_t numBuildingVariations;             // 0x1F
         uint32_t buildingPartHeightsOffset;        // 0x20 This is the height of a building image
         uint32_t buildingPartAnimationsOffset;     // 0x24
-        const uint8_t* animationSequences[4];      // 0x28 Access with getAnimationSequence helper method
+        uint32_t animationSequenceOffsets[4];      // 0x28 Access with getAnimationSequence helper method
         uint32_t var_38_Offset;                    // 0x38 Access with getUnk38 helper method
         uint32_t buildingVariationPartOffsets[32]; // 0x3C Access with getBuildingParts helper method
         uint8_t minNumBuildings;                   // 0xBC

--- a/src/OpenLoco/src/Objects/IndustryObject.h
+++ b/src/OpenLoco/src/Objects/IndustryObject.h
@@ -86,7 +86,7 @@ namespace OpenLoco
         uint32_t buildingPartHeightsOffset;                  // 0x20 This is the height of a building image
         const BuildingPartAnimation* buildingPartAnimations; // 0x24
         const uint8_t* animationSequences[4];                // 0x28 Access with getAnimationSequence helper method
-        const IndustryObjectUnk38* var_38;                   // 0x38 Access with getUnk38 helper method
+        uint32_t var_38_Offset;                              // 0x38 Access with getUnk38 helper method
         uint32_t buildingVariationPartOffsets[32];           // 0x3C Access with getBuildingParts helper method
         uint8_t minNumBuildings;                             // 0xBC
         uint8_t maxNumBuildings;                             // 0xBD

--- a/src/OpenLoco/src/Objects/IndustryObject.h
+++ b/src/OpenLoco/src/Objects/IndustryObject.h
@@ -87,7 +87,7 @@ namespace OpenLoco
         const BuildingPartAnimation* buildingPartAnimations; // 0x24
         const uint8_t* animationSequences[4];                // 0x28 Access with getAnimationSequence helper method
         const IndustryObjectUnk38* var_38;                   // 0x38 Access with getUnk38 helper method
-        const uint8_t* buildingVariationParts[32];           // 0x3C Access with getBuildingParts helper method
+        uint32_t buildingVariationPartOffsets[32];           // 0x3C Access with getBuildingParts helper method
         uint8_t minNumBuildings;                             // 0xBC
         uint8_t maxNumBuildings;                             // 0xBD
         const uint8_t* buildings;                            // 0xBE

--- a/src/OpenLoco/src/Paint/PaintIndustry.cpp
+++ b/src/OpenLoco/src/Paint/PaintIndustry.cpp
@@ -44,6 +44,7 @@ namespace OpenLoco::Paint
         uint32_t buildingType = elIndustry.buildingType();
         const auto buildingParts = indObj.getBuildingParts(buildingType);
         const auto partHeights = indObj.getBuildingPartHeights();
+        const auto buildingPartAnims = indObj.getBuildingPartAnimations();
 
         // 0x00525D4F
         uint8_t totalSectionHeight = 0;
@@ -96,7 +97,7 @@ namespace OpenLoco::Paint
             {
                 break;
             }
-            auto& buildingAnimation = indObj.buildingPartAnimations[buildingPart];
+            auto& buildingAnimation = buildingPartAnims[buildingPart];
             auto adjustedBuildingPart = buildingPart;
             if (buildingAnimation.numFrames)
             {

--- a/src/OpenLoco/src/Paint/PaintIndustry.cpp
+++ b/src/OpenLoco/src/Paint/PaintIndustry.cpp
@@ -43,6 +43,7 @@ namespace OpenLoco::Paint
 
         uint32_t buildingType = elIndustry.buildingType();
         const auto buildingParts = indObj.getBuildingParts(buildingType);
+        const auto partHeights = indObj.getBuildingPartHeights();
 
         // 0x00525D4F
         uint8_t totalSectionHeight = 0;
@@ -51,7 +52,7 @@ namespace OpenLoco::Paint
             int8_t sectionCount = numSections;
             for (const auto buildingPart : buildingParts)
             {
-                totalSectionHeight += indObj.buildingPartHeights[buildingPart];
+                totalSectionHeight += partHeights[buildingPart];
                 sectionCount--;
                 if (sectionCount == -1)
                 {
@@ -118,7 +119,7 @@ namespace OpenLoco::Paint
                     adjustedBuildingPart += animationSequence[tickThing];
                 }
             }
-            const auto sectionHeight = indObj.buildingPartHeights[adjustedBuildingPart];
+            const auto sectionHeight = partHeights[adjustedBuildingPart];
             const uint32_t imageIdx = adjustedBuildingPart * 4 + indObj.buildingImageIds + rotation;
             ImageId image = baseColour.withIndex(imageIdx);
             if (sectionCount == 0 && !baseColour.isBlended())


### PR DESCRIPTION
Before we decide on the new object format this will at least allow x64 builds before we even get there, the changes aren't too big and this is not the only object that needs to do it like this, also a plus side is of having getters so the data source can be whatever at the end.