### PR TITLE
Fix reliability penalty not being removed for newly designed vehicles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: OpenLoco/TestData
-          ref: c787563d0ec37b8173e303bf00416d8cde2c51fc
+          ref: 3621e988e3b3cdbbd4040119991afbc72e6d72f2
           path: TestData
       - name: Run Simulate Test
         if: ${{ github.repository == 'OpenLoco/OpenLoco' && env.ASSETS_SSH_KEY != null }} 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 25.02+ (???)
 ------------------------------------------------------------------------
 - Change: [#2457] Right mouse dragging in ScrollViews now respects "Invert right mouse dragging" option.
+- Fix: [#1689] Reliability penalty for newly designed vehicles not removed after two years.
 - Fix: [#2972] More vehicle-related messages not using the correct vehicle name string.
 - Fix: [#2984] Areas of forbid trams checkboxes covering forbidding trucks checkboxes.
 - Fix: [#3017] Bankruptcy warnings in wrong order.

--- a/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
@@ -155,7 +155,7 @@ namespace OpenLoco::GameCommands
         int32_t reliability = vehObject.reliability * 256;
         if (vehObject.designed + 2 > getCurrentYear())
         {
-            // Vanilla intended to reduce reliability by 1/8th twice for the first two years after year designed, then reduce reliability by 1/8th once for the third year. However, a bug in the vanilla assembly meant that the third-year condition was only true if the two-year condition was true, so only the twice-applied 1/8th reduction for the first two years was applied.
+            // Vanilla intended to reduce reliability by 1/8th twice for the first two years after the year designed, then reduce reliability by 1/8th once for the third year. However, a bug meant that only the two 1/8th reductions were applied.
             reliability -= reliability / 8;
             reliability -= reliability / 8;
         }

--- a/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
@@ -155,13 +155,9 @@ namespace OpenLoco::GameCommands
         int32_t reliability = vehObject.reliability * 256;
         if (vehObject.designed + 2 > getCurrentYear())
         {
-            // Reduce reliability by an eighth after 2 years past design
+            // Reduce reliability by an eighth twice until 2 years past design year
             reliability -= reliability / 8;
-            if (vehObject.designed + 3 > getCurrentYear())
-            {
-                // Reduce reliability by a further eighth (quarter total) after 3 years past design
-                reliability -= reliability / 8;
-            }
+            reliability -= reliability / 8;
         }
         if (reliability != 0)
         {

--- a/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
@@ -155,7 +155,7 @@ namespace OpenLoco::GameCommands
         int32_t reliability = vehObject.reliability * 256;
         if (vehObject.designed + 2 > getCurrentYear())
         {
-            // Reduce reliability by an eighth twice until 2 years past design year
+            // Vanilla intended to reduce reliability by 1/8th twice for the first two years after year designed, then reduce reliability by 1/8th once for the third year. However, a bug in the vanilla assembly meant that the third-year condition was only true if the two-year condition was true, so only the twice-applied 1/8th reduction for the first two years was applied.
             reliability -= reliability / 8;
             reliability -= reliability / 8;
         }

--- a/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
@@ -155,7 +155,7 @@ namespace OpenLoco::GameCommands
         int32_t reliability = vehObject.reliability * 256;
         if (vehObject.designed + 2 > getCurrentYear())
         {
-            // Vanilla intended to reduce reliability by 1/8th twice for the first two years after the year designed, then reduce reliability by 1/8th once for the third year. However, a bug meant that only the two 1/8th reductions were applied.
+            // Vanilla intended to reduce reliability by 1/8th twice for the first two years after the year designed, then reduce reliability by 1/8th once for the third year. However, a bug meant that the two 1/8th reductions were always applied.
             reliability -= reliability / 8;
             reliability -= reliability / 8;
         }

--- a/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/CreateVehicle.cpp
@@ -153,11 +153,11 @@ namespace OpenLoco::GameCommands
         newBogie->var_38 = Flags38::none;
 
         int32_t reliability = vehObject.reliability * 256;
-        if (getCurrentYear() + 2 > vehObject.designed)
+        if (vehObject.designed + 2 > getCurrentYear())
         {
             // Reduce reliability by an eighth after 2 years past design
             reliability -= reliability / 8;
-            if (getCurrentYear() + 3 > vehObject.designed)
+            if (vehObject.designed + 3 > getCurrentYear())
             {
                 // Reduce reliability by a further eighth (quarter total) after 3 years past design
                 reliability -= reliability / 8;


### PR DESCRIPTION
Fixes #1689. The reliability penalty on newly designed vehicles will now be removed after two years, matching vanilla behaviour.