### PR TITLE
Always install vcpkg with the specified commit

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,10 +16,6 @@
                 "rhs": "Windows"
             },
             "cacheVariables": {
-                "VCPKG_ROOT": {
-                    "type": "PATH",
-                    "value": "$env{VCPKG_ROOT}"
-                },
                 "VCPKG_TARGET_TRIPLET": {
                     "type": "STRING",
                     "value": "x86-windows-static"


### PR DESCRIPTION
This seems to cause more problems than it solves. Vcpkg will cache the files in appdata anyway so its better to just stick to the version specified by the project.