### PR TITLE
Implement sub_4AA625 as VehicleHead::landCrashedUpdate()

### DIFF
--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -146,6 +146,51 @@ namespace OpenLoco::Vehicles
         call(0x004AA464, regs);
     }
 
+    // 0x004AA625
+    void VehicleHead::landCrashedUpdate()
+    {
+        VehicleBase* currentVehicle = reinterpret_cast<VehicleBase*>(this);
+        EntityId nextVehicleId = currentVehicle->id;
+
+        while(currentVehicle)
+        {
+            switch(currentVehicle->getSubType())
+            {
+                case VehicleEntityType::head:
+                    reinterpret_cast<VehicleHead*>(currentVehicle)->sub_4AA64B();
+                    break;
+                case VehicleEntityType::vehicle_1:
+                    // calls nullsub_21: empty subroutine
+                    break;
+                case VehicleEntityType::vehicle_2:
+                    // calls nullsub_22: empty subroutine
+                    break;
+                case VehicleEntityType::bogie:
+                    reinterpret_cast<VehicleBogie*>(currentVehicle)->sub_4AA68E();
+                    break;
+                case VehicleEntityType::body_start:
+                case VehicleEntityType::body_continued:
+                    reinterpret_cast<VehicleBody*>(currentVehicle)->sub_4AA904();
+                    break;
+                case VehicleEntityType::tail:
+                    // calls nullsub_23: empty subroutine
+                    break;
+                default:
+                    break;
+            }
+
+            nextVehicleId = currentVehicle->getNextCar();
+            if(nextVehicleId == EntityId::null)
+            {
+                return;
+            }
+            else
+            {
+                currentVehicle = EntityManager::get<VehicleBase>(nextVehicleId);
+            }
+        }
+    }
+
     static bool updateRoadMotionNewRoadPiece(VehicleCommon& component)
     {
         auto newRoutingHandle = component.routingHandle;

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -154,9 +154,7 @@ namespace OpenLoco::Vehicles
         const auto numParticles = std::min(spriteWidth / 4, 7);
         for (auto i = 0; i < numParticles; ++i)
         {
-            ColourScheme colourScheme = (subType == VehicleEntityType::bogie) ?
-                                            reinterpret_cast<VehicleBogie*>(this)->colourScheme :
-                                            reinterpret_cast<VehicleBody*>(this)->colourScheme;
+            ColourScheme colourScheme = (subType == VehicleEntityType::bogie) ? reinterpret_cast<VehicleBogie*>(this)->colourScheme : reinterpret_cast<VehicleBody*>(this)->colourScheme;
             VehicleCrashParticle::create(pos, colourScheme);
         }
     }

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -146,51 +146,6 @@ namespace OpenLoco::Vehicles
         call(0x004AA464, regs);
     }
 
-    // 0x004AA625
-    void VehicleHead::landCrashedUpdate()
-    {
-        VehicleBase* currentVehicle = reinterpret_cast<VehicleBase*>(this);
-        EntityId nextVehicleId = currentVehicle->id;
-
-        while(currentVehicle)
-        {
-            switch(currentVehicle->getSubType())
-            {
-                case VehicleEntityType::head:
-                    reinterpret_cast<VehicleHead*>(currentVehicle)->sub_4AA64B();
-                    break;
-                case VehicleEntityType::vehicle_1:
-                    // calls nullsub_21: empty subroutine
-                    break;
-                case VehicleEntityType::vehicle_2:
-                    // calls nullsub_22: empty subroutine
-                    break;
-                case VehicleEntityType::bogie:
-                    reinterpret_cast<VehicleBogie*>(currentVehicle)->sub_4AA68E();
-                    break;
-                case VehicleEntityType::body_start:
-                case VehicleEntityType::body_continued:
-                    reinterpret_cast<VehicleBody*>(currentVehicle)->sub_4AA904();
-                    break;
-                case VehicleEntityType::tail:
-                    // calls nullsub_23: empty subroutine
-                    break;
-                default:
-                    break;
-            }
-
-            nextVehicleId = currentVehicle->getNextCar();
-            if(nextVehicleId == EntityId::null)
-            {
-                return;
-            }
-            else
-            {
-                currentVehicle = EntityManager::get<VehicleBase>(nextVehicleId);
-            }
-        }
-    }
-
     static bool updateRoadMotionNewRoadPiece(VehicleCommon& component)
     {
         auto newRoutingHandle = component.routingHandle;

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -399,6 +399,8 @@ namespace OpenLoco::Vehicles
         uint32_t getCarCount() const;
         void applyBreakdownToTrain();
         void sub_4AF7A4();
+        void landCrashedUpdate();
+        void sub_4AA64B();
         uint32_t getVehicleTotalLength() const;
         constexpr bool hasBreakdownFlags(BreakdownFlags flagsToTest) const
         {
@@ -453,7 +455,6 @@ namespace OpenLoco::Vehicles
         void produceLeavingDockSound();
         void produceTouchdownAirportSound();
         uint8_t sub_4AA36A();
-        void sub_4AA625();
         std::tuple<uint8_t, uint8_t, StationId> sub_4ACEE7(uint32_t unk1, uint32_t var_113612C);
         bool sub_4AC1C2();
         bool opposingTrainAtSignal();
@@ -605,6 +606,7 @@ namespace OpenLoco::Vehicles
         const VehicleObject* getObject() const;
         bool update();
         void secondaryAnimationUpdate();
+        void sub_4AA904();
         void sub_4AAB0B();
         void updateCargoSprite();
         constexpr bool hasBreakdownFlags(BreakdownFlags flagsToTest) const
@@ -672,6 +674,7 @@ namespace OpenLoco::Vehicles
     public:
         AirportObjectFlags getCompatibleAirportType();
         bool update();
+        void sub_4AA68E();
         bool isOnRackRail();
         constexpr bool hasBreakdownFlags(BreakdownFlags flagsToTest) const
         {

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -400,7 +400,7 @@ namespace OpenLoco::Vehicles
         void applyBreakdownToTrain();
         void sub_4AF7A4();
         void landCrashedUpdate();
-        void sub_4AA64B();
+        void updateSegmentCrashed();
         uint32_t getVehicleTotalLength() const;
         constexpr bool hasBreakdownFlags(BreakdownFlags flagsToTest) const
         {

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -686,7 +686,6 @@ namespace OpenLoco::Vehicles
         bool sub_4AA959(World::Pos3& pos);
         void updateRoll();
         void collision();
-        bool rotateAndExplodeIfNotAlreadyExploded();
     };
     static_assert(sizeof(VehicleBogie) == 0x6B); // Can't use offset_of change this to last field if more found
 

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -296,6 +296,7 @@ namespace OpenLoco::Vehicles
         VehicleBase* nextVehicleComponent();
         VehicleBase* previousVehicleComponent();
         bool updateComponent();
+        void explodeComponent();
         void sub_4AA464();
         uint8_t sub_47D959(const World::Pos3& loc, const TrackAndDirection::_RoadAndDirection trackAndDirection, const bool setOccupied);
         int32_t updateTrackMotion(int32_t unk1);

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -686,6 +686,7 @@ namespace OpenLoco::Vehicles
         bool sub_4AA959(World::Pos3& pos);
         void updateRoll();
         void collision();
+        bool rotateAndExplodeIfNotAlreadyExploded();
     };
     static_assert(sizeof(VehicleBogie) == 0x6B); // Can't use offset_of change this to last field if more found
 

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -675,7 +675,7 @@ namespace OpenLoco::Vehicles
     public:
         AirportObjectFlags getCompatibleAirportType();
         bool update();
-        void sub_4AA68E();
+        void updateSegmentCrashed();
         bool isOnRackRail();
         constexpr bool hasBreakdownFlags(BreakdownFlags flagsToTest) const
         {
@@ -683,6 +683,7 @@ namespace OpenLoco::Vehicles
         }
 
     private:
+        bool sub_4AA959(World::Pos3& pos);
         void updateRoll();
         void collision();
     };

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -607,7 +607,7 @@ namespace OpenLoco::Vehicles
         const VehicleObject* getObject() const;
         bool update();
         void secondaryAnimationUpdate();
-        void sub_4AA904();
+        void updateSegmentCrashed();
         void sub_4AAB0B();
         void updateCargoSprite();
         constexpr bool hasBreakdownFlags(BreakdownFlags flagsToTest) const

--- a/src/OpenLoco/src/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBody.cpp
@@ -147,12 +147,12 @@ namespace OpenLoco::Vehicles
         invalidateSprite();
         animationUpdate();
         sub_4AAB0B();
-        if(!hasVehicleFlags(VehicleFlags::unk_5))
+        if (!hasVehicleFlags(VehicleFlags::unk_5))
         {
             VehicleBogie* frontBogie = _vehicleUpdate_frontBogie;
             VehicleBogie* backBogie = _vehicleUpdate_backBogie;
 
-            if(frontBogie->hasVehicleFlags(VehicleFlags::unk_5)
+            if (frontBogie->hasVehicleFlags(VehicleFlags::unk_5)
                 || backBogie->hasVehicleFlags(VehicleFlags::unk_5))
             {
                 explodeComponent();

--- a/src/OpenLoco/src/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBody.cpp
@@ -141,9 +141,23 @@ namespace OpenLoco::Vehicles
 
     void VehicleBody::sub_4AA904()
     {
-        registers regs;
-        regs.esi = X86Pointer(this);
-        call(0x004AA904, regs);
+        invalidateSprite();
+        sub_4AC255(_vehicleUpdate_backBogie, _vehicleUpdate_frontBogie);
+        invalidateSprite();
+        animationUpdate();
+        sub_4AAB0B();
+        if(!hasVehicleFlags(VehicleFlags::unk_5))
+        {
+            VehicleBogie* frontBogie = _vehicleUpdate_frontBogie;
+            VehicleBogie* backBogie = _vehicleUpdate_backBogie;
+
+            if(frontBogie->hasVehicleFlags(VehicleFlags::unk_5)
+                || backBogie->hasVehicleFlags(VehicleFlags::unk_5))
+            {
+                explodeComponent();
+                this->vehicleFlags |= VehicleFlags::unk_5;
+            }
+        }
     }
 
     // 0x004AAB0B

--- a/src/OpenLoco/src/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBody.cpp
@@ -139,6 +139,13 @@ namespace OpenLoco::Vehicles
         secondaryAnimationUpdate();
     }
 
+    void VehicleBody::sub_4AA904()
+    {
+        registers regs;
+        regs.esi = X86Pointer(this);
+        call(0x004AA904, regs);
+    }
+
     // 0x004AAB0B
     void VehicleBody::sub_4AAB0B()
     {

--- a/src/OpenLoco/src/Vehicles/VehicleBody.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBody.cpp
@@ -139,7 +139,8 @@ namespace OpenLoco::Vehicles
         secondaryAnimationUpdate();
     }
 
-    void VehicleBody::sub_4AA904()
+    // 0x004AA904
+    void VehicleBody::updateSegmentCrashed()
     {
         invalidateSprite();
         sub_4AC255(_vehicleUpdate_backBogie, _vehicleUpdate_frontBogie);

--- a/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
@@ -113,7 +113,7 @@ namespace OpenLoco::Vehicles
         this->spriteYaw = (this->spriteYaw + 4) & 0x3F;
 
         // explode, if we haven't already
-        if(!this->hasVehicleFlags(VehicleFlags::unk_5))
+        if (!this->hasVehicleFlags(VehicleFlags::unk_5))
         {
             this->explodeComponent();
             this->vehicleFlags |= VehicleFlags::unk_5;
@@ -134,7 +134,7 @@ namespace OpenLoco::Vehicles
         uint32_t speed = this->var_5A & 0x7FFFFFFF;
         uint32_t var_5A_msb_flag_temp = this->var_5A & 0x80000000;
         speed = speed - (speed / 64);
-        if(speed <= 8192)
+        if (speed <= 8192)
         {
             speed = 0;
         }
@@ -145,11 +145,11 @@ namespace OpenLoco::Vehicles
 
         this->updateRoll();
 
-        if((this->var_5A & 0x80000000) == 0x80000000)
+        if ((this->var_5A & 0x80000000) == 0x80000000)
         {
             int32_t distance = this->var_5A & 0x7FFFFFFF;
 
-            if(distance >= 0x10000)
+            if (distance >= 0x10000)
             {
                 int32_t cos_angle = Math::Trigonometry::kYawToDirectionVector[this->spriteYaw].x;
                 int32_t sin_angle = Math::Trigonometry::kYawToDirectionVector[this->spriteYaw].y;
@@ -161,14 +161,14 @@ namespace OpenLoco::Vehicles
                 int16_t x_distance_hi = x_distance / 65536;
                 int16_t y_distance_hi = y_distance / 65536;
                 int32_t newTileX = this->tileX + x_distance_low;
-                if(newTileX >= 0x00010000)
+                if (newTileX >= 0x00010000)
                 {
-                    x_distance_hi += 1;   // carry bit
+                    x_distance_hi += 1; // carry bit
                 }
                 this->tileX = newTileX & 0x0000FFFF;
 
                 int32_t newTileY = this->tileY + y_distance_low;
-                if(newTileY >= 0x00010000)
+                if (newTileY >= 0x00010000)
                 {
                     y_distance_hi += 1; // carry bit
                 }
@@ -180,15 +180,15 @@ namespace OpenLoco::Vehicles
                 // Calculate new position - but don't update yet!! This is pushed to the stack.
                 World::Pos3 newPosition{ this->position.x + x_distance_hi, this->position.y + y_distance_hi, this->position.z - zDistance };
 
-                if(!sub_4AA959(this->position))
+                if (!sub_4AA959(this->position))
                 {
-                    World::Pos3 position_to_test = {newPosition.x, newPosition.y, this->position.z};
-                    if(sub_4AA959(position_to_test))
+                    World::Pos3 position_to_test = { newPosition.x, newPosition.y, this->position.z };
+                    if (sub_4AA959(position_to_test))
                     {
                         newPosition.x = this->position.x;
                         newPosition.y = this->position.y;
 
-                        if(this->var_5A >= 0x50000)
+                        if (this->var_5A >= 0x50000)
                         {
                             rotateAndExplodeIfNotAlreadyExploded();
                         }
@@ -196,10 +196,10 @@ namespace OpenLoco::Vehicles
                         this->var_5A = ((this->var_5A & 0x7FFFFFFF) / 2) | 0x80000000;
                     }
 
-                    if(sub_4AA959(newPosition))
+                    if (sub_4AA959(newPosition))
                     {
                         newPosition.z = this->position.z;
-                        if(this->tileBaseZ >= 0x0A)
+                        if (this->tileBaseZ >= 0x0A)
                         {
                             rotateAndExplodeIfNotAlreadyExploded();
                         }
@@ -208,12 +208,12 @@ namespace OpenLoco::Vehicles
                     }
                 }
 
-                World::Pos2 currentPosition2D{newPosition.x, newPosition.y};
+                World::Pos2 currentPosition2D{ newPosition.x, newPosition.y };
                 auto newTileHeight = World::TileManager::getHeight(currentPosition2D);
-                if(newTileHeight.landHeight >= this->position.z
+                if (newTileHeight.landHeight >= this->position.z
                     || newTileHeight.landHeight >= newPosition.z)
                 {
-                    if(newTileHeight.landHeight < this->position.z
+                    if (newTileHeight.landHeight < this->position.z
                         && newTileHeight.landHeight >= newPosition.z)
                     {
                         newTileHeight.landHeight = this->position.z;
@@ -224,7 +224,7 @@ namespace OpenLoco::Vehicles
                     newPosition.x = this->position.x;
                     newPosition.y = this->position.y;
 
-                    if(this->var_5A >= 0x50000)
+                    if (this->var_5A >= 0x50000)
                     {
                         rotateAndExplodeIfNotAlreadyExploded();
                     }
@@ -232,15 +232,15 @@ namespace OpenLoco::Vehicles
                     this->var_5A = ((this->var_5A & 0x7FFFFFFF) / 2) | 0x80000000;
                 }
 
-                if(newTileHeight.waterHeight != 0
+                if (newTileHeight.waterHeight != 0
                     && newTileHeight.waterHeight < this->position.z
                     && newTileHeight.waterHeight >= newPosition.z)
                 {
-                    if(rotateAndExplodeIfNotAlreadyExploded())
+                    if (rotateAndExplodeIfNotAlreadyExploded())
                     {
-                        World::Pos3 splashPos{this->position.x, this->position.y, newTileHeight.waterHeight};
+                        World::Pos3 splashPos{ this->position.x, this->position.y, newTileHeight.waterHeight };
                         Splash::create(splashPos);
-                        Audio::playSound(Audio::SoundId::splash2, splashPos, 0x8001);   // TODO: use kPlayAtLocation instead of hex literal for 0x8001
+                        Audio::playSound(Audio::SoundId::splash2, splashPos, 0x8001); // TODO: use kPlayAtLocation instead of hex literal for 0x8001
                     }
                 }
 
@@ -251,10 +251,10 @@ namespace OpenLoco::Vehicles
         else
         {
             _vehicleUpdate_var_1136114 = 0;
-            if(this->mode != TransportMode::road)
+            if (this->mode != TransportMode::road)
             {
                 this->updateTrackMotion(_vehicleUpdate_var_113612C);
-                if((_vehicleUpdate_var_1136114 & 0x3) != 0)
+                if ((_vehicleUpdate_var_1136114 & 0x3) != 0)
                 {
                     this->var_5A |= 0x80000000;
                 }

--- a/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
@@ -119,6 +119,13 @@ namespace OpenLoco::Vehicles
         }
     }
 
+    void VehicleBogie::sub_4AA68E()
+    {
+        registers regs;
+        regs.esi = X86Pointer(this);
+        call(0x004AA68E, regs);
+    }
+
     // 0x004AA0DF
     void VehicleBogie::collision()
     {

--- a/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
@@ -23,6 +23,7 @@ namespace OpenLoco::Vehicles
     static loco_global<int32_t, 0x01136130> _vehicleUpdate_var_1136130; // Speed
     static loco_global<EntityId, 0x0113610E> _vehicleUpdate_collisionCarComponent;
 
+/*
     // 0x004AA407
     template<typename T>
     void explodeComponent(T& component)
@@ -39,12 +40,12 @@ namespace OpenLoco::Vehicles
         {
             VehicleCrashParticle::create(pos, component.colourScheme);
         }
-    }
+    }   */
 
     template<typename T>
     void applyDestructionToComponent(T& component)
     {
-        explodeComponent(component);
+        component.explodeComponent();
         component.var_5A &= ~(1u << 31);
         component.var_5A >>= 3;
         component.var_5A |= (1u << 31);

--- a/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
@@ -108,16 +108,16 @@ namespace OpenLoco::Vehicles
     // To replace several instances of the same exact code in
     // VehicleBogie::updateSegmentCrashed(). Returns true if the
     // vehicle crashed in the process.
-    bool VehicleBogie::rotateAndExplodeIfNotAlreadyExploded()
+    static bool rotateAndExplodeIfNotAlreadyExploded(VehicleBogie& bogie, bool direction)
     {
-        // update sprite yaw
-        this->spriteYaw = (this->spriteYaw + 4) & 0x3F;
+        const auto slightlyRotated = direction ? 4 : -4;
+        bogie.spriteYaw = (bogie.spriteYaw + slightlyRotated) & 0x3F;
 
         // explode, if we haven't already
-        if (!this->hasVehicleFlags(VehicleFlags::unk_5))
+        if (!bogie.hasVehicleFlags(VehicleFlags::unk_5))
         {
-            this->explodeComponent();
-            this->vehicleFlags |= VehicleFlags::unk_5;
+            bogie.explodeComponent();
+            bogie.vehicleFlags |= VehicleFlags::unk_5;
             return true;
         }
         else
@@ -130,7 +130,7 @@ namespace OpenLoco::Vehicles
     void VehicleBogie::updateSegmentCrashed()
     {
         _vehicleUpdate_frontBogie = _vehicleUpdate_backBogie;
-        _vehicleUpdate_backBogie = X86Pointer(this);
+        _vehicleUpdate_backBogie = this;
 
         Speed32 speed = Speed32(var_5A & 0x7FFFFFFF);
         bool isComponentDestroyed = this->var_5A & (1U << 31);
@@ -153,19 +153,21 @@ namespace OpenLoco::Vehicles
                 const auto distanceTravelled = speed.getRaw() / 16;
                 auto xyDistance = Math::Trigonometry::computeXYVector(distanceTravelled, spriteYaw);
 
-                int16_t xDistanceLow = xyDistance.x & 0x0000FFFF;
-                int16_t yDistanceLow = xyDistance.y & 0x0000FFFF;
-                World::Pos2 distanceWorld(xyDistance.x / 65536, xyDistance.y / 65536);
-                // We are storing the lower precision in tileX and tileY they aren't actually being used
-                // as tileX and tileY.
-                int32_t newTileX = this->tileX + xDistanceLow;
+                uint16_t xDistanceLow = xyDistance.x & 0x0000FFFF;
+                uint16_t yDistanceLow = xyDistance.y & 0x0000FFFF;
+                // This is being casted to uint32_t as we want a negative value to round away from zero
+                // this is due to splitting the precision of the distance into two parts
+                World::Pos2 distanceWorld(static_cast<uint32_t>(xyDistance.x) / 65536, static_cast<uint32_t>(xyDistance.y) / 65536);
+                // We are storing the lower precision in tileX and tileY they aren't actually being used as tileX and tileY.
+                // Yay reusing fields for different purposes means we need to be careful with the sign of the type
+                int32_t newTileX = static_cast<uint16_t>(this->tileX) + xDistanceLow;
                 if (newTileX >= 0x00010000)
                 {
                     distanceWorld.x++;
                 }
                 this->tileX = newTileX & 0x0000FFFF;
 
-                int32_t newTileY = this->tileY + yDistanceLow;
+                int32_t newTileY = static_cast<uint16_t>(this->tileY) + yDistanceLow;
                 if (newTileY >= 0x00010000)
                 {
                     distanceWorld.y++;
@@ -188,7 +190,7 @@ namespace OpenLoco::Vehicles
 
                         if (speed >= 5.0_mph)
                         {
-                            rotateAndExplodeIfNotAlreadyExploded();
+                            rotateAndExplodeIfNotAlreadyExploded(*this, true);
                         }
 
                         this->var_5A = ((speed / 2).getRaw() | (1U << 31));
@@ -199,15 +201,14 @@ namespace OpenLoco::Vehicles
                         newPosition.z = this->position.z;
                         if (this->tileBaseZ >= 0x0A)
                         {
-                            rotateAndExplodeIfNotAlreadyExploded();
+                            rotateAndExplodeIfNotAlreadyExploded(*this, false);
                         }
 
                         this->tileBaseZ = 0;
                     }
                 }
 
-                World::Pos2 currentPosition2D{ newPosition.x, newPosition.y };
-                const auto newTileHeight = World::TileManager::getHeight(currentPosition2D);
+                const auto newTileHeight = World::TileManager::getHeight(newPosition);
                 if (newTileHeight.landHeight >= this->position.z
                     || newTileHeight.landHeight >= newPosition.z)
                 {
@@ -223,7 +224,7 @@ namespace OpenLoco::Vehicles
 
                     if (speed >= 5.0_mph)
                     {
-                        rotateAndExplodeIfNotAlreadyExploded();
+                        rotateAndExplodeIfNotAlreadyExploded(*this, true);
                     }
 
                     this->var_5A = ((speed / 2).getRaw() | (1U << 31));
@@ -233,11 +234,13 @@ namespace OpenLoco::Vehicles
                     && newTileHeight.waterHeight < this->position.z
                     && newTileHeight.waterHeight >= newPosition.z)
                 {
-                    if (rotateAndExplodeIfNotAlreadyExploded())
+                    this->spriteYaw = (this->spriteYaw + 4) & 0x3F;
+                    if (!this->hasVehicleFlags(VehicleFlags::unk_5))
                     {
                         World::Pos3 splashPos{ this->position.x, this->position.y, newTileHeight.waterHeight };
                         Splash::create(splashPos);
                         Audio::playSound(Audio::SoundId::splash2, splashPos);
+                        this->vehicleFlags |= VehicleFlags::unk_5;
                     }
                 }
 

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3653,15 +3653,13 @@ namespace OpenLoco::Vehicles
     // 0x004AA625
     void VehicleHead::landCrashedUpdate()
     {
-        VehicleBase* currentVehicle = reinterpret_cast<VehicleBase*>(this);
-        EntityId nextVehicleId = currentVehicle->id;
-
-        while (currentVehicle)
+        VehicleBase* currentVehicle = this;
+        while (currentVehicle != nullptr)
         {
             switch (currentVehicle->getSubType())
             {
                 case VehicleEntityType::head:
-                    reinterpret_cast<VehicleHead*>(currentVehicle)->updateSegmentCrashed();
+                    currentVehicle->asVehicleHead()->updateSegmentCrashed();
                     break;
                 case VehicleEntityType::vehicle_1:
                     // calls nullsub_21: empty subroutine
@@ -3670,11 +3668,11 @@ namespace OpenLoco::Vehicles
                     // calls nullsub_22: empty subroutine
                     break;
                 case VehicleEntityType::bogie:
-                    reinterpret_cast<VehicleBogie*>(currentVehicle)->updateSegmentCrashed();
+                    currentVehicle->asVehicleBogie()->updateSegmentCrashed();
                     break;
                 case VehicleEntityType::body_start:
                 case VehicleEntityType::body_continued:
-                    reinterpret_cast<VehicleBody*>(currentVehicle)->updateSegmentCrashed();
+                    currentVehicle->asVehicleBody()->updateSegmentCrashed();
                     break;
                 case VehicleEntityType::tail:
                     // calls nullsub_23: empty subroutine
@@ -3683,28 +3681,20 @@ namespace OpenLoco::Vehicles
                     break;
             }
 
-            nextVehicleId = currentVehicle->getNextCar();
-            if (nextVehicleId == EntityId::null)
-            {
-                return;
-            }
-            else
-            {
-                currentVehicle = EntityManager::get<VehicleBase>(nextVehicleId);
-            }
+            currentVehicle = currentVehicle->nextVehicleComponent();
         }
     }
 
     // 0x004AA64B
     void VehicleHead::updateSegmentCrashed()
     {
-        _vehicleUpdate_head = X86Pointer(this);
+        Vehicle train(head);
+        _vehicleUpdate_head = this;
         _vehicleUpdate_frontBogie = reinterpret_cast<VehicleBogie*>(0xFFFFFFFF);
         _vehicleUpdate_backBogie = reinterpret_cast<VehicleBogie*>(0xFFFFFFFF);
 
-        VehicleBase* nextCar = EntityManager::get<VehicleBase>(this->getNextCar());
-        _vehicleUpdate_1 = reinterpret_cast<Vehicle1*>(nextCar);
-        _vehicleUpdate_2 = EntityManager::get<Vehicle2>(nextCar->getNextCar());
+        _vehicleUpdate_1 = train.veh1;
+        _vehicleUpdate_2 = train.veh2;
     }
 
     // 0x004ACEE7

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3650,6 +3650,51 @@ namespace OpenLoco::Vehicles
         call(0x004AD778, regs);
     }
 
+    // 0x004AA625
+    void VehicleHead::landCrashedUpdate()
+    {
+        VehicleBase* currentVehicle = reinterpret_cast<VehicleBase*>(this);
+        EntityId nextVehicleId = currentVehicle->id;
+
+        while(currentVehicle)
+        {
+            switch(currentVehicle->getSubType())
+            {
+                case VehicleEntityType::head:
+                    reinterpret_cast<VehicleHead*>(currentVehicle)->sub_4AA64B();
+                    break;
+                case VehicleEntityType::vehicle_1:
+                    // calls nullsub_21: empty subroutine
+                    break;
+                case VehicleEntityType::vehicle_2:
+                    // calls nullsub_22: empty subroutine
+                    break;
+                case VehicleEntityType::bogie:
+                    reinterpret_cast<VehicleBogie*>(currentVehicle)->sub_4AA68E();
+                    break;
+                case VehicleEntityType::body_start:
+                case VehicleEntityType::body_continued:
+                    reinterpret_cast<VehicleBody*>(currentVehicle)->sub_4AA904();
+                    break;
+                case VehicleEntityType::tail:
+                    // calls nullsub_23: empty subroutine
+                    break;
+                default:
+                    break;
+            }
+
+            nextVehicleId = currentVehicle->getNextCar();
+            if(nextVehicleId == EntityId::null)
+            {
+                return;
+            }
+            else
+            {
+                currentVehicle = EntityManager::get<VehicleBase>(nextVehicleId);
+            }
+        }
+    }
+
     // 0x004AA64B
     void VehicleHead::sub_4AA64B()
     {

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3656,9 +3656,9 @@ namespace OpenLoco::Vehicles
         VehicleBase* currentVehicle = reinterpret_cast<VehicleBase*>(this);
         EntityId nextVehicleId = currentVehicle->id;
 
-        while(currentVehicle)
+        while (currentVehicle)
         {
-            switch(currentVehicle->getSubType())
+            switch (currentVehicle->getSubType())
             {
                 case VehicleEntityType::head:
                     reinterpret_cast<VehicleHead*>(currentVehicle)->updateSegmentCrashed();
@@ -3684,7 +3684,7 @@ namespace OpenLoco::Vehicles
             }
 
             nextVehicleId = currentVehicle->getNextCar();
-            if(nextVehicleId == EntityId::null)
+            if (nextVehicleId == EntityId::null)
             {
                 return;
             }

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3670,7 +3670,7 @@ namespace OpenLoco::Vehicles
                     // calls nullsub_22: empty subroutine
                     break;
                 case VehicleEntityType::bogie:
-                    reinterpret_cast<VehicleBogie*>(currentVehicle)->sub_4AA68E();
+                    reinterpret_cast<VehicleBogie*>(currentVehicle)->updateSegmentCrashed();
                     break;
                 case VehicleEntityType::body_start:
                 case VehicleEntityType::body_continued:

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3661,12 +3661,6 @@ namespace OpenLoco::Vehicles
                 case VehicleEntityType::head:
                     currentVehicle->asVehicleHead()->updateSegmentCrashed();
                     break;
-                case VehicleEntityType::vehicle_1:
-                    // calls nullsub_21: empty subroutine
-                    break;
-                case VehicleEntityType::vehicle_2:
-                    // calls nullsub_22: empty subroutine
-                    break;
                 case VehicleEntityType::bogie:
                     currentVehicle->asVehicleBogie()->updateSegmentCrashed();
                     break;
@@ -3674,10 +3668,9 @@ namespace OpenLoco::Vehicles
                 case VehicleEntityType::body_continued:
                     currentVehicle->asVehicleBody()->updateSegmentCrashed();
                     break;
+                case VehicleEntityType::vehicle_1:
+                case VehicleEntityType::vehicle_2:
                 case VehicleEntityType::tail:
-                    // calls nullsub_23: empty subroutine
-                    break;
-                default:
                     break;
             }
 

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3661,7 +3661,7 @@ namespace OpenLoco::Vehicles
             switch(currentVehicle->getSubType())
             {
                 case VehicleEntityType::head:
-                    reinterpret_cast<VehicleHead*>(currentVehicle)->sub_4AA64B();
+                    reinterpret_cast<VehicleHead*>(currentVehicle)->updateSegmentCrashed();
                     break;
                 case VehicleEntityType::vehicle_1:
                     // calls nullsub_21: empty subroutine
@@ -3696,11 +3696,15 @@ namespace OpenLoco::Vehicles
     }
 
     // 0x004AA64B
-    void VehicleHead::sub_4AA64B()
+    void VehicleHead::updateSegmentCrashed()
     {
-        registers regs;
-        regs.esi = X86Pointer(this);
-        call(0x004AA64B, regs);
+        _vehicleUpdate_head = X86Pointer(this);
+        _vehicleUpdate_frontBogie = reinterpret_cast<VehicleBogie*>(0xFFFFFFFF);
+        _vehicleUpdate_backBogie = reinterpret_cast<VehicleBogie*>(0xFFFFFFFF);
+
+        VehicleBase* nextCar = EntityManager::get<VehicleBase>(this->getNextCar());
+        _vehicleUpdate_1 = reinterpret_cast<Vehicle1*>(nextCar);
+        _vehicleUpdate_2 = EntityManager::get<Vehicle2>(nextCar->getNextCar());
     }
 
     // 0x004ACEE7

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3674,7 +3674,7 @@ namespace OpenLoco::Vehicles
                     break;
                 case VehicleEntityType::body_start:
                 case VehicleEntityType::body_continued:
-                    reinterpret_cast<VehicleBody*>(currentVehicle)->sub_4AA904();
+                    reinterpret_cast<VehicleBody*>(currentVehicle)->updateSegmentCrashed();
                     break;
                 case VehicleEntityType::tail:
                     // calls nullsub_23: empty subroutine

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -1090,7 +1090,7 @@ namespace OpenLoco::Vehicles
         }
         else if (status == Status::crashed)
         {
-            sub_4AA625();
+            landCrashedUpdate();
 
             return false;
         }
@@ -3650,12 +3650,12 @@ namespace OpenLoco::Vehicles
         call(0x004AD778, regs);
     }
 
-    // 0x004AA625
-    void VehicleHead::sub_4AA625()
+    // 0x004AA64B
+    void VehicleHead::sub_4AA64B()
     {
         registers regs;
         regs.esi = X86Pointer(this);
-        call(0x004AA625, regs);
+        call(0x004AA64B, regs);
     }
 
     // 0x004ACEE7


### PR DESCRIPTION
- VehicleHead::sub_4AA625() is implemented
  - Renamed to VehicleHead::landCrashedUpdate()
- Several other subroutines used by sub_4AA625 are also implemented
  - sub_4AA64B as VehicleHead::updateSegmentCrashed
  - sub_4AA904 as VehicleBody::updateSegmentCrashed
  - sub_4AA68E as VehicleBogie::updateSegmentCrashed
- explodeComponent() is refactored as a member function of VehicleBase