### PR TITLE
Fix missing outline for construction button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 25.03+ (???)
 ------------------------------------------------------------------------
 - Fix: [#3067] Prevent pixel artifacts from incomplete redraws when shifting the viewport.
+- Fix: [#3068] The construction button is missing a border around it.
 
 25.03 (2025-03-31)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -114,7 +114,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         Widgets::ImageButton({ 81, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_slope_up, StringIds::tooltip_slope_up),
         Widgets::ImageButton({ 105, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_steep_slope_up, StringIds::tooltip_steep_slope_up),
         Widgets::dropdownWidgets({ 40, 123 }, { 58, 20 }, WindowColour::secondary, StringIds::empty, StringIds::tooltip_bridge_stats),
-        Widgets::Tab({ 3, 145 }, { 132, 100 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_construct),
+        Widgets::Wt3Widget({ 3, 145 }, { 132, 100 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_construct),
         Widgets::ImageButton({ 6, 248 }, { 46, 24 }, WindowColour::secondary, ImageIds::construction_remove, StringIds::tooltip_remove),
         Widgets::ImageButton({ 57, 248 }, { 24, 24 }, WindowColour::secondary, ImageIds::rotate_object, StringIds::rotate_90));
 


### PR DESCRIPTION
Before / after:
![Screenshot (3)](https://github.com/user-attachments/assets/2d195fb2-3429-4355-af9b-8d13c8482bda) ![Screenshot (2)](https://github.com/user-attachments/assets/749d0b03-fd1c-458a-9b6b-58b2e32a14d4)
