### PR TITLE
Rename tool drag events

### DIFF
--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -490,7 +490,7 @@ namespace OpenLoco::Input
                     if (tool != nullptr)
                     {
                         // TODO: Handle widget id properly for tools.
-                        tool->callToolDragEnd(ToolManager::getToolWidgetIndex(), WidgetId::none);
+                        tool->callToolUp(ToolManager::getToolWidgetIndex(), WidgetId::none);
                     }
                 }
                 else if (!hasFlag(Flags::leftMousePressed))

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -468,7 +468,7 @@ namespace OpenLoco::Input
                         if (tool != nullptr)
                         {
                             // TODO: Handle widget id properly for tools.
-                            tool->callToolDragContinue(ToolManager::getToolWidgetIndex(), WidgetId::none, x, y);
+                            tool->callToolDrag(ToolManager::getToolWidgetIndex(), WidgetId::none, x, y);
                         }
                     }
                 }

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -490,7 +490,7 @@ namespace OpenLoco::Input
                     if (tool != nullptr)
                     {
                         // TODO: Handle widget id properly for tools.
-                        tool->callToolUp(ToolManager::getToolWidgetIndex(), WidgetId::none);
+                        tool->callToolUp(ToolManager::getToolWidgetIndex(), WidgetId::none, x, y);
                     }
                 }
                 else if (!hasFlag(Flags::leftMousePressed))

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -1089,14 +1089,14 @@ namespace OpenLoco::Ui
         eventHandlers->toolDrag(*this, widgetIndex, id, xPos, yPos);
     }
 
-    void Window::callToolUp(const WidgetIndex_t widgetIndex, const WidgetId id)
+    void Window::callToolUp(const WidgetIndex_t widgetIndex, const WidgetId id, const int16_t xPos, const int16_t yPos)
     {
         if (eventHandlers->toolUp == nullptr)
         {
             return;
         }
 
-        eventHandlers->toolUp(*this, widgetIndex, id);
+        eventHandlers->toolUp(*this, widgetIndex, id, xPos, yPos);
     }
 
     void Window::callToolAbort(WidgetIndex_t widgetIndex, const WidgetId id)

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -1079,14 +1079,14 @@ namespace OpenLoco::Ui
         eventHandlers->onToolDown(*this, widgetIndex, id, xPos, yPos);
     }
 
-    void Window::callToolDragContinue(const WidgetIndex_t widgetIndex, const WidgetId id, const int16_t xPos, const int16_t yPos)
+    void Window::callToolDrag(const WidgetIndex_t widgetIndex, const WidgetId id, const int16_t xPos, const int16_t yPos)
     {
-        if (eventHandlers->toolDragContinue == nullptr)
+        if (eventHandlers->toolDrag == nullptr)
         {
             return;
         }
 
-        eventHandlers->toolDragContinue(*this, widgetIndex, id, xPos, yPos);
+        eventHandlers->toolDrag(*this, widgetIndex, id, xPos, yPos);
     }
 
     void Window::callToolDragEnd(const WidgetIndex_t widgetIndex, const WidgetId id)

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -1089,14 +1089,14 @@ namespace OpenLoco::Ui
         eventHandlers->toolDrag(*this, widgetIndex, id, xPos, yPos);
     }
 
-    void Window::callToolDragEnd(const WidgetIndex_t widgetIndex, const WidgetId id)
+    void Window::callToolUp(const WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        if (eventHandlers->toolDragEnd == nullptr)
+        if (eventHandlers->toolUp == nullptr)
         {
             return;
         }
 
-        eventHandlers->toolDragEnd(*this, widgetIndex, id);
+        eventHandlers->toolUp(*this, widgetIndex, id);
     }
 
     void Window::callToolAbort(WidgetIndex_t widgetIndex, const WidgetId id)

--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -384,8 +384,8 @@ namespace OpenLoco::Ui
         void call_9();                                                                                                    // 9
         void callToolUpdate(WidgetIndex_t widgetIndex, WidgetId id, int16_t xPos, int16_t yPos);                          // 10
         void callToolDown(WidgetIndex_t widgetIndex, WidgetId id, int16_t xPos, int16_t yPos);                            // 11
-        void callToolDrag(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);        // 12
-        void callToolUp(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);          // 13
+        void callToolDrag(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);                // 12
+        void callToolUp(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);                  // 13
         void callToolAbort(WidgetIndex_t widgetIndex, WidgetId id);                                                       // 14
         Ui::CursorId callToolCursor(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out);                        // 15
         void callGetScrollSize(uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);                      // 16

--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -81,7 +81,7 @@ namespace OpenLoco::Ui
         void (*onToolUpdate)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
         void (*onToolDown)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
         void (*toolDrag)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
-        void (*toolUp)(Window&, const WidgetIndex_t, WidgetId) = nullptr;
+        void (*toolUp)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
         void (*onToolAbort)(Window&, const WidgetIndex_t, WidgetId) = nullptr;
         Ui::CursorId (*toolCursor)(Window&, const int16_t x, const int16_t y, const Ui::CursorId, bool&) = nullptr;
         void (*getScrollSize)(Window&, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight) = nullptr;
@@ -385,7 +385,7 @@ namespace OpenLoco::Ui
         void callToolUpdate(WidgetIndex_t widgetIndex, WidgetId id, int16_t xPos, int16_t yPos);                          // 10
         void callToolDown(WidgetIndex_t widgetIndex, WidgetId id, int16_t xPos, int16_t yPos);                            // 11
         void callToolDrag(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);        // 12
-        void callToolUp(WidgetIndex_t widgetIndex, WidgetId id);                                                     // 13
+        void callToolUp(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);          // 13
         void callToolAbort(WidgetIndex_t widgetIndex, WidgetId id);                                                       // 14
         Ui::CursorId callToolCursor(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out);                        // 15
         void callGetScrollSize(uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);                      // 16

--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -80,7 +80,7 @@ namespace OpenLoco::Ui
         void (*event_09)(Window&) = nullptr;
         void (*onToolUpdate)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
         void (*onToolDown)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
-        void (*toolDragContinue)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
+        void (*toolDrag)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
         void (*toolDragEnd)(Window&, const WidgetIndex_t, WidgetId) = nullptr;
         void (*onToolAbort)(Window&, const WidgetIndex_t, WidgetId) = nullptr;
         Ui::CursorId (*toolCursor)(Window&, const int16_t x, const int16_t y, const Ui::CursorId, bool&) = nullptr;
@@ -384,7 +384,7 @@ namespace OpenLoco::Ui
         void call_9();                                                                                                    // 9
         void callToolUpdate(WidgetIndex_t widgetIndex, WidgetId id, int16_t xPos, int16_t yPos);                          // 10
         void callToolDown(WidgetIndex_t widgetIndex, WidgetId id, int16_t xPos, int16_t yPos);                            // 11
-        void callToolDragContinue(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);        // 12
+        void callToolDrag(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);        // 12
         void callToolDragEnd(WidgetIndex_t widgetIndex, WidgetId id);                                                     // 13
         void callToolAbort(WidgetIndex_t widgetIndex, WidgetId id);                                                       // 14
         Ui::CursorId callToolCursor(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out);                        // 15

--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -81,7 +81,7 @@ namespace OpenLoco::Ui
         void (*onToolUpdate)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
         void (*onToolDown)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
         void (*toolDrag)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
-        void (*toolDragEnd)(Window&, const WidgetIndex_t, WidgetId) = nullptr;
+        void (*toolUp)(Window&, const WidgetIndex_t, WidgetId) = nullptr;
         void (*onToolAbort)(Window&, const WidgetIndex_t, WidgetId) = nullptr;
         Ui::CursorId (*toolCursor)(Window&, const int16_t x, const int16_t y, const Ui::CursorId, bool&) = nullptr;
         void (*getScrollSize)(Window&, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight) = nullptr;
@@ -385,7 +385,7 @@ namespace OpenLoco::Ui
         void callToolUpdate(WidgetIndex_t widgetIndex, WidgetId id, int16_t xPos, int16_t yPos);                          // 10
         void callToolDown(WidgetIndex_t widgetIndex, WidgetId id, int16_t xPos, int16_t yPos);                            // 11
         void callToolDrag(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);        // 12
-        void callToolDragEnd(WidgetIndex_t widgetIndex, WidgetId id);                                                     // 13
+        void callToolUp(WidgetIndex_t widgetIndex, WidgetId id);                                                     // 13
         void callToolAbort(WidgetIndex_t widgetIndex, WidgetId id);                                                       // 14
         Ui::CursorId callToolCursor(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out);                        // 15
         void callGetScrollSize(uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);                      // 16

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -1110,7 +1110,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC701
-        static void toolDragEnd([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void toolUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex == Common::widx::panel)
             {
@@ -1191,7 +1191,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             .onToolUpdate = onToolUpdate,
             .onToolDown = onToolDown,
             .toolDrag = toolDrag,
-            .toolDragEnd = toolDragEnd,
+            .toolUp = toolUp,
             .prepareDraw = prepareDraw,
             .draw = draw,
         };
@@ -1722,7 +1722,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCA5D
-        static void toolDragEnd([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void toolUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             switch (widgetIndex)
             {
@@ -1877,7 +1877,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             .onToolUpdate = onToolUpdate,
             .onToolDown = onToolDown,
             .toolDrag = toolDrag,
-            .toolDragEnd = toolDragEnd,
+            .toolUp = toolUp,
             .prepareDraw = prepareDraw,
             .draw = draw,
         };
@@ -2131,7 +2131,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCDE8
-        static void toolDragEnd([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void toolUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             if (widgetIndex == Common::widx::panel)
             {
@@ -2222,7 +2222,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             .onToolUpdate = onToolUpdate,
             .onToolDown = onToolDown,
             .toolDrag = toolDrag,
-            .toolDragEnd = toolDragEnd,
+            .toolUp = toolUp,
             .prepareDraw = prepareDraw,
             .draw = draw,
         };

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -1095,7 +1095,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC682
-        static void toolDragContinue([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
+        static void toolDrag([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -1190,7 +1190,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             .onUpdate = Common::onUpdate,
             .onToolUpdate = onToolUpdate,
             .onToolDown = onToolDown,
-            .toolDragContinue = toolDragContinue,
+            .toolDrag = toolDrag,
             .toolDragEnd = toolDragEnd,
             .prepareDraw = prepareDraw,
             .draw = draw,
@@ -1648,7 +1648,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC9E2
-        static void toolDragContinue([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
+        static void toolDrag([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             switch (widgetIndex)
             {
@@ -1876,7 +1876,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             .onUpdate = Common::onUpdate,
             .onToolUpdate = onToolUpdate,
             .onToolDown = onToolDown,
-            .toolDragContinue = toolDragContinue,
+            .toolDrag = toolDrag,
             .toolDragEnd = toolDragEnd,
             .prepareDraw = prepareDraw,
             .draw = draw,
@@ -2069,7 +2069,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCDBF
-        static void toolDragContinue([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
+        static void toolDrag([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
         {
             if (widgetIndex != Common::widx::panel)
             {
@@ -2221,7 +2221,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             .onUpdate = Common::onUpdate,
             .onToolUpdate = onToolUpdate,
             .onToolDown = onToolDown,
-            .toolDragContinue = toolDragContinue,
+            .toolDrag = toolDrag,
             .toolDragEnd = toolDragEnd,
             .prepareDraw = prepareDraw,
             .draw = draw,

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -1110,7 +1110,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC701
-        static void toolUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void toolUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
         {
             if (widgetIndex == Common::widx::panel)
             {
@@ -1722,7 +1722,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCA5D
-        static void toolUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void toolUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
         {
             switch (widgetIndex)
             {
@@ -2131,7 +2131,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCDE8
-        static void toolUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void toolUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y)
         {
             if (widgetIndex == Common::widx::panel)
             {


### PR DESCRIPTION
This PR renames the `ToolDragContinue` event to `ToolDrag`, and more importantly the `ToolDragEnd` event to `ToolUp`. Unlike what the previous name suggests, dragging is not necessary for the up event to fire. This will allow some more creative tool (map selection) usage that I hadn't thought possible yet.

For reference, the events were originally named in #635.