### PR TITLE
Allow dragging the construction tool to build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 25.03+ (???)
 ------------------------------------------------------------------------
+- Feature: [#3073] Track/road/station construction can now be done by dragging the construction marker.
 - Fix: [#2703, #2704, #3033] Set currently playing track correctly after clicking "Next music track" button and after unchecking "Play Music".
 - Fix: [#3067] Prevent pixel artifacts from incomplete redraws when shifting the viewport.
 - Fix: [#3068] The construction button is missing a border around it.

--- a/src/OpenLoco/src/Map/MapSelection.cpp
+++ b/src/OpenLoco/src/Map/MapSelection.cpp
@@ -196,10 +196,10 @@ namespace OpenLoco::World
 
     void setMapSelectionArea(const Pos2& locA, const Pos2& locB)
     {
-        _mapSelectionAX = locA.x;
-        _mapSelectionAY = locA.y;
-        _mapSelectionBX = locB.x;
-        _mapSelectionBY = locB.y;
+        _mapSelectionAX = std::min(locA.x, locB.x);
+        _mapSelectionAY = std::min(locA.y, locB.y);
+        _mapSelectionBX = std::max(locA.x, locB.x);
+        _mapSelectionBY = std::max(locA.y, locB.y);
     }
 
     std::pair<Pos2, Pos2> getMapSelectionArea()

--- a/src/OpenLoco/src/Map/MapSelection.cpp
+++ b/src/OpenLoco/src/Map/MapSelection.cpp
@@ -9,8 +9,6 @@ using namespace OpenLoco::Interop;
 
 namespace OpenLoco::World
 {
-    static loco_global<int16_t, 0x0050A000> _adjustToolSize;
-
     static loco_global<MapSelectionFlags, 0x00F24484> _mapSelectionFlags;
     static loco_global<coord_t, 0x00F24486> _mapSelectionAX;
     static loco_global<coord_t, 0x00F24488> _mapSelectionBX;
@@ -22,7 +20,7 @@ namespace OpenLoco::World
     static loco_global<Pos2[kMapSelectedTilesSize], 0x00F24490> _mapSelectedTiles;
 
     // TODO: Return std::optional
-    uint16_t setMapSelectionTiles(const Pos2& loc, const MapSelectionType selectionType)
+    uint16_t setMapSelectionTiles(const Pos2& loc, const MapSelectionType selectionType, uint16_t toolSizeA)
     {
         uint16_t xPos = loc.x;
         uint16_t yPos = loc.y;
@@ -39,8 +37,6 @@ namespace OpenLoco::World
             _word_F2448E = selectionType;
             count++;
         }
-
-        uint16_t toolSizeA = _adjustToolSize;
 
         if (!toolSizeA)
         {

--- a/src/OpenLoco/src/Map/MapSelection.h
+++ b/src/OpenLoco/src/Map/MapSelection.h
@@ -37,7 +37,7 @@ namespace OpenLoco::World
         edge3,
     };
 
-    uint16_t setMapSelectionTiles(const Pos2& loc, const MapSelectionType selectionType);
+    uint16_t setMapSelectionTiles(const Pos2& loc, const MapSelectionType selectionType, uint16_t toolSize);
     uint16_t setMapSelectionSingleTile(const Pos2& loc, bool setQuadrant = false);
     void mapInvalidateSelectionRect();
     void mapInvalidateMapSelectionTiles();

--- a/src/OpenLoco/src/Ui/Windows/Construction/Construction.h
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Construction.h
@@ -37,7 +37,6 @@ namespace OpenLoco::Ui::Windows::Construction
 
     constexpr uint16_t mapSelectedTilesSize = 300;
     static loco_global<Pos2[mapSelectedTilesSize], 0x00F24490> _mapSelectedTiles;
-    static loco_global<char[512], 0x0112CC04> _stringFormatBuffer;
 
 #pragma pack(push, 1)
     struct ConstructionState

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -2554,7 +2554,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     template<typename TGetPieceId, typename TTryMakeJunction, typename TGetPiece>
-    static void onToolDownT(const int16_t x, const int16_t y, TGetPieceId&& getPieceId, TTryMakeJunction&& tryMakeJunction, TGetPiece&& getPiece)
+    static void onToolUpT(const int16_t x, const int16_t y, TGetPieceId&& getPieceId, TTryMakeJunction&& tryMakeJunction, TGetPiece&& getPiece)
     {
         mapInvalidateMapSelectionTiles();
         removeConstructionGhosts();
@@ -2623,7 +2623,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049DC97
-    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
+    static void onToolUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::construct)
         {
@@ -2632,11 +2632,11 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
         if (_cState->trackType & (1 << 7))
         {
-            onToolDownT(x, y, getRoadPieceId, tryMakeRoadJunctionAtLoc, TrackData::getRoadPiece);
+            onToolUpT(x, y, getRoadPieceId, tryMakeRoadJunctionAtLoc, TrackData::getRoadPiece);
         }
         else
         {
-            onToolDownT(x, y, getTrackPieceId, tryMakeTrackJunctionAtLoc, TrackData::getTrackPiece);
+            onToolUpT(x, y, getTrackPieceId, tryMakeTrackJunctionAtLoc, TrackData::getTrackPiece);
         }
     }
 
@@ -3133,7 +3133,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         .onDropdown = onDropdown,
         .onUpdate = onUpdate,
         .onToolUpdate = onToolUpdate,
-        .onToolDown = onToolDown,
+        .toolUp = onToolUp,
         .tooltip = tooltip,
         .cursor = cursor,
         .prepareDraw = prepareDraw,

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -2468,7 +2468,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
     // 0x004A1968
     template<typename TGetPieceId, typename TTryMakeJunction, typename TGetPiece, typename GetPlacementArgsFunc, typename PlaceGhostFunc>
-    static void onToolUpdateTrack(const int16_t x, const int16_t y, TGetPieceId&& getPieceId, TTryMakeJunction&& tryMakeJunction, TGetPiece&& getPiece, GetPlacementArgsFunc&& getPlacementArgs, PlaceGhostFunc&& placeGhost)
+    static void onToolUpdateSingle(const int16_t x, const int16_t y, TGetPieceId&& getPieceId, TTryMakeJunction&& tryMakeJunction, TGetPiece&& getPiece, GetPlacementArgsFunc&& getPlacementArgs, PlaceGhostFunc&& placeGhost)
     {
         World::mapInvalidateMapSelectionTiles();
         World::resetMapSelectionFlag(World::MapSelectionFlags::enable | World::MapSelectionFlags::enableConstruct | World::MapSelectionFlags::enableConstructionArrow);
@@ -2545,16 +2545,16 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
         if (_cState->trackType & (1 << 7))
         {
-            onToolUpdateTrack(x, y, getRoadPieceId, tryMakeRoadJunctionAtLoc, TrackData::getRoadPiece, getRoadPlacementArgs, placeRoadGhost);
+            onToolUpdateSingle(x, y, getRoadPieceId, tryMakeRoadJunctionAtLoc, TrackData::getRoadPiece, getRoadPlacementArgs, placeRoadGhost);
         }
         else
         {
-            onToolUpdateTrack(x, y, getTrackPieceId, tryMakeTrackJunctionAtLoc, TrackData::getTrackPiece, getTrackPlacementArgs, placeTrackGhost);
+            onToolUpdateSingle(x, y, getTrackPieceId, tryMakeTrackJunctionAtLoc, TrackData::getTrackPiece, getTrackPlacementArgs, placeTrackGhost);
         }
     }
 
     template<typename TGetPieceId, typename TTryMakeJunction, typename TGetPiece>
-    static void onToolUpT(const int16_t x, const int16_t y, TGetPieceId&& getPieceId, TTryMakeJunction&& tryMakeJunction, TGetPiece&& getPiece)
+    static void onToolUpSingle(const int16_t x, const int16_t y, TGetPieceId&& getPieceId, TTryMakeJunction&& tryMakeJunction, TGetPiece&& getPiece)
     {
         mapInvalidateMapSelectionTiles();
         removeConstructionGhosts();
@@ -2632,11 +2632,11 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
         if (_cState->trackType & (1 << 7))
         {
-            onToolUpT(x, y, getRoadPieceId, tryMakeRoadJunctionAtLoc, TrackData::getRoadPiece);
+            onToolUpSingle(x, y, getRoadPieceId, tryMakeRoadJunctionAtLoc, TrackData::getRoadPiece);
         }
         else
         {
-            onToolUpT(x, y, getTrackPieceId, tryMakeTrackJunctionAtLoc, TrackData::getTrackPiece);
+            onToolUpSingle(x, y, getTrackPieceId, tryMakeTrackJunctionAtLoc, TrackData::getTrackPiece);
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -2080,7 +2080,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         return { std::make_pair(startHeight, elTrack->trackId()) };
     }
 
-    static void constructionLoop(const Pos2& mapPos, uint32_t maxRetries, int16_t height, bool cancelAfter = false)
+    static void constructionLoop(const Pos2& mapPos, uint32_t maxRetries, int16_t height)
     {
         while (true)
         {
@@ -2122,11 +2122,6 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
                         continue;
                     }
                 }
-            }
-
-            if (maxRetries == 0 && cancelAfter)
-            {
-                return;
             }
 
             // Failed to place track piece -- rotate and make error sound
@@ -2613,7 +2608,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     template<typename TGetPieceId, typename TTryMakeJunction, typename TGetPiece>
-    static void onToolUpSingle(const int16_t x, const int16_t y, TGetPieceId&& getPieceId, TTryMakeJunction&& tryMakeJunction, TGetPiece&& getPiece, bool cancelAfter = true)
+    static void onToolUpSingle(const int16_t x, const int16_t y, TGetPieceId&& getPieceId, TTryMakeJunction&& tryMakeJunction, TGetPiece&& getPiece)
     {
         mapInvalidateMapSelectionTiles();
         removeConstructionGhosts();
@@ -2652,11 +2647,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
             _cState->makeJunction = 0;
         }
-
-        if (cancelAfter)
-        {
-            ToolManager::toolCancel();
-        }
+        ToolManager::toolCancel();
 
         auto maxRetries = 0;
         if (Input::hasKeyModifier(Input::KeyModifier::shift) || _cState->makeJunction != 1)
@@ -2682,7 +2673,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         // Height should never go negative
         constructHeight = std::max<int16_t>(0, constructHeight);
 
-        constructionLoop(constructPos, maxRetries, constructHeight, !cancelAfter);
+        constructionLoop(constructPos, maxRetries, constructHeight);
     }
 
     static void onToolUpMultiple(Window& self, const WidgetIndex_t widgetIndex)

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -2742,6 +2742,16 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         }
     }
 
+    static void onToolAbort([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    {
+        if (widgetIndex != widx::construct)
+        {
+            return;
+        }
+
+        _isDragging = false;
+    }
+
     // 0x0049D4F5
     static Ui::CursorId cursor([[maybe_unused]] Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
     {
@@ -3238,6 +3248,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         .onToolDown = onToolDown,
         .toolDrag = onToolDrag,
         .toolUp = onToolUp,
+        .onToolAbort = onToolAbort,
         .tooltip = tooltip,
         .cursor = cursor,
         .prepareDraw = prepareDraw,

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -2684,6 +2684,8 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         auto dirX = _toolPosDrag.x - _toolPosInitial.x > 0 ? 1 : -1;
         auto dirY = _toolPosDrag.y - _toolPosInitial.y > 0 ? 1 : -1;
 
+        bool builtAnything = false;
+
         for (auto yPos = _toolPosInitial.y; yPos != _toolPosDrag.y + dirY; yPos += dirY)
         {
             for (auto xPos = _toolPosInitial.x; xPos != _toolPosDrag.x + dirX; xPos += dirX)
@@ -2699,12 +2701,18 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
                 _suppressErrorSound = true;
                 constructTrackOrRoad(&self, widgetIndex);
                 _suppressErrorSound = false;
-                WindowManager::close(WindowType::error);
+
+                builtAnything |= _cState->dword_1135F42 != GameCommands::FAILURE;
 
                 // Prevent automatic track advancement when constructing track
                 _cState->constructionRotation = rotation;
                 _cState->lastSelectedTrackPiece = piece;
             }
+        }
+
+        if (builtAnything)
+        {
+            WindowManager::close(WindowType::error);
         }
 
         // Leave the tool active, but make ghost piece visible for the next round

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -2597,14 +2597,11 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             return;
         }
 
-        auto posA = World::toWorldSpace({ std::min(_toolPosInitial.x, _toolPosDrag.x), std::min(_toolPosInitial.y, _toolPosDrag.y) });
-        auto posB = World::toWorldSpace({ std::max(_toolPosInitial.x, _toolPosDrag.x), std::max(_toolPosInitial.y, _toolPosDrag.y) });
+        setMapSelectionFlags(MapSelectionFlags::enable);
+        setMapSelectionCorner(MapSelectionType::full);
 
-        World::setMapSelectionFlags(World::MapSelectionFlags::enable);
-        World::setMapSelectionCorner(MapSelectionType::full);
-
-        World::setMapSelectionArea(posA, posB);
-        World::mapInvalidateSelectionRect();
+        setMapSelectionArea(toWorldSpace(_toolPosInitial), toWorldSpace(_toolPosDrag));
+        mapInvalidateSelectionRect();
     }
 
     template<typename TGetPieceId, typename TTryMakeJunction, typename TGetPiece>

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -54,6 +54,11 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     static loco_global<uint8_t, 0x0112C2E9> _alternateTrackObjectId; // set from GameCommands::createRoad
     static loco_global<uint8_t[18], 0x0050A006> _availableObjects;   // top toolbar
 
+    // TODO: move to ConstructionState when no longer a loco_global?
+    static bool _isDragging = false;
+    static World::TilePos2 _toolPosDrag;
+    static World::TilePos2 _toolPosInitial;
+
     namespace TrackPiece
     {
         enum
@@ -2090,7 +2095,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             activateSelectedConstructionWidgets();
             auto window = WindowManager::find(WindowType::construction);
 
-            // Attempt to place track piece -- in silent
+            // Attempt to place track piece -- in silence
             _suppressErrorSound = true;
             onMouseUp(*window, widx::construct, WidgetId::none);
             _suppressErrorSound = false;
@@ -2539,10 +2544,6 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         constructionGhostLoop({ constructPos.x, constructPos.y, constructHeight }, maxRetries, getPlacementArgs, placeGhost);
         World::mapInvalidateMapSelectionTiles();
     }
-
-    static bool _isDragging = false;
-    static World::TilePos2 _toolPosDrag;
-    static World::TilePos2 _toolPosInitial;
 
     // 0x0049DC8C
     static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -2678,34 +2678,37 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         mapInvalidateMapSelectionTiles();
         removeConstructionGhosts();
 
-        auto posA = World::TilePos2{ std::min(_toolPosInitial.x, _toolPosDrag.x), std::min(_toolPosInitial.y, _toolPosDrag.y) };
-        auto posB = World::TilePos2{ std::max(_toolPosInitial.x, _toolPosDrag.x), std::max(_toolPosInitial.y, _toolPosDrag.y) };
-
         auto rotation = _cState->constructionRotation;
         auto piece = _cState->lastSelectedTrackPiece;
 
-        for (auto tilePos : TilePosRangeView(posA, posB))
+        auto dirX = _toolPosDrag.x - _toolPosInitial.x > 0 ? 1 : -1;
+        auto dirY = _toolPosDrag.y - _toolPosInitial.y > 0 ? 1 : -1;
+
+        for (auto yPos = _toolPosInitial.y; yPos != _toolPosDrag.y + dirY; yPos += dirY)
         {
-            auto pos = World::toWorldSpace(tilePos);
-            _cState->x = pos.x;
-            _cState->y = pos.y;
+            for (auto xPos = _toolPosInitial.x; xPos != _toolPosDrag.x + dirX; xPos += dirX)
+            {
+                auto pos = World::toWorldSpace({ xPos, yPos });
+                _cState->x = pos.x;
+                _cState->y = pos.y;
 
-            auto height = TileManager::getHeight(pos);
-            _cState->constructionZ = height.landHeight;
+                auto height = TileManager::getHeight(pos);
+                _cState->constructionZ = height.landHeight;
 
-            // Try placing the track at this location, ignoring errors if they occur
-            _suppressErrorSound = true;
-            constructTrack(&self, widgetIndex);
-            _suppressErrorSound = false;
-            WindowManager::close(WindowType::error);
+                // Try placing the track at this location, ignoring errors if they occur
+                _suppressErrorSound = true;
+                constructTrack(&self, widgetIndex);
+                _suppressErrorSound = false;
+                WindowManager::close(WindowType::error);
 
-            // Prevent automatic track advancement when constructing track
-            _cState->constructionRotation = rotation;
-            _cState->lastSelectedTrackPiece = piece;
-
-            // Leave the tool active, but make ghost piece visible for the next round
-            _isDragging = false;
+                // Prevent automatic track advancement when constructing track
+                _cState->constructionRotation = rotation;
+                _cState->lastSelectedTrackPiece = piece;
+            }
         }
+
+        // Leave the tool active, but make ghost piece visible for the next round
+        _isDragging = false;
     }
 
     // 0x0049DC97

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -320,7 +320,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049F92D
-    static void constructTrack([[maybe_unused]] Window* self, [[maybe_unused]] WidgetIndex_t widgetIndex)
+    static void constructTrackOrRoad([[maybe_unused]] Window* self, [[maybe_unused]] WidgetIndex_t widgetIndex)
     {
         if (_cState->trackType & (1 << 7))
         {
@@ -525,7 +525,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
                 break;
 
             case widx::construct:
-                constructTrack(&self, widgetIndex);
+                constructTrackOrRoad(&self, widgetIndex);
                 break;
 
             case widx::remove:
@@ -1871,7 +1871,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             {
                 if (Input::getClickRepeatTicks() >= 40)
                 {
-                    constructTrack(&self, widgetIndex);
+                    constructTrackOrRoad(&self, widgetIndex);
                 }
                 break;
             }
@@ -2697,7 +2697,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
                 // Try placing the track at this location, ignoring errors if they occur
                 _suppressErrorSound = true;
-                constructTrack(&self, widgetIndex);
+                constructTrackOrRoad(&self, widgetIndex);
                 _suppressErrorSound = false;
                 WindowManager::close(WindowType::error);
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -2691,7 +2691,9 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
         auto posA = World::TilePos2{ std::min(_toolPosInitial.x, _toolPosDrag.x), std::min(_toolPosInitial.y, _toolPosDrag.y) };
         auto posB = World::TilePos2{ std::max(_toolPosInitial.x, _toolPosDrag.x), std::max(_toolPosInitial.y, _toolPosDrag.y) };
+
         auto rotation = _cState->constructionRotation;
+        auto piece = _cState->lastSelectedTrackPiece;
 
         for (auto tilePos : TilePosRangeView(posA, posB))
         {
@@ -2708,8 +2710,9 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             _suppressErrorSound = false;
             WindowManager::close(WindowType::error);
 
-            // Prevent automatic rotation when constructing track
+            // Prevent automatic track advancement when constructing track
             _cState->constructionRotation = rotation;
+            _cState->lastSelectedTrackPiece = piece;
 
             // Leave the tool active, but make ghost piece visible for the next round
             _isDragging = false;

--- a/src/OpenLoco/src/Ui/Windows/Construction/OverheadTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/OverheadTab.cpp
@@ -343,7 +343,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
     }
 
     // 0x0049EC20
-    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
+    static void onToolUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::image)
         {
@@ -562,7 +562,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
         .onDropdown = onDropdown,
         .onUpdate = onUpdate,
         .onToolUpdate = onToolUpdate,
-        .onToolDown = onToolDown,
+        .toolUp = onToolUp,
         .prepareDraw = prepareDraw,
         .draw = draw,
     };

--- a/src/OpenLoco/src/Ui/Windows/Construction/SignalTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/SignalTab.cpp
@@ -262,7 +262,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
     }
 
     // 0x0049E75A
-    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
+    static void onToolUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::single_direction && widgetIndex != widx::both_directions)
         {
@@ -368,7 +368,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
         .onDropdown = onDropdown,
         .onUpdate = onUpdate,
         .onToolUpdate = onToolUpdate,
-        .onToolDown = onToolDown,
+        .toolUp = onToolUp,
         .prepareDraw = prepareDraw,
         .draw = draw,
     };

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -932,7 +932,6 @@ namespace OpenLoco::Ui::Windows::Construction::Station
             return std::nullopt;
         }
 
-
         GameCommands::TrainStationPlacementArgs placementArgs;
         placementArgs.pos = World::Pos3(pos.x, pos.y, elTrack->baseHeight());
         placementArgs.rotation = elTrack->rotation();

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -598,7 +598,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     }
 
     // 0x004A5550
-    static void onToolDownAirport(const int16_t x, const int16_t y)
+    static void onToolUpAirport(const int16_t x, const int16_t y)
     {
         removeConstructionGhosts();
 
@@ -736,7 +736,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     }
 
     // 0x004A55AB
-    static void onToolDownDock(const int16_t x, const int16_t y)
+    static void onToolUpDock(const int16_t x, const int16_t y)
     {
         removeConstructionGhosts();
 
@@ -780,7 +780,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     }
 
     // 0x004A548F
-    static void onToolDownRoadStation(const int16_t x, const int16_t y)
+    static void onToolUpRoadStation(const int16_t x, const int16_t y)
     {
         removeConstructionGhosts();
 
@@ -827,7 +827,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     }
 
     // 0x004A5390
-    static void onToolDownTrainStation(const int16_t x, const int16_t y)
+    static void onToolUpTrainStation(const int16_t x, const int16_t y)
     {
         removeConstructionGhosts();
 
@@ -855,7 +855,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     }
 
     // 0x0049E42C
-    static void onToolDown([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
+    static void onToolUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)
     {
         if (widgetIndex != widx::image)
         {
@@ -864,19 +864,19 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
         if (_cState->byte_1136063 & (1 << 7))
         {
-            onToolDownAirport(x, y);
+            onToolUpAirport(x, y);
         }
         else if (_cState->byte_1136063 & (1 << 6))
         {
-            onToolDownDock(x, y);
+            onToolUpDock(x, y);
         }
         else if (_cState->trackType & (1 << 7))
         {
-            onToolDownRoadStation(x, y);
+            onToolUpRoadStation(x, y);
         }
         else
         {
-            onToolDownTrainStation(x, y);
+            onToolUpTrainStation(x, y);
         }
     }
 
@@ -1104,7 +1104,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         .onDropdown = onDropdown,
         .onUpdate = onUpdate,
         .onToolUpdate = onToolUpdate,
-        .onToolDown = onToolDown,
+        .toolUp = onToolUp,
         .prepareDraw = prepareDraw,
         .draw = draw,
     };

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -1031,6 +1031,8 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         auto dirX = _toolPosDrag.x - _toolPosInitial.x > 0 ? 1 : -1;
         auto dirY = _toolPosDrag.y - _toolPosInitial.y > 0 ? 1 : -1;
 
+        bool builtAnything = false;
+
         for (auto yPos = _toolPosInitial.y; yPos != _toolPosDrag.y + dirY; yPos += dirY)
         {
             for (auto xPos = _toolPosInitial.x; xPos != _toolPosDrag.x + dirX; xPos += dirX)
@@ -1044,10 +1046,14 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
                 // Try placing the station at this location, ignoring errors if they occur
                 _suppressErrorSound = true;
-                constructPieceAtPosition(pos);
+                builtAnything |= constructPieceAtPosition(pos) != GameCommands::FAILURE;
                 _suppressErrorSound = false;
-                WindowManager::close(WindowType::error);
             }
+        }
+
+        if (builtAnything)
+        {
+            WindowManager::close(WindowType::error);
         }
 
         // Leave the tool active, but make ghost piece visible for the next round

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -1047,7 +1047,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             auto res = Ui::ViewportInteraction::getSurfaceLocFromUi({ x, y });
             if (res)
             {
-                if (setMapSelectionTiles(res->first, MapSelectionType::full) == 0)
+                if (setMapSelectionTiles(res->first, MapSelectionType::full, _adjustToolSize) == 0)
                 {
                     return;
                 }
@@ -1508,7 +1508,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             auto res = Ui::ViewportInteraction::getSurfaceLocFromUi({ x, y });
             if (res)
             {
-                if (setMapSelectionTiles(res->first, MapSelectionType::full) == 0)
+                if (setMapSelectionTiles(res->first, MapSelectionType::full, _adjustToolSize) == 0)
                 {
                     return;
                 }
@@ -1552,7 +1552,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     }
                     else
                     {
-                        auto count = setMapSelectionTiles(res->first, MapSelectionType::full);
+                        auto count = setMapSelectionTiles(res->first, MapSelectionType::full, _adjustToolSize);
 
                         if (!count)
                         {
@@ -1999,7 +1999,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     setAdjustCost(0x80000000, 0x80000000);
                     return;
                 }
-                if (!setMapSelectionTiles(interaction.pos + World::Pos2(16, 16), MapSelectionType::fullWater))
+                if (!setMapSelectionTiles(interaction.pos + World::Pos2(16, 16), MapSelectionType::fullWater, _adjustToolSize))
                 {
                     // no change in selection
                     return;


### PR DESCRIPTION
This PR introduces an alternate mode for the construction tool, allowing players to build a grid of track/road pieces at once by dragging the selection tool over the map. This is done in a way that is not intrusive to (and indeed fully compatible with) the vanilla method.

To achieve this, the selection tool is now activated using the ToolUp event instead of the ToolDown event. When ToolDown is activated, the initial tile position is stored. On ToolDrag, the current tile position is stored. If the two positions are identical, then the game takes the vanilla code path: you'll see a ghost track piece, and clicking (ToolUp) will build that piece, and activate interactive mode.

Conversely, if the two positions aren't identical, the new 'dragging' mode is activated. Instead of a ghost piece, you'll now just see the map selection grid, showing what tiles will be filled with track pieces.

Dragging can be cancelled if you return the cursor to the initial position (i.e. as though you were drawing 1x1 tiles). Indeed, this is the same way in which we retain 'backwards' compatibility.

NB: this currently only extends to the track/road and station construction tabs. The signal and overhead tabs have not been adapted. Considering they have different requirements with respect to spacing, I don't plan on tackling them in this PR.

Here's a short clip of the new tool in action:

https://github.com/user-attachments/assets/317bf08e-b505-4c9f-89a4-fe04f2f7ff16
