### PR TITLE
Bump vcpkg to April 2025; remove openal-soft version override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         uses: lukka/run-vcpkg@v11.5
         with:
           vcpkgDirectory: '${{ github.workspace }}/vcpkg'
-          vcpkgGitCommitId: c63619856b89f0af4d77ba2049396039e4985418
+          vcpkgGitCommitId: d5182f703b51d7b258f83f94d936ac03488dcdbe
       - name: Build OpenLoco
         shell: cmd
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if (WIN32)
         endif ()
         FetchContent_Declare(vcpkg
             GIT_REPOSITORY https://github.com/microsoft/vcpkg.git
-            GIT_TAG c63619856b89f0af4d77ba2049396039e4985418)
+            GIT_TAG d5182f703b51d7b258f83f94d936ac03488dcdbe)
         FetchContent_MakeAvailable(vcpkg)
 
         set(CMAKE_TOOLCHAIN_FILE "${vcpkg_SOURCE_DIR}/scripts/buildsystems/vcpkg.cmake"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -24,12 +24,5 @@
         }
       ]
     }
-  ],
-  "builtin-baseline": "300239058e33420acd153135b3f6e6b187828992",
-  "overrides": [
-    {
-      "name": "openal-soft",
-      "version": "1.24.1"
-    }
   ]
 }


### PR DESCRIPTION
Following up on #3048, with OpenAL having released v1.24.3.