### PR TITLE
Allow replacing existing station elements directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 25.04+ (???)
 ------------------------------------------------------------------------
+- Feature: [#3087] Allow replacing existing station elements directly in the station construction tool.
+- Fix: [#3092] Drag selection area is not correctly removed after dragging station elements.
 
 25.04 (2025-04-28)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/GameCommands/Road/CreateRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/CreateRoadStation.cpp
@@ -273,6 +273,18 @@ namespace OpenLoco::GameCommands
                 setErrorText(StringIds::empty);
                 return FAILURE;
             }
+
+            if (initialElRoad->hasStationElement())
+            {
+                auto* elStation = getStationElement(args.pos);
+                // Will happen if its an aiAllocated station
+                if (elStation == nullptr)
+                {
+                    setErrorText(StringIds::empty);
+                    return FAILURE;
+                }
+                // Otherwise, allow replacement
+            }
         }
         auto& roadPieces = World::TrackData::getRoadPiece(args.roadId);
         auto& argPiece = roadPieces[index];

--- a/src/OpenLoco/src/GameCommands/Road/CreateRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/CreateRoadStation.cpp
@@ -273,21 +273,6 @@ namespace OpenLoco::GameCommands
                 setErrorText(StringIds::empty);
                 return FAILURE;
             }
-
-            if (initialElRoad->hasStationElement())
-            {
-                auto* elStation = getStationElement(args.pos);
-                // Will happen if its an aiAllocated station
-                if (elStation == nullptr)
-                {
-                    setErrorText(StringIds::empty);
-                }
-                else
-                {
-                    setErrorText(StringIds::station_in_the_way);
-                }
-                return FAILURE;
-            }
         }
         auto& roadPieces = World::TrackData::getRoadPiece(args.roadId);
         auto& argPiece = roadPieces[index];
@@ -511,7 +496,8 @@ namespace OpenLoco::GameCommands
             if (piece.index == 0)
             {
                 bool calculateCost = true;
-                // Why?? we already blocked this from occurring???
+
+                // Replace station if it already exists
                 if (!unk112C7F3 && elRoads[1]->hasStationElement())
                 {
                     auto* elStation = elRoads[1]->next()->as<World::StationElement>();
@@ -531,6 +517,7 @@ namespace OpenLoco::GameCommands
                         totalCost += cost;
                     }
                 }
+
                 if (calculateCost)
                 {
                     auto placementCostBase = Economy::getInflationAdjustedCost(stationObj->buildCostFactor, stationObj->costIndex, 8);
@@ -660,6 +647,7 @@ namespace OpenLoco::GameCommands
             newStationElement->setOwner(getUpdatingCompanyId());
             Ui::ViewportManager::invalidate(roadLoc, newStationElement->baseHeight(), newStationElement->clearHeight());
         }
+
         if (!(flags & Flags::ghost) && (flags & Flags::apply))
         {
             if (_112C7A9)

--- a/src/OpenLoco/src/GameCommands/Track/CreateTrainStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Track/CreateTrainStation.cpp
@@ -240,12 +240,6 @@ namespace OpenLoco::GameCommands
         }
         else
         {
-            if (initialElTrack->hasStationElement())
-            {
-                setErrorText(StringIds::station_in_the_way);
-                return FAILURE;
-            }
-
             if (!sub_431E6A(initialElTrack->owner(), reinterpret_cast<World::TileElement*>(initialElTrack)))
             {
                 return FAILURE;
@@ -405,7 +399,8 @@ namespace OpenLoco::GameCommands
                 if (piece.index == 0)
                 {
                     bool calculateCost = true;
-                    // Why?? we already blocked this from occurring???
+
+                    // Replace station if it already exists
                     if (elTrack->hasStationElement())
                     {
                         auto* elStation = elTrack->next()->as<World::StationElement>();
@@ -425,6 +420,7 @@ namespace OpenLoco::GameCommands
                             totalCost += cost;
                         }
                     }
+
                     if (calculateCost)
                     {
                         auto placementCostBase = Economy::getInflationAdjustedCost(stationObj->buildCostFactor, stationObj->costIndex, 8);
@@ -523,6 +519,7 @@ namespace OpenLoco::GameCommands
                 Ui::ViewportManager::invalidate(trackLoc, newStationElement->baseHeight(), newStationElement->clearHeight());
             }
         }
+
         if (!(flags & Flags::ghost) && (flags & Flags::apply))
         {
             if (updateStationTileRegistration)

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -824,19 +824,21 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
     static std::optional<GameCommands::RoadStationPlacementArgs> getRoadStationPlacementArgsFromCursor(const int16_t x, const int16_t y)
     {
-        const auto res = ViewportInteraction::getMapCoordinatesFromPos(x, y, ~ViewportInteraction::InteractionItemFlags::roadAndTram);
+        const auto res = ViewportInteraction::getMapCoordinatesFromPos(x, y, ~(ViewportInteraction::InteractionItemFlags::roadAndTram | ViewportInteraction::InteractionItemFlags::station));
         const auto& interaction = res.first;
-        if (interaction.type != ViewportInteraction::InteractionItem::road)
+        if (interaction.type != ViewportInteraction::InteractionItem::road && interaction.type != ViewportInteraction::InteractionItem::roadStation)
         {
             return std::nullopt;
         }
 
         auto* elRoad = reinterpret_cast<const TileElement*>(interaction.object)->as<RoadElement>();
-        if (elRoad == nullptr)
+        auto* elStation = reinterpret_cast<const TileElement*>(interaction.object)->as<StationElement>();
+        if (elRoad == nullptr && elStation == nullptr)
         {
             return std::nullopt;
         }
 
+        // Deliberately always passing road and not station element, even if nullptr
         return getRoadStationPlacementArgs(interaction.pos, elRoad);
     }
 
@@ -895,19 +897,21 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
     static std::optional<GameCommands::TrainStationPlacementArgs> getTrainStationPlacementArgsFromCursor(const int16_t x, const int16_t y)
     {
-        const auto res = ViewportInteraction::getMapCoordinatesFromPos(x, y, ~ViewportInteraction::InteractionItemFlags::track);
+        const auto res = ViewportInteraction::getMapCoordinatesFromPos(x, y, ~(ViewportInteraction::InteractionItemFlags::track | ViewportInteraction::InteractionItemFlags::station));
         const auto& interaction = res.first;
-        if (interaction.type != ViewportInteraction::InteractionItem::track)
+        if (interaction.type != ViewportInteraction::InteractionItem::track && interaction.type != ViewportInteraction::InteractionItem::trainStation)
         {
             return std::nullopt;
         }
 
         auto* elTrack = reinterpret_cast<const TileElement*>(interaction.object)->as<TrackElement>();
-        if (elTrack == nullptr)
+        auto* elStation = reinterpret_cast<const TileElement*>(interaction.object)->as<StationElement>();
+        if (elTrack == nullptr && elStation == nullptr)
         {
             return std::nullopt;
         }
 
+        // Deliberately always passing track and not station element, even if nullptr
         return getTrainStationPlacementArgs(interaction.pos, elTrack);
     }
 


### PR DESCRIPTION
This PR changes the station placement tool such that existing station elements may be replaced. Fortunately, the game commands appear to have supported this already, but errored out instead of actually replacing the element! Replacement cost is even calculated.

These changes apply to the new drag tool as well as the original single station tile placement.

https://github.com/user-attachments/assets/87b0b192-2183-428b-a883-8403cc52d20a

