### PR TITLE
Improve invalidation for station drag selection

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -2675,8 +2675,9 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
     static void onToolUpMultiple(Window& self, const WidgetIndex_t widgetIndex)
     {
-        mapInvalidateMapSelectionTiles();
+        mapInvalidateSelectionRect();
         removeConstructionGhosts();
+        World::resetMapSelectionFlags();
 
         auto rotation = _cState->constructionRotation;
         auto piece = _cState->lastSelectedTrackPiece;

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -1025,8 +1025,9 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
     static void onToolUpMultiple()
     {
-        mapInvalidateMapSelectionTiles();
+        mapInvalidateSelectionRect();
         removeConstructionGhosts();
+        World::resetMapSelectionFlags();
 
         auto dirX = _toolPosDrag.x - _toolPosInitial.x > 0 ? 1 : -1;
         auto dirY = _toolPosDrag.y - _toolPosInitial.y > 0 ? 1 : -1;


### PR DESCRIPTION
This PR improve invalidation for station drag selection, particularly when part of the selection fails to build.

This was not an issue for the construction tab, as the map selection flags were reset elsewhere down the code path. I've still applied the same patch to keep things consistent, though.