### PR TITLE
Check the correct tab for overhead animation

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -849,7 +849,7 @@ namespace OpenLoco::Ui::Windows::Construction
             // Overhead tab
             {
                 Widget::drawTab(self, drawingCtx, ImageIds::null, widx::tab_overhead);
-                if (!self->isDisabled(widx::tab_station))
+                if (!self->isDisabled(widx::tab_overhead))
                 {
                     auto x = self->widgets[widx::tab_overhead].left + self->x + 2;
                     auto y = self->widgets[widx::tab_overhead].top + self->y + 2;
@@ -1012,7 +1012,7 @@ namespace OpenLoco::Ui::Windows::Construction
             // Overhead Tab
             {
                 Widget::drawTab(self, drawingCtx, ImageIds::null, widx::tab_overhead);
-                if (!self->isDisabled(widx::tab_station))
+                if (!self->isDisabled(widx::tab_overhead))
                 {
                     auto x = self->widgets[widx::tab_overhead].left + self->x + 2;
                     auto y = self->widgets[widx::tab_overhead].top + self->y + 2;


### PR DESCRIPTION
Looks like a minor copy/paste mistake. Don't think this will actually affect anything.