### PR TITLE
Automatically search for Steam installation of Locomotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#3087] Allow replacing existing station elements directly in the station construction tool.
 - Change: [#3095] The Tile Inspector can now be accessed in the Scenario Editor when the cheats menu is enabled.
+- Change: [#3098] Automatically detect Steam installation of Locomotion.
 - Fix: [#3092] Drag selection area is not correctly removed after dragging station elements.
 - Fix: [#3096] Buildings are removed over time in the scenario editor (original bug).
 

--- a/src/OpenLoco/src/Environment.cpp
+++ b/src/OpenLoco/src/Environment.cpp
@@ -56,6 +56,7 @@ namespace OpenLoco::Environment
             "C:/Program Files (x86)/Atari/Locomotion",
             "C:/GOG Games/Chris Sawyer's Locomotion",
             "C:/GOG Games/Locomotion",
+            "C:/Program Files (x86)/Steam/steamapps/common/Locomotion",
         };
 
         Logging::info("Searching for Locomotion install path...");

--- a/src/OpenLoco/src/Environment.cpp
+++ b/src/OpenLoco/src/Environment.cpp
@@ -56,6 +56,7 @@ namespace OpenLoco::Environment
             "C:/Program Files (x86)/Atari/Locomotion",
             "C:/GOG Games/Chris Sawyer's Locomotion",
             "C:/GOG Games/Locomotion",
+            "C:/Program Files/Steam/steamapps/common/Locomotion",
             "C:/Program Files (x86)/Steam/steamapps/common/Locomotion",
         };
 


### PR DESCRIPTION
I am confident that this is the most typical installation path of Chris Sawyer's Locomotion when installed with Steam on Windows.

I tested this by deleting my openloco.yml file: OpenLoco now automatically detects a Steam installation of Locomotion when run for the first time.