### PR TITLE
Implement createRoadMod command

### DIFF
--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -102,6 +102,7 @@ set(OLOCO_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Industries/RemoveIndustry.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Industries/RenameIndustry.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Road/CreateRoad.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Road/CreateRoadMod.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Road/CreateRoadStation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Road/RemoveRoad.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Road/RemoveRoadStation.cpp"

--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -105,6 +105,7 @@ set(OLOCO_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Road/CreateRoadMod.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Road/CreateRoadStation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Road/RemoveRoad.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Road/RemoveRoadMod.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Road/RemoveRoadStation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Terraform/ChangeLandMaterial.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/GameCommands/Terraform/ClearLand.cpp"

--- a/src/OpenLoco/src/GameCommands/GameCommands.cpp
+++ b/src/OpenLoco/src/GameCommands/GameCommands.cpp
@@ -166,7 +166,7 @@ namespace OpenLoco::GameCommands
         { GameCommand::vehicleOrderSkip,             vehicleOrderSkip,          0x0047071A, false },
         { GameCommand::createRoad,                   createRoad,                0x00475FBC, true  },
         { GameCommand::removeRoad,                   removeRoad,                0x004775A5, true  },
-        { GameCommand::createRoadMod,                nullptr,                   0x0047A21E, true  },
+        { GameCommand::createRoadMod,                createRoadMod,             0x0047A21E, true  },
         { GameCommand::removeRoadMod,                nullptr,                   0x0047A42F, true  },
         { GameCommand::createRoadStation,            createRoadStation,         0x0048C708, true  },
         { GameCommand::removeRoadStation,            removeRoadStation,         0x0048D2AC, true  },

--- a/src/OpenLoco/src/GameCommands/GameCommands.cpp
+++ b/src/OpenLoco/src/GameCommands/GameCommands.cpp
@@ -167,7 +167,7 @@ namespace OpenLoco::GameCommands
         { GameCommand::createRoad,                   createRoad,                0x00475FBC, true  },
         { GameCommand::removeRoad,                   removeRoad,                0x004775A5, true  },
         { GameCommand::createRoadMod,                createRoadMod,             0x0047A21E, true  },
-        { GameCommand::removeRoadMod,                nullptr,                   0x0047A42F, true  },
+        { GameCommand::removeRoadMod,                removeRoadMod,             0x0047A42F, true  },
         { GameCommand::createRoadStation,            createRoadStation,         0x0048C708, true  },
         { GameCommand::removeRoadStation,            removeRoadStation,         0x0048D2AC, true  },
         { GameCommand::createBuilding,               createBuilding,            0x0042D133, true  },

--- a/src/OpenLoco/src/GameCommands/Road/CreateRoadMod.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/CreateRoadMod.cpp
@@ -1,0 +1,92 @@
+#include "CreateRoadMod.h"
+#include "Map/RoadElement.h"
+#include "Map/TileManager.h"
+#include "Map/Track/TrackData.h"
+
+namespace OpenLoco::GameCommands
+{
+    /*
+    struct RoadModsPlacementArgs
+    {
+        World::Pos3 pos;
+        uint8_t rotation;
+        uint8_t roadId;
+        uint8_t index;
+        uint8_t type;
+        uint8_t roadObjType;
+        World::Track::ModSection modSection;
+
+        registers regs;
+        regs.ax = pos.x;
+        regs.cx = pos.y;
+        regs.bh = rotation;
+        regs.dl = roadId;
+        regs.dh = index;
+        regs.edi = pos.z | (type << 16);
+        regs.ebp = roadObjType | (enumValue(modSection) << 16);
+    };
+    */
+
+    static World::RoadElement* getRoadElement(const RoadModsPlacementArgs& args)
+    {
+        auto tile = World::TileManager::get(args.pos);
+        for (auto& element : tile)
+        {
+            auto* roadEl = element.as<World::RoadElement>();
+            if (roadEl == nullptr)
+            {
+                continue;
+            }
+            if (roadEl->baseHeight() != args.pos.z)
+            {
+                continue;
+            }
+            if (roadEl->rotation() != args.rotation)
+            {
+                continue;
+            }
+            if (roadEl->rotation() != args.rotation)
+            {
+                continue;
+            }
+            if (roadEl->sequenceIndex() != args.index)
+            {
+                continue;
+            }
+            if (roadEl->roadObjectId() != args.roadObjType)
+            {
+                continue;
+            }
+            if (roadEl->roadId() != args.roadId)
+            {
+                continue;
+            }
+            return roadEl;
+        }
+        return nullptr;
+    }
+
+    // 0x0047A21E
+    static uint32_t createRoadMod(const RoadModsPlacementArgs& args, uint8_t flags)
+    {
+        uint32_t totalCost = 0;
+
+        auto* roadEl = getRoadElement(args);
+        if (roadEl == nullptr || !sub_431E6A(roadEl->owner(), reinterpret_cast<const World::TileElement*>(roadEl)))
+        {
+            return FAILURE;
+        }
+
+        auto& piece = World::TrackData::getRoadPiece(args.roadId)[roadEl->sequenceIndex()];
+        const auto roadLoc = args.pos + World::Pos3{ Math::Vector::rotate(World::Pos2{ piece.x, piece.y }, args.rotation), piece.z };
+
+        // 0x0047A34C
+
+        return totalCost;
+    }
+
+    void createRoadMod(registers& regs)
+    {
+        regs.ebx = createRoadMod(RoadModsPlacementArgs(regs), regs.bl);
+    }
+}

--- a/src/OpenLoco/src/GameCommands/Road/CreateRoadMod.h
+++ b/src/OpenLoco/src/GameCommands/Road/CreateRoadMod.h
@@ -42,4 +42,6 @@ namespace OpenLoco::GameCommands
             return regs;
         }
     };
+
+    void createRoadMod(registers& regs);
 }

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoadMod.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoadMod.cpp
@@ -1,0 +1,87 @@
+#include "RemoveRoadMod.h"
+#include "Economy/Expenditures.h"
+#include "Map/RoadElement.h"
+#include "Map/TileManager.h"
+#include "Map/Track/TrackData.h"
+#include "Ui/WindowManager.h"
+#include "Vehicles/Vehicle.h"
+#include <OpenLoco/Math/Vector.hpp>
+
+using namespace OpenLoco::Interop;
+
+namespace OpenLoco::GameCommands
+{
+    // 0x0047A42F
+    static currency32_t removeRoadMod(const RoadModsRemovalArgs& args, uint8_t flags)
+    {
+        setExpenditureType(ExpenditureType::Construction);
+        setPosition(args.pos + World::Pos3(16, 16, 0));
+
+        auto* elRoad = [&args]() -> const World::RoadElement* {
+            const auto tile = World::TileManager::get(args.pos);
+            for (const auto& el : tile)
+            {
+                auto* elRoad = el.as<World::RoadElement>();
+                if (elRoad == nullptr)
+                {
+                    continue;
+                }
+
+                if (elRoad->baseHeight() != args.pos.z)
+                {
+                    continue;
+                }
+
+                if (elRoad->rotation() != args.rotation)
+                {
+                    continue;
+                }
+
+                if (elRoad->sequenceIndex() != args.index)
+                {
+                    continue;
+                }
+
+                if (elRoad->roadObjectId() != args.roadObjType)
+                {
+                    continue;
+                }
+
+                if (elRoad->roadId() != args.roadId)
+                {
+                    continue;
+                }
+
+                return elRoad;
+            }
+            return nullptr;
+        }();
+
+        if (elRoad == nullptr)
+        {
+            return FAILURE;
+        }
+
+        if (!sub_431E6A(elRoad->owner(), reinterpret_cast<const World::TileElement*>(elRoad)))
+        {
+            return FAILURE;
+        }
+
+        const auto& piece = World::TrackData::getRoadPiece(elRoad->roadId())[elRoad->sequenceIndex()];
+        const auto offsetToFirstTile = World::Pos3{
+            Math::Vector::rotate(World::Pos2{ piece.x, piece.y }, elRoad->rotation()),
+            piece.z
+        };
+        const auto firstTilePos = args.pos - offsetToFirstTile;
+        const auto tad = Vehicles::TrackAndDirection::_RoadAndDirection(elRoad->roadId(), elRoad->rotation());
+
+        auto cost = Vehicles::removeRoadModsToTrackNetwork(firstTilePos, tad, elRoad->owner(), args.roadObjType, flags, args.modSection, args.type);
+
+        return cost;
+    }
+
+    void removeRoadMod(registers& regs)
+    {
+        regs.ebx = removeRoadMod(RoadModsRemovalArgs(regs), regs.bl);
+    }
+}

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoadMod.h
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoadMod.h
@@ -42,4 +42,6 @@ namespace OpenLoco::GameCommands
             return regs;
         }
     };
+
+    void removeRoadMod(registers& regs);
 }

--- a/src/OpenLoco/src/Map/Track/Track.h
+++ b/src/OpenLoco/src/Map/Track/Track.h
@@ -22,11 +22,13 @@ namespace OpenLoco::World::Track
     namespace AdditionalTaDFlags
     {
         constexpr uint16_t basicTaDMask = 0b0000'0001'1111'1111;
+        constexpr uint16_t basicRaDMask = 0b0000'0000'0111'1111;
         constexpr uint16_t bridgeMask = 0b0000'1110'0000'0000;
         constexpr uint16_t hasBridge = (1U << 12);
         constexpr uint16_t hasMods = (1U << 13);
         constexpr uint16_t hasSignal = (1U << 15); // Track only (not roads)
         constexpr uint16_t basicTaDWithSignalMask = basicTaDMask | hasSignal;
+        constexpr uint16_t basicRaDWithSignalMask = basicRaDMask | hasSignal; // Roads don't have signals so this seems a bit pointless
     }
 
     struct RoadConnections

--- a/src/OpenLoco/src/Vehicles/Routing.cpp
+++ b/src/OpenLoco/src/Vehicles/Routing.cpp
@@ -3,6 +3,7 @@
 #include "Entities/EntityManager.h"
 #include "GameCommands/GameCommands.h"
 #include "Map/AnimationManager.h"
+#include "Map/RoadElement.h"
 #include "Map/SignalElement.h"
 #include "Map/Tile.h"
 #include "Map/TileManager.h"

--- a/src/OpenLoco/src/Vehicles/Routing.cpp
+++ b/src/OpenLoco/src/Vehicles/Routing.cpp
@@ -1515,7 +1515,7 @@ namespace OpenLoco::Vehicles
         return false;
     }
 
-    ApplyTrackModsResult applyRoadModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection::_RoadAndDirection trackAndDirection, CompanyId company, uint8_t trackType, uint8_t flags, ModSection modSelection, uint8_t trackModObjIds)
+    ApplyTrackModsResult applyRoadModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection::_RoadAndDirection roadAndDirection, CompanyId company, uint8_t roadType, uint8_t flags, ModSection modSelection, uint8_t roadModObjIds)
     {
         ApplyTrackModsResult result{};
         result.cost = 0;
@@ -1524,17 +1524,17 @@ namespace OpenLoco::Vehicles
 
         if (modSelection == Track::ModSection::single)
         {
-            LocationOfInterest interest{ pos, trackAndDirection._data, company, trackType };
-            applyRoadModToRoad(interest, flags, nullptr, modSelection, trackType, trackModObjIds, result.cost, company, result.allPlacementsFailed);
+            LocationOfInterest interest{ pos, roadAndDirection._data, company, roadType };
+            applyRoadModToRoad(interest, flags, nullptr, modSelection, roadType, roadModObjIds, result.cost, company, result.allPlacementsFailed);
             return result;
         }
 
         LocationOfInterestHashMap interestHashMap{ kTrackModHashMapSize };
 
-        auto filterFunction = [flags, modSelection, trackType, trackModObjIds, &result, company, &interestHashMap](const LocationOfInterest& interest) {
-            return applyRoadModToRoad(interest, flags, &interestHashMap, modSelection, trackType, trackModObjIds, result.cost, company, result.allPlacementsFailed);
+        auto filterFunction = [flags, modSelection, roadType, roadModObjIds, &result, company, &interestHashMap](const LocationOfInterest& interest) {
+            return applyRoadModToRoad(interest, flags, &interestHashMap, modSelection, roadType, roadModObjIds, result.cost, company, result.allPlacementsFailed);
         };
-        findAllRoadsFilterTransform(interestHashMap, TrackNetworkSearchFlags::unk0, pos, trackAndDirection, company, trackType, filterFunction, kNullTransformFunction);
+        findAllRoadsFilterTransform(interestHashMap, TrackNetworkSearchFlags::unk0, pos, roadAndDirection, company, roadType, filterFunction, kNullTransformFunction);
         result.networkTooComplex = interestHashMap.count >= interestHashMap.maxEntries;
         return result;
     }

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -244,6 +244,7 @@ namespace OpenLoco::Vehicles
     };
     ApplyTrackModsResult applyTrackModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection::_TrackAndDirection trackAndDirection, CompanyId company, uint8_t trackType, uint8_t flags, World::Track::ModSection modSelection, uint8_t trackModObjIds);
     currency32_t removeTrackModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection::_TrackAndDirection trackAndDirection, CompanyId company, uint8_t trackType, uint8_t flags, World::Track::ModSection modSelection, uint8_t trackModObjIds);
+    ApplyTrackModsResult applyRoadModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection::_RoadAndDirection roadAndDirection, CompanyId company, uint8_t roadType, uint8_t flags, World::Track::ModSection modSelection, uint8_t roadModObjIds);
     void leaveLevelCrossing(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint16_t unk);
 
     enum class RoadOccupationFlags : uint8_t

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -245,6 +245,7 @@ namespace OpenLoco::Vehicles
     ApplyTrackModsResult applyTrackModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection::_TrackAndDirection trackAndDirection, CompanyId company, uint8_t trackType, uint8_t flags, World::Track::ModSection modSelection, uint8_t trackModObjIds);
     currency32_t removeTrackModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection::_TrackAndDirection trackAndDirection, CompanyId company, uint8_t trackType, uint8_t flags, World::Track::ModSection modSelection, uint8_t trackModObjIds);
     ApplyTrackModsResult applyRoadModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection::_RoadAndDirection roadAndDirection, CompanyId company, uint8_t roadType, uint8_t flags, World::Track::ModSection modSelection, uint8_t roadModObjIds);
+    currency32_t removeRoadModsToTrackNetwork(const World::Pos3& pos, Vehicles::TrackAndDirection::_RoadAndDirection roadAndDirection, CompanyId company, uint8_t roadType, uint8_t flags, World::Track::ModSection modSelection, uint8_t roadModObjIds);
     void leaveLevelCrossing(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint16_t unk);
 
     enum class RoadOccupationFlags : uint8_t


### PR DESCRIPTION
I've hijacked this PR ~@duncanspumpkin

Implements both createRoadMod and removeRoadMod a mostly useless game command that can only be accessed from the tram building window and only after you disable road mods for the tram. I'm not sure why you would want to remove road mods for trams but it is doable.