### PR TITLE
Clip render target for widgets, do not draw them with window relatives

### DIFF
--- a/src/OpenLoco/src/Ui/Widget.cpp
+++ b/src/OpenLoco/src/Ui/Widget.cpp
@@ -85,14 +85,24 @@ namespace OpenLoco::Ui
         widgetState.hovered = (hoveredWidgets & (1ULL << widgetIndex)) != 0;
         widgetState.scrollviewIndex = scrollviewIndex;
 
+        auto clippedRT = clipRenderTarget(drawingCtx.currentRenderTarget(), Rect{ left, top, width(), height() });
+        if (!clippedRT)
+        {
+            // Widget position is outside the windows canvas which is the current clipped RT.
+            return;
+        }
+
+        drawingCtx.pushRenderTarget(*clippedRT);
+
         // With the only exception of WidgetType::empty everything else should implement it.
         assert(events.draw != nullptr);
 
         if (events.draw != nullptr)
         {
             events.draw(drawingCtx, *this, widgetState);
-            return;
         }
+
+        drawingCtx.popRenderTarget();
     }
 
     // 0x004CF194

--- a/src/OpenLoco/src/Ui/Widgets/ButtonWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ButtonWidget.cpp
@@ -17,7 +17,7 @@ namespace OpenLoco::Ui::Widgets
             flags |= Gfx::RectInsetFlags::borderInset;
         }
 
-        drawingCtx.fillRectInset(widget.position(), widget.size(), widgetState.colour, flags);
+        drawingCtx.fillRectInset({}, widget.size(), widgetState.colour, flags);
 
         Label::draw(drawingCtx, widget, widgetState);
     }

--- a/src/OpenLoco/src/Ui/Widgets/CaptionWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/CaptionWidget.cpp
@@ -14,23 +14,22 @@ namespace OpenLoco::Ui::Widgets
     {
         auto tr = Gfx::TextRenderer(drawingCtx);
 
-        const auto pos = widget.position();
         const auto size = widget.size();
 
         drawingCtx.fillRectInset(
-            pos,
+            {},
             size,
             widgetState.colour,
             widgetState.flags | Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillDarker);
 
         drawingCtx.fillRect(
-            pos + Ui::Point(1, 1),
+            Ui::Point(1, 1),
             size - Ui::Size(2, 2),
             enumValue(ExtColour::unk2E),
             Gfx::RectFlags::transparent);
 
         int16_t width = size.width - 4 - 10;
-        auto centerPos = pos + Point(2 + (width / 2), 1);
+        auto centerPos = Point(2 + (width / 2), 1);
 
         auto formatArgs = FormatArguments(widget.textArgs);
         tr.drawStringCentredClipped(
@@ -73,12 +72,11 @@ namespace OpenLoco::Ui::Widgets
 
         StringManager::formatString(&stringBuffer[1], widget.text, formatArgs);
 
-        const auto pos = widget.position();
         const auto size = widget.size();
 
         int16_t width = size.width - 4 - 14;
 
-        auto stationNamePos = pos + Ui::Point(2 + (width / 2), 1);
+        auto stationNamePos = Ui::Point(2 + (width / 2), 1);
 
         auto tr = Gfx::TextRenderer(drawingCtx);
         tr.setCurrentFont(Gfx::Font::medium_bold);

--- a/src/OpenLoco/src/Ui/Widgets/CheckboxWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/CheckboxWidget.cpp
@@ -12,10 +12,8 @@ namespace OpenLoco::Ui::Widgets
     // 0x004CB00B
     static void drawCheckBox(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        const auto pos = widget.position();
-
         drawingCtx.fillRectInset(
-            pos,
+            {},
             kCheckMarkSize,
             widgetState.colour,
             widgetState.flags | Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillDarker);
@@ -32,7 +30,7 @@ namespace OpenLoco::Ui::Widgets
             }
 
             tr.setCurrentFont(widget.font);
-            tr.drawString(pos, colour.opaque(), strCheckmark);
+            tr.drawString({}, colour.opaque(), strCheckmark);
         }
     }
 
@@ -57,8 +55,7 @@ namespace OpenLoco::Ui::Widgets
         auto tr = Gfx::TextRenderer(drawingCtx);
         tr.setCurrentFont(widget.font);
 
-        const auto pos = widget.position();
-        tr.drawStringLeft(pos + Point{ kCheckMarkSize.width + kLabelMarginLeft, 0 }, colour, widget.text, formatArgs);
+        tr.drawStringLeft(Point{ kCheckMarkSize.width + kLabelMarginLeft, 0 }, colour, widget.text, formatArgs);
     }
 
     void Checkbox::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)

--- a/src/OpenLoco/src/Ui/Widgets/ColourButtonWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ColourButtonWidget.cpp
@@ -35,7 +35,6 @@ namespace OpenLoco::Ui::Widgets
             imageId = imageId.withPrimary(widgetState.colour.c());
         }
 
-        const auto pos = widget.position();
-        drawingCtx.drawImage(pos, imageId);
+        drawingCtx.drawImage({}, imageId);
     }
 }

--- a/src/OpenLoco/src/Ui/Widgets/DropdownWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/DropdownWidget.cpp
@@ -26,23 +26,21 @@ namespace OpenLoco::Ui::Widgets
             colour = colour.FD();
         }
 
-        const auto pos = widget.position();
         const auto size = widget.size();
 
         auto tr = Gfx::TextRenderer(drawingCtx);
         auto formatArgs = FormatArgumentsView(widget.textArgs);
-        tr.drawStringLeftClipped(pos + Ui::Point{ 1, 1 }, size.width - 2, colour, widget.text, formatArgs);
+        tr.drawStringLeftClipped(Ui::Point{ 1, 1 }, size.width - 2, colour, widget.text, formatArgs);
     }
 
     // 0x004CB164
     void ComboBox::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        const auto pos = widget.position();
         const auto size = widget.size();
 
         const auto flags = widgetState.flags | Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillDarker;
         drawingCtx.fillRectInset(
-            pos,
+            {},
             size,
             widgetState.colour,
             flags);

--- a/src/OpenLoco/src/Ui/Widgets/FrameWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/FrameWidget.cpp
@@ -21,10 +21,9 @@ namespace OpenLoco::Ui::Widgets
             return;
         }
 
-        const auto pos = widget.position();
         const auto size = widget.size();
 
-        const auto resizeBarPos = pos + Ui::Point(size.width - 18, size.height - 18);
+        const auto resizeBarPos = Ui::Point(size.width - 18, size.height - 18);
 
         uint32_t image = Gfx::recolour(ImageIds::window_resize_handle, colour.c());
         drawingCtx.drawImage(resizeBarPos, image);
@@ -35,27 +34,19 @@ namespace OpenLoco::Ui::Widgets
     {
         auto* window = widgetState.window;
 
-        const auto pos = widget.position();
         const auto size = widget.size();
 
-        const auto& rt = drawingCtx.currentRenderTarget();
-        const auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(pos.x, pos.y, size.width, 41));
-        if (clipped)
+        uint32_t imageId = widget.image;
+        if (window->hasFlags(WindowFlags::flag_11))
         {
-            uint32_t imageId = widget.image;
-            if (window->hasFlags(WindowFlags::flag_11))
-            {
-                imageId = Gfx::recolour(ImageIds::frame_background_image, widgetState.colour.c());
-            }
-            else
-            {
-                imageId = Gfx::recolour(ImageIds::frame_background_image_alt, widgetState.colour.c());
-            }
-
-            drawingCtx.pushRenderTarget(*clipped);
-            drawingCtx.drawImage(0, 0, imageId);
-            drawingCtx.popRenderTarget();
+            imageId = Gfx::recolour(ImageIds::frame_background_image, widgetState.colour.c());
         }
+        else
+        {
+            imageId = Gfx::recolour(ImageIds::frame_background_image_alt, widgetState.colour.c());
+        }
+
+        drawingCtx.drawImage(0, 0, imageId);
 
         uint8_t shade;
         if (window->hasFlags(WindowFlags::flag_11))
@@ -69,7 +60,7 @@ namespace OpenLoco::Ui::Widgets
 
         // Shadow at the right side.
         drawingCtx.fillRect(
-            pos + Point{ size.width - 1, 0 },
+            Point{ size.width - 1, 0 },
             Ui::Size{ 1, 40u },
             shade,
             Gfx::RectFlags::none);

--- a/src/OpenLoco/src/Ui/Widgets/GroupBoxWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/GroupBoxWidget.cpp
@@ -8,11 +8,10 @@ namespace OpenLoco::Ui::Widgets
 {
     void GroupBox::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        const auto position = widget.position();
         const auto size = widget.size();
 
         auto colour = widgetState.colour.opaque();
-        int16_t textEndPos = position.x + 5;
+        int16_t textEndPos = 5;
 
         // Draw label text if present
         if (widget.text != StringIds::null)
@@ -23,13 +22,13 @@ namespace OpenLoco::Ui::Widgets
             char buffer[512] = { 0 };
             StringManager::formatString(buffer, sizeof(buffer), widget.text);
 
-            auto point = Point(position.x + 5, position.y);
+            auto point = Point(5, 0);
             tr.drawString(point, colour, buffer);
-            textEndPos = position.x + 5 + tr.getStringWidth(buffer) + 1;
+            textEndPos = 5 + tr.getStringWidth(buffer) + 1;
         }
 
         // Prepare border position and size
-        const auto borderPos = position + Ui::Point{ 0, 4 };
+        const auto borderPos = Ui::Point{ 0, 4 };
         const auto borderSize = Ui::Size{ size.width + 0, size.height - 4 };
 
         // Border left of text

--- a/src/OpenLoco/src/Ui/Widgets/ImageButtonWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ImageButtonWidget.cpp
@@ -11,8 +11,6 @@ namespace OpenLoco::Ui::Widgets
     // 0x004CADE8
     static void drawImage(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        const auto pos = widget.position();
-
         const bool isColourSet = widget.image & Widget::kImageIdColourSet;
         ImageId imageId = ImageId::fromUInt32(widget.image & ~Widget::kImageIdColourSet);
 
@@ -31,16 +29,16 @@ namespace OpenLoco::Ui::Widgets
             if (colour.isTranslucent())
             {
                 c = Colours::getShade(colour.c(), 4);
-                drawingCtx.drawImageSolid(pos + Ui::Point{ 1, 1 }, pureImage, c);
+                drawingCtx.drawImageSolid(Ui::Point{ 1, 1 }, pureImage, c);
                 c = Colours::getShade(colour.c(), 2);
-                drawingCtx.drawImageSolid(pos, pureImage, c);
+                drawingCtx.drawImageSolid({}, pureImage, c);
             }
             else
             {
                 c = Colours::getShade(colour.c(), 6);
-                drawingCtx.drawImageSolid(pos + Ui::Point{ 1, 1 }, pureImage, c);
+                drawingCtx.drawImageSolid(Ui::Point{ 1, 1 }, pureImage, c);
                 c = Colours::getShade(colour.c(), 4);
-                drawingCtx.drawImageSolid(pos, pureImage, c);
+                drawingCtx.drawImageSolid({}, pureImage, c);
             }
 
             return;
@@ -61,14 +59,13 @@ namespace OpenLoco::Ui::Widgets
             imageId = ImageId::fromUInt32(Gfx::recolour(imageId.getIndex(), colour.c()));
         }
 
-        drawingCtx.drawImage(pos, imageId);
+        drawingCtx.drawImage({}, imageId);
     }
 
     static void draw_3(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
         auto* window = widgetState.window;
 
-        const auto pos = widget.position();
         const auto size = widget.size();
 
         auto flags = widgetState.flags;
@@ -80,17 +77,17 @@ namespace OpenLoco::Ui::Widgets
         if (widget.content == Widget::kContentUnk)
         {
             flags |= Gfx::RectInsetFlags::fillNone;
-            drawingCtx.fillRectInset(pos, size, widgetState.colour, flags);
+            drawingCtx.fillRectInset({}, size, widgetState.colour, flags);
             return;
         }
 
         if (window->hasFlags(WindowFlags::flag_6))
         {
-            drawingCtx.fillRect(pos, size, enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
+            drawingCtx.fillRect({}, size, enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
         }
 
         // TODO: Add a setting to decide if it should be translucent or not, for now it seems all ImageButton's require this.
-        drawingCtx.fillRectInset(pos, size, widgetState.colour.translucent(), flags);
+        drawingCtx.fillRectInset({}, size, widgetState.colour.translucent(), flags);
 
         if (widget.content == Widget::kContentNull)
         {
@@ -110,7 +107,6 @@ namespace OpenLoco::Ui::Widgets
             return;
         }
 
-        const auto pos = widget.position();
         const auto size = widget.size();
 
         if (widgetState.activated)
@@ -122,12 +118,12 @@ namespace OpenLoco::Ui::Widgets
                 // 0x004CABE8
 
                 flags |= Gfx::RectInsetFlags::fillNone;
-                drawingCtx.fillRectInset(pos, size, widgetState.colour, flags);
+                drawingCtx.fillRectInset({}, size, widgetState.colour, flags);
 
                 return;
             }
 
-            drawingCtx.fillRectInset(pos, size, widgetState.colour, flags);
+            drawingCtx.fillRectInset({}, size, widgetState.colour, flags);
         }
 
         if (widget.content == Widget::kContentNull)

--- a/src/OpenLoco/src/Ui/Widgets/LabelWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/LabelWidget.cpp
@@ -23,7 +23,6 @@ namespace OpenLoco::Ui::Widgets
             colour = colour.inset();
         }
 
-        const auto position = widget.position();
         const auto size = widget.size();
 
         auto formatArgs = FormatArguments(widget.textArgs);
@@ -33,18 +32,18 @@ namespace OpenLoco::Ui::Widgets
         const auto x = [&]() -> int16_t {
             if (widget.contentAlign == ContentAlign::left)
             {
-                return position.x;
+                return 0;
             }
             else if (widget.contentAlign == ContentAlign::center)
             {
-                return position.x + (size.width - 1) / 2;
+                return (size.width - 1) / 2;
             }
             else if (widget.contentAlign == ContentAlign::right)
             {
                 char buffer[512]{};
                 StringManager::formatString(buffer, std::size(buffer), widget.text, formatArgs);
                 const auto stringWidth = tr.getStringWidthNewLined(buffer);
-                return position.x + size.width - stringWidth - 1;
+                return size.width - stringWidth - 1;
             }
             assert(false);
             return {};
@@ -53,7 +52,7 @@ namespace OpenLoco::Ui::Widgets
         const auto fontHeight = tr.getLineHeight(tr.getCurrentFont());
         // NOTE: -1 is an ugly hack for buttons with inset border, remove that when all buttons have consistent height.
         const int16_t yOffset = std::max<int16_t>(0, (size.height - fontHeight) / 2 - 1);
-        const int16_t y = position.y + yOffset;
+        const int16_t y = yOffset;
         const int16_t width = size.width - 2;
 
         if (widget.contentAlign == ContentAlign::left)

--- a/src/OpenLoco/src/Ui/Widgets/NewsPanelWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/NewsPanelWidget.cpp
@@ -10,14 +10,13 @@ namespace OpenLoco::Ui::Widgets
 {
     void NewsPanel::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, [[maybe_unused]] const WidgetState& widgetState)
     {
-        const auto pos = widget.position();
-        const auto centerPos = pos + Point(widget.width() / 2, 0);
+        const auto centerPos = Point(widget.width() / 2, 0);
 
         const auto style = static_cast<Style>(widget.styleData);
         if (style == Style::old)
         {
             auto imageId = Gfx::recolour(ImageIds::news_background_old_left, ExtColour::translucentBrown1);
-            drawingCtx.drawImage(pos, imageId);
+            drawingCtx.drawImage({}, imageId);
 
             imageId = Gfx::recolour(ImageIds::news_background_old_right, ExtColour::translucentBrown1);
 
@@ -25,7 +24,7 @@ namespace OpenLoco::Ui::Widgets
         }
         else if (style == Style::new_)
         {
-            drawingCtx.drawImage(pos, ImageIds::news_background_new_left);
+            drawingCtx.drawImage({}, ImageIds::news_background_new_left);
 
             drawingCtx.drawImage(centerPos, ImageIds::news_background_new_right);
         }

--- a/src/OpenLoco/src/Ui/Widgets/PanelWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/PanelWidget.cpp
@@ -20,10 +20,9 @@ namespace OpenLoco::Ui::Widgets
             return;
         }
 
-        const auto pos = widget.position();
         const auto size = widget.size();
 
-        const auto resizeBarPos = pos + Ui::Point(size.width - 18, size.height - 18);
+        const auto resizeBarPos = Ui::Point(size.width - 18, size.height - 18);
 
         uint32_t image = Gfx::recolour(ImageIds::window_resize_handle, colour.c());
         drawingCtx.drawImage(resizeBarPos, image);
@@ -34,11 +33,10 @@ namespace OpenLoco::Ui::Widgets
     {
         auto* window = widgetState.window;
 
-        const auto pos = widget.position();
         const auto size = widget.size();
 
         drawingCtx.fillRectInset(
-            pos,
+            {},
             size,
             widgetState.colour,
             widgetState.flags);

--- a/src/OpenLoco/src/Ui/Widgets/ScrollViewWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ScrollViewWidget.cpp
@@ -17,12 +17,11 @@ namespace OpenLoco::Ui::Widgets
 
     static void drawHScroll(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState, const ScrollArea& scrollArea)
     {
-        const auto position = widget.position();
         const auto size = widget.size();
         const auto colour = widgetState.colour;
 
         // Calculate adjusted dimensions
-        auto scrollPos = position + Point{ kScrollbarMargin, size.height - kScrollbarSize - kScrollbarMargin };
+        auto scrollPos = Point{ kScrollbarMargin, size.height - kScrollbarSize - kScrollbarMargin };
         auto scrollSize = Ui::Size{ size.width - (kScrollbarMargin * 2), kScrollbarSize };
 
         if (scrollArea.hasFlags(Ui::ScrollFlags::vscrollbarVisible))
@@ -93,12 +92,11 @@ namespace OpenLoco::Ui::Widgets
 
     static void drawVScroll(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState, const ScrollArea& scrollArea)
     {
-        const auto position = widget.position();
         const auto size = widget.size();
         const auto colour = widgetState.colour;
 
         // Calculate adjusted dimensions
-        auto scrollPos = position + Point{ size.width - kScrollbarSize - kScrollbarMargin, kScrollbarMargin };
+        auto scrollPos = Point{ size.width - kScrollbarSize - kScrollbarMargin, kScrollbarMargin };
         auto scrollSize = Ui::Size{ kScrollbarSize, size.height - (kScrollbarMargin * 2) };
 
         if (scrollArea.hasFlags(ScrollFlags::hscrollbarVisible))
@@ -170,16 +168,16 @@ namespace OpenLoco::Ui::Widgets
     void ScrollView::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
         auto* window = widgetState.window;
-        const auto position = widget.position();
+
         const auto size = widget.size();
 
         auto tr = Gfx::TextRenderer(drawingCtx);
 
         // Draw background with inset
-        drawingCtx.fillRectInset(position, size, widgetState.colour, widgetState.flags | Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillDarker);
+        drawingCtx.fillRectInset({}, size, widgetState.colour, widgetState.flags | Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillDarker);
 
         // Adjusted content area (1px inset)
-        auto contentPos = position + Point{ kScrollbarMargin, kScrollbarMargin };
+        auto contentPos = Point{ kScrollbarMargin, kScrollbarMargin };
         auto contentSize = Ui::Size{ size.width - (kScrollbarMargin * 2), size.height - (kScrollbarMargin * 2) };
 
         const auto& scrollArea = window->scrollAreas[widgetState.scrollviewIndex];

--- a/src/OpenLoco/src/Ui/Widgets/TabWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/TabWidget.cpp
@@ -9,8 +9,6 @@ namespace OpenLoco::Ui::Widgets
     // 0x004CADE8
     static void drawTabBackground(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        const auto pos = widget.position();
-
         ImageId imageId = ImageId{ ImageIds::tab };
 
         // TODO: Separate content image and background image.
@@ -33,16 +31,16 @@ namespace OpenLoco::Ui::Widgets
             if (colour.isTranslucent())
             {
                 c = Colours::getShade(colour.c(), 4);
-                drawingCtx.drawImageSolid(pos + Ui::Point{ 1, 1 }, imageId, c);
+                drawingCtx.drawImageSolid(Ui::Point{ 1, 1 }, imageId, c);
                 c = Colours::getShade(colour.c(), 2);
-                drawingCtx.drawImageSolid(pos, imageId, c);
+                drawingCtx.drawImageSolid({}, imageId, c);
             }
             else
             {
                 c = Colours::getShade(colour.c(), 6);
-                drawingCtx.drawImageSolid(pos + Ui::Point{ 1, 1 }, imageId, c);
+                drawingCtx.drawImageSolid(Ui::Point{ 1, 1 }, imageId, c);
                 c = Colours::getShade(colour.c(), 4);
-                drawingCtx.drawImageSolid(pos, imageId, c);
+                drawingCtx.drawImageSolid({}, imageId, c);
             }
 
             return;
@@ -50,14 +48,12 @@ namespace OpenLoco::Ui::Widgets
 
         imageId = imageId.withPrimary(colour.c());
 
-        drawingCtx.drawImage(pos, imageId);
+        drawingCtx.drawImage({}, imageId);
     }
 
     static void drawTabContent(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
         auto* window = widgetState.window;
-
-        const auto pos = widget.position();
 
         if (widgetState.disabled)
         {
@@ -75,18 +71,18 @@ namespace OpenLoco::Ui::Widgets
         {
             if (widget.image != Widget::kContentNull)
             {
-                drawingCtx.drawImage(pos.x, pos.y, widget.image);
+                drawingCtx.drawImage(0, 0, widget.image);
             }
         }
         else
         {
             if (widget.image != Widget::kContentUnk)
             {
-                drawingCtx.drawImage(pos.x, pos.y + 1, widget.image);
+                drawingCtx.drawImage(0, 1, widget.image);
             }
 
-            drawingCtx.drawImage(pos.x, pos.y, Gfx::recolourTranslucent(ImageIds::tab, ExtColour::unk33));
-            drawingCtx.drawRect(pos.x, pos.y + 26, 31, 1, Colours::getShade(window->getColour(WindowColour::secondary).c(), 7), Gfx::RectFlags::none);
+            drawingCtx.drawImage(0, 0, Gfx::recolourTranslucent(ImageIds::tab, ExtColour::unk33));
+            drawingCtx.drawRect(0, 26, 31, 1, Colours::getShade(window->getColour(WindowColour::secondary).c(), 7), Gfx::RectFlags::none);
         }
     }
 

--- a/src/OpenLoco/src/Ui/Widgets/TextBoxWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/TextBoxWidget.cpp
@@ -23,23 +23,21 @@ namespace OpenLoco::Ui::Widgets
             colour = colour.FD();
         }
 
-        const auto pos = widget.position();
         const auto size = widget.size();
 
         auto tr = Gfx::TextRenderer(drawingCtx);
         auto formatArgs = FormatArgumentsView(widget.textArgs);
-        tr.drawStringLeftClipped(pos + Point{ 1, 1 }, size.width - 2, colour, widget.text, formatArgs);
+        tr.drawStringLeftClipped(Point{ 1, 1 }, size.width - 2, colour, widget.text, formatArgs);
     }
 
     // 0x4CB29C
     void TextBox::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        const auto pos = widget.position();
         const auto size = widget.size();
 
         const auto flags = widgetState.flags | Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillDarker;
         drawingCtx.fillRectInset(
-            pos,
+            {},
             size,
             widgetState.colour,
             flags);

--- a/src/OpenLoco/src/Ui/Widgets/ViewportWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ViewportWidget.cpp
@@ -24,7 +24,7 @@ namespace OpenLoco::Ui::Widgets
         }
 
         auto formatArgs = FormatArguments(widget.textArgs);
-        auto point = Point(widget.left + 1, widget.top);
+        auto point = Point(1, 0);
         int width = widget.right - widget.left - 2;
 
         auto tr = Gfx::TextRenderer(drawingCtx);

--- a/src/OpenLoco/src/Ui/Widgets/ViewportWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ViewportWidget.cpp
@@ -1,4 +1,5 @@
 #include "ViewportWidget.h"
+#include "Graphics/RenderTarget.h"
 #include "Graphics/SoftwareDrawingEngine.h"
 #include "Graphics/TextRenderer.h"
 #include "TextBoxWidget.h"
@@ -39,14 +40,33 @@ namespace OpenLoco::Ui::Widgets
         // TODO: Move viewports into the Widget
         auto& viewports = window->viewports;
 
-        if (viewports[0] != nullptr)
+        auto* vp0 = viewports[0];
+        auto* vp1 = viewports[1];
+        auto hasViewport = vp0 != nullptr || vp1 != nullptr;
+
+        // TODO: This is a hack, we need to step back in the render target stack to render the viewports,
+        // viewports currently store their position which is used to render in screen space coordinates
+        // also relative to the current invalidated region, it's a bit of a mess.
+        Gfx::RenderTarget savedRT;
+        if (hasViewport)
         {
-            viewports[0]->render(drawingCtx);
+            savedRT = drawingCtx.currentRenderTarget();
+            drawingCtx.popRenderTarget();
         }
 
-        if (viewports[1] != nullptr)
+        if (vp0 != nullptr)
         {
-            viewports[1]->render(drawingCtx);
+            vp0->render(drawingCtx);
+        }
+
+        if (vp1 != nullptr)
+        {
+            vp1->render(drawingCtx);
+        }
+
+        if (hasViewport)
+        {
+            drawingCtx.pushRenderTarget(savedRT);
         }
     }
 

--- a/src/OpenLoco/src/Ui/Widgets/Wt3Widget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/Wt3Widget.cpp
@@ -6,8 +6,6 @@ namespace OpenLoco::Ui::Widgets
 {
     static void sub_4CADE8(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
-        const auto position = widget.position();
-
         const bool isColourSet = widget.image & Widget::kImageIdColourSet;
         ImageId imageId = ImageId::fromUInt32(widget.image & ~Widget::kImageIdColourSet);
 
@@ -26,16 +24,16 @@ namespace OpenLoco::Ui::Widgets
             if (colour.isTranslucent())
             {
                 c = Colours::getShade(colour.c(), 4);
-                drawingCtx.drawImageSolid(position + Ui::Point{ 1, 1 }, pureImage, c);
+                drawingCtx.drawImageSolid(Ui::Point{ 1, 1 }, pureImage, c);
                 c = Colours::getShade(colour.c(), 2);
-                drawingCtx.drawImageSolid(position, pureImage, c);
+                drawingCtx.drawImageSolid({}, pureImage, c);
             }
             else
             {
                 c = Colours::getShade(colour.c(), 6);
-                drawingCtx.drawImageSolid(position + Ui::Point{ 1, 1 }, pureImage, c);
+                drawingCtx.drawImageSolid(Ui::Point{ 1, 1 }, pureImage, c);
                 c = Colours::getShade(colour.c(), 4);
-                drawingCtx.drawImageSolid(position, pureImage, c);
+                drawingCtx.drawImageSolid({}, pureImage, c);
             }
 
             return;
@@ -51,21 +49,14 @@ namespace OpenLoco::Ui::Widgets
             imageId = imageId.withPrimary(colour.c());
         }
 
-        drawingCtx.drawImage(position, imageId);
+        drawingCtx.drawImage({}, imageId);
     }
 
     void Wt3Widget::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
     {
         auto* window = widgetState.window;
 
-        const auto position = widget.position();
         const auto size = widget.size();
-
-        int16_t t, l, b, r;
-        t = widget.top;
-        l = widget.left;
-        r = widget.right;
-        b = widget.bottom;
 
         auto flags = widgetState.flags;
         if (widgetState.activated)
@@ -76,16 +67,16 @@ namespace OpenLoco::Ui::Widgets
         if (widget.content == Widget::kContentUnk)
         {
             flags |= Gfx::RectInsetFlags::fillNone;
-            drawingCtx.fillRectInset(position, size, widgetState.colour, flags);
+            drawingCtx.fillRectInset({}, size, widgetState.colour, flags);
             return;
         }
 
         if (window->hasFlags(WindowFlags::flag_6))
         {
-            drawingCtx.fillRect(position, size, enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
+            drawingCtx.fillRect({}, size, enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
         }
 
-        drawingCtx.fillRectInset(l, t, r, b, widgetState.colour, flags);
+        drawingCtx.fillRectInset({ 0, 0 }, size, widgetState.colour, flags);
 
         if (widget.content == Widget::kContentNull)
         {


### PR DESCRIPTION
Now windows and widgets will always use the local coordinate space for drawing.
