### PR TITLE
Fix mistake with pathfinding mods

### DIFF
--- a/src/OpenLoco/src/World/CompanyAi/CompanyAiPathfinding.cpp
+++ b/src/OpenLoco/src/World/CompanyAi/CompanyAiPathfinding.cpp
@@ -48,7 +48,7 @@ namespace OpenLoco::CompanyAi
                 {
                     continue;
                 }
-                if (thought.mods & (1U << i))
+                if (thought.mods & (1U << roadObj->mods[i]))
                 {
                     unkMods |= (1U << (16 + i));
                 }
@@ -70,7 +70,7 @@ namespace OpenLoco::CompanyAi
                 {
                     continue;
                 }
-                if (thought.mods & (1U << i))
+                if (thought.mods & (1U << trackObj->mods[i]))
                 {
                     unkMods |= (1U << (16 + i));
                 }


### PR DESCRIPTION
Found this little mistake in #3124. It doesn't often cause an issue as usually there isn't mods and usually the mod used is the first one loaded.