### PR TITLE
Implement VehicleBase::sub_4AA464, rename to destroyTrain

### DIFF
--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -173,7 +173,7 @@ namespace OpenLoco::Vehicles
     }
 
     // 0x004AA464
-    void VehicleBase::sub_4AA464()
+    void VehicleBase::destroyTrain()
     {
         VehicleHead* head = EntityManager::get<VehicleHead>(this->getHead());
         if (head->status != Status::crashed && head->status != Status::stuck)

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -231,31 +231,28 @@ namespace OpenLoco::Vehicles
                 currentVehicle->tileBaseZ = 0;
             }
         }
+        else if (this->getSubType() == VehicleEntityType::bogie)
+        {
+            VehicleBogie* bogie = this->asVehicleBogie();
+            bogie->var_5A |= (1U << 31);
+            bogie->tileX = 0;
+            bogie->tileY = 0;
+            bogie->tileBaseZ = 0;
+        }
         else
         {
-            if (this->getSubType() == VehicleEntityType::bogie)
-            {
-                VehicleBogie* bogie = this->asVehicleBogie();
-                bogie->var_5A |= (1U << 31);
-                bogie->tileX = 0;
-                bogie->tileY = 0;
-                bogie->tileBaseZ = 0;
-            }
-            else
-            {
-                // The disassembled code splits into two identical paths, here.
-                currentVehicle = head->asVehicleBogie();
+            // The disassembled code splits into two identical paths, here.
+            currentVehicle = head->asVehicleBogie();
 
-                while (EntityManager::get<VehicleBogie>(currentVehicle->getNextCar()) != this)
-                {
-                    currentVehicle = EntityManager::get<VehicleBogie>(currentVehicle->getNextCar());
-                }
-
-                currentVehicle->var_5A |= (1U << 31);
-                currentVehicle->tileX = 0;
-                currentVehicle->tileY = 0;
-                currentVehicle->tileBaseZ = 0;
+            while (EntityManager::get<VehicleBogie>(currentVehicle->getNextCar()) != this)
+            {
+                currentVehicle = EntityManager::get<VehicleBogie>(currentVehicle->getNextCar());
             }
+
+            currentVehicle->var_5A |= (1U << 31);
+            currentVehicle->tileX = 0;
+            currentVehicle->tileY = 0;
+            currentVehicle->tileBaseZ = 0;
         }
     }
 

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -603,7 +603,9 @@ namespace OpenLoco::Vehicles
         uint32_t var_5A;
         uint8_t wheelSlipping;         // 0x5E timeout that counts up
         BreakdownFlags breakdownFlags; // 0x5F
-        uint8_t pad_60[0x6A - 0x60];
+        uint16_t pad_60;               // 0x60
+        uint32_t refundCost;           // 0x62
+        uint8_t pad_66[0x6A - 0x66];
         uint8_t breakdownTimeout; // 0x6A (likely unused)
 
         const VehicleObject* getObject() const;

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -299,7 +299,7 @@ namespace OpenLoco::Vehicles
         void setColourScheme(ColourScheme colourScheme);
         bool updateComponent();
         void explodeComponent();
-        void sub_4AA464();
+        void destroyTrain();
         uint8_t sub_47D959(const World::Pos3& loc, const TrackAndDirection::_RoadAndDirection trackAndDirection, const bool setOccupied);
         int32_t updateTrackMotion(int32_t unk1);
     };

--- a/src/OpenLoco/src/Vehicles/Vehicle2.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle2.cpp
@@ -297,7 +297,7 @@ namespace OpenLoco::Vehicles
         _vehicleUpdate_var_1136130 = _vehicleUpdate_var_1136130 - res;
         if (_vehicleUpdate_var_1136114 & (1 << 1))
         {
-            sub_4AA464();
+            destroyTrain();
             return false;
         }
 

--- a/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleBogie.cpp
@@ -70,7 +70,7 @@ namespace OpenLoco::Vehicles
         _vehicleUpdate_var_1136130 = stash1136130;
         if (_vehicleUpdate_var_1136114 & (1 << 1))
         {
-            sub_4AA464();
+            destroyTrain();
             return false;
         }
         else if (!(_vehicleUpdate_var_1136114 & (1 << 2)))
@@ -265,7 +265,7 @@ namespace OpenLoco::Vehicles
     // 0x004AA0DF
     void VehicleBogie::collision()
     {
-        sub_4AA464();
+        destroyTrain();
         applyDestructionToComponent(*this);
         vehicleFlags |= VehicleFlags::unk_5;
 
@@ -297,7 +297,7 @@ namespace OpenLoco::Vehicles
             Vehicle collideTrain(collideCarComponent->getHead());
             if (collideTrain.head->status != Status::crashed)
             {
-                collideCarComponent->sub_4AA464();
+                collideCarComponent->destroyTrain();
             }
 
             for (auto& car : train.cars)

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -1202,7 +1202,7 @@ namespace OpenLoco::Vehicles
         else
         {
             Vehicle train(head);
-            train.veh2->sub_4AA464();
+            train.veh2->destroyTrain();
             return false;
         }
     }
@@ -1460,7 +1460,7 @@ namespace OpenLoco::Vehicles
                     }
 
                     // Crash
-                    vehType2->sub_4AA464();
+                    vehType2->destroyTrain();
                     return false;
                 }
 

--- a/src/OpenLoco/src/Vehicles/VehicleTail.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleTail.cpp
@@ -81,7 +81,7 @@ namespace OpenLoco::Vehicles
 
         if (*_vehicleUpdate_var_1136114 & (1 << 1))
         {
-            sub_4AA464();
+            destroyTrain();
             return false;
         }
 


### PR DESCRIPTION
This function displays the "vehicle has crashed" message (if the train belongs to the player company), marks the head as "crashed", sets the refund value of the train and each vehicle to zero, and does something with var_5A that I don't fully understand the purpose of.