### PR TITLE
Fix minor issue with clearing of surface/industry tiles

### DIFF
--- a/src/OpenLoco/src/GameSaveCompare.cpp
+++ b/src/OpenLoco/src/GameSaveCompare.cpp
@@ -622,7 +622,7 @@ namespace OpenLoco::GameSaveCompare
                         }
                         if (divergentBytesTotal == 0 || displayAllDivergences)
                         {
-                            Logging::info("TILE ELEMENT[{}] x:{}, y:{}", elementCount, x, y);
+                            Logging::info("TILE ELEMENT[{}] TYPE[{}] x:{}, y:{}", elementCount, (t1s[i].type & 0x3C) >> 2, x, y);
                         }
                         divergentBytesTotal = bitWiseLogDivergence("Elements[" + std::to_string(elementCount) + "] x:" + std::to_string(x) + ", y:" + std::to_string(y), t1s[i], t2s[i], displayAllDivergences, divergentBytesTotal);
                     }

--- a/src/OpenLoco/src/Map/TileManager.cpp
+++ b/src/OpenLoco/src/Map/TileManager.cpp
@@ -83,7 +83,7 @@ namespace OpenLoco::World::TileManager
                 return;
             }
             // If quite high in the air
-            if (pos.z - elSurface->baseHeight() > 12 * World::kSmallZStep)
+            if (pos.z - elSurface->baseHeight() >= 12 * World::kSmallZStep)
             {
                 return;
             }
@@ -1285,7 +1285,7 @@ namespace OpenLoco::World::TileManager
             return;
         }
         // If quite high in the air
-        if (pos.z - elSurface->baseHeight() > 12 * World::kSmallZStep)
+        if (pos.z - elSurface->baseHeight() >= 12 * World::kSmallZStep)
         {
             return;
         }


### PR DESCRIPTION
Found in #3124. Just keeping it separate as it has nothing to do with pathfinding. I don't think it really needs a changelog as its such a minor change.

Also changed the game save compare to log the tile type as it simplifies debuging.