### PR TITLE
Fix minor divergence issues

### DIFF
--- a/src/OpenLoco/src/GameCommands/Track/CreateTrainStation.h
+++ b/src/OpenLoco/src/GameCommands/Track/CreateTrainStation.h
@@ -10,7 +10,7 @@ namespace OpenLoco::GameCommands
         explicit TrainStationPlacementArgs(const registers& regs)
             : pos(regs.ax, regs.cx, regs.di)
             , rotation(regs.bh & 0x3)
-            , trackId(regs.dl & 0xF)
+            , trackId(regs.dl & 0x3F)
             , index(regs.dh & 0x3)
             , trackObjectId(regs.bp)
             , type(regs.edi >> 16)

--- a/src/OpenLoco/src/World/CompanyAi/CompanyAi.cpp
+++ b/src/OpenLoco/src/World/CompanyAi/CompanyAi.cpp
@@ -6554,7 +6554,7 @@ namespace OpenLoco
         }
 
         const auto rotation = tad & 0x3;
-        const auto trackId = (tad >> 3) & 0xF;
+        const auto trackId = (tad >> 3) & 0x3F;
 
         TrackRoadRemoveQueryFlags flags = none;
         auto& trackPieces = TrackData::getTrackPiece(trackId);
@@ -6887,7 +6887,7 @@ namespace OpenLoco
                     }
                 }
 
-                const auto trackId = (trackStartTad >> 3) & 0xF;
+                const auto trackId = (trackStartTad >> 3) & 0x3F;
                 const auto rotation = trackStartTad & 0x3;
                 trackStart.z += TrackData::getTrackPiece(trackId)[0].z;
 

--- a/src/OpenLoco/src/World/CompanyAi/CompanyAiPathfinding.cpp
+++ b/src/OpenLoco/src/World/CompanyAi/CompanyAiPathfinding.cpp
@@ -17,7 +17,7 @@ namespace OpenLoco::CompanyAi
     static Interop::loco_global<World::Pos2, 0x0112C3C2> _unk1Pos112C3C2;
     static Interop::loco_global<World::SmallZ, 0x0112C515> _unk1PosBaseZ112C515;
     static Interop::loco_global<World::Pos2, 0x0112C3C6> _unk2Pos112C3C6;
-    static Interop::loco_global<World::SmallZ, 0x0112C3C6> _unk2PosBaseZ112C517;
+    static Interop::loco_global<World::SmallZ, 0x0112C517> _unk2PosBaseZ112C517;
     static Interop::loco_global<World::Pos2, 0x0112C3CC> _unk3Pos112C3CC;
     static Interop::loco_global<World::SmallZ, 0x0112C59C> _unk3PosBaseZ112C59C;
     static Interop::loco_global<uint32_t, 0x0112C388> _createTrackRoadCommandMods;


### PR DESCRIPTION
Found these whilst investigating @LeftofZen's saves. The most important one is the trackId being corrupted which causes the ai to never remove tracked hills.