### PR TITLE
Fix focusing on entities on the main viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Feature: [#3274] Add a button to rotate company headquarters when building them.
 - Change: [#3227] The accuracy of cursor-relative zooming has been improved.
 - Change: [#3258] Current currency dropdown is now disabled when in the title screen.
+- Fix: [#3135] Follow vehicle on main view not working.
 - Fix: [#3232] Crash when moving vehicle window when a message is showing a vehicle.
 - Fix: [#3256] Preferred currency not being loaded from config.
 - Fix: [#3266] When text input reached the maximum length it can instead trigger shortcuts.

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -615,9 +615,10 @@ namespace OpenLoco::Input
                 {
                     _ticksSinceDragStart = 1000;
 
-                    if (window->viewportIsFocusedOnAnyEntity())
+                    auto* main = WindowManager::getMainWindow();
+                    if (Windows::Main::viewportIsFocusedOnAnyEntity(*main))
                     {
-                        window->viewportUnfocusFromEntity();
+                        Windows::Main::viewportUnfocusFromEntity(*main);
                     }
                     else
                     {

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -606,7 +606,8 @@ namespace OpenLoco::Ui
         moveWindowToLocation(pos);
     }
 
-    void Window::viewportCentreMain()
+    // Centres the main viewport on this window's saved view.
+    void Window::viewportCentreMain() const
     {
         if (viewports[0] == nullptr || savedView.isEmpty())
         {
@@ -632,7 +633,7 @@ namespace OpenLoco::Ui
 
     void Window::viewportFocusOnEntity(EntityId targetEntity)
     {
-        if (viewports[0] == nullptr || savedView.isEmpty())
+        if (viewports[0] == nullptr)
         {
             return;
         }
@@ -642,7 +643,7 @@ namespace OpenLoco::Ui
 
     bool Window::viewportIsFocusedOnEntity(EntityId targetEntity) const
     {
-        if (targetEntity == EntityId::null || viewports[0] == nullptr || savedView.isEmpty())
+        if (targetEntity == EntityId::null || viewports[0] == nullptr)
         {
             return false;
         }
@@ -652,7 +653,7 @@ namespace OpenLoco::Ui
 
     bool Window::viewportIsFocusedOnAnyEntity() const
     {
-        if (viewports[0] == nullptr || savedView.isEmpty())
+        if (viewports[0] == nullptr)
         {
             return false;
         }
@@ -660,9 +661,10 @@ namespace OpenLoco::Ui
         return viewportConfigurations[0].viewportTargetSprite != EntityId::null;
     }
 
+    // Stop following the followed entity, leaving the viewport centred on it.
     void Window::viewportUnfocusFromEntity()
     {
-        if (viewports[0] == nullptr || savedView.isEmpty())
+        if (viewports[0] == nullptr)
         {
             return;
         }

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -617,7 +617,7 @@ namespace OpenLoco::Ui
         auto main = WindowManager::getMainWindow();
 
         // Unfocus the viewport.
-        main->viewportConfigurations[0].viewportTargetSprite = EntityId::null;
+        Ui::Windows::Main::viewportFocusOnEntity(*main, EntityId::null);
 
         // Centre viewport on tile/entity.
         if (savedView.isEntityView())
@@ -629,54 +629,6 @@ namespace OpenLoco::Ui
         {
             main->viewportCentreOnTile(savedView.getPos());
         }
-    }
-
-    void Window::viewportFocusOnEntity(EntityId targetEntity)
-    {
-        if (viewports[0] == nullptr)
-        {
-            return;
-        }
-
-        viewportConfigurations[0].viewportTargetSprite = targetEntity;
-    }
-
-    bool Window::viewportIsFocusedOnEntity(EntityId targetEntity) const
-    {
-        if (targetEntity == EntityId::null || viewports[0] == nullptr)
-        {
-            return false;
-        }
-
-        return viewportConfigurations[0].viewportTargetSprite == targetEntity;
-    }
-
-    bool Window::viewportIsFocusedOnAnyEntity() const
-    {
-        if (viewports[0] == nullptr)
-        {
-            return false;
-        }
-
-        return viewportConfigurations[0].viewportTargetSprite != EntityId::null;
-    }
-
-    // Stop following the followed entity, leaving the viewport centred on it.
-    void Window::viewportUnfocusFromEntity()
-    {
-        if (viewports[0] == nullptr)
-        {
-            return;
-        }
-
-        if (viewportConfigurations[0].viewportTargetSprite == EntityId::null)
-        {
-            return;
-        }
-
-        auto entity = EntityManager::get<EntityBase>(viewportConfigurations[0].viewportTargetSprite);
-        viewportConfigurations[0].viewportTargetSprite = EntityId::null;
-        viewportCentreOnTile(entity->position);
     }
 
     void Window::viewportZoomSet(int8_t zoomLevel, bool toCursor)

--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -337,7 +337,7 @@ namespace OpenLoco::Ui
         void initScrollWidgets();
         int8_t getScrollDataIndex(WidgetIndex_t index);
         void setDisabledWidgetsAndInvalidate(uint32_t _disabledWidgets);
-        void viewportCentreMain();
+        void viewportCentreMain() const;
         void viewportSetUndergroundFlag(bool underground, Ui::Viewport* vp);
         void viewportGetMapCoordsByCursor(int16_t* mapX, int16_t* mapY, int16_t* offsetX, int16_t* offsetY);
         void moveWindowToLocation(viewport_pos pos);

--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -343,10 +343,6 @@ namespace OpenLoco::Ui
         void moveWindowToLocation(viewport_pos pos);
         void viewportCentreOnTile(const World::Pos3& loc);
         void viewportCentreTileAroundCursor(int16_t mapX, int16_t mapY, int16_t offsetX, int16_t offsetY);
-        void viewportFocusOnEntity(EntityId targetEntity);
-        bool viewportIsFocusedOnEntity(EntityId targetEntity) const;
-        bool viewportIsFocusedOnAnyEntity() const;
-        void viewportUnfocusFromEntity();
         void viewportZoomSet(int8_t zoomLevel, bool toCursor);
         void viewportZoomIn(bool toCursor);
         void viewportZoomOut(bool toCursor);

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -218,6 +218,11 @@ namespace OpenLoco::Ui::Windows
         void hideGridlines();
         void showDirectionArrows();
         void hideDirectionArrows();
+
+        void viewportFocusOnEntity(Window& main, EntityId targetEntity);
+        bool viewportIsFocusedOnEntity(const Window& main, EntityId targetEntity);
+        bool viewportIsFocusedOnAnyEntity(const Window& main);
+        void viewportUnfocusFromEntity(Window& main);
     }
 
     namespace MapToolTip

--- a/src/OpenLoco/src/Ui/Windows/Main.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Main.cpp
@@ -1,4 +1,5 @@
 #include "Config.h"
+#include "Entities/EntityManager.h"
 #include "Graphics/Gfx.h"
 #include "Map/Tile.h"
 #include "Ui/Widget.h"
@@ -109,6 +110,54 @@ namespace OpenLoco::Ui::Windows::Main
 
         mainWindow->viewports[0]->flags &= ~ViewportFlags::one_way_direction_arrows;
         mainWindow->invalidate();
+    }
+
+    void viewportFocusOnEntity(Window& main, EntityId targetEntity)
+    {
+        if (main.viewports[0] == nullptr)
+        {
+            return;
+        }
+
+        main.viewportConfigurations[0].viewportTargetSprite = targetEntity;
+    }
+
+    bool viewportIsFocusedOnEntity(const Window& main, EntityId targetEntity)
+    {
+        if (targetEntity == EntityId::null || main.viewports[0] == nullptr)
+        {
+            return false;
+        }
+
+        return main.viewportConfigurations[0].viewportTargetSprite == targetEntity;
+    }
+
+    bool viewportIsFocusedOnAnyEntity(const Window& main)
+    {
+        if (main.viewports[0] == nullptr)
+        {
+            return false;
+        }
+
+        return main.viewportConfigurations[0].viewportTargetSprite != EntityId::null;
+    }
+
+    // Stop following the followed entity, leaving the viewport centred on it.
+    void viewportUnfocusFromEntity(Window& main)
+    {
+        if (main.viewports[0] == nullptr)
+        {
+            return;
+        }
+
+        if (main.viewportConfigurations[0].viewportTargetSprite == EntityId::null)
+        {
+            return;
+        }
+
+        auto entity = EntityManager::get<EntityBase>(main.viewportConfigurations[0].viewportTargetSprite);
+        main.viewportConfigurations[0].viewportTargetSprite = EntityId::null;
+        main.viewportCentreOnTile(entity->position);
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -775,7 +775,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
                 // Focus viewport on vehicle, with locking.
                 auto main = WindowManager::getMainWindow();
-                main->viewportFocusOnEntity(targetEntity);
+                Windows::Main::viewportFocusOnEntity(*main, targetEntity);
             }
         }
 
@@ -4981,9 +4981,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
             Vehicles::Vehicle train(*head);
             EntityId viewportFollowEntity = train.veh2->id;
             auto main = Ui::WindowManager::getMainWindow();
-            if (main->viewportIsFocusedOnEntity(viewportFollowEntity))
+            if (Windows::Main::viewportIsFocusedOnEntity(*main, viewportFollowEntity))
             {
-                main->viewportUnfocusFromEntity();
+                Windows::Main::viewportUnfocusFromEntity(*main);
             }
 
             GameCommands::setErrorTitle(StringIds::cant_remove_string_id);

--- a/src/OpenLoco/src/Vehicles/VehicleManager.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleManager.cpp
@@ -354,9 +354,9 @@ namespace OpenLoco::VehicleManager
         Vehicles::Vehicle train(head);
         EntityId viewportFollowEntity = train.veh2->id;
         auto main = Ui::WindowManager::getMainWindow();
-        if (main->viewportIsFocusedOnEntity(viewportFollowEntity))
+        if (Ui::Windows::Main::viewportIsFocusedOnEntity(*main, viewportFollowEntity))
         {
-            main->viewportUnfocusFromEntity();
+            Ui::Windows::Main::viewportUnfocusFromEntity(*main);
         }
 
         Ui::WindowManager::close(Ui::WindowType::vehicle, enumValue(head.id));


### PR DESCRIPTION
~~Removes `savedView.isEmpty()` checks from Window methods related to focusing viewports on entities, as they served no clear purpose (correct me if I'm wrong!)~~ and caused following (and unfollowing) vehicles on the main view to not work.

Fixes #3135