### PR TITLE
Add logger to track globals

### DIFF
--- a/src/Interop/include/OpenLoco/Interop/Interop.hpp
+++ b/src/Interop/include/OpenLoco/Interop/Interop.hpp
@@ -152,6 +152,23 @@ namespace OpenLoco::Interop
     int32_t call(int32_t address);
     int32_t call(int32_t address, registers& registers);
 
+    struct GlobalStore
+    {
+    public:
+        static GlobalStore& getInstance();
+
+        static void addAddressRange(uint32_t begin, uint32_t size);
+
+    private:
+        GlobalStore() = default;
+
+        bool isAddressInRange(uint32_t address, uint32_t size) const;
+
+        std::vector<std::pair<uint32_t, uint32_t>> addressRanges; // Pairs of (begin, size)
+
+        static GlobalStore gStoreInstance;
+    };
+
     template<typename T, uintptr_t TAddress>
     struct loco_global
     {
@@ -168,6 +185,7 @@ namespace OpenLoco::Interop
         loco_global()
         {
             _Myptr = &(addr<TAddress, T>());
+            GlobalStore::addAddressRange(TAddress, sizeof(T));
         }
 
         loco_global(const loco_global<T, TAddress>&) = delete; // Do not copy construct a loco global
@@ -327,6 +345,7 @@ namespace OpenLoco::Interop
         {
             _Myfirst = get();
             _Mylast = _Myfirst + TCount;
+            GlobalStore::addAddressRange(TAddress, TCount * sizeof(T));
         }
 
         operator pointer()

--- a/src/Interop/src/Interop.cpp
+++ b/src/Interop/src/Interop.cpp
@@ -373,4 +373,45 @@ namespace OpenLoco::Interop
             rhs.getState().begin(),
             rhs.getState().end());
     }
+
+    GlobalStore GlobalStore::gStoreInstance = GlobalStore();
+
+    GlobalStore& GlobalStore::getInstance()
+    {
+        return gStoreInstance;
+    }
+
+    void GlobalStore::addAddressRange(uint32_t begin, uint32_t size)
+    {
+#ifdef _LOG_GLOBAL_STORE_
+        auto& gs = getInstance();
+        if (gs.isAddressInRange(begin, size))
+        {
+            Logging::warn("Address range {:#08x}-{:#08x} overlaps with existing ranges.\n", begin, begin + size);
+            return;
+        }
+        gs.addressRanges.emplace_back(begin, size);
+#endif
+    }
+
+    bool GlobalStore::isAddressInRange(uint32_t address, uint32_t size) const
+    {
+        for (auto& range : addressRanges)
+        {
+            if (address >= range.first && address < (range.first + range.second))
+            {
+                return true;
+            }
+        }
+        const auto end = address + size;
+        for (auto& range : addressRanges)
+        {
+            if (end > range.first && end <= (range.first + range.second))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/Interop/src/Interop.cpp
+++ b/src/Interop/src/Interop.cpp
@@ -381,7 +381,7 @@ namespace OpenLoco::Interop
         return gStoreInstance;
     }
 
-    void GlobalStore::addAddressRange(uint32_t begin, uint32_t size)
+    void GlobalStore::addAddressRange([[maybe_unused]] uint32_t begin, [[maybe_unused]] uint32_t size)
     {
 #ifdef _LOG_GLOBAL_STORE_
         auto& gs = getInstance();


### PR DESCRIPTION
This will be helpful to look for overlaps and deduplicate the global instances which we will need to do when we become standalone. Its disabled by default. Enable with `_LOG_GLOBAL_STORE_`.