### PR TITLE
Fix sub_4A6DA9 causing a crash when there are no rail loaded

### DIFF
--- a/src/OpenLoco/src/World/CompanyManager.cpp
+++ b/src/OpenLoco/src/World/CompanyManager.cpp
@@ -787,7 +787,7 @@ namespace OpenLoco::CompanyManager
     {
         auto* playerCompany = getPlayerCompany();
         auto& gameState = getGameState();
-        auto roadType = gameState.lastTrackTypeOption;
+        auto roadType = gameState.lastTrackTypeOption | (1U << 7);
         if (roadType == 0xFFU)
         {
             const auto roads = companyGetAvailableRoads(playerCompany->id());


### PR DESCRIPTION
Superseeds #3169