### PR TITLE
Use correct type for arguments to alignTo

### DIFF
--- a/src/Core/src/MemoryStream.cpp
+++ b/src/Core/src/MemoryStream.cpp
@@ -120,7 +120,7 @@ namespace OpenLoco
         if (len > spaceLeft)
         {
             constexpr auto kGrowthFactor = 2.0f;
-            constexpr auto kPageSize = 0x1000U;
+            constexpr std::size_t kPageSize = 0x1000;
 
             const auto newCapacity = _capacity + len;
             const auto finalCapacity = alignTo(static_cast<std::size_t>(newCapacity * kGrowthFactor), kPageSize);


### PR DESCRIPTION
alignTo template takes arguments of the same type. Ensure both arguments passed to it are of actually the same type.