### PR TITLE
Fix #3116: Visual artifacts with additional viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Change: [#3104] Landscape generation confirmation prompts now prevent you from clicking other windows until a choice is made.
 - Fix: [#3019] Mouse getting stuck on edges of monitor when right mouse dragging scroll views.
+- Fix: [#3116] Visual artifacts when additional viewports are visible, most prominently with news message window.
 - Fix: [#3167] Dropdown for terrain type selection is displayed at the wrong position.
 - Fix: [#3171] Background of station labels have a visible gap due to being off by one pixel.
 - Fix: [#3184] The minimum size of the map window is miscalculated when it is dragged past a certain point.

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -1853,6 +1853,14 @@ namespace OpenLoco::Ui::WindowManager
      */
     void viewportShiftPixels(Ui::Window* window, Ui::Viewport* viewport, int16_t dX, int16_t dY)
     {
+        auto vpX = viewport->x;
+        auto vpY = viewport->y;
+        if (viewport->owner != nullptr)
+        {
+            vpX += viewport->owner->x;
+            vpY += viewport->owner->y;
+        }
+
         const auto index = indexOf(*window);
         for (auto it = _windows.begin() + index; it != _windows.end(); it++)
         {
@@ -1872,22 +1880,22 @@ namespace OpenLoco::Ui::WindowManager
                 continue;
             }
 
-            if (viewport->x + viewport->width <= w.x)
+            if (vpX + viewport->width <= w.x)
             {
                 continue;
             }
 
-            if (w.x + w.width <= viewport->x)
+            if (w.x + w.width <= vpX)
             {
                 continue;
             }
 
-            if (viewport->y + viewport->height <= w.y)
+            if (vpY + viewport->height <= w.y)
             {
                 continue;
             }
 
-            if (w.y + w.height <= viewport->y)
+            if (w.y + w.height <= vpY)
             {
                 continue;
             }
@@ -1900,25 +1908,25 @@ namespace OpenLoco::Ui::WindowManager
             bottom = w.y + w.height;
 
             // TODO: replace these with min/max
-            cx = viewport->x;
+            cx = vpX;
             if (left < cx)
             {
                 left = cx;
             }
 
-            cx = viewport->x + viewport->width;
+            cx = vpX + viewport->width;
             if (right > cx)
             {
                 right = cx;
             }
 
-            cx = viewport->y;
+            cx = vpY;
             if (top < cx)
             {
                 top = cx;
             }
 
-            cx = viewport->y + viewport->height;
+            cx = vpY + viewport->height;
             if (bottom > cx)
             {
                 bottom = cx;
@@ -1943,15 +1951,23 @@ namespace OpenLoco::Ui::WindowManager
      */
     void viewportRedrawAfterShift(Window* window, Viewport* viewport, int16_t x, int16_t y)
     {
+        auto vpX = viewport->x;
+        auto vpY = viewport->y;
+        if (viewport->owner != nullptr)
+        {
+            vpX += viewport->owner->x;
+            vpY += viewport->owner->y;
+        }
+
         while (window != nullptr)
         {
             // skip current window and non-intersecting windows
             if (viewport == window->viewports[0]
                 || viewport == window->viewports[1]
-                || viewport->x + viewport->width <= window->x
-                || viewport->x >= window->x + window->width
-                || viewport->y + viewport->height <= window->y
-                || viewport->y >= window->y + window->height)
+                || vpX + viewport->width <= window->x
+                || vpX >= window->x + window->width
+                || vpY + viewport->height <= window->y
+                || vpY >= window->y + window->height)
             {
                 size_t nextWindowIndex = WindowManager::indexOf(*window) + 1;
                 window = nextWindowIndex >= count() ? nullptr : WindowManager::get(nextWindowIndex);
@@ -2015,8 +2031,8 @@ namespace OpenLoco::Ui::WindowManager
             return;
         }
 
-        int16_t left = viewport->x;
-        int16_t top = viewport->y;
+        int16_t left = vpX;
+        int16_t top = vpY;
         int16_t right = left + viewport->width;
         int16_t bottom = top + viewport->height;
 

--- a/src/OpenLoco/src/Viewport.hpp
+++ b/src/OpenLoco/src/Viewport.hpp
@@ -15,6 +15,7 @@ namespace OpenLoco::Gfx
 namespace OpenLoco::Ui
 {
     struct SavedViewSimple;
+    struct Window;
 
     struct viewport_pos
     {
@@ -91,6 +92,7 @@ namespace OpenLoco::Ui
         uint8_t zoom;        // 0x10
         uint8_t pad_11;      // 0x11
         ViewportFlags flags; // 0x12
+        Window* owner;
 
         constexpr bool contains(const viewport_pos& vpos)
         {
@@ -195,7 +197,6 @@ namespace OpenLoco::Ui
     private:
         void paint(Gfx::DrawingContext& drawingCtx, const Ui::Rect& rect);
     };
-    static_assert(sizeof(Viewport) == 0x14);
 
     struct ViewportConfig
     {

--- a/src/OpenLoco/src/ViewportManager.cpp
+++ b/src/OpenLoco/src/ViewportManager.cpp
@@ -62,7 +62,7 @@ namespace OpenLoco::Ui::ViewportManager
         }
     }
 
-    static Viewport* initViewport(Ui::Point origin, Ui::Size size, ZoomLevel zoom)
+    static Viewport* initViewport(Ui::Point origin, Ui::Size size, ZoomLevel zoom, Window* owner)
     {
         // Viewports with 0 width are invalid.
         if (size.width == 0)
@@ -86,6 +86,7 @@ namespace OpenLoco::Ui::ViewportManager
         vp->viewHeight = size.height << static_cast<uint8_t>(zoom);
         vp->zoom = static_cast<uint8_t>(zoom);
         vp->flags = ViewportFlags::none;
+        vp->owner = owner;
 
         if (OpenLoco::Config::get().hasFlags(Config::Flags::gridlinesOnLandscape))
         {
@@ -172,7 +173,7 @@ namespace OpenLoco::Ui::ViewportManager
      */
     Viewport* create(Window* window, int viewportIndex, Ui::Point origin, Ui::Size size, ZoomLevel zoom, EntityId entityId)
     {
-        Viewport* viewport = initViewport(origin, size, zoom);
+        Viewport* viewport = initViewport(origin, size, zoom, window);
 
         if (viewport == nullptr)
         {
@@ -202,7 +203,7 @@ namespace OpenLoco::Ui::ViewportManager
      */
     Viewport* create(Window* window, int viewportIndex, Ui::Point origin, Ui::Size size, ZoomLevel zoom, World::Pos3 tile)
     {
-        Viewport* viewport = initViewport(origin, size, zoom);
+        Viewport* viewport = initViewport(origin, size, zoom, window);
 
         if (viewport == nullptr)
         {
@@ -256,6 +257,14 @@ namespace OpenLoco::Ui::ViewportManager
             top += viewport.y;
             bottom += viewport.y;
 
+            if (viewport.owner != nullptr)
+            {
+                left += viewport.owner->x;
+                right += viewport.owner->x;
+                top += viewport.owner->y;
+                bottom += viewport.owner->y;
+            }
+
             Gfx::invalidateRegion(left, top, right, bottom);
         }
     }
@@ -306,6 +315,14 @@ namespace OpenLoco::Ui::ViewportManager
             right += viewport.x;
             top += viewport.y;
             bottom += viewport.y;
+
+            if (viewport.owner != nullptr)
+            {
+                left += viewport.owner->x;
+                right += viewport.owner->x;
+                top += viewport.owner->y;
+                bottom += viewport.owner->y;
+            }
 
             Gfx::invalidateRegion(left, top, right, bottom);
         }


### PR DESCRIPTION
My refactoring caused this, the issue is that viewports store their positions now relative to the parent (window) and it used that to shift the pixels which requires the absolute screen position. Viewports now store the owner so we can compute the correct position when the absolute one is needed, there was also an issue that invalidation didn't correctly work but on busy maps its hard to notice that.

Closes #3116