### PR TITLE
Create and use PauseFlags enum

### DIFF
--- a/src/OpenLoco/src/Game.cpp
+++ b/src/OpenLoco/src/Game.cpp
@@ -42,7 +42,7 @@ namespace OpenLoco::Game
     static bool openBrowsePrompt(StringId titleId, browse_type type, const char* filter)
     {
         Audio::pauseSound();
-        SceneManager::setPauseFlag(1 << 2);
+        SceneManager::setPauseFlag(PauseFlags::BrowsePrompt);
         Gfx::invalidateScreen();
         Gfx::renderAndUpdate();
 
@@ -50,7 +50,7 @@ namespace OpenLoco::Game
 
         Audio::unpauseSound();
         Ui::processMessagesMini();
-        SceneManager::unsetPauseFlag(1 << 2);
+        SceneManager::unsetPauseFlag(PauseFlags::BrowsePrompt);
         Gfx::invalidateScreen();
         Gfx::renderAndUpdate();
 

--- a/src/OpenLoco/src/Game.cpp
+++ b/src/OpenLoco/src/Game.cpp
@@ -42,7 +42,7 @@ namespace OpenLoco::Game
     static bool openBrowsePrompt(StringId titleId, browse_type type, const char* filter)
     {
         Audio::pauseSound();
-        SceneManager::setPauseFlag(PauseFlags::BrowsePrompt);
+        SceneManager::setPauseFlag(PauseFlags::browsePrompt);
         Gfx::invalidateScreen();
         Gfx::renderAndUpdate();
 
@@ -50,7 +50,7 @@ namespace OpenLoco::Game
 
         Audio::unpauseSound();
         Ui::processMessagesMini();
-        SceneManager::unsetPauseFlag(PauseFlags::BrowsePrompt);
+        SceneManager::unsetPauseFlag(PauseFlags::browsePrompt);
         Gfx::invalidateScreen();
         Gfx::renderAndUpdate();
 

--- a/src/OpenLoco/src/GameCommands/GameCommands.cpp
+++ b/src/OpenLoco/src/GameCommands/GameCommands.cpp
@@ -343,9 +343,9 @@ namespace OpenLoco::GameCommands
 
         if (commandRequiresUnpausingGame(command, flags) && _updatingCompanyId == CompanyManager::getControllingId())
         {
-            if (SceneManager::getPauseFlags() & 1)
+            if ((SceneManager::getPauseFlags() & PauseFlags::Standard) == PauseFlags::Standard)
             {
-                SceneManager::unsetPauseFlag(1);
+                SceneManager::unsetPauseFlag(PauseFlags::Standard);
                 WindowManager::invalidate(WindowType::timeToolbar);
                 Audio::unpauseSound();
                 Ui::Windows::PlayerInfoPanel::invalidateFrame();

--- a/src/OpenLoco/src/GameCommands/GameCommands.cpp
+++ b/src/OpenLoco/src/GameCommands/GameCommands.cpp
@@ -343,9 +343,9 @@ namespace OpenLoco::GameCommands
 
         if (commandRequiresUnpausingGame(command, flags) && _updatingCompanyId == CompanyManager::getControllingId())
         {
-            if ((SceneManager::getPauseFlags() & PauseFlags::Standard) == PauseFlags::Standard)
+            if ((SceneManager::getPauseFlags() & PauseFlags::standard) == PauseFlags::standard)
             {
-                SceneManager::unsetPauseFlag(PauseFlags::Standard);
+                SceneManager::unsetPauseFlag(PauseFlags::standard);
                 WindowManager::invalidate(WindowType::timeToolbar);
                 Audio::unpauseSound();
                 Ui::Windows::PlayerInfoPanel::invalidateFrame();

--- a/src/OpenLoco/src/GameCommands/GameCommands.cpp
+++ b/src/OpenLoco/src/GameCommands/GameCommands.cpp
@@ -343,7 +343,7 @@ namespace OpenLoco::GameCommands
 
         if (commandRequiresUnpausingGame(command, flags) && _updatingCompanyId == CompanyManager::getControllingId())
         {
-            if ((SceneManager::getPauseFlags() & PauseFlags::standard) == PauseFlags::standard)
+            if ((SceneManager::getPauseFlags() & PauseFlags::standard) != PauseFlags::none)
             {
                 SceneManager::unsetPauseFlag(PauseFlags::standard);
                 WindowManager::invalidate(WindowType::timeToolbar);

--- a/src/OpenLoco/src/GameCommands/General/TogglePause.cpp
+++ b/src/OpenLoco/src/GameCommands/General/TogglePause.cpp
@@ -20,7 +20,7 @@ namespace OpenLoco::GameCommands
 
         Ui::WindowManager::invalidate(Ui::WindowType::timeToolbar);
 
-        if ((SceneManager::getPauseFlags() & PauseFlags::standard) == PauseFlags::standard)
+        if ((SceneManager::getPauseFlags() & PauseFlags::standard) != PauseFlags::none)
         {
             SceneManager::unsetPauseFlag(PauseFlags::standard);
             Audio::unpauseSound();

--- a/src/OpenLoco/src/GameCommands/General/TogglePause.cpp
+++ b/src/OpenLoco/src/GameCommands/General/TogglePause.cpp
@@ -20,14 +20,14 @@ namespace OpenLoco::GameCommands
 
         Ui::WindowManager::invalidate(Ui::WindowType::timeToolbar);
 
-        if (SceneManager::isPaused())
+        if ((SceneManager::getPauseFlags() & PauseFlags::Standard) == PauseFlags::Standard)
         {
-            SceneManager::unsetPauseFlag(1 << 0);
+            SceneManager::unsetPauseFlag(PauseFlags::Standard);
             Audio::unpauseSound();
         }
         else
         {
-            SceneManager::setPauseFlag(1 << 0);
+            SceneManager::setPauseFlag(PauseFlags::Standard);
             Audio::pauseSound();
             Ui::Windows::TimePanel::invalidateFrame();
         }

--- a/src/OpenLoco/src/GameCommands/General/TogglePause.cpp
+++ b/src/OpenLoco/src/GameCommands/General/TogglePause.cpp
@@ -20,14 +20,14 @@ namespace OpenLoco::GameCommands
 
         Ui::WindowManager::invalidate(Ui::WindowType::timeToolbar);
 
-        if ((SceneManager::getPauseFlags() & PauseFlags::Standard) == PauseFlags::Standard)
+        if ((SceneManager::getPauseFlags() & PauseFlags::standard) == PauseFlags::standard)
         {
-            SceneManager::unsetPauseFlag(PauseFlags::Standard);
+            SceneManager::unsetPauseFlag(PauseFlags::standard);
             Audio::unpauseSound();
         }
         else
         {
-            SceneManager::setPauseFlag(PauseFlags::Standard);
+            SceneManager::setPauseFlag(PauseFlags::standard);
             Audio::pauseSound();
             Ui::Windows::TimePanel::invalidateFrame();
         }

--- a/src/OpenLoco/src/SceneManager.cpp
+++ b/src/OpenLoco/src/SceneManager.cpp
@@ -106,19 +106,19 @@ namespace OpenLoco::SceneManager
         return _pausedState != 0;
     }
 
-    uint8_t getPauseFlags()
+    PauseFlags getPauseFlags()
     {
-        return _pausedState;
+        return (PauseFlags)*_pausedState;
     }
 
-    void setPauseFlag(uint8_t value)
+    void setPauseFlag(PauseFlags value)
     {
-        *_pausedState |= value;
+        *_pausedState |= (uint8_t)value;
     }
 
-    void unsetPauseFlag(uint8_t value)
+    void unsetPauseFlag(PauseFlags value)
     {
-        *_pausedState &= ~(value);
+        *_pausedState &= ~((uint8_t)value);
     }
 
     GameSpeed getGameSpeed()

--- a/src/OpenLoco/src/SceneManager.cpp
+++ b/src/OpenLoco/src/SceneManager.cpp
@@ -8,7 +8,7 @@ namespace OpenLoco::SceneManager
 {
     loco_global<uint16_t, 0x00508F12> _sceneAge;
     loco_global<Flags, 0x00508F14> _sceneFlags;
-    loco_global<uint8_t, 0x00508F17> _pausedState;
+    loco_global<PauseFlags, 0x00508F17> _pausedState;
     loco_global<GameSpeed, 0x00508F1A> _gameSpeed;
 
     void resetSceneAge()
@@ -103,22 +103,22 @@ namespace OpenLoco::SceneManager
 
     bool isPaused()
     {
-        return _pausedState != 0;
+        return _pausedState != PauseFlags::none;
     }
 
     PauseFlags getPauseFlags()
     {
-        return (PauseFlags)*_pausedState;
+        return _pausedState;
     }
 
     void setPauseFlag(PauseFlags value)
     {
-        *_pausedState |= (uint8_t)value;
+        *_pausedState |= value;
     }
 
     void unsetPauseFlag(PauseFlags value)
     {
-        *_pausedState &= ~((uint8_t)value);
+        *_pausedState &= ~(value);
     }
 
     GameSpeed getGameSpeed()

--- a/src/OpenLoco/src/SceneManager.h
+++ b/src/OpenLoco/src/SceneManager.h
@@ -16,9 +16,9 @@ namespace OpenLoco
     enum class PauseFlags : uint8_t
     {
         none = 0U,
-        Standard = 1 << 0,   // Used when the player toggles paused
-        PromptSave = 1 << 1, // Set when PromptSaveWindow is open
-        BrowsePrompt = 1 << 2,
+        standard = 1 << 0,   // Used when the player toggles paused
+        promptSave = 1 << 1, // Set when PromptSaveWindow is open
+        browsePrompt = 1 << 2,
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(PauseFlags);
 

--- a/src/OpenLoco/src/SceneManager.h
+++ b/src/OpenLoco/src/SceneManager.h
@@ -16,7 +16,7 @@ namespace OpenLoco
     enum class PauseFlags : uint8_t
     {
         none = 0U,
-        Standard = 1 << 0, // Used when the player toggles paused
+        Standard = 1 << 0,   // Used when the player toggles paused
         PromptSave = 1 << 1, // Set when PromptSaveWindow is open
         BrowsePrompt = 1 << 2,
     };

--- a/src/OpenLoco/src/SceneManager.h
+++ b/src/OpenLoco/src/SceneManager.h
@@ -13,6 +13,15 @@ namespace OpenLoco
         MAX = ExtraFastForward,
     };
 
+    enum class PauseFlags : uint8_t
+    {
+        none = 0U,
+        Standard = 1 << 0, // Used when the player toggles paused
+        PromptSave = 1 << 1, // Set when PromptSaveWindow is open
+        BrowsePrompt = 1 << 2,
+    };
+    OPENLOCO_ENABLE_ENUM_OPERATORS(PauseFlags);
+
     namespace SceneManager
     {
         enum class Flags : uint16_t
@@ -48,9 +57,9 @@ namespace OpenLoco
         bool isSandboxMode();
         bool isPauseOverrideEnabled();
         bool isPaused();
-        uint8_t getPauseFlags();
-        void setPauseFlag(uint8_t value);
-        void unsetPauseFlag(uint8_t value);
+        PauseFlags getPauseFlags();
+        void setPauseFlag(PauseFlags value);
+        void unsetPauseFlag(PauseFlags value);
         GameSpeed getGameSpeed();
         void setGameSpeed(const GameSpeed speed);
     }

--- a/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
@@ -167,7 +167,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
             return;
         }
 
-        if ((SceneManager::getPauseFlags() & PauseFlags::browsePrompt) == PauseFlags::browsePrompt)
+        if ((SceneManager::getPauseFlags() & PauseFlags::browsePrompt) != PauseFlags::none)
         {
             return;
         }

--- a/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
@@ -167,7 +167,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
             return;
         }
 
-        if ((SceneManager::getPauseFlags() & PauseFlags::BrowsePrompt) == PauseFlags::BrowsePrompt)
+        if ((SceneManager::getPauseFlags() & PauseFlags::browsePrompt) == PauseFlags::browsePrompt)
         {
             return;
         }

--- a/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
@@ -167,7 +167,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
             return;
         }
 
-        if (SceneManager::getPauseFlags() & (1 << 2))
+        if ((SceneManager::getPauseFlags() & PauseFlags::BrowsePrompt) == PauseFlags::BrowsePrompt)
         {
             return;
         }

--- a/src/OpenLoco/src/Ui/Windows/PromptSaveWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptSaveWindow.cpp
@@ -70,7 +70,7 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
             window->setColour(WindowColour::primary, AdvancedColour(Colour::mutedDarkRed).translucent());
             window->flags |= Ui::WindowFlags::transparent;
 
-            SceneManager::setPauseFlag(PauseFlags::PromptSave);
+            SceneManager::setPauseFlag(PauseFlags::promptSave);
             Audio::pauseSound();
             WindowManager::invalidate(WindowType::timeToolbar);
         }
@@ -150,7 +150,7 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
     // 0x0043C577
     static void onClose([[maybe_unused]] Window& self)
     {
-        SceneManager::unsetPauseFlag(PauseFlags::PromptSave);
+        SceneManager::unsetPauseFlag(PauseFlags::promptSave);
         Audio::unpauseSound();
         WindowManager::invalidate(WindowType::timeToolbar);
     }

--- a/src/OpenLoco/src/Ui/Windows/PromptSaveWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptSaveWindow.cpp
@@ -70,7 +70,7 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
             window->setColour(WindowColour::primary, AdvancedColour(Colour::mutedDarkRed).translucent());
             window->flags |= Ui::WindowFlags::transparent;
 
-            SceneManager::setPauseFlag(1 << 1);
+            SceneManager::setPauseFlag(PauseFlags::PromptSave);
             Audio::pauseSound();
             WindowManager::invalidate(WindowType::timeToolbar);
         }
@@ -150,7 +150,7 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
     // 0x0043C577
     static void onClose([[maybe_unused]] Window& self)
     {
-        SceneManager::unsetPauseFlag(2);
+        SceneManager::unsetPauseFlag(PauseFlags::PromptSave);
         Audio::unpauseSound();
         WindowManager::invalidate(WindowType::timeToolbar);
     }

--- a/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
@@ -164,7 +164,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
         args.push<uint32_t>(getCurrentDay());
 
         StringId format = StringIds::date_daymonthyear;
-        if (SceneManager::isPaused() && (SceneManager::getPauseFlags() & PauseFlags::BrowsePrompt) == PauseFlags::none) // Is this the correct logic?
+        if (SceneManager::isPaused() && (SceneManager::getPauseFlags() & PauseFlags::browsePrompt) == PauseFlags::none) // Is this the correct logic?
         {
             if (self.numTicksVisible >= 30)
             {

--- a/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
@@ -164,7 +164,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
         args.push<uint32_t>(getCurrentDay());
 
         StringId format = StringIds::date_daymonthyear;
-        if (SceneManager::isPaused() && (SceneManager::getPauseFlags() & (1 << 2)) == 0)
+        if (SceneManager::isPaused() && (SceneManager::getPauseFlags() & PauseFlags::BrowsePrompt) == PauseFlags::none) // Is this the correct logic?
         {
             if (self.numTicksVisible >= 30)
             {


### PR DESCRIPTION
The toggle pause game command now works properly even if the game is also paused by a different flag (though it may not be currently possible to experience this in normal gameplay anyway). Otherwise, the behaviour should be unchanged.