### PR TITLE
Reduce minimum width of map window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 25.07+ (???)
 ------------------------------------------------------------------------
 - Change: [#3104] Landscape generation confirmation prompts now prevent you from clicking other windows until a choice is made.
+- Change: [#] Reduced minimum width of map window.
 - Fix: [#3167] Dropdown for terrain type selection is displayed at the wrong position.
 - Fix: [#3171] Background of station labels have a visible gap due to being off by one pixel.
 

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -216,7 +216,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     static void onResize(Window& self)
     {
         self.flags |= WindowFlags::resizable;
-        self.minWidth = 350;
+        self.minWidth = 161;
         self.maxWidth = 800; // NB: frame background is only 800px :(
         self.maxHeight = 800;
 


### PR DESCRIPTION
It feels bad when you're resizing a window and you hit against its minimum width way before you expect to. The minimum width of the map window felt just a bit too wide to me, when playing at a small resolution - a very mild inconvenience.

Reduced it from 350 to 161 (chosen to nicely frame the max number of tabs it has). Now the map can be resized to be too small to be useful, which I think is better.

Before/after:
<img width="417" height="288" alt="image" src="https://github.com/user-attachments/assets/f06e4837-02d0-4c49-ac71-ac05d369614d" />
