### PR TITLE
Change minimum map window size to make the map square at its minimum size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 25.07+ (???)
 ------------------------------------------------------------------------
 - Change: [#3104] Landscape generation confirmation prompts now prevent you from clicking other windows until a choice is made.
+- Change: [#3193] Changed minimum size of map window.
 - Fix: [#3019] Mouse getting stuck on edges of monitor when right mouse dragging scroll views.
 - Fix: [#3116] Visual artifacts when additional viewports are visible, most prominently with news message window.
 - Fix: [#3167] Dropdown for terrain type selection is displayed at the wrong position.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 25.07+ (???)
 ------------------------------------------------------------------------
 - Change: [#3104] Landscape generation confirmation prompts now prevent you from clicking other windows until a choice is made.
-- Change: [#3193] Changed minimum size of map window.
+- Change: [#3193] The minimum size of the map window was changed to accommodate all elements.
 - Fix: [#3019] Mouse getting stuck on edges of monitor when right mouse dragging scroll views.
 - Fix: [#3116] Visual artifacts when additional viewports are visible, most prominently with news message window.
 - Fix: [#3167] Dropdown for terrain type selection is displayed at the wrong position.

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -54,6 +54,9 @@ using namespace OpenLoco::World;
 
 namespace OpenLoco::Ui::Windows::MapWindow
 {
+    static constexpr uint16_t kMinimumWindowWidth = 229; // Chosen so that the map cannot be smaller than its key
+    static constexpr uint16_t kMinimumWindowHeight = 176; // Chosen so that the minimum size makes the map square
+
     static constexpr int16_t kRenderedMapWidth = kMapColumns * 2;
     static constexpr int16_t kRenderedMapHeight = kRenderedMapWidth;
     static constexpr int32_t kRenderedMapSize = kRenderedMapWidth * kRenderedMapHeight;
@@ -216,7 +219,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     static void onResize(Window& self)
     {
         self.flags |= WindowFlags::resizable;
-        self.minWidth = 350;
+        self.minWidth = kMinimumWindowWidth;
         self.maxWidth = 800; // NB: frame background is only 800px :(
         self.maxHeight = 800;
 
@@ -1691,7 +1694,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
             }
 
             y += 14;
-            y = std::max(y, static_cast<uint16_t>(92));
+            y = std::max(y, kMinimumWindowHeight);
 
             self.minHeight = y;
         }

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -54,7 +54,7 @@ using namespace OpenLoco::World;
 
 namespace OpenLoco::Ui::Windows::MapWindow
 {
-    static constexpr uint16_t kMinimumWindowWidth = 229; // Chosen so that the map cannot be smaller than its key
+    static constexpr uint16_t kMinimumWindowWidth = 229;  // Chosen so that the map cannot be smaller than its key
     static constexpr uint16_t kMinimumWindowHeight = 176; // Chosen so that the minimum size makes the map square
 
     static constexpr int16_t kRenderedMapWidth = kMapColumns * 2;


### PR DESCRIPTION

This PR is an alternative to #3191.

As mentioned in the code comments, the constraints I chose to determine the new minimum window size was to make the map be square when at minimum size, and to not allow the map to be thinner than the part of the window with the key. This means the user can now make the map window somewhat thinner, but not as short. (The initial window size when the player opens the window for the first time remains unchanged.)

**Before:** (Minimum window size in original Locomotion)
<img width="370" height="112" alt="image" src="https://github.com/user-attachments/assets/ed33e3a9-1db3-4481-82fb-cfd55cdcf77a" />
**After:**
<img width="370" height="196" alt="image" src="https://github.com/user-attachments/assets/fbd0c625-8399-4136-89fc-cf5c71299628" />

(Dotted black square on map in both screenshots above are indicative of 1280x720 game resolution and fully zoomed in).

**Additional screenshot:** hovering over an item on the industries tab (the key having more items forces the window to be a little taller) (1080p game resolution)
<img width="246" height="205" alt="image" src="https://github.com/user-attachments/assets/44aacd21-7fc6-4025-98b0-dc2dc6f18f7e" />

