### PR TITLE
Fix non-ASCII keyboard input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix: [#3171] Background of station labels have a visible gap due to being off by one pixel.
 - Fix: [#3184] The minimum size of the map window is miscalculated when it is dragged past a certain point.
 - Fix: [#3190] The map window's minimap isn't centred correctly when it is first opened.
+- Fix: [#3198] Cannot write non-English letters in text boxes.
 
 25.07 (2025-07-15)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -178,7 +178,7 @@ namespace OpenLoco::Input
         }
 
         uint32_t index = _keyQueueLastWrite;
-        auto unsignedText = reinterpret_cast<const unsigned char*>(text);
+        auto unsignedText = reinterpret_cast<const uint8_t*>(text);
         _keyQueue[index].charCode = convertUnicodeToLoco(readCodePoint(&unsignedText));
     }
 

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -20,6 +20,7 @@
 #include <SDL2/SDL.h>
 #include <cstdint>
 #include <functional>
+#include <Localisation/Unicode.h>
 
 using namespace OpenLoco::Interop;
 using namespace OpenLoco::Ui;
@@ -168,11 +169,13 @@ namespace OpenLoco::Input
 
     void enqueueText(const char* text)
     {
-        if (text != nullptr && text[0] != '\0')
+        if (text == nullptr || text[0] == '\0')
         {
-            uint32_t index = _keyQueueLastWrite;
-            _keyQueue[index].charCode = text[0];
+            return;
         }
+
+        uint32_t index = _keyQueueLastWrite;
+        _keyQueue[index].charCode = Localisation::readCodePoint((unsigned char**)&text);
     }
 
     // 0x00407028

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -15,6 +15,7 @@
 #include "Ui/WindowManager.h"
 #include "Vehicles/Vehicle.h"
 #include "World/CompanyManager.h"
+#include <Localisation/Conversion.h>
 #include <Localisation/Unicode.h>
 #include <OpenLoco/Engine/Input/ShortcutManager.h>
 #include <OpenLoco/Interop/Interop.hpp>
@@ -175,7 +176,7 @@ namespace OpenLoco::Input
         }
 
         uint32_t index = _keyQueueLastWrite;
-        _keyQueue[index].charCode = Localisation::readCodePoint((unsigned char**)&text);
+        _keyQueue[index].charCode = Localisation::convertUnicodeToLoco(Localisation::readCodePoint((unsigned char**)&text));
     }
 
     // 0x00407028

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -15,12 +15,12 @@
 #include "Ui/WindowManager.h"
 #include "Vehicles/Vehicle.h"
 #include "World/CompanyManager.h"
+#include <Localisation/Unicode.h>
 #include <OpenLoco/Engine/Input/ShortcutManager.h>
 #include <OpenLoco/Interop/Interop.hpp>
 #include <SDL2/SDL.h>
 #include <cstdint>
 #include <functional>
-#include <Localisation/Unicode.h>
 
 using namespace OpenLoco::Interop;
 using namespace OpenLoco::Ui;

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -170,13 +170,16 @@ namespace OpenLoco::Input
 
     void enqueueText(const char* text)
     {
+        using namespace Localisation;
+
         if (text == nullptr || text[0] == '\0')
         {
             return;
         }
 
         uint32_t index = _keyQueueLastWrite;
-        _keyQueue[index].charCode = Localisation::convertUnicodeToLoco(Localisation::readCodePoint((unsigned char**)&text));
+        auto unsignedText = reinterpret_cast<const unsigned char*>(text);
+        _keyQueue[index].charCode = convertUnicodeToLoco(readCodePoint(&unsignedText));
     }
 
     // 0x00407028

--- a/src/OpenLoco/src/Localisation/Conversion.cpp
+++ b/src/OpenLoco/src/Localisation/Conversion.cpp
@@ -85,7 +85,7 @@ namespace OpenLoco::Localisation
     std::string convertUnicodeToLoco(const std::string& unicodeString)
     {
         std::string out;
-        uint8_t* input = (uint8_t*)unicodeString.c_str();
+        const uint8_t* input = (uint8_t*)unicodeString.c_str();
         while (utf32_t unicodePoint = readCodePoint(&input))
         {
             out += convertUnicodeToLoco(unicodePoint);

--- a/src/OpenLoco/src/Localisation/LanguageFiles.cpp
+++ b/src/OpenLoco/src/Localisation/LanguageFiles.cpp
@@ -61,7 +61,7 @@ namespace OpenLoco::Localisation
         auto str = std::make_unique<char[]>(size + 1);
         char* out = str.get();
 
-        utf8_t* ptr = (utf8_t*)value;
+        const utf8_t* ptr = (utf8_t*)value;
         while (true)
         {
             utf32_t codepoint = readCodePoint(&ptr);

--- a/src/OpenLoco/src/Localisation/Unicode.cpp
+++ b/src/OpenLoco/src/Localisation/Unicode.cpp
@@ -3,11 +3,11 @@
 
 namespace OpenLoco::Localisation
 {
-    utf32_t readCodePoint(utf8_t** string)
+    utf32_t readCodePoint(const utf8_t** string)
     {
         utf32_t read = 0;
 
-        utf8_t* ptr = *string;
+        const utf8_t* ptr = *string;
 
         if ((ptr[0] & 0b10000000) == 0)
         {

--- a/src/OpenLoco/src/Localisation/Unicode.h
+++ b/src/OpenLoco/src/Localisation/Unicode.h
@@ -7,5 +7,5 @@ namespace OpenLoco::Localisation
     using utf8_t = uint8_t;
     using utf32_t = uint32_t;
 
-    utf32_t readCodePoint(utf8_t** string);
+    utf32_t readCodePoint(const utf8_t** string);
 }


### PR DESCRIPTION
Fixes #3198

It feels kind of stupid, both to be using a module named localization here, ~~as well as the crazy cast,~~ but it works.

Previously the behaviour was bugged such that `ä` would become `{keyCode=228 charCode=4294967235}` instead of `{keyCode=228 charCode=228}`.
