### PR TITLE
Implement Bring Track Element to Front

### DIFF
--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3916,7 +3916,7 @@ namespace OpenLoco::Vehicles
             const bool isLastElement = lastTrackElement->isLast();
             lastTrackElement->setLastFlag(false);
             auto* iter = lastTrackElement;
-            while (iter >= beginTrackElement)
+            while (iter > beginTrackElement)
             {
                 std::swap(*iter, *(iter - 1));
                 iter--;


### PR DESCRIPTION
Qutie an odd function TBH seems like when a train enters a junction the rail it is on always becomes the front tile.

Replays match.