### PR TITLE
Add logging for input state, also example case

### DIFF
--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -163,6 +163,7 @@ set(OLOCO_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Graphics/TextRenderer.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Gui.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Input.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/InputFmt.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Input/Keyboard.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Input/MouseInput.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/Input/Shortcuts.cpp"

--- a/src/OpenLoco/src/Input.cpp
+++ b/src/OpenLoco/src/Input.cpp
@@ -5,10 +5,12 @@
 #include "Ui.h"
 #include "Ui/ScrollView.h"
 #include "Ui/Window.h"
+#include <OpenLoco/Diagnostics/Logging.h>
 #include <OpenLoco/Interop/Interop.hpp>
 #include <map>
 
 using namespace OpenLoco::Interop;
+using namespace OpenLoco::Diagnostics;
 
 namespace OpenLoco::Input
 {
@@ -45,6 +47,7 @@ namespace OpenLoco::Input
 
     void state(State state)
     {
+        Logging::verbose("Input state change, old: {0}, new: {1}", *_state, state);
         _state = state;
     }
 
@@ -85,4 +88,5 @@ namespace OpenLoco::Input
 
         return { static_cast<int16_t>(delta.x), static_cast<int16_t>(delta.y) };
     }
+
 }

--- a/src/OpenLoco/src/Input.h
+++ b/src/OpenLoco/src/Input.h
@@ -16,6 +16,8 @@ namespace OpenLoco::Input
         rightReleased = 4,
     };
 
+    std::string_view format_as(MouseButton state);
+
     enum class State : uint8_t
     {
         reset,             // 0
@@ -29,6 +31,8 @@ namespace OpenLoco::Input
         resizing,          // 8
         scrollRight,       // 9
     };
+
+    std::string_view format_as(State state);
 
     enum class Flags : uint32_t
     {

--- a/src/OpenLoco/src/InputFmt.cpp
+++ b/src/OpenLoco/src/InputFmt.cpp
@@ -1,0 +1,72 @@
+#include "Input.h"
+#include <fmt/format.h>
+
+namespace OpenLoco::Input
+{
+    std::string_view format_as(MouseButton state)
+    {
+        std::string_view name = "Input::mouseButton::<invalid>";
+        switch (state)
+        {
+            case OpenLoco::Input::MouseButton::released:
+                name = "Input::MouseButton::released";
+                break;
+            case OpenLoco::Input::MouseButton::leftPressed:
+                name = "Input::MouseButton::leftPressed";
+                break;
+            case OpenLoco::Input::MouseButton::leftReleased:
+                name = "Input::MouseButton::leftReleased";
+                break;
+            case OpenLoco::Input::MouseButton::rightPressed:
+                name = "Input::MouseButton::rightPressed";
+                break;
+            case OpenLoco::Input::MouseButton::rightReleased:
+                name = "Input::MouseButton::rightReleased";
+                break;
+            default:
+                break;
+        }
+        return name;
+    }
+
+    std::string_view format_as(State value)
+    {
+        std::string_view name = "Input::state::<invalid>";
+        switch (value)
+        {
+            case OpenLoco::Input::State::reset:
+                name = "Input::State::reset";
+                break;
+            case OpenLoco::Input::State::normal:
+                name = "Input::State::normal";
+                break;
+            case OpenLoco::Input::State::widgetPressed:
+                name = "Input::State::widgetPressed";
+                break;
+            case OpenLoco::Input::State::positioningWindow:
+                name = "Input::State::positioningWindow";
+                break;
+            case OpenLoco::Input::State::viewportRight:
+                name = "Input::State::viewportRight";
+                break;
+            case OpenLoco::Input::State::dropdownActive:
+                name = "Input::State::dropdownActive";
+                break;
+            case OpenLoco::Input::State::viewportLeft:
+                name = "Input::State::viewportLeft";
+                break;
+            case OpenLoco::Input::State::scrollLeft:
+                name = "Input::State::scrollLeft";
+                break;
+            case OpenLoco::Input::State::resizing:
+                name = "Input::State::resizing";
+                break;
+            case OpenLoco::Input::State::scrollRight:
+                name = "Input::State::scrollRight";
+                break;
+            default:
+                break;
+        }
+        return name;
+    }
+}


### PR DESCRIPTION
I was looking into an issue and since it requires user interaction it was easier to log the things, this made me think that we should maybe have a standard way to log certain enum values since this is just easier than looking up the numeric values so this is what I propose. Generally speaking we should not be shy to log way more, anything that is debug related should be just verbose and those messages already filter by default, the way the logging code currently works makes this nearly zero cost for when its disabled so there is no reason not to do it more often.