### PR TITLE
Fix #3195: Ui state is reset each frame preventing scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix: [#3171] Background of station labels have a visible gap due to being off by one pixel.
 - Fix: [#3184] The minimum size of the map window is miscalculated when it is dragged past a certain point.
 - Fix: [#3190] The map window's minimap isn't centred correctly when it is first opened.
+- Fix: [#3195] In the Landscape Generation window, UI state is reset each frame, preventing scrolling the land type list.
 
 25.07 (2025-07-15)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -224,8 +224,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
         static void prepareDraw(Window& window)
         {
-            switchTabWidgets(&window);
-
             window.widgets[widx::frame].right = window.width - 1;
             window.widgets[widx::frame].bottom = window.height - 1;
 


### PR DESCRIPTION
I don't know how this call got in there but it's not needed.

Closes #3195