### PR TITLE
Fix #3137: Viewport interaction is offset by window position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Change: [#3193] The minimum size of the map window was changed to accommodate all elements.
 - Fix: [#3019] Mouse getting stuck on edges of monitor when right mouse dragging scroll views.
 - Fix: [#3116] Visual artifacts when additional viewports are visible, most prominently with news message window.
+- Fix: [#3137] Viewport interaction is offset by window position.
 - Fix: [#3167] Dropdown for terrain type selection is displayed at the wrong position.
 - Fix: [#3171] Background of station labels have a visible gap due to being off by one pixel.
 - Fix: [#3184] The minimum size of the map window is miscalculated when it is dragged past a certain point.

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -954,9 +954,10 @@ namespace OpenLoco::Ui::ViewportInteraction
         auto w = WindowManager::findAt(screenPos);
         if (w != nullptr)
         {
+            const auto relPos = screenPos - w->position();
             for (auto vp : w->viewports)
             {
-                if (vp != nullptr && vp->containsUi({ screenPos.x, screenPos.y }))
+                if (vp != nullptr && vp->containsUi(relPos))
                 {
                     if (vp->hasFlags(ViewportFlags::seeThroughBuildings))
                     {
@@ -1495,13 +1496,14 @@ namespace OpenLoco::Ui::ViewportInteraction
                 continue;
             }
 
-            if (!vp->containsUi({ screenPos.x, screenPos.y }))
+            const auto relPos = screenPos - w->position();
+            if (!vp->containsUi(relPos))
             {
                 continue;
             }
 
             chosenV = vp;
-            auto vpPos = vp->screenToViewport({ screenPos.x, screenPos.y });
+            auto vpPos = vp->screenToViewport(relPos);
             _rt1->zoomLevel = vp->zoom;
             _rt1->x = (0xFFFF << vp->zoom) & vpPos.x;
             _rt1->y = (0xFFFF << vp->zoom) & vpPos.y;

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -129,9 +129,9 @@ namespace OpenLoco::Ui
             return std::nullopt;
         }
 
-        if (vp->containsUi(mouse))
+        if (vp->containsUi(mouse - w->position()))
         {
-            viewport_pos vpos = vp->screenToViewport(mouse);
+            viewport_pos vpos = vp->screenToViewport(mouse - w->position());
             World::Pos2 position = viewportCoordToMapCoord(vpos.x, vpos.y, z, WindowManager::getCurrentRotation());
             if (World::validCoords(position))
             {


### PR DESCRIPTION
This is not the prettiest solution, ideally it transforms the position underneath but there is a bit of cleaning up to do, for now this will fix the issue without having major refactoring going on.

Closes #3137