### PR TITLE
Implement Road Longest Pathing

### DIFF
--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -4689,7 +4689,10 @@ namespace OpenLoco::Vehicles
         curTad._data = tad;
         for (; true;)
         {
-            state.totalTrackWeighting += World::TrackData::getRoadMiscData(curTad.id()).unkWeighting;
+            // TODO: This is a vanilla mistake where it accesses the wrong data!
+            // CHANGE THIS WHEN WE DIVERGE FROM VANILLA
+            state.totalTrackWeighting += World::TrackData::getTrackMiscData(curTad.id()).unkWeighting;
+            // state.totalTrackWeighting += World::TrackData::getRoadMiscData(curTad.id()).unkWeighting;
             if (state.totalTrackWeighting > 1280)
             {
                 break;
@@ -4698,7 +4701,7 @@ namespace OpenLoco::Vehicles
             state.bestTrackWeighting = std::max(state.bestTrackWeighting, state.totalTrackWeighting);
 
             auto [nextPos, nextRotation] = Track::getRoadConnectionEnd(curPos, curTad._data & World::Track::AdditionalTaDFlags::basicTaDMask);
-            auto tc = World::Track::getRoadConnectionsOneWay(nextPos, nextRotation, companyId, roadObjectId, requiredMods, queryMods);
+            auto tc = World::Track::getRoadConnections(nextPos, nextRotation, companyId, roadObjectId, requiredMods, queryMods);
 
             if (tc.connections.empty())
             {

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -4719,6 +4719,7 @@ namespace OpenLoco::Vehicles
                 auto recurseState = state;
                 recurseState.recursionDepth++;
                 roadLongestPathingCalculateRecurse(curPos, connectTad, companyId, roadObjectId, requiredMods, queryMods, recurseState);
+                state.bestTrackWeighting = recurseState.bestTrackWeighting;
             }
             break;
         }


### PR DESCRIPTION
I'm not 100% sure why this is used in some places but I think its so that there is a deterministic pathing function. Its definitly used when placing road vehicles but its also used when they turn around and a few other places (look for head->var_52 = 1 which triggers this code). Needs to have the same signature as roadPathing (thats why it has the empty vars)

~~Note: Replays don't pass just yet.~~
Replays pass