### PR TITLE
CompanyWindow: don't override bankrupt string

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -1872,7 +1872,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 {
                     cashFormat = StringIds::cash_bankrupt;
                 }
-                if (company->cash.var_04 < 0)
+                else if (company->cash.var_04 < 0)
                 {
                     cashFormat = StringIds::cash_negative;
                 }


### PR DESCRIPTION
The company window should display 'Bankrupt!' when the company has gone out of business. The check for a negative cash balance currently overrides this.