### PR TITLE
Mouse Wheel zooms in more reliably

### DIFF
--- a/src/OpenLoco/src/Ui.cpp
+++ b/src/OpenLoco/src/Ui.cpp
@@ -513,7 +513,7 @@ namespace OpenLoco::Ui
                     break;
                 }
                 case SDL_MOUSEWHEEL:
-                    Input::mouseWheel(e.wheel.y);
+                    Input::mouseWheel(e.wheel.preciseY);
                     break;
                 case SDL_MOUSEBUTTONDOWN:
                 {


### PR DESCRIPTION
SDL's scroll wheel input interpretation seems bugged resulting in scrolling in either direction to result in a zoom out. This seems to fix the issue