### PR TITLE
Changes scrollbar types to 32 bits to account for very large scroll content sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 25.07+ (???)
 ------------------------------------------------------------------------
+- Change: [#1682, #3216] Scroll widgets now support much larger sizes.
 - Change: [#3104] Landscape generation confirmation prompts now prevent you from clicking other windows until a choice is made.
 - Change: [#3193] The minimum size of the map window was changed to accommodate all elements.
 - Fix: [#3019] Mouse getting stuck on edges of monitor when right mouse dragging scroll views.

--- a/src/OpenLoco/src/Ui/ScrollFlags.hpp
+++ b/src/OpenLoco/src/Ui/ScrollFlags.hpp
@@ -46,14 +46,14 @@ namespace OpenLoco::Ui
     struct ScrollArea
     {
         ScrollFlags flags;      // 0x00
-        int16_t contentOffsetX; // 0x02
-        int16_t contentWidth;   // 0x04
-        uint16_t hThumbLeft;    // 0x06
-        uint16_t hThumbRight;   // 0x08
-        int16_t contentOffsetY; // 0x0A
-        int16_t contentHeight;  // 0x0C
-        uint16_t vThumbTop;     // 0x0E
-        uint16_t vThumbBottom;  // 0x10
+        int32_t contentOffsetX; // 0x02
+        int32_t contentWidth;   // 0x04
+        uint32_t hThumbLeft;    // 0x06
+        uint32_t hThumbRight;   // 0x08
+        int32_t contentOffsetY; // 0x0A
+        int32_t contentHeight;  // 0x0C
+        uint32_t vThumbTop;     // 0x0E
+        uint32_t vThumbBottom;  // 0x10
 
         constexpr bool hasFlags(ScrollFlags flagsToTest) const
         {

--- a/src/OpenLoco/src/Ui/ScrollFlags.hpp
+++ b/src/OpenLoco/src/Ui/ScrollFlags.hpp
@@ -48,12 +48,12 @@ namespace OpenLoco::Ui
         ScrollFlags flags;      // 0x00
         int32_t contentOffsetX; // 0x02
         int32_t contentWidth;   // 0x04
-        uint32_t hThumbLeft;    // 0x06
-        uint32_t hThumbRight;   // 0x08
+        int32_t hThumbLeft;     // 0x06
+        int32_t hThumbRight;    // 0x08
         int32_t contentOffsetY; // 0x0A
         int32_t contentHeight;  // 0x0C
-        uint32_t vThumbTop;     // 0x0E
-        uint32_t vThumbBottom;  // 0x10
+        int32_t vThumbTop;      // 0x0E
+        int32_t vThumbBottom;   // 0x10
 
         constexpr bool hasFlags(ScrollFlags flagsToTest) const
         {

--- a/src/OpenLoco/src/Ui/ScrollView.cpp
+++ b/src/OpenLoco/src/Ui/ScrollView.cpp
@@ -229,13 +229,13 @@ namespace OpenLoco::Ui::ScrollView
                 return res;
             }
 
-            if (x < scroll.hThumbLeft + left)
+            if (x < static_cast<int32_t>(scroll.hThumbLeft) + left)
             {
                 res.area = ScrollPart::hscrollbarTrackLeft;
                 return res;
             }
 
-            if (x > scroll.hThumbRight + left)
+            if (x > static_cast<int32_t>(scroll.hThumbRight) + left)
             {
                 res.area = ScrollPart::hscrollbarTrackRight;
                 return res;
@@ -270,13 +270,13 @@ namespace OpenLoco::Ui::ScrollView
                 return res;
             }
 
-            if (y < scroll.vThumbTop + top)
+            if (y < static_cast<int32_t>(scroll.vThumbTop) + top)
             {
                 res.area = ScrollPart::vscrollbarTrackTop;
                 return res;
             }
 
-            if (y > scroll.vThumbBottom + top)
+            if (y > static_cast<int32_t>(scroll.vThumbBottom) + top)
             {
                 res.area = ScrollPart::vscrollbarTrackBottom;
                 return res;

--- a/src/OpenLoco/src/Ui/ScrollView.cpp
+++ b/src/OpenLoco/src/Ui/ScrollView.cpp
@@ -229,13 +229,13 @@ namespace OpenLoco::Ui::ScrollView
                 return res;
             }
 
-            if (x < static_cast<int32_t>(scroll.hThumbLeft) + left)
+            if (x < scroll.hThumbLeft + left)
             {
                 res.area = ScrollPart::hscrollbarTrackLeft;
                 return res;
             }
 
-            if (x > static_cast<int32_t>(scroll.hThumbRight) + left)
+            if (x > scroll.hThumbRight + left)
             {
                 res.area = ScrollPart::hscrollbarTrackRight;
                 return res;
@@ -270,13 +270,13 @@ namespace OpenLoco::Ui::ScrollView
                 return res;
             }
 
-            if (y < static_cast<int32_t>(scroll.vThumbTop) + top)
+            if (y < scroll.vThumbTop + top)
             {
                 res.area = ScrollPart::vscrollbarTrackTop;
                 return res;
             }
 
-            if (y > static_cast<int32_t>(scroll.vThumbBottom) + top)
+            if (y > scroll.vThumbBottom + top)
             {
                 res.area = ScrollPart::vscrollbarTrackBottom;
                 return res;

--- a/src/OpenLoco/src/Ui/Widgets/ScrollViewWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ScrollViewWidget.cpp
@@ -84,8 +84,8 @@ namespace OpenLoco::Ui::Widgets
             f = Gfx::RectInsetFlags::borderInset;
         }
         drawingCtx.fillRectInset(
-            scrollPos + Point{ scrollArea.hThumbLeft, 0 },
-            { scrollArea.hThumbRight - scrollArea.hThumbLeft - kScrollbarMargin, +scrollSize.height },
+            scrollPos + Point{ static_cast<int32_t>(scrollArea.hThumbLeft), 0 },
+            { static_cast<int32_t>(scrollArea.hThumbRight - scrollArea.hThumbLeft - kScrollbarMargin), +scrollSize.height },
             colour,
             f);
     }
@@ -158,8 +158,8 @@ namespace OpenLoco::Ui::Widgets
             f = widgetState.flags | Gfx::RectInsetFlags::borderInset;
         }
         drawingCtx.fillRectInset(
-            scrollPos + Point{ 0, scrollArea.vThumbTop },
-            { +scrollSize.width, scrollArea.vThumbBottom - scrollArea.vThumbTop - kScrollbarMargin },
+            scrollPos + Point{ 0, static_cast<int32_t>(scrollArea.vThumbTop) },
+            { +scrollSize.width, static_cast<int32_t>(scrollArea.vThumbBottom - scrollArea.vThumbTop - kScrollbarMargin) },
             colour,
             f);
     }

--- a/src/OpenLoco/src/Ui/Widgets/ScrollViewWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ScrollViewWidget.cpp
@@ -84,8 +84,8 @@ namespace OpenLoco::Ui::Widgets
             f = Gfx::RectInsetFlags::borderInset;
         }
         drawingCtx.fillRectInset(
-            scrollPos + Point{ static_cast<int32_t>(scrollArea.hThumbLeft), 0 },
-            { static_cast<int32_t>(scrollArea.hThumbRight - scrollArea.hThumbLeft - kScrollbarMargin), +scrollSize.height },
+            scrollPos + Point{ scrollArea.hThumbLeft, 0 },
+            { scrollArea.hThumbRight - scrollArea.hThumbLeft - kScrollbarMargin, +scrollSize.height },
             colour,
             f);
     }
@@ -158,8 +158,8 @@ namespace OpenLoco::Ui::Widgets
             f = widgetState.flags | Gfx::RectInsetFlags::borderInset;
         }
         drawingCtx.fillRectInset(
-            scrollPos + Point{ 0, static_cast<int32_t>(scrollArea.vThumbTop) },
-            { +scrollSize.width, static_cast<int32_t>(scrollArea.vThumbBottom - scrollArea.vThumbTop - kScrollbarMargin) },
+            scrollPos + Point{ 0, scrollArea.vThumbTop },
+            { +scrollSize.width, scrollArea.vThumbBottom - scrollArea.vThumbTop - kScrollbarMargin },
             colour,
             f);
     }

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -434,14 +434,14 @@ namespace OpenLoco::Ui
                 continue;
             }
 
-            uint16_t scrollWidth = 0, scrollHeight = 0;
+            uint32_t scrollWidth = 0, scrollHeight = 0;
             this->callGetScrollSize(s, &scrollWidth, &scrollHeight);
 
             bool invalidate = false;
 
             if (widget.content & Scrollbars::horizontal)
             {
-                if (this->scrollAreas[s].contentWidth != scrollWidth + 1)
+                if (this->scrollAreas[s].contentWidth != static_cast<int32_t>(scrollWidth) + 1)
                 {
                     this->scrollAreas[s].contentWidth = scrollWidth + 1;
                     invalidate = true;
@@ -450,7 +450,7 @@ namespace OpenLoco::Ui
 
             if (widget.content & Scrollbars::vertical)
             {
-                if (this->scrollAreas[s].contentHeight != scrollHeight + 1)
+                if (this->scrollAreas[s].contentHeight != static_cast<int32_t>(scrollHeight) + 1)
                 {
                     this->scrollAreas[s].contentHeight = scrollHeight + 1;
                     invalidate = true;
@@ -483,7 +483,7 @@ namespace OpenLoco::Ui
 
             this->scrollAreas[s].flags = ScrollFlags::none;
 
-            uint16_t scrollWidth = 0, scrollHeight = 0;
+            uint32_t scrollWidth = 0, scrollHeight = 0;
             this->callGetScrollSize(s, &scrollWidth, &scrollHeight);
             this->scrollAreas[s].contentOffsetX = 0;
             this->scrollAreas[s].contentWidth = scrollWidth + 1;
@@ -1181,7 +1181,7 @@ namespace OpenLoco::Ui
         eventHandlers->onDropdown(*this, widgetIndex, id, itemIndex);
     }
 
-    void Window::callGetScrollSize(uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+    void Window::callGetScrollSize(uint32_t scrollIndex, uint32_t* scrollWidth, uint32_t* scrollHeight)
     {
         if (eventHandlers->getScrollSize == nullptr)
         {

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -435,7 +435,7 @@ namespace OpenLoco::Ui
             }
 
             int32_t scrollWidth = 0, scrollHeight = 0;
-            this->callGetScrollSize(s, &scrollWidth, &scrollHeight);
+            this->callGetScrollSize(s, scrollWidth, scrollHeight);
 
             bool invalidate = false;
 
@@ -484,7 +484,7 @@ namespace OpenLoco::Ui
             this->scrollAreas[s].flags = ScrollFlags::none;
 
             int32_t scrollWidth = 0, scrollHeight = 0;
-            this->callGetScrollSize(s, &scrollWidth, &scrollHeight);
+            this->callGetScrollSize(s, scrollWidth, scrollHeight);
             this->scrollAreas[s].contentOffsetX = 0;
             this->scrollAreas[s].contentWidth = scrollWidth + 1;
             this->scrollAreas[s].contentOffsetY = 0;
@@ -1181,7 +1181,7 @@ namespace OpenLoco::Ui
         eventHandlers->onDropdown(*this, widgetIndex, id, itemIndex);
     }
 
-    void Window::callGetScrollSize(uint32_t scrollIndex, int32_t* scrollWidth, int32_t* scrollHeight)
+    void Window::callGetScrollSize(uint32_t scrollIndex, int32_t& scrollWidth, int32_t& scrollHeight)
     {
         if (eventHandlers->getScrollSize == nullptr)
         {

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -434,14 +434,14 @@ namespace OpenLoco::Ui
                 continue;
             }
 
-            uint32_t scrollWidth = 0, scrollHeight = 0;
+            int32_t scrollWidth = 0, scrollHeight = 0;
             this->callGetScrollSize(s, &scrollWidth, &scrollHeight);
 
             bool invalidate = false;
 
             if (widget.content & Scrollbars::horizontal)
             {
-                if (this->scrollAreas[s].contentWidth != static_cast<int32_t>(scrollWidth) + 1)
+                if (this->scrollAreas[s].contentWidth != scrollWidth + 1)
                 {
                     this->scrollAreas[s].contentWidth = scrollWidth + 1;
                     invalidate = true;
@@ -450,7 +450,7 @@ namespace OpenLoco::Ui
 
             if (widget.content & Scrollbars::vertical)
             {
-                if (this->scrollAreas[s].contentHeight != static_cast<int32_t>(scrollHeight) + 1)
+                if (this->scrollAreas[s].contentHeight != scrollHeight + 1)
                 {
                     this->scrollAreas[s].contentHeight = scrollHeight + 1;
                     invalidate = true;
@@ -483,7 +483,7 @@ namespace OpenLoco::Ui
 
             this->scrollAreas[s].flags = ScrollFlags::none;
 
-            uint32_t scrollWidth = 0, scrollHeight = 0;
+            int32_t scrollWidth = 0, scrollHeight = 0;
             this->callGetScrollSize(s, &scrollWidth, &scrollHeight);
             this->scrollAreas[s].contentOffsetX = 0;
             this->scrollAreas[s].contentWidth = scrollWidth + 1;
@@ -1181,7 +1181,7 @@ namespace OpenLoco::Ui
         eventHandlers->onDropdown(*this, widgetIndex, id, itemIndex);
     }
 
-    void Window::callGetScrollSize(uint32_t scrollIndex, uint32_t* scrollWidth, uint32_t* scrollHeight)
+    void Window::callGetScrollSize(uint32_t scrollIndex, int32_t* scrollWidth, int32_t* scrollHeight)
     {
         if (eventHandlers->getScrollSize == nullptr)
         {

--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -84,7 +84,7 @@ namespace OpenLoco::Ui
         void (*toolUp)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
         void (*onToolAbort)(Window&, const WidgetIndex_t, WidgetId) = nullptr;
         Ui::CursorId (*toolCursor)(Window&, const int16_t x, const int16_t y, const Ui::CursorId, bool&) = nullptr;
-        void (*getScrollSize)(Window&, uint32_t scrollIndex, uint32_t* scrollWidth, uint32_t* scrollHeight) = nullptr;
+        void (*getScrollSize)(Window&, uint32_t scrollIndex, int32_t* scrollWidth, int32_t* scrollHeight) = nullptr;
         void (*scrollMouseDown)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
         void (*scrollMouseDrag)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
         void (*scrollMouseOver)(Ui::Window& window, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
@@ -376,7 +376,7 @@ namespace OpenLoco::Ui
         void callToolUp(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);                  // 13
         void callToolAbort(WidgetIndex_t widgetIndex, WidgetId id);                                                       // 14
         Ui::CursorId callToolCursor(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out);                        // 15
-        void callGetScrollSize(uint32_t scrollIndex, uint32_t* scrollWidth, uint32_t* scrollHeight);                      // 16
+        void callGetScrollSize(uint32_t scrollIndex, int32_t* scrollWidth, int32_t* scrollHeight);                        // 16
         void callScrollMouseDown(int16_t x, int16_t y, uint8_t scrollIndex);                                              // 17
         void callScrollMouseDrag(int16_t x, int16_t y, uint8_t scrollIndex);                                              // 18
         void callScrollMouseOver(int16_t x, int16_t y, uint8_t scrollIndex);                                              // 19

--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -84,7 +84,7 @@ namespace OpenLoco::Ui
         void (*toolUp)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
         void (*onToolAbort)(Window&, const WidgetIndex_t, WidgetId) = nullptr;
         Ui::CursorId (*toolCursor)(Window&, const int16_t x, const int16_t y, const Ui::CursorId, bool&) = nullptr;
-        void (*getScrollSize)(Window&, uint32_t scrollIndex, int32_t* scrollWidth, int32_t* scrollHeight) = nullptr;
+        void (*getScrollSize)(Window&, uint32_t scrollIndex, int32_t& scrollWidth, int32_t& scrollHeight) = nullptr;
         void (*scrollMouseDown)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
         void (*scrollMouseDrag)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
         void (*scrollMouseOver)(Ui::Window& window, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
@@ -376,7 +376,7 @@ namespace OpenLoco::Ui
         void callToolUp(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);                  // 13
         void callToolAbort(WidgetIndex_t widgetIndex, WidgetId id);                                                       // 14
         Ui::CursorId callToolCursor(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out);                        // 15
-        void callGetScrollSize(uint32_t scrollIndex, int32_t* scrollWidth, int32_t* scrollHeight);                        // 16
+        void callGetScrollSize(uint32_t scrollIndex, int32_t& scrollWidth, int32_t& scrollHeight);                        // 16
         void callScrollMouseDown(int16_t x, int16_t y, uint8_t scrollIndex);                                              // 17
         void callScrollMouseDrag(int16_t x, int16_t y, uint8_t scrollIndex);                                              // 18
         void callScrollMouseOver(int16_t x, int16_t y, uint8_t scrollIndex);                                              // 19

--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -84,7 +84,7 @@ namespace OpenLoco::Ui
         void (*toolUp)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
         void (*onToolAbort)(Window&, const WidgetIndex_t, WidgetId) = nullptr;
         Ui::CursorId (*toolCursor)(Window&, const int16_t x, const int16_t y, const Ui::CursorId, bool&) = nullptr;
-        void (*getScrollSize)(Window&, uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight) = nullptr;
+        void (*getScrollSize)(Window&, uint32_t scrollIndex, uint32_t* scrollWidth, uint32_t* scrollHeight) = nullptr;
         void (*scrollMouseDown)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
         void (*scrollMouseDrag)(Ui::Window&, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
         void (*scrollMouseOver)(Ui::Window& window, int16_t x, int16_t y, uint8_t scrollIndex) = nullptr;
@@ -376,7 +376,7 @@ namespace OpenLoco::Ui
         void callToolUp(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);                  // 13
         void callToolAbort(WidgetIndex_t widgetIndex, WidgetId id);                                                       // 14
         Ui::CursorId callToolCursor(int16_t xPos, int16_t yPos, Ui::CursorId fallback, bool* out);                        // 15
-        void callGetScrollSize(uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight);                      // 16
+        void callGetScrollSize(uint32_t scrollIndex, uint32_t* scrollWidth, uint32_t* scrollHeight);                      // 16
         void callScrollMouseDown(int16_t x, int16_t y, uint8_t scrollIndex);                                              // 17
         void callScrollMouseDrag(int16_t x, int16_t y, uint8_t scrollIndex);                                              // 18
         void callScrollMouseOver(int16_t x, int16_t y, uint8_t scrollIndex);                                              // 19

--- a/src/OpenLoco/src/Ui/Windows/AboutMusic.cpp
+++ b/src/OpenLoco/src/Ui/Windows/AboutMusic.cpp
@@ -78,7 +78,7 @@ namespace OpenLoco::Ui::Windows::AboutMusic
     }
 
     // 0x0043BFBB
-    static void getScrollSize(Ui::Window&, uint32_t, uint16_t*, uint16_t* const scrollHeight)
+    static void getScrollSize(Ui::Window&, uint32_t, uint32_t*, uint32_t* const scrollHeight)
     {
         *scrollHeight = numSongs * (kRowHeight * 3 + 4);
     }

--- a/src/OpenLoco/src/Ui/Windows/AboutMusic.cpp
+++ b/src/OpenLoco/src/Ui/Windows/AboutMusic.cpp
@@ -78,9 +78,9 @@ namespace OpenLoco::Ui::Windows::AboutMusic
     }
 
     // 0x0043BFBB
-    static void getScrollSize(Ui::Window&, uint32_t, int32_t*, int32_t* const scrollHeight)
+    static void getScrollSize(Ui::Window&, uint32_t, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        *scrollHeight = numSongs * (kRowHeight * 3 + 4);
+        scrollHeight = numSongs * (kRowHeight * 3 + 4);
     }
 
     // 0x0043BFC0

--- a/src/OpenLoco/src/Ui/Windows/AboutMusic.cpp
+++ b/src/OpenLoco/src/Ui/Windows/AboutMusic.cpp
@@ -78,7 +78,7 @@ namespace OpenLoco::Ui::Windows::AboutMusic
     }
 
     // 0x0043BFBB
-    static void getScrollSize(Ui::Window&, uint32_t, uint32_t*, uint32_t* const scrollHeight)
+    static void getScrollSize(Ui::Window&, uint32_t, int32_t*, int32_t* const scrollHeight)
     {
         *scrollHeight = numSongs * (kRowHeight * 3 + 4);
     }

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -1025,7 +1025,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     }
 
     // 0x4C37B9
-    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
     {
         *scrollHeight = window.var_83C * window.rowHeight;
     }

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -1025,7 +1025,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     }
 
     // 0x4C37B9
-    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
     {
         *scrollHeight = window.var_83C * window.rowHeight;
     }

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -1025,9 +1025,9 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     }
 
     // 0x4C37B9
-    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        *scrollHeight = window.var_83C * window.rowHeight;
+        scrollHeight = window.var_83C * window.rowHeight;
     }
 
     // 0x4C384B

--- a/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
@@ -149,9 +149,9 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x4352BB
-    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] int32_t* const scrollWidth, int32_t* const scrollHeight)
+    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        *scrollHeight = _competitorList.size() * kRowHeight;
+        scrollHeight = _competitorList.size() * kRowHeight;
     }
 
     static bool isInUseCompetitor(const uint32_t objIndex)

--- a/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
@@ -149,9 +149,9 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x4352BB
-    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint32_t* const scrollWidth, uint32_t* const scrollHeight)
+    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] int32_t* const scrollWidth, int32_t* const scrollHeight)
     {
-        *scrollHeight = static_cast<uint32_t>(_competitorList.size()) * kRowHeight;
+        *scrollHeight = _competitorList.size() * kRowHeight;
     }
 
     static bool isInUseCompetitor(const uint32_t objIndex)

--- a/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
@@ -149,9 +149,9 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x4352BB
-    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint16_t* const scrollWidth, uint16_t* const scrollHeight)
+    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint32_t* const scrollWidth, uint32_t* const scrollHeight)
     {
-        *scrollHeight = static_cast<uint16_t>(_competitorList.size()) * kRowHeight;
+        *scrollHeight = static_cast<uint32_t>(_competitorList.size()) * kRowHeight;
     }
 
     static bool isInUseCompetitor(const uint32_t objIndex)

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -337,7 +337,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00436321
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
         {
             *scrollHeight = self.var_83C * kRowHeight;
         }

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -337,7 +337,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00436321
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
         {
             *scrollHeight = self.var_83C * kRowHeight;
         }

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -337,9 +337,9 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x00436321
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            *scrollHeight = self.var_83C * kRowHeight;
+            scrollHeight = self.var_83C * kRowHeight;
         }
 
         // 0x004363A0

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -2147,7 +2147,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x0043386F
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, uint16_t* scrollWidth, [[maybe_unused]] uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, uint32_t* scrollWidth, [[maybe_unused]] uint32_t* scrollHeight)
         {
             const auto& company = CompanyManager::get(CompanyId(self.number));
             *scrollWidth = company->numExpenditureYears * expenditureColumnWidth;

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -2147,10 +2147,10 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x0043386F
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, int32_t* scrollWidth, [[maybe_unused]] int32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, int32_t& scrollWidth, [[maybe_unused]] int32_t& scrollHeight)
         {
             const auto& company = CompanyManager::get(CompanyId(self.number));
-            *scrollWidth = company->numExpenditureYears * expenditureColumnWidth;
+            scrollWidth = company->numExpenditureYears * expenditureColumnWidth;
         }
 
         // 0x00433887

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -2147,7 +2147,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x0043386F
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, uint32_t* scrollWidth, [[maybe_unused]] uint32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, int32_t* scrollWidth, [[maybe_unused]] int32_t* scrollHeight)
         {
             const auto& company = CompanyManager::get(CompanyId(self.number));
             *scrollWidth = company->numExpenditureYears * expenditureColumnWidth;

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -448,9 +448,9 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458108
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            *scrollHeight = kRowHeight * self.var_83C;
+            scrollHeight = kRowHeight * self.var_83C;
         }
 
         // 0x00457D2A
@@ -1002,14 +1002,14 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x004586EA
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            *scrollHeight = (4 + self.var_83C) / 5;
-            if (*scrollHeight == 0)
+            scrollHeight = (4 + self.var_83C) / 5;
+            if (scrollHeight == 0)
             {
-                *scrollHeight += 1;
+                scrollHeight += 1;
             }
-            *scrollHeight *= kRowHeight;
+            scrollHeight *= kRowHeight;
         }
 
         // 0x00458352
@@ -1223,8 +1223,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
         // 0x00458B51
         static void updateActiveThumb(Window& self)
         {
-            int32_t scrollHeight = 0;
-            self.callGetScrollSize(0, nullptr, &scrollHeight);
+            int32_t scrollWidth = 0, scrollHeight = 0;
+            self.callGetScrollSize(0, scrollWidth, scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
             auto i = 0;

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -448,7 +448,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458108
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
         {
             *scrollHeight = kRowHeight * self.var_83C;
         }
@@ -1002,7 +1002,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x004586EA
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
         {
             *scrollHeight = (4 + self.var_83C) / 5;
             if (*scrollHeight == 0)
@@ -1223,7 +1223,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         // 0x00458B51
         static void updateActiveThumb(Window& self)
         {
-            uint32_t scrollHeight = 0;
+            int32_t scrollHeight = 0;
             self.callGetScrollSize(0, nullptr, &scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -1223,7 +1223,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         // 0x00458B51
         static void updateActiveThumb(Window& self)
         {
-           uint32_t scrollHeight = 0;
+            uint32_t scrollHeight = 0;
             self.callGetScrollSize(0, nullptr, &scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -448,7 +448,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458108
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
         {
             *scrollHeight = kRowHeight * self.var_83C;
         }
@@ -1002,7 +1002,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x004586EA
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
         {
             *scrollHeight = (4 + self.var_83C) / 5;
             if (*scrollHeight == 0)
@@ -1223,7 +1223,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         // 0x00458B51
         static void updateActiveThumb(Window& self)
         {
-            uint16_t scrollHeight = 0;
+           uint32_t scrollHeight = 0;
             self.callGetScrollSize(0, nullptr, &scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -236,9 +236,9 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     }
 
     // 0x004BE84E
-    static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+    static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        *scrollHeight = self.rowCount * kRowHeight;
+        scrollHeight = self.rowCount * kRowHeight;
     }
 
     // 0x004BE853

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -236,7 +236,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     }
 
     // 0x004BE84E
-    static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
     {
         *scrollHeight = self.rowCount * kRowHeight;
     }

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -236,7 +236,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     }
 
     // 0x004BE84E
-    static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+    static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
     {
         *scrollHeight = self.rowCount * kRowHeight;
     }

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -702,7 +702,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E2AC
-        static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
         {
             *scrollHeight = 0;
 

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -702,7 +702,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E2AC
-        static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+        static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
         {
             *scrollHeight = 0;
 

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -702,9 +702,9 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E2AC
-        static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+        static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            *scrollHeight = 0;
+            scrollHeight = 0;
 
             for (uint16_t i = 0; i < kMaxLandObjects; i++)
             {
@@ -714,7 +714,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     continue;
                 }
 
-                *scrollHeight += kRowHeight;
+                scrollHeight += kRowHeight;
             }
         }
 

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -1121,7 +1121,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046B9E7
-    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, uint32_t* scrollWidth, uint32_t* scrollHeight)
+    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, int32_t* scrollWidth, int32_t* scrollHeight)
     {
         *scrollWidth = kRenderedMapWidth;
         *scrollHeight = kRenderedMapHeight;

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -1121,10 +1121,10 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046B9E7
-    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, int32_t* scrollWidth, int32_t* scrollHeight)
+    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        *scrollWidth = kRenderedMapWidth;
-        *scrollHeight = kRenderedMapHeight;
+        scrollWidth = kRenderedMapWidth;
+        scrollHeight = kRenderedMapHeight;
     }
 
     // 0x0046B9D4

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -1121,7 +1121,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
     }
 
     // 0x0046B9E7
-    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, uint32_t* scrollWidth, uint32_t* scrollHeight)
     {
         *scrollWidth = kRenderedMapWidth;
         *scrollHeight = kRenderedMapHeight;

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -139,9 +139,9 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042A871
-        static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+        static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            *scrollHeight = MessageManager::getNumMessages() * messageHeight;
+            scrollHeight = MessageManager::getNumMessages() * messageHeight;
         }
 
         // 0x0042A8B9
@@ -375,8 +375,8 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         window->callPrepareDraw();
         window->initScrollWidgets();
 
-        int32_t scrollHeight = 0;
-        window->callGetScrollSize(0, nullptr, &scrollHeight);
+        int32_t scrollWidth = 0, scrollHeight = 0;
+        window->callGetScrollSize(0, scrollWidth, scrollHeight);
 
         scrollHeight -= window->widgets[Messages::widx::scrollview].height();
 

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -139,7 +139,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042A871
-        static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+        static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
         {
             *scrollHeight = MessageManager::getNumMessages() * messageHeight;
         }
@@ -375,7 +375,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         window->callPrepareDraw();
         window->initScrollWidgets();
 
-        uint32_t scrollHeight = 0;
+        int32_t scrollHeight = 0;
         window->callGetScrollSize(0, nullptr, &scrollHeight);
 
         scrollHeight -= window->widgets[Messages::widx::scrollview].height();

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -375,7 +375,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         window->callPrepareDraw();
         window->initScrollWidgets();
 
-       uint32_t scrollHeight = 0;
+        uint32_t scrollHeight = 0;
         window->callGetScrollSize(0, nullptr, &scrollHeight);
 
         scrollHeight -= window->widgets[Messages::widx::scrollview].height();

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -139,7 +139,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042A871
-        static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
         {
             *scrollHeight = MessageManager::getNumMessages() * messageHeight;
         }
@@ -375,7 +375,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         window->callPrepareDraw();
         window->initScrollWidgets();
 
-        uint16_t scrollHeight = 0;
+       uint32_t scrollHeight = 0;
         window->callGetScrollSize(0, nullptr, &scrollHeight);
 
         scrollHeight -= window->widgets[Messages::widx::scrollview].height();

--- a/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
@@ -145,9 +145,9 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     }
 
     // 0x004C176C
-    static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+    static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        *scrollHeight = kRowHeight * Jukebox::kNumMusicTracks;
+        scrollHeight = kRowHeight * Jukebox::kNumMusicTracks;
     }
 
     // 0x004C1757

--- a/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
@@ -145,7 +145,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     }
 
     // 0x004C176C
-    static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+    static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
     {
         *scrollHeight = kRowHeight * Jukebox::kNumMusicTracks;
     }

--- a/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
@@ -145,7 +145,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     }
 
     // 0x004C176C
-    static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize([[maybe_unused]] Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
     {
         *scrollHeight = kRowHeight * Jukebox::kNumMusicTracks;
     }

--- a/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
@@ -243,7 +243,7 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
         }
     }
 
-    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
     {
         *scrollHeight = kRowHeight * window.rowCount;
     }

--- a/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
@@ -243,9 +243,9 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
         }
     }
 
-    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        *scrollHeight = kRowHeight * window.rowCount;
+        scrollHeight = kRowHeight * window.rowCount;
     }
 
     static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)

--- a/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
@@ -243,7 +243,7 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
         }
     }
 
-    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
     {
         *scrollHeight = kRowHeight * window.rowCount;
     }

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -1476,7 +1476,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x004738ED
-    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
     {
         *scrollHeight = _numVisibleObjectsListed * kRowHeight;
     }

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -1476,9 +1476,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x004738ED
-    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        *scrollHeight = _numVisibleObjectsListed * kRowHeight;
+        scrollHeight = _numVisibleObjectsListed * kRowHeight;
     }
 
     // 0x00473900

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -1476,7 +1476,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     }
 
     // 0x004738ED
-    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
     {
         *scrollHeight = _numVisibleObjectsListed * kRowHeight;
     }

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -235,7 +235,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x004464A1
-    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
     {
         *scrollHeight = window.rowHeight * static_cast<uint16_t>(_files.size());
     }

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -235,9 +235,9 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x004464A1
-    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
     {
-        *scrollHeight = window.rowHeight * static_cast<uint16_t>(_files.size());
+        *scrollHeight = window.rowHeight * _files.size();
     }
 
     // 0x004464F7

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -235,9 +235,9 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x004464A1
-    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        *scrollHeight = window.rowHeight * _files.size();
+        scrollHeight = window.rowHeight * _files.size();
     }
 
     // 0x004464F7

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -492,7 +492,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     }
 
     // 0x00443EF6
-    static void getScrollSize(Window& self, uint32_t, uint16_t*, uint16_t* const scrollHeight)
+    static void getScrollSize(Window& self, uint32_t, uint32_t*, uint32_t* const scrollHeight)
     {
         *scrollHeight = ScenarioManager::getScenarioCountByCategory(self.currentTab) * kRowHeight;
     }

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -492,9 +492,9 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     }
 
     // 0x00443EF6
-    static void getScrollSize(Window& self, uint32_t, int32_t*, int32_t* const scrollHeight)
+    static void getScrollSize(Window& self, uint32_t, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        *scrollHeight = ScenarioManager::getScenarioCountByCategory(self.currentTab) * kRowHeight;
+        scrollHeight = ScenarioManager::getScenarioCountByCategory(self.currentTab) * kRowHeight;
     }
 
     // 0x00443F32

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -492,7 +492,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     }
 
     // 0x00443EF6
-    static void getScrollSize(Window& self, uint32_t, uint32_t*, uint32_t* const scrollHeight)
+    static void getScrollSize(Window& self, uint32_t, int32_t*, int32_t* const scrollHeight)
     {
         *scrollHeight = ScenarioManager::getScenarioCountByCategory(self.currentTab) * kRowHeight;
     }

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -785,7 +785,7 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x00491999
-    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
     {
         *scrollHeight = kRowHeight * window.var_83C;
     }

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -785,9 +785,9 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x00491999
-    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        *scrollHeight = kRowHeight * window.var_83C;
+        scrollHeight = kRowHeight * window.var_83C;
     }
 
     // 0x00491841

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -785,7 +785,7 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x00491999
-    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+    static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
     {
         *scrollHeight = kRowHeight * window.var_83C;
     }

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -475,7 +475,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EB64
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
         {
             auto station = StationManager::get(StationId(self.number));
             *scrollHeight = 0;
@@ -673,7 +673,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EE4A
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
         {
             auto station = StationManager::get(StationId(self.number));
             *scrollHeight = 0;
@@ -1107,7 +1107,7 @@ namespace OpenLoco::Ui::Windows::Station
             }
         }
 
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
         {
             *scrollHeight = self.var_83C * self.rowHeight;
         }

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -475,7 +475,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EB64
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
         {
             auto station = StationManager::get(StationId(self.number));
             *scrollHeight = 0;
@@ -673,7 +673,7 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EE4A
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
         {
             auto station = StationManager::get(StationId(self.number));
             *scrollHeight = 0;
@@ -1107,7 +1107,7 @@ namespace OpenLoco::Ui::Windows::Station
             }
         }
 
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
         {
             *scrollHeight = self.var_83C * self.rowHeight;
         }

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -475,18 +475,18 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EB64
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
             auto station = StationManager::get(StationId(self.number));
-            *scrollHeight = 0;
+            scrollHeight = 0;
             for (const auto& cargoStats : station->cargoStats)
             {
                 if (cargoStats.quantity != 0)
                 {
-                    *scrollHeight += 12;
+                    scrollHeight += 12;
                     if (cargoStats.origin != StationId(self.number))
                     {
-                        *scrollHeight += 10;
+                        scrollHeight += 10;
                     }
                 }
             }
@@ -673,15 +673,15 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EE4A
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
             auto station = StationManager::get(StationId(self.number));
-            *scrollHeight = 0;
+            scrollHeight = 0;
             for (uint8_t i = 0; i < 32; i++)
             {
                 if (station->cargoStats[i].origin != StationId::null)
                 {
-                    *scrollHeight += 10;
+                    scrollHeight += 10;
                 }
             }
         }
@@ -1107,9 +1107,9 @@ namespace OpenLoco::Ui::Windows::Station
             }
         }
 
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            *scrollHeight = self.var_83C * self.rowHeight;
+            scrollHeight = self.var_83C * self.rowHeight;
         }
 
         static CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, CursorId fallback)

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -186,8 +186,8 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BC4B7
         static void updateActiveThumb(Window& self)
         {
-            int32_t scrollHeight = 0;
-            self.callGetScrollSize(0, nullptr, &scrollHeight);
+            int32_t scrollWidth = 0, scrollHeight = 0;
+            self.callGetScrollSize(0, scrollWidth, scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
             auto i = 0;
@@ -630,14 +630,14 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBEC1
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            *scrollHeight = (self.var_83C + 8) / 9;
-            if (*scrollHeight == 0)
+            scrollHeight = (self.var_83C + 8) / 9;
+            if (scrollHeight == 0)
             {
-                *scrollHeight += 1;
+                scrollHeight += 1;
             }
-            *scrollHeight *= kRowHeight;
+            scrollHeight *= kRowHeight;
         }
 
         static int getRowIndex(int16_t x, int16_t y)
@@ -2255,8 +2255,8 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BC506
         static void updateActiveThumb(Window& self)
         {
-            int32_t scrollHeight = 0;
-            self.callGetScrollSize(0, nullptr, &scrollHeight);
+            int32_t scrollWidth = 0, scrollHeight = 0;
+            self.callGetScrollSize(0, scrollWidth, scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
             auto i = 0;
@@ -2554,14 +2554,14 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC359
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            *scrollHeight = (self.var_83C + 9) / 10;
-            if (*scrollHeight == 0)
+            scrollHeight = (self.var_83C + 9) / 10;
+            if (scrollHeight == 0)
             {
-                *scrollHeight += 1;
+                scrollHeight += 1;
             }
-            *scrollHeight *= kRowHeight;
+            scrollHeight *= kRowHeight;
         }
 
         static int getRowIndex(int16_t x, int16_t y)

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -186,7 +186,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BC4B7
         static void updateActiveThumb(Window& self)
         {
-            uint16_t scrollHeight = 0;
+            uint32_t scrollHeight = 0;
             self.callGetScrollSize(0, nullptr, &scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
@@ -630,7 +630,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBEC1
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
         {
             *scrollHeight = (self.var_83C + 8) / 9;
             if (*scrollHeight == 0)
@@ -2255,7 +2255,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BC506
         static void updateActiveThumb(Window& self)
         {
-            uint16_t scrollHeight = 0;
+            uint32_t scrollHeight = 0;
             self.callGetScrollSize(0, nullptr, &scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
@@ -2554,7 +2554,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC359
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
         {
             *scrollHeight = (self.var_83C + 9) / 10;
             if (*scrollHeight == 0)

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -186,7 +186,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BC4B7
         static void updateActiveThumb(Window& self)
         {
-            uint32_t scrollHeight = 0;
+            int32_t scrollHeight = 0;
             self.callGetScrollSize(0, nullptr, &scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
@@ -630,7 +630,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBEC1
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
         {
             *scrollHeight = (self.var_83C + 8) / 9;
             if (*scrollHeight == 0)
@@ -2255,7 +2255,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BC506
         static void updateActiveThumb(Window& self)
         {
-            uint32_t scrollHeight = 0;
+            int32_t scrollHeight = 0;
             self.callGetScrollSize(0, nullptr, &scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
@@ -2554,7 +2554,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC359
-        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+        static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
         {
             *scrollHeight = (self.var_83C + 9) / 10;
             if (*scrollHeight == 0)

--- a/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
@@ -517,7 +517,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         }
     }
 
-    static void getScrollSize(Ui::Window& self, uint32_t, uint16_t*, uint16_t* const scrollHeight)
+    static void getScrollSize(Ui::Window& self, uint32_t, uint32_t*, uint32_t* const scrollHeight)
     {
         if (_currentPosition == TilePos2(0, 0))
         {

--- a/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
@@ -517,15 +517,15 @@ namespace OpenLoco::Ui::Windows::TileInspector
         }
     }
 
-    static void getScrollSize(Ui::Window& self, uint32_t, int32_t*, int32_t* const scrollHeight)
+    static void getScrollSize(Ui::Window& self, uint32_t, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
         if (_currentPosition == TilePos2(0, 0))
         {
-            *scrollHeight = 0;
+            scrollHeight = 0;
             return;
         }
 
-        *scrollHeight = self.rowCount * self.rowHeight;
+        scrollHeight = self.rowCount * self.rowHeight;
     }
 
     static void onToolUpdate([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t x, const int16_t y)

--- a/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
@@ -517,7 +517,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
         }
     }
 
-    static void getScrollSize(Ui::Window& self, uint32_t, uint32_t*, uint32_t* const scrollHeight)
+    static void getScrollSize(Ui::Window& self, uint32_t, int32_t*, int32_t* const scrollHeight)
     {
         if (_currentPosition == TilePos2(0, 0))
         {

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -1223,7 +1223,7 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049B2B5
         static void updateActiveThumb(Window& self)
         {
-           uint32_t scrollHeight = 0;
+            uint32_t scrollHeight = 0;
             self.callGetScrollSize(0, nullptr, &scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -492,7 +492,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A4FA
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
         {
             *scrollHeight = kRowHeight * self.var_83C;
         }
@@ -1223,7 +1223,7 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049B2B5
         static void updateActiveThumb(Window& self)
         {
-            uint32_t scrollHeight = 0;
+            int32_t scrollHeight = 0;
             self.callGetScrollSize(0, nullptr, &scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
@@ -1262,7 +1262,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AE83
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
         {
             *scrollHeight = (4 + self.var_83C) / 5;
             if (*scrollHeight == 0)

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -492,7 +492,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A4FA
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
         {
             *scrollHeight = kRowHeight * self.var_83C;
         }
@@ -1223,7 +1223,7 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049B2B5
         static void updateActiveThumb(Window& self)
         {
-            uint16_t scrollHeight = 0;
+           uint32_t scrollHeight = 0;
             self.callGetScrollSize(0, nullptr, &scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
@@ -1262,7 +1262,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AE83
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
         {
             *scrollHeight = (4 + self.var_83C) / 5;
             if (*scrollHeight == 0)

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -492,9 +492,9 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A4FA
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            *scrollHeight = kRowHeight * self.var_83C;
+            scrollHeight = kRowHeight * self.var_83C;
         }
 
         // 0x00491841
@@ -1223,8 +1223,8 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049B2B5
         static void updateActiveThumb(Window& self)
         {
-            int32_t scrollHeight = 0;
-            self.callGetScrollSize(0, nullptr, &scrollHeight);
+            int32_t scrollWidth = 0, scrollHeight = 0;
+            self.callGetScrollSize(0, scrollWidth, scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
             auto i = 0;
@@ -1262,14 +1262,14 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AE83
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            *scrollHeight = (4 + self.var_83C) / 5;
-            if (*scrollHeight == 0)
+            scrollHeight = (4 + self.var_83C) / 5;
+            if (scrollHeight == 0)
             {
-                *scrollHeight += 1;
+                scrollHeight += 1;
             }
-            *scrollHeight *= kRowHeight;
+            scrollHeight *= kRowHeight;
         }
 
         // 0x0049ABBB

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -1379,9 +1379,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x4B38FA
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint16_t* const width, uint16_t* const height)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint32_t* const scrollWidth, uint32_t* const scrollHeight)
         {
-            *height = static_cast<uint16_t>(Common::getNumCars(self) * self.rowHeight);
+            *scrollHeight = static_cast<uint32_t>(Common::getNumCars(self) * self.rowHeight);
         }
 
         // 0x004B3B54
@@ -2467,9 +2467,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4360
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint16_t* const width, uint16_t* const height)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint32_t* const scrollWidth, uint32_t* const scrollHeight)
         {
-            *height = static_cast<uint16_t>(Common::getNumCars(self) * self.rowHeight);
+            *scrollHeight = static_cast<uint32_t>(Common::getNumCars(self) * self.rowHeight);
         }
 
         static char* generateCargoTooltipDetails(char* buffer, const StringId cargoFormat, const uint8_t cargoType, const uint8_t maxCargo, const uint32_t acceptedCargoTypes)
@@ -3561,7 +3561,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4D9B
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint16_t* const width, uint16_t* const height)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint32_t* const scrollWidth, uint32_t* const scrollHeight)
         {
             auto head = Common::getVehicle(self);
             if (head == nullptr)
@@ -3569,10 +3569,10 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 return;
             }
             auto table = getOrderTable(head);
-            *height = lineHeight * std::distance(table.begin(), table.end());
+            *scrollHeight = lineHeight * std::distance(table.begin(), table.end());
 
             // Space for the 'end of orders' item
-            *height += lineHeight;
+            *scrollHeight += lineHeight;
         }
 
         static void scrollMouseDown(Window& self, [[maybe_unused]] const int16_t x, const int16_t y, [[maybe_unused]] const uint8_t scrollIndex)

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -1379,9 +1379,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x4B38FA
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] int32_t* const scrollWidth, int32_t* const scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            *scrollHeight = Common::getNumCars(self) * self.rowHeight;
+            scrollHeight = Common::getNumCars(self) * self.rowHeight;
         }
 
         // 0x004B3B54
@@ -2467,9 +2467,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4360
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] int32_t* const scrollWidth, int32_t* const scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            *scrollHeight = Common::getNumCars(self) * self.rowHeight;
+            scrollHeight = Common::getNumCars(self) * self.rowHeight;
         }
 
         static char* generateCargoTooltipDetails(char* buffer, const StringId cargoFormat, const uint8_t cargoType, const uint8_t maxCargo, const uint32_t acceptedCargoTypes)
@@ -3561,7 +3561,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4D9B
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] int32_t* const scrollWidth, int32_t* const scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
             auto head = Common::getVehicle(self);
             if (head == nullptr)
@@ -3569,10 +3569,10 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 return;
             }
             auto table = getOrderTable(head);
-            *scrollHeight = lineHeight * std::distance(table.begin(), table.end());
+            scrollHeight = lineHeight * std::distance(table.begin(), table.end());
 
             // Space for the 'end of orders' item
-            *scrollHeight += lineHeight;
+            scrollHeight += lineHeight;
         }
 
         static void scrollMouseDown(Window& self, [[maybe_unused]] const int16_t x, const int16_t y, [[maybe_unused]] const uint8_t scrollIndex)

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -1379,9 +1379,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x4B38FA
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint32_t* const scrollWidth, uint32_t* const scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] int32_t* const scrollWidth, int32_t* const scrollHeight)
         {
-            *scrollHeight = static_cast<uint32_t>(Common::getNumCars(self) * self.rowHeight);
+            *scrollHeight = Common::getNumCars(self) * self.rowHeight;
         }
 
         // 0x004B3B54
@@ -2467,9 +2467,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4360
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint32_t* const scrollWidth, uint32_t* const scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] int32_t* const scrollWidth, int32_t* const scrollHeight)
         {
-            *scrollHeight = static_cast<uint32_t>(Common::getNumCars(self) * self.rowHeight);
+            *scrollHeight = Common::getNumCars(self) * self.rowHeight;
         }
 
         static char* generateCargoTooltipDetails(char* buffer, const StringId cargoFormat, const uint8_t cargoType, const uint8_t maxCargo, const uint32_t acceptedCargoTypes)
@@ -3561,7 +3561,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4D9B
-        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] uint32_t* const scrollWidth, uint32_t* const scrollHeight)
+        static void getScrollSize(Ui::Window& self, [[maybe_unused]] const uint32_t scrollIndex, [[maybe_unused]] int32_t* const scrollWidth, int32_t* const scrollHeight)
         {
             auto head = Common::getVehicle(self);
             if (head == nullptr)

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -1024,9 +1024,9 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C265B
-    static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
+    static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        *scrollHeight = self.var_83C * self.rowHeight;
+        scrollHeight = self.var_83C * self.rowHeight;
     }
 
     // 0x004C266D

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -1024,7 +1024,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C265B
-    static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
+    static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t* scrollWidth, int32_t* scrollHeight)
     {
         *scrollHeight = self.var_83C * self.rowHeight;
     }

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -1024,7 +1024,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C265B
-    static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint16_t* scrollWidth, uint16_t* scrollHeight)
+    static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] uint32_t* scrollWidth, uint32_t* scrollHeight)
     {
         *scrollHeight = self.var_83C * self.rowHeight;
     }


### PR DESCRIPTION
Changes scrollbar types to 32 bits to account for very large scroll content sizes. Changing the height is necessary, but changing the width isn't that necessary since there are no large-horizontally-scrolling windows in the game currently