### PR TITLE
Vcpkg changes

### DIFF
--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -782,7 +782,7 @@ target_link_libraries(OpenLoco
     Engine
     ${SDL2_LIB}
     Threads::Threads
-    yaml-cpp
+    yaml-cpp::yaml-cpp
     ${PNG_LIBRARY}
     ${OPENAL_LIBRARIES})
 

--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -782,7 +782,7 @@ target_link_libraries(OpenLoco
     Engine
     ${SDL2_LIB}
     Threads::Threads
-    yaml-cpp::yaml-cpp
+    yaml-cpp
     ${PNG_LIBRARY}
     ${OPENAL_LIBRARIES})
 

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,5 +1,27 @@
 # TODO: look into using FetchContent's FIND_PACKAGE_ARGS when next increasing CMake version
-find_package(yaml-cpp REQUIRED CONFIG)
+find_package(yaml-cpp QUIET)
+if ( NOT yaml-cpp_FOUND )
+    ## yaml-cpp
+    # Get rid of yaml uninstall target
+    add_library(uninstall INTERFACE)
+    set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "")
+    set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "")
+    set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "")
+    set(YAML_BUILD_SHARED_LIBS OFF CACHE BOOL "")
+    set(YAML_CPP_INSTALL OFF CACHE BOOL "")
+    set(YAML_CPP_FORMAT_SOURCE OFF CACHE BOOL "")
+
+    FetchContent_Declare(
+        yaml-cpp
+        GIT_REPOSITORY      https://github.com/jbeder/yaml-cpp
+        GIT_TAG             c2680200486572baf8221ba052ef50b58ecd816e # 0.8.0 + cmake fix patch 
+    )
+    FetchContent_MakeAvailable(yaml-cpp)
+    loco_thirdparty_target_compile_link_flags(yaml-cpp)
+
+    # Group all the ThirdParty items under a ThirdParty folder in IDEs
+    set_target_properties(yaml-cpp PROPERTIES FOLDER "ThirdParty")
+endif()
 
 if (${OPENLOCO_BUILD_TESTS})
     find_package(GTest REQUIRED)
@@ -40,7 +62,22 @@ if (MSVC)
     set(BREAKPAD_LIBRARIES unofficial::breakpad::libbreakpad unofficial::breakpad::libbreakpad_client)
 endif()
 
-find_package(fmt CONFIG REQUIRED)
+find_package(fmt QUIET)
+if ( NOT fmt_FOUND )	
+    ## fmt	
+    FetchContent_Declare(	
+        fmt	
+        GIT_REPOSITORY      https://github.com/fmtlib/fmt	
+        GIT_TAG             11.1.4	
+        GIT_SHALLOW         ON	
+    )	
+    FetchContent_MakeAvailable(fmt)	
+
+    loco_thirdparty_target_compile_link_flags(fmt)	
+
+    # Group all the ThirdParty items under a ThirdParty folder in IDEs	
+    set_target_properties(fmt PROPERTIES FOLDER "ThirdParty")	
+endif()
 
 find_package(sfl QUIET)
 if ( NOT sfl_FOUND )

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -52,7 +52,4 @@ if ( NOT sfl_FOUND )
         GIT_SHALLOW         ON
     )
     FetchContent_MakeAvailable(sfl)
-    
-    # Group all the ThirdParty items under a ThirdParty folder in IDEs
-    set_target_properties(sfl PROPERTIES FOLDER "ThirdParty")
 endif()

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,27 +1,5 @@
 # TODO: look into using FetchContent's FIND_PACKAGE_ARGS when next increasing CMake version
-find_package(yaml-cpp QUIET)
-if ( NOT yaml-cpp_FOUND )
-    ## yaml-cpp
-    # Get rid of yaml uninstall target
-    add_library(uninstall INTERFACE)
-    set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "")
-    set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "")
-    set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "")
-    set(YAML_BUILD_SHARED_LIBS OFF CACHE BOOL "")
-    set(YAML_CPP_INSTALL OFF CACHE BOOL "")
-    set(YAML_CPP_FORMAT_SOURCE OFF CACHE BOOL "")
-
-    FetchContent_Declare(
-        yaml-cpp
-        GIT_REPOSITORY      https://github.com/jbeder/yaml-cpp
-        GIT_TAG             c2680200486572baf8221ba052ef50b58ecd816e # 0.8.0 + cmake fix patch 
-    )
-    FetchContent_MakeAvailable(yaml-cpp)
-    loco_thirdparty_target_compile_link_flags(yaml-cpp)
-
-    # Group all the ThirdParty items under a ThirdParty folder in IDEs
-    set_target_properties(yaml-cpp PROPERTIES FOLDER "ThirdParty")
-endif()
+find_package(yaml-cpp REQUIRED CONFIG)
 
 if (${OPENLOCO_BUILD_TESTS})
     find_package(GTest REQUIRED)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -40,22 +40,7 @@ if (MSVC)
     set(BREAKPAD_LIBRARIES unofficial::breakpad::libbreakpad unofficial::breakpad::libbreakpad_client)
 endif()
 
-find_package(fmt QUIET)
-if ( NOT fmt_FOUND )
-    ## fmt
-    FetchContent_Declare(
-        fmt
-        GIT_REPOSITORY      https://github.com/fmtlib/fmt
-        GIT_TAG             11.1.4
-        GIT_SHALLOW         ON
-    )
-    FetchContent_MakeAvailable(fmt)
-    
-    loco_thirdparty_target_compile_link_flags(fmt)
-    
-    # Group all the ThirdParty items under a ThirdParty folder in IDEs
-    set_target_properties(fmt PROPERTIES FOLDER "ThirdParty")
-endif()
+find_package(fmt CONFIG REQUIRED)
 
 find_package(sfl QUIET)
 if ( NOT sfl_FOUND )

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,6 +11,7 @@
     "libpng",
     "openal-soft",
     "yaml-cpp",
+    "fmt",
     {
       "name": "sdl2",
       "default-features": false,

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,7 @@
     "gtest",
     "libpng",
     "openal-soft",
+    "yaml-cpp",
     {
       "name": "sdl2",
       "default-features": false,


### PR DESCRIPTION
With this PR it fetches yaml-cpp and fmt over vcpkg, it's kinda annoying that yaml-cpp is always rebuilt and now its out of the VS project as well.