### PR TITLE
Improve automatic loan repayment by adding minimum balance for payments

### DIFF
--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2280,7 +2280,7 @@ strings:
   2225: "Construction: Remove at current position"
   2226: "Construction: Select position"
   2227: "Trains reverse at signals"
-  2228: Autopay
+  2228: "Autopay - Minimum Balance:"
   2229: "{SMALLFONT}{COLOUR BLACK}Once per day, any current funds you have will be used to pay off your loan, if you have one."
   2230: "{COLOUR WINDOW_2}Year:"
   2231: "{COLOUR WINDOW_2}Month:"
@@ -2413,3 +2413,6 @@ strings:
   2358: "Toggle paint tool"
   2359: "{SMALLFONT}{COLOUR BLACK}Repaint {POP16}{STRINGID} vehicles{NEWLINE}shift+click to paint all{NEWLINE}ctrl+click to paint sub-vehicles"
   2360: "Paint all connected"
+  2361: "{CURRENCY32}"
+  2362: "Can't raise autopay minimum balance anymore!"
+  2363: "Minimum balance cannot go higher!"

--- a/src/OpenLoco/src/GameCommands/Company/ChangeAutopayMinimumBalance.cpp
+++ b/src/OpenLoco/src/GameCommands/Company/ChangeAutopayMinimumBalance.cpp
@@ -1,0 +1,46 @@
+#include "ChangeAutopayMinimumBalance.h"
+#include "Economy/Economy.h"
+#include "GameCommands/GameCommands.h"
+#include "Localisation/StringIds.h"
+#include "Ui/WindowManager.h"
+#include "World/CompanyManager.h"
+
+using namespace OpenLoco::Interop;
+
+namespace OpenLoco::GameCommands
+{
+    static const currency32_t kMaximumAutopayMinimumBalance = 500000;
+
+    static uint32_t changeAutopayMinBalance(const currency32_t newMinimumBalance, const uint8_t flags)
+    {
+        auto* company = CompanyManager::get(GameCommands::getUpdatingCompanyId());
+
+        if (newMinimumBalance < 0)
+        {
+            return 0;
+        }
+        else if (newMinimumBalance > kMaximumAutopayMinimumBalance)
+        {
+            GameCommands::setErrorTitle(StringIds::loan_autopay_min_balance_upper_limit_title);
+            GameCommands::setErrorText(StringIds::loan_autopay_min_balance_upper_limit_text);
+            return FAILURE;
+        }
+
+        if (flags & Flags::apply)
+        {
+            company->setLoanAutopayMinimumBalance(newMinimumBalance);
+            Ui::WindowManager::invalidate(Ui::WindowType::company, static_cast<uint16_t>(GameCommands::getUpdatingCompanyId()));
+            if (CompanyManager::getControllingId() == GameCommands::getUpdatingCompanyId())
+            {
+                Ui::Windows::PlayerInfoPanel::invalidateFrame();
+            }
+        }
+        return 0;
+    }
+
+    void changeAutopayMinBalance(registers& regs)
+    {
+        ChangeAutopayMinimumBalanceArgs args(regs);
+        regs.ebx = changeAutopayMinBalance(args.newMinimumBalance, regs.bl);
+    }
+}

--- a/src/OpenLoco/src/GameCommands/Company/ChangeAutopayMinimumBalance.h
+++ b/src/OpenLoco/src/GameCommands/Company/ChangeAutopayMinimumBalance.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "GameCommands/GameCommands.h"
+
+namespace OpenLoco::GameCommands
+{
+    struct ChangeAutopayMinimumBalanceArgs
+    {
+        static constexpr auto command = GameCommand::changeAutopayMinBalance;
+        ChangeAutopayMinimumBalanceArgs() = default;
+        explicit ChangeAutopayMinimumBalanceArgs(const registers& regs)
+            : newMinimumBalance(regs.edx)
+        {
+        }
+
+        currency32_t newMinimumBalance;
+
+        explicit operator registers() const
+        {
+            registers regs;
+            regs.edx = newMinimumBalance;
+            return regs;
+        }
+    };
+
+    void changeAutopayMinBalance(registers& regs);
+}

--- a/src/OpenLoco/src/GameCommands/GameCommands.cpp
+++ b/src/OpenLoco/src/GameCommands/GameCommands.cpp
@@ -6,6 +6,7 @@
 #include "Buildings/RemoveBuilding.h"
 #include "Cheats/Cheat.h"
 #include "Company/BuildCompanyHeadquarters.h"
+#include "Company/ChangeAutopayMinimumBalance.h"
 #include "Company/ChangeCompanyColour.h"
 #include "Company/ChangeCompanyFace.h"
 #include "Company/ChangeLoan.h"
@@ -125,7 +126,7 @@ namespace OpenLoco::GameCommands
     };
 
     // clang-format off
-    static constexpr GameCommandInfo kGameCommandDefinitions[85] = {
+    static constexpr GameCommandInfo kGameCommandDefinitions[86] = {
         { GameCommand::vehicleRearrange,             vehicleRearrange,          0x004AF1DF, true  },
         { GameCommand::vehiclePlace,                 vehiclePlace,              0x004B01B6, true  },
         { GameCommand::vehiclePickup,                vehiclePickup,             0x004B0826, true  },
@@ -211,6 +212,7 @@ namespace OpenLoco::GameCommands
         { GameCommand::setGameSpeed,                 setGameSpeed,              0,          true  },
         { GameCommand::vehicleOrderReverse,          vehicleOrderReverse,       0,          false },
         { GameCommand::vehicleRepaint,               vehicleRepaint,            0,          false },
+        { GameCommand::changeAutopayMinBalance,      changeAutopayMinBalance,   0,          false },
     };
     // clang-format on
 

--- a/src/OpenLoco/src/GameCommands/GameCommands.h
+++ b/src/OpenLoco/src/GameCommands/GameCommands.h
@@ -122,6 +122,7 @@ namespace OpenLoco::GameCommands
         setGameSpeed = 82,
         vehicleOrderReverse = 83,
         vehicleRepaint = 84,
+        changeAutopayMinBalance = 85,
     };
 
     constexpr uint32_t FAILURE = 0x80000000;

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -2024,6 +2024,9 @@ namespace OpenLoco::StringIds
     constexpr StringId vehicleRepaintTool = 2358;
     constexpr StringId vehicleRepaintTooltip = 2359;
     constexpr StringId vehicleRepaintEntireVehicle = 2360;
+    constexpr StringId loan_autopay_min_balance = 2361;
+    constexpr StringId loan_autopay_min_balance_upper_limit_title = 2362;
+    constexpr StringId loan_autopay_min_balance_upper_limit_text = 2363;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/World/Company.cpp
+++ b/src/OpenLoco/src/World/Company.cpp
@@ -771,10 +771,10 @@ namespace OpenLoco
 
     void Company::updateLoanAutorepay()
     {
-        if (currentLoan > 0 && cash > 0 && ((challengeFlags & CompanyFlags::autopayLoan) != CompanyFlags::none))
+        if (currentLoan > 0 && cash > _LoanAutopayMinimumBalance && ((challengeFlags & CompanyFlags::autopayLoan) != CompanyFlags::none))
         {
             GameCommands::ChangeLoanArgs args{};
-            args.newLoan = currentLoan - std::max<currency32_t>(0, std::min<currency32_t>(currentLoan, cash.asInt64()));
+            args.newLoan = currentLoan - std::max<currency32_t>(0, std::min<currency32_t>(currentLoan, cash.asInt64() - _LoanAutopayMinimumBalance));
 
             GameCommands::setUpdatingCompanyId(id());
             GameCommands::doCommand(args, GameCommands::Flags::apply);
@@ -899,6 +899,16 @@ namespace OpenLoco
     uint8_t Company::getHeadquarterPerformanceVariation() const
     {
         return std::min(performanceIndex / 200, 4);
+    }
+
+    currency32_t Company::getLoanAutopayMinimumBalance() const
+    {
+        return _LoanAutopayMinimumBalance;
+    }
+
+    void Company::setLoanAutopayMinimumBalance(currency32_t newMinimumBalance)
+    {
+        _LoanAutopayMinimumBalance = newMinimumBalance;
     }
 
     bool Company::hashTableContains(const Unk25C0HashTableEntry& entry) const

--- a/src/OpenLoco/src/World/Company.h
+++ b/src/OpenLoco/src/World/Company.h
@@ -16,6 +16,9 @@
 
 namespace OpenLoco
 {
+    // TODO change this to Company attribute when supported, this may not work for multiplayer
+    static currency32_t _LoanAutopayMinimumBalance = 0;
+
     enum class CompanyFlags : uint32_t
     {
         none = 0U,
@@ -290,6 +293,8 @@ namespace OpenLoco
         void updateHeadquartersColour();
         void updateOwnerEmotion();
         uint8_t getHeadquarterPerformanceVariation() const;
+        currency32_t getLoanAutopayMinimumBalance() const;
+        void setLoanAutopayMinimumBalance(currency32_t newMinimumBalance);
 
         bool hashTableContains(const Unk25C0HashTableEntry& entry) const;
         bool addHashTableEntry(const Unk25C0HashTableEntry& entry);


### PR DESCRIPTION
Improves autopay QoL by adding a a minimum required balance for autopay, preventing negative balances at end of month and bankruptcy warnings:
<img width="984" height="104" alt="image" src="https://github.com/user-attachments/assets/486b8b67-87ec-44db-9bdc-1527a4c39a4d" />
