### PR TITLE
Initialise default track road mods

### DIFF
--- a/src/OpenLoco/src/Scenario.cpp
+++ b/src/OpenLoco/src/Scenario.cpp
@@ -395,7 +395,7 @@ namespace OpenLoco::Scenario
         CompanyManager::setRecords(CompanyManager::kZeroRecords);
         getObjectiveProgress().timeLimitUntilYear = getObjective().timeLimitYears - 1 + gameState.currentYear;
         getObjectiveProgress().monthsInChallenge = 0;
-        call(0x0049B546);
+        initialiseDefaultTrackRoadMods();
         gameState.lastMapWindowAttributes.flags = WindowFlags::none;
 
         TownManager::updateLabels();

--- a/src/OpenLoco/src/ScenarioConstruction.cpp
+++ b/src/OpenLoco/src/ScenarioConstruction.cpp
@@ -1,5 +1,10 @@
-#include "./ScenarioConstruction.h"
-#include "./GameState.h"
+#include "ScenarioConstruction.h"
+#include "GameState.h"
+#include "Objects/ObjectManager.h"
+#include "Objects/RoadObject.h"
+#include "Objects/TrackObject.h"
+#include "Objects/VehicleObject.h"
+#include "World/CompanyManager.h"
 
 namespace OpenLoco::Scenario
 {
@@ -27,5 +32,131 @@ namespace OpenLoco::Scenario
         std::fill(std::begin(construction.bridges), std::end(construction.bridges), 0xFF);
         std::fill(std::begin(construction.trainStations), std::end(construction.trainStations), 0xFF);
         std::fill(std::begin(construction.trackMods), std::end(construction.trackMods), 0xFF);
+    }
+
+    // 0x0049B546
+    void initialiseDefaultTrackRoadMods()
+    {
+        auto& construction = getConstruction();
+
+        for (uint8_t trackObjId = 0; trackObjId < ObjectManager::getMaxObjects(ObjectType::track); ++trackObjId)
+        {
+            auto* trackObj = ObjectManager::get<TrackObject>(trackObjId);
+            if (trackObj == nullptr)
+            {
+                continue;
+            }
+            uint32_t requiredMods = 0xFFFFFFFFU;
+            for (uint8_t vehicleObjId = 0; vehicleObjId < ObjectManager::getMaxObjects(ObjectType::vehicle); ++vehicleObjId)
+            {
+                auto* vehObj = ObjectManager::get<VehicleObject>(vehicleObjId);
+                if (vehObj == nullptr)
+                {
+                    continue;
+                }
+
+                if (vehObj->mode != TransportMode::rail)
+                {
+                    continue;
+                }
+
+                if (vehObj->trackType != trackObjId)
+                {
+                    continue;
+                }
+
+                if (vehObj->power == 0)
+                {
+                    continue;
+                }
+
+                auto* playerCompany = CompanyManager::getPlayerCompany();
+                if (!playerCompany->isVehicleIndexUnlocked(vehicleObjId))
+                {
+                    continue;
+                }
+
+                uint32_t mods = 0U;
+                for (auto i = 0; i < vehObj->numTrackExtras; ++i)
+                {
+                    mods |= 1U << vehObj->requiredTrackExtras[i];
+                }
+                requiredMods &= mods;
+            }
+            construction.trackMods[trackObjId] = 0xFFU;
+
+            if (requiredMods != 0xFFFFFFFFU && requiredMods != 0)
+            {
+                uint8_t presetMods = 0U;
+                for (auto i = 0; i < trackObj->numMods; ++i)
+                {
+                    if (requiredMods & (1U << trackObj->mods[i]))
+                    {
+                        presetMods |= 1U << i;
+                    }
+                }
+                construction.trackMods[trackObjId] = presetMods;
+            }
+        }
+
+        for (uint8_t roadObjId = 0; roadObjId < ObjectManager::getMaxObjects(ObjectType::road); ++roadObjId)
+        {
+            auto* roadObj = ObjectManager::get<RoadObject>(roadObjId);
+            if (roadObj == nullptr)
+            {
+                continue;
+            }
+            uint32_t requiredMods = 0xFFFFFFFFU;
+            for (uint8_t vehicleObjId = 0; vehicleObjId < ObjectManager::getMaxObjects(ObjectType::vehicle); ++vehicleObjId)
+            {
+                auto* vehObj = ObjectManager::get<VehicleObject>(vehicleObjId);
+                if (vehObj == nullptr)
+                {
+                    continue;
+                }
+
+                if (vehObj->mode != TransportMode::road)
+                {
+                    continue;
+                }
+
+                if (vehObj->trackType != roadObjId)
+                {
+                    continue;
+                }
+
+                if (vehObj->power == 0)
+                {
+                    continue;
+                }
+
+                auto* playerCompany = CompanyManager::getPlayerCompany();
+                if (!playerCompany->isVehicleIndexUnlocked(vehicleObjId))
+                {
+                    continue;
+                }
+
+                uint32_t mods = 0U;
+                for (auto i = 0; i < vehObj->numTrackExtras; ++i)
+                {
+                    mods |= 1U << vehObj->requiredTrackExtras[i];
+                }
+                requiredMods &= mods;
+            }
+            construction.roadMods[roadObjId] = 0xFFU;
+
+            if (requiredMods != 0xFFFFFFFFU && requiredMods != 0)
+            {
+                uint8_t presetMods = 0U;
+                for (auto i = 0; i < roadObj->numMods; ++i)
+                {
+                    if (requiredMods & (1U << roadObj->mods[i]))
+                    {
+                        presetMods |= 1U << i;
+                    }
+                }
+                construction.trackMods[roadObjId] = presetMods;
+            }
+        }
     }
 }

--- a/src/OpenLoco/src/ScenarioConstruction.cpp
+++ b/src/OpenLoco/src/ScenarioConstruction.cpp
@@ -155,7 +155,7 @@ namespace OpenLoco::Scenario
                         presetMods |= 1U << i;
                     }
                 }
-                construction.trackMods[roadObjId] = presetMods;
+                construction.roadMods[roadObjId] = presetMods;
             }
         }
     }

--- a/src/OpenLoco/src/ScenarioConstruction.h
+++ b/src/OpenLoco/src/ScenarioConstruction.h
@@ -21,4 +21,6 @@ namespace OpenLoco::Scenario
     Construction& getConstruction();
     void resetRoadObjects();
     void resetTrackObjects();
+
+    void initialiseDefaultTrackRoadMods();
 }


### PR DESCRIPTION
Nothing too exciting it sets the default track mods for a track in the construction window. For example it makes sure that trams track by default has its catenary wire road mod.