### PR TITLE
Remove and rework some loco_globals

### DIFF
--- a/src/OpenLoco/src/Environment.cpp
+++ b/src/OpenLoco/src/Environment.cpp
@@ -19,9 +19,7 @@ namespace OpenLoco::Environment
     loco_global<char[257], 0x0050B0CE> _pathInstall;
     loco_global<char[257], 0x0050B1CF> _pathSavesSinglePlayer;
     loco_global<char[257], 0x0050B2EC> _pathSavesTwoPlayer;
-    loco_global<char[257], 0x0050B406> _pathScenarios;
     loco_global<char[257], 0x0050B518> _pathLandscapes;
-    loco_global<char[257], 0x0050B635> _pathObjects;
 
     static fs::path getBasePath(PathId id);
     static fs::path getSubPath(PathId id);
@@ -262,8 +260,6 @@ namespace OpenLoco::Environment
         auto landscapeDirectory = tryPathOrDefault(configLastLandscapePath, PathId::landscape);
 
         setDirectory(_pathLandscapes, landscapeDirectory / "*.SC5");
-        setDirectory(_pathScenarios, basePath / "Scenarios/*.SC5");
-        setDirectory(_pathObjects, basePath / "ObjData/*.DAT");
 
         autoCreateDirectory(getPath(PathId::customObjects));
     }

--- a/src/OpenLoco/src/Game.cpp
+++ b/src/OpenLoco/src/Game.cpp
@@ -30,7 +30,6 @@ namespace OpenLoco::Game
     // TODO: make accessible from Environment
     static loco_global<char[257], 0x0050B1CF> _pathSavesSinglePlayer;
     static loco_global<char[257], 0x0050B2EC> _pathSavesTwoPlayer;
-    static loco_global<char[257], 0x0050B406> _pathScenarios;
     static loco_global<char[257], 0x0050B518> _pathLandscapes;
 
     static loco_global<char[256], 0x0050B745> _currentScenarioFilename;
@@ -101,7 +100,7 @@ namespace OpenLoco::Game
     // 0x004418DB
     bool saveScenarioOpen()
     {
-        auto path = fs::u8path(&_pathScenarios[0]).parent_path() / Scenario::getOptions().scenarioName;
+        auto path = Environment::getPath(Environment::PathId::scenarios) / Scenario::getOptions().scenarioName;
         strncpy(&_savePath[0], path.u8string().c_str(), std::size(_savePath));
         strncat(&_savePath[0], S5::extensionSC5, std::size(_savePath));
 

--- a/src/OpenLoco/src/Game.cpp
+++ b/src/OpenLoco/src/Game.cpp
@@ -27,11 +27,6 @@ namespace OpenLoco::Game
 {
     static loco_global<LoadOrQuitMode, 0x0050A002> _savePromptType;
 
-    // TODO: make accessible from Environment
-    static loco_global<char[257], 0x0050B1CF> _pathSavesSinglePlayer;
-    static loco_global<char[257], 0x0050B2EC> _pathSavesTwoPlayer;
-    static loco_global<char[257], 0x0050B518> _pathLandscapes;
-
     static loco_global<char[256], 0x0050B745> _currentScenarioFilename;
 
     static loco_global<char[512], 0x0112CE04> _savePath;
@@ -59,14 +54,8 @@ namespace OpenLoco::Game
     // 0x004416FF
     bool loadSaveGameOpen()
     {
-        if (!SceneManager::isNetworked())
-        {
-            strncpy(&_savePath[0], &_pathSavesSinglePlayer[0], std::size(_savePath));
-        }
-        else
-        {
-            strncpy(&_savePath[0], &_pathSavesTwoPlayer[0], std::size(_savePath));
-        }
+        auto path = Environment::getPath(Environment::PathId::save).make_preferred().u8string();
+        strncpy(&_savePath[0], path.c_str(), std::size(_savePath));
 
         return openBrowsePrompt(StringIds::title_prompt_load_game, browse_type::load, S5::filterSV5);
     }
@@ -74,7 +63,8 @@ namespace OpenLoco::Game
     // 0x004417A7
     bool loadLandscapeOpen()
     {
-        strncpy(&_savePath[0], &_pathLandscapes[0], std::size(_savePath));
+        auto path = Environment::getPath(Environment::PathId::landscape).make_preferred().u8string();
+        strncpy(&_savePath[0], path.c_str(), std::size(_savePath));
 
         return openBrowsePrompt(StringIds::title_prompt_load_landscape, browse_type::load, S5::filterSC5);
     }
@@ -117,7 +107,7 @@ namespace OpenLoco::Game
             S5::drawScenarioPreviewImage();
         }
 
-        auto path = fs::u8path(&_pathLandscapes[0]).parent_path() / Scenario::getOptions().scenarioName;
+        auto path = Environment::getPath(Environment::PathId::landscape) / Scenario::getOptions().scenarioName;
         strncpy(&_savePath[0], path.u8string().c_str(), std::size(_savePath));
         strncat(&_savePath[0], S5::extensionSC5, std::size(_savePath));
 

--- a/src/OpenLoco/src/Map/MapSelection.cpp
+++ b/src/OpenLoco/src/Map/MapSelection.cpp
@@ -16,8 +16,8 @@ namespace OpenLoco::World
     static loco_global<coord_t, 0x00F2448C> _mapSelectionBY;
     static loco_global<MapSelectionType, 0x00F2448E> _word_F2448E;
 
-    constexpr uint16_t kMapSelectedTilesSize = 300;
-    static loco_global<Pos2[kMapSelectedTilesSize], 0x00F24490> _mapSelectedTiles;
+    constexpr uint16_t kMapSelectedFreeFormTilesSize = 300;
+    sfl::static_vector<Pos2, kMapSelectedFreeFormTilesSize> _mapSelectedFreeFormTiles;
 
     // TODO: Return std::optional
     uint16_t setMapSelectionTiles(const Pos2& loc, const MapSelectionType selectionType, uint16_t toolSizeA)
@@ -153,45 +153,43 @@ namespace OpenLoco::World
         }
     }
 
+    void resetMapSelectionFreeFormTiles()
+    {
+        _mapSelectedFreeFormTiles.clear();
+    }
+
+    void addMapSelectionFreeFormTile(const Pos2& pos)
+    {
+        _mapSelectedFreeFormTiles.push_back(pos);
+    }
+
+    std::span<const Pos2> getMapSelectionFreeFormTiles()
+    {
+        return _mapSelectedFreeFormTiles;
+    }
+
     // 0x0046112C
-    void mapInvalidateMapSelectionTiles()
+    void mapInvalidateMapSelectionFreeFormTiles()
     {
         if (!World::hasMapSelectionFlag(World::MapSelectionFlags::enableConstruct))
         {
             return;
         }
 
-        for (uint16_t index = 0; index < kMapSelectedTilesSize; ++index)
+        for (const auto& position : _mapSelectedFreeFormTiles)
         {
-            auto& position = _mapSelectedTiles[index];
-            if (position.x == -1)
-            {
-                break;
-            }
             TileManager::mapInvalidateTileFull(position);
         }
     }
 
-    bool isWithinMapSelectionTiles(const Pos2 pos)
+    bool isWithinMapSelectionFreeFormTiles(const Pos2 pos)
     {
         if (!World::hasMapSelectionFlag(World::MapSelectionFlags::enableConstruct))
         {
             return false;
         }
 
-        for (uint16_t index = 0; index < kMapSelectedTilesSize; ++index)
-        {
-            auto& position = _mapSelectedTiles[index];
-            if (position.x == -1)
-            {
-                return false;
-            }
-            if (position == pos)
-            {
-                return true;
-            }
-        }
-        return false;
+        return std::ranges::find(_mapSelectedFreeFormTiles, pos) != _mapSelectedFreeFormTiles.end();
     }
 
     void setMapSelectionArea(const Pos2& locA, const Pos2& locB)

--- a/src/OpenLoco/src/Map/MapSelection.h
+++ b/src/OpenLoco/src/Map/MapSelection.h
@@ -3,6 +3,7 @@
 #include <OpenLoco/Core/EnumFlags.hpp>
 #include <OpenLoco/Engine/Types.hpp>
 #include <OpenLoco/Engine/World.hpp>
+#include <span>
 
 namespace OpenLoco::World
 {
@@ -40,8 +41,12 @@ namespace OpenLoco::World
     uint16_t setMapSelectionTiles(const Pos2& loc, const MapSelectionType selectionType, uint16_t toolSize);
     uint16_t setMapSelectionSingleTile(const Pos2& loc, bool setQuadrant = false);
     void mapInvalidateSelectionRect();
-    void mapInvalidateMapSelectionTiles();
-    bool isWithinMapSelectionTiles(const Pos2 pos);
+
+    void resetMapSelectionFreeFormTiles();
+    void addMapSelectionFreeFormTile(const Pos2& pos);
+    std::span<const Pos2> getMapSelectionFreeFormTiles();
+    void mapInvalidateMapSelectionFreeFormTiles();
+    bool isWithinMapSelectionFreeFormTiles(const Pos2 pos);
 
     void setMapSelectionArea(const Pos2& locA, const Pos2& locB);
     std::pair<Pos2, Pos2> getMapSelectionArea();

--- a/src/OpenLoco/src/Paint/PaintSurface.cpp
+++ b/src/OpenLoco/src/Paint/PaintSurface.cpp
@@ -1571,7 +1571,7 @@ namespace OpenLoco::Paint
 
         if (World::hasMapSelectionFlag(World::MapSelectionFlags::enableConstruct))
         {
-            if (isWithinMapSelectionTiles(session.getUnkPosition()))
+            if (isWithinMapSelectionFreeFormTiles(session.getUnkPosition()))
             {
                 const auto colour = World::hasMapSelectionFlag(World::MapSelectionFlags::unk_03) ? ExtColour::unk2B : ExtColour::unk25;
 

--- a/src/OpenLoco/src/Ui/ToolManager.cpp
+++ b/src/OpenLoco/src/Ui/ToolManager.cpp
@@ -92,7 +92,7 @@ namespace OpenLoco::ToolManager
             Input::resetFlag(Input::Flags::toolActive);
 
             World::mapInvalidateSelectionRect();
-            World::mapInvalidateMapSelectionTiles();
+            World::mapInvalidateMapSelectionFreeFormTiles();
 
             resetMapSelectionFlag(MapSelectionFlags::enable | MapSelectionFlags::enableConstruct | MapSelectionFlags::enableConstructionArrow | MapSelectionFlags::unk_03 | MapSelectionFlags::unk_04);
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -843,7 +843,7 @@ namespace OpenLoco::Ui::Windows::Construction
             }
 
             removeConstructionGhosts();
-            World::mapInvalidateMapSelectionTiles();
+            World::mapInvalidateMapSelectionFreeFormTiles();
             World::resetMapSelectionFlag(World::MapSelectionFlags::enableConstruct);
             _cState->trackCost = 0x80000000;
             _cState->signalCost = 0x80000000;
@@ -1172,7 +1172,7 @@ namespace OpenLoco::Ui::Windows::Construction
         {
             removeConstructionGhosts();
             WindowManager::viewportSetVisibility(WindowManager::ViewportVisibility::reset);
-            World::mapInvalidateMapSelectionTiles();
+            World::mapInvalidateMapSelectionFreeFormTiles();
             World::resetMapSelectionFlag(World::MapSelectionFlags::enableConstruct);
             World::resetMapSelectionFlag(World::MapSelectionFlags::enableConstructionArrow);
             Windows::Main::hideDirectionArrows();

--- a/src/OpenLoco/src/Ui/Windows/Construction/Construction.h
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Construction.h
@@ -35,9 +35,6 @@ namespace OpenLoco::Ui::Windows::Construction
     static loco_global<uint8_t, 0x00522095> _byte_522095;
     static loco_global<GhostVisibilityFlags, 0x00522096> _ghostVisibilityFlags;
 
-    constexpr uint16_t mapSelectedTilesSize = 300;
-    static loco_global<Pos2[mapSelectedTilesSize], 0x00F24490> _mapSelectedTiles;
-
 #pragma pack(push, 1)
     struct ConstructionState
     {

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -249,14 +249,13 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
     static void setMapSelectedTilesFromRange(const World::TilePosRangeView& range)
     {
-        size_t i = 0;
+        resetMapSelectionFreeFormTiles();
         for (const auto& pos : range)
         {
-            _mapSelectedTiles[i++] = World::toWorldSpace(pos);
+            addMapSelectionFreeFormTile(World::toWorldSpace(pos));
         }
 
-        _mapSelectedTiles[i].x = -1;
-        mapInvalidateMapSelectionTiles();
+        mapInvalidateMapSelectionFreeFormTiles();
     }
 
     static std::optional<GameCommands::AirportPlacementArgs> getAirportPlacementArgsFromCursor(const int16_t x, const int16_t y);
@@ -286,7 +285,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     // 0x004A4F3B
     static void onToolUpdateAirport(const Ui::Point& mousePos)
     {
-        World::mapInvalidateMapSelectionTiles();
+        World::mapInvalidateMapSelectionFreeFormTiles();
         World::resetMapSelectionFlag(World::MapSelectionFlags::enable | World::MapSelectionFlags::enableConstruct | World::MapSelectionFlags::enableConstructionArrow);
         const auto args = getAirportPlacementArgsFromCursor(mousePos.x, mousePos.y);
         if (!args.has_value())
@@ -349,7 +348,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     // 0x004A5158
     static void onToolUpdateDock(const Ui::Point& mousePos)
     {
-        World::mapInvalidateMapSelectionTiles();
+        World::mapInvalidateMapSelectionFreeFormTiles();
         World::resetMapSelectionFlag(World::MapSelectionFlags::enable | World::MapSelectionFlags::enableConstruct | World::MapSelectionFlags::enableConstructionArrow);
         const auto args = getDockPlacementArgsFromCursor(mousePos.x, mousePos.y);
         if (!args.has_value())
@@ -551,7 +550,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
         if (_isDragging)
         {
-            mapInvalidateMapSelectionTiles();
+            mapInvalidateMapSelectionFreeFormTiles();
             removeConstructionGhosts();
             return;
         }

--- a/src/OpenLoco/src/ViewportManager.cpp
+++ b/src/OpenLoco/src/ViewportManager.cpp
@@ -378,7 +378,7 @@ namespace OpenLoco::Ui::ViewportManager
             0x0046112C,
             [](registers& regs) FORCE_ALIGN_ARG_POINTER -> uint8_t {
                 registers backup = regs;
-                World::mapInvalidateMapSelectionTiles();
+                World::mapInvalidateMapSelectionFreeFormTiles();
                 regs = backup;
                 return 0;
             });


### PR DESCRIPTION
The main changes are around configurable paths. These are paths that record where you last used them (such as save location) to the config file but also have a default location. We had a bunch of code for handling two player and single player save locations but both locations were always the same so I've removed that. Also we had a bunch of copy into a global only to copy out of the global so that is also removed.

Also reworked the freeform map selection tiles which was using duplicated loco globals to pass state and was a bit of a mess. Its still a mess but its a bit less now. (yeah i should have probably done these as two PRs...)