### PR TITLE
Change _editingShortcutIndex to be a member of Window struct

### DIFF
--- a/src/Engine/include/OpenLoco/Engine/Input/ShortcutManager.h
+++ b/src/Engine/include/OpenLoco/Engine/Input/ShortcutManager.h
@@ -13,7 +13,7 @@ namespace OpenLoco
 
 namespace OpenLoco::Input
 {
-    enum class Shortcut : uint32_t;
+    enum class Shortcut : uint16_t;
 }
 
 namespace OpenLoco::Input::ShortcutManager

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -48,7 +48,6 @@ namespace OpenLoco::Input
     static uint32_t _keyQueueReadIndex;
     static uint32_t _keyQueueWriteIndex;
     static std::array<uint8_t, 256> _keyboardState;
-    static uint8_t _editingShortcutIndex;
     static bool _hasKeyboardState = false;
 
     static const std::pair<std::string, std::function<void()>> kCheats[] = {
@@ -304,7 +303,7 @@ namespace OpenLoco::Input
         }
     }
 
-    static void editShortcut(const Key& k)
+    static void editShortcut(const Key& k, Input::Shortcut editingShortcutIndex)
     {
         if (k.keyCode == SDLK_UP)
         {
@@ -348,7 +347,7 @@ namespace OpenLoco::Input
         }
 
         // Assign this keybinding to the shortcut we're currently rebinding.
-        auto& shortcut = cfg.shortcuts.at(static_cast<Input::Shortcut>(_editingShortcutIndex));
+        auto& shortcut = cfg.shortcuts.at(editingShortcutIndex);
         shortcut.keyCode = k.keyCode;
         shortcut.modifiers = _keyModifier;
 
@@ -397,7 +396,7 @@ namespace OpenLoco::Input
             auto ti = WindowManager::find(WindowType::editKeyboardShortcut);
             if (ti != nullptr)
             {
-                editShortcut(*nextKey);
+                editShortcut(*nextKey, ti->editingShortcutIndex);
                 continue;
             }
 

--- a/src/OpenLoco/src/Input/Shortcuts.h
+++ b/src/OpenLoco/src/Input/Shortcuts.h
@@ -4,7 +4,7 @@
 
 namespace OpenLoco::Input
 {
-    enum class Shortcut : uint32_t
+    enum class Shortcut : uint16_t
     {
         closeTopmostWindow,
         closeAllFloatingWindows,

--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -23,6 +23,11 @@ namespace OpenLoco::Gfx
     class DrawingContext;
 }
 
+namespace OpenLoco::Input
+{
+    enum class Shortcut : uint16_t;
+}
+
 namespace OpenLoco::Ui
 {
     using WindowNumber_t = uint16_t;
@@ -217,6 +222,7 @@ namespace OpenLoco::Ui
         {
             uint16_t filterLevel;     // ObjectSelectionWindow
             uint16_t numTicksVisible; // TimePanel
+            Input::Shortcut editingShortcutIndex; // EditKeyboardShortcut
         };
         uint16_t var_858 = 0;
         uint16_t currentTab = 0;

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -182,7 +182,7 @@ namespace OpenLoco::Ui::Windows
 
     namespace EditKeyboardShortcut
     {
-        Window* open(uint8_t shortcutIndex);
+        Window* open(Input::Shortcut shortcutIndex);
     }
 
     namespace Error

--- a/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
+++ b/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
@@ -24,8 +24,6 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
 {
     static constexpr Ui::Size32 kWindowSize = { 280, 72 };
 
-    static loco_global<uint8_t, 0x011364A4> _editingShortcutIndex;
-
     static constexpr auto _widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, kWindowSize, WindowColour::primary),
         Widgets::Caption({ 1, 1 }, { kWindowSize.width - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::change_keyboard_shortcut),
@@ -46,12 +44,13 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
     }
 
     // 0x004BF7B9
-    Window* open(const uint8_t shortcutIndex)
+    Window* open(const Input::Shortcut shortcutIndex)
     {
         WindowManager::close(WindowType::editKeyboardShortcut);
-        _editingShortcutIndex = shortcutIndex;
 
         auto window = WindowManager::createWindow(WindowType::editKeyboardShortcut, kWindowSize, WindowFlags::none, getEvents());
+
+        window->editingShortcutIndex = shortcutIndex;
 
         window->setWidgets(_widgets);
         window->initScrollWidgets();
@@ -71,7 +70,7 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
         self.draw(drawingCtx);
 
         FormatArguments args{};
-        args.push(ShortcutManager::getName(static_cast<Shortcut>(*_editingShortcutIndex)));
+        args.push(ShortcutManager::getName(self.editingShortcutIndex));
         auto point = Ui::Point(140, 32);
         tr.drawStringCentredWrapped(point, 272, Colour::black, StringIds::change_keyboard_shortcut_desc, args);
     }

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -268,7 +268,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
             return;
         }
 
-        EditKeyboardShortcut::open(row);
+        EditKeyboardShortcut::open(static_cast<Input::Shortcut>(row));
     }
 
     static constexpr WindowEventList kEvents = {


### PR DESCRIPTION
This is my suggestion for one way to fix #3262. I have little idea if these changes would be considered a good idea or not, so please do not hesitate if you want to ignore this and create an alternative fix instead.

I did not include a changelog entry. Do we do those for bugs that would have been introduced in the same release?