### PR TITLE
Fix incorrect curve and slope options appearing for one frame when opening construction window at track and road

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix: [#2248, #3681] Newly placed signals can incorrectly update track network.
 - Fix: [#3173] Having multiple (station) vehicle lists open at once may cause duplicates and/or flashing listings.
 - Fix: [#3183] Sound and music being unpaused when the game is still paused in certain situations.
+- Fix: [#3332] Incorrect curve and slope options appear for one frame when right-clicking on track or road.
 - Fix: [#3334] Auto order of cars with centrePosition flag incorrectly calculated.
 - Fix: [#3467] 'Menu' key is not localised in the keyboard shortcuts list.
 - Fix: [#3634] Invalidation issue when show AI planning is turned off.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 - Fix: [#3029] Even when audio is muted, the game continues to advance the jukebox playlist.
 - Fix: [#3173] Having multiple (station) vehicle lists open at once may cause duplicates and/or flashing listings.
 - Fix: [#3183] Sound and music being unpaused when the game is still paused in certain situations.
+- Fix: [#3332] Incorrect curve and slope options appear for one frame when right-clicking on track or road.
 - Fix: [#3334] Auto order of cars with centrePosition flag incorrectly calculated.
 - Fix: [#3467] 'Menu' key is not localised in the keyboard shortcuts list.
 - Fix: [#3634] Invalidation issue when show AI planning is turned off.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix: [#2753] Unable to remove walls and trees at heights above 127.
 - Fix: [#2992] Track and Road additions may incorrectly draw on some curves.
 - Fix: [#3112] Scenario challenge is not failed when exceeding its time limit.
+- Fix: [#3332] Incorrect curve and slope options appear for one frame when right-clicking on track or road.
 - Fix: [#3676] Roads added using object selection window could not be used by vehicles.
 - Fix: [#3943] Unable to place or remove signals on multi tile track elements.
 - Fix: [#3955] Terraform window can break dimensions of construction window.
@@ -88,7 +89,6 @@
 - Fix: [#3029] Even when audio is muted, the game continues to advance the jukebox playlist.
 - Fix: [#3173] Having multiple (station) vehicle lists open at once may cause duplicates and/or flashing listings.
 - Fix: [#3183] Sound and music being unpaused when the game is still paused in certain situations.
-- Fix: [#3332] Incorrect curve and slope options appear for one frame when right-clicking on track or road.
 - Fix: [#3334] Auto order of cars with centrePosition flag incorrectly calculated.
 - Fix: [#3467] 'Menu' key is not localised in the keyboard shortcuts list.
 - Fix: [#3634] Invalidation issue when show AI planning is turned off.

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -67,8 +67,8 @@ namespace OpenLoco::Ui::Windows::Construction
         {
             Common::setDisabledWidgets(window);
         }
-
         Construction::activateSelectedConstructionWidgets();
+
         window = WindowManager::find(WindowType::construction);
 
         if (window != nullptr)
@@ -340,14 +340,13 @@ namespace OpenLoco::Ui::Windows::Construction
         cState.lastSelectedMods = copyElement->mods();
         cState.byte_113603A = 0;
 
-        Construction::activateSelectedConstructionWidgets();
-
         auto* window = WindowManager::find(WindowType::construction);
 
         if (window != nullptr)
         {
             Common::setDisabledWidgets(window);
         }
+        Construction::activateSelectedConstructionWidgets();
 
         return window;
     }
@@ -440,14 +439,13 @@ namespace OpenLoco::Ui::Windows::Construction
         }
         cState.byte_113603A = 0;
 
-        Construction::activateSelectedConstructionWidgets();
-
         auto* window = WindowManager::find(WindowType::construction);
 
         if (window != nullptr)
         {
             Common::setDisabledWidgets(window);
         }
+        Construction::activateSelectedConstructionWidgets();
 
         return window;
     }

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -339,6 +339,9 @@ namespace OpenLoco::Ui::Windows::Construction
 
         cState.lastSelectedMods = copyElement->mods();
         cState.byte_113603A = 0;
+
+        Construction::activateSelectedConstructionWidgets();
+
         auto* window = WindowManager::find(WindowType::construction);
 
         if (window != nullptr)
@@ -436,6 +439,8 @@ namespace OpenLoco::Ui::Windows::Construction
             cState.lastSelectedMods = copyElement->mods();
         }
         cState.byte_113603A = 0;
+
+        Construction::activateSelectedConstructionWidgets();
 
         auto* window = WindowManager::find(WindowType::construction);
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -342,6 +342,9 @@ namespace OpenLoco::Ui::Windows::Construction
 
         cState.lastSelectedMods = copyElement->mods();
         cState.byte_113603A = 0;
+
+        Construction::activateSelectedConstructionWidgets();
+
         auto* window = WindowManager::find(WindowType::construction);
 
         if (window != nullptr)
@@ -438,6 +441,8 @@ namespace OpenLoco::Ui::Windows::Construction
             cState.lastSelectedMods = copyElement->mods();
         }
         cState.byte_113603A = 0;
+
+        Construction::activateSelectedConstructionWidgets();
 
         auto* window = WindowManager::find(WindowType::construction);
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -68,8 +68,8 @@ namespace OpenLoco::Ui::Windows::Construction
         {
             Common::setDisabledWidgets(window);
         }
-
         Construction::activateSelectedConstructionWidgets();
+
         window = WindowManager::find(WindowType::construction);
 
         if (window != nullptr)
@@ -343,14 +343,13 @@ namespace OpenLoco::Ui::Windows::Construction
         cState.lastSelectedMods = copyElement->mods();
         cState.byte_113603A = 0;
 
-        Construction::activateSelectedConstructionWidgets();
-
         auto* window = WindowManager::find(WindowType::construction);
 
         if (window != nullptr)
         {
             Common::setDisabledWidgets(window);
         }
+        Construction::activateSelectedConstructionWidgets();
 
         return window;
     }
@@ -442,14 +441,13 @@ namespace OpenLoco::Ui::Windows::Construction
         }
         cState.byte_113603A = 0;
 
-        Construction::activateSelectedConstructionWidgets();
-
         auto* window = WindowManager::find(WindowType::construction);
 
         if (window != nullptr)
         {
             Common::setDisabledWidgets(window);
         }
+        Construction::activateSelectedConstructionWidgets();
 
         return window;
     }


### PR DESCRIPTION
Fixes #3332. Calling Construction::activateSelectedConstructionWidgets() in openAtTrack() and openAtRoad() seems to be the simplest way to fix the issue.

I also tried in Common::resetWindow(), but this did not work correctly, presumably because that is called before _cState->trackType is set.

**Remaining issues:**
- The text showing the cost to build the road/track is delayed one frame.
- When right-clicking on track or road while dock or airport construction is open, a left curve is highlighted for one frame.

But these are less noticeable, at least.