### PR TITLE
Rework _customObjectsInIndex to remove loco_global

### DIFF
--- a/src/OpenLoco/src/Objects/ObjectIndex.cpp
+++ b/src/OpenLoco/src/Objects/ObjectIndex.cpp
@@ -46,6 +46,7 @@ namespace OpenLoco::ObjectManager
 {
     // Was previously 0x0050D13C count was in 0x0112A110
     static std::vector<ObjectIndexEntry> _installedObjectList;
+    static bool _customObjectsInIndex;
 
     static loco_global<bool, 0x0050AEAD> _isFirstTime;
     static loco_global<bool, 0x0050D161> _isPartialLoaded;
@@ -154,27 +155,17 @@ namespace OpenLoco::ObjectManager
         return currentState;
     }
 
-    static std::optional<bool> _customObjectsInIndex;
-
     // 0x00471712
-    bool hasCustomObjectsInIndex()
+    static bool hasCustomObjectsInIndex()
     {
-        if (_customObjectsInIndex.has_value())
-        {
-            return *_customObjectsInIndex;
-        }
-
         for (auto& obj : _installedObjectList)
         {
             if (obj._header.isCustom())
             {
-                _customObjectsInIndex = true;
-                return *_customObjectsInIndex;
+                return true;
             }
         }
-
-        _customObjectsInIndex = false;
-        return *_customObjectsInIndex;
+        return false;
     }
 
     static void serialiseEntry(Stream& stream, const ObjectIndexEntry& entry)
@@ -570,6 +561,13 @@ namespace OpenLoco::ObjectManager
         {
             createIndex(currentState);
         }
+
+        _customObjectsInIndex = hasCustomObjectsInIndex();
+    }
+
+    bool getCustomObjectsInIndexStatus()
+    {
+        return _customObjectsInIndex;
     }
 
     uint32_t getNumInstalledObjects()

--- a/src/OpenLoco/src/Objects/ObjectIndex.h
+++ b/src/OpenLoco/src/Objects/ObjectIndex.h
@@ -45,8 +45,8 @@ namespace OpenLoco::ObjectManager
         ObjectIndexEntry object;
     };
 
+    bool getCustomObjectsInIndexStatus();
     uint32_t getNumInstalledObjects();
-    bool hasCustomObjectsInIndex();
 
     void loadIndex();
 

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -2372,7 +2372,7 @@ namespace OpenLoco::Ui::Windows::Options
                 w.activatedWidgets |= (1ULL << Widx::export_plugin_objects);
             }
 
-            w.widgets[Widx::export_plugin_objects].hidden = !ObjectManager::hasCustomObjectsInIndex();
+            w.widgets[Widx::export_plugin_objects].hidden = !ObjectManager::getCustomObjectsInIndexStatus();
         }
 
         static void drawDropdownContent(Window* w, Gfx::DrawingContext& drawingCtx, WidgetIndex_t widgetIndex, StringId stringId, int32_t value)


### PR DESCRIPTION
This introduces `ObjectManager::getCustomObjectsInIndexStatus` and integrates the `_customObjectsInIndex` to remove the `loco_global`.

NB: Other object manager / index globals have already been reworked in #3288. Pending splitting off to a PR of their own.