### PR TITLE
Convert from unicode to loco later in the keyboard input process

### DIFF
--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -15,7 +15,6 @@
 #include "Ui/WindowManager.h"
 #include "Vehicles/Vehicle.h"
 #include "World/CompanyManager.h"
-#include <Localisation/Conversion.h>
 #include <Localisation/Unicode.h>
 #include <OpenLoco/Engine/Input/ShortcutManager.h>
 #include <SDL2/SDL_keyboard.h>
@@ -227,7 +226,7 @@ namespace OpenLoco::Input
 
         uint32_t index = _keyQueueLastWrite;
         auto unsignedText = reinterpret_cast<const uint8_t*>(text);
-        _keyQueue[index].charCode = convertUnicodeToLoco(readCodePoint(&unsignedText));
+        _keyQueue[index].charCode = readCodePoint(&unsignedText);
     }
 
     // 0x00407028

--- a/src/OpenLoco/src/Ui/TextInput.cpp
+++ b/src/OpenLoco/src/Ui/TextInput.cpp
@@ -1,6 +1,7 @@
 #include "Ui/TextInput.h"
 #include "Graphics/SoftwareDrawingEngine.h"
 #include "Graphics/TextRenderer.h"
+#include "Localisation/Conversion.h"
 #include "Localisation/Formatting.h"
 #include "Localisation/StringManager.h"
 #include <OpenLoco/Interop/Interop.hpp>
@@ -14,7 +15,9 @@ namespace OpenLoco::Ui::TextInput
     // Common code from 0x0044685C, 0x004CE910
     bool InputSession::handleInput(uint32_t charCode, uint32_t keyCode)
     {
-        if ((charCode >= SDLK_SPACE && charCode < SDLK_DELETE) || (charCode >= 159 && charCode <= 255))
+        uint8_t locoCharCode = Localisation::convertUnicodeToLoco(charCode);
+
+        if ((locoCharCode >= SDLK_SPACE && locoCharCode < SDLK_DELETE) || (locoCharCode >= 159))
         {
             if (inputLenLimit > 0 && buffer.length() == inputLenLimit)
             {
@@ -24,11 +27,11 @@ namespace OpenLoco::Ui::TextInput
 
             if (cursorPosition == buffer.length())
             {
-                buffer.append(1, (char)charCode);
+                buffer.append(1, locoCharCode);
             }
             else
             {
-                buffer.insert(cursorPosition, 1, (char)charCode);
+                buffer.insert(cursorPosition, 1, locoCharCode);
             }
             cursorPosition += 1;
         }


### PR DESCRIPTION
charCode is converted from unicode to loco in later in the process, in TextInput.cpp's `InputSession::handleInput()` instead of Keyboard.cpp's `enqueueText()`