### PR TITLE
Convert InputSession buffer to UTF-32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fix: [#3281] Modifying the news options does not trigger a config file write, potentially losing the changes.
 - Fix: [#3314] Players can remove roads owned by other companies.
 - Fix: [#3315] Players can replace station elements owned by other companies.
+- Fix: [#3354] Characters can be added beyond the length limit when inputting text if the limit has already been exeeded.
 - Fix: [#3355] Text encoding issues with save/load file browse prompt when save file names have non-ASCII characters.
 
 25.10 (2025-10-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Change: [#3473] Fences can now be interacted with in viewports outside of the scenario editor as well.
 - Fix: [#2957] Bridge supports not being drawn under different corners than in vanilla.
 - Fix: [#3313] Vehicle orders not being deleted correctly when the station is deallocated.
+- Fix: [#3354] Characters can be added beyond the length limit when inputting text if the limit has already been exeeded.
 - Fix: [#3395] Text input windows no longer show character limits.
 - Fix: [#3401] The character limit label is using the wrong text colour.
 - Fix: [#3422] Window resize handles don't work properly in windows with status bars.
@@ -25,7 +26,6 @@
 - Fix: [#3281] Modifying the news options does not trigger a config file write, potentially losing the changes.
 - Fix: [#3314] Players can remove roads owned by other companies.
 - Fix: [#3315] Players can replace station elements owned by other companies.
-- Fix: [#3354] Characters can be added beyond the length limit when inputting text if the limit has already been exeeded.
 - Fix: [#3355] Text encoding issues with save/load file browse prompt when save file names have non-ASCII characters.
 
 25.10 (2025-10-10)

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -15,7 +15,6 @@
 #include "Ui/WindowManager.h"
 #include "Vehicles/Vehicle.h"
 #include "World/CompanyManager.h"
-#include <Localisation/Conversion.h>
 #include <Localisation/Unicode.h>
 #include <OpenLoco/Core/BitSet.hpp>
 #include <OpenLoco/Engine/Input/ShortcutManager.h>
@@ -228,7 +227,7 @@ namespace OpenLoco::Input
 
         uint32_t index = _keyQueueLastWrite;
         auto unsignedText = reinterpret_cast<const uint8_t*>(text);
-        _keyQueue[index].charCode = convertUnicodeToLoco(readCodePoint(&unsignedText));
+        _keyQueue[index].charCode = readCodePoint(&unsignedText);
     }
 
     // 0x00407028

--- a/src/OpenLoco/src/Localisation/Conversion.cpp
+++ b/src/OpenLoco/src/Localisation/Conversion.cpp
@@ -75,6 +75,17 @@ namespace OpenLoco::Localisation
         return locoCode;
     }
 
+    // Converts a string in Locomotion's 8-bit encoding to a UTF-32 string
+    std::u32string convertLocoToUnicode32(const std::string& locoString)
+    {
+        std::u32string out;
+        for (uint8_t locoCode : locoString)
+        {
+            out += convertLocoToUnicode(locoCode);
+        }
+        return out;
+    }
+
     uint8_t convertUnicodeToLoco(utf32_t unicode)
     {
         const auto it = std::ranges::lower_bound(
@@ -96,6 +107,7 @@ namespace OpenLoco::Localisation
         return LocoChar::replacement_character;
     }
 
+    // Converts a UTF-8 string to a string in Locomotion's encoding
     std::string convertUnicodeToLoco(const std::string& unicodeString)
     {
         std::string out;
@@ -105,6 +117,17 @@ namespace OpenLoco::Localisation
             out += convertUnicodeToLoco(unicodePoint);
         }
 
+        return out;
+    }
+
+    // Converts a UTF-32 string to a string in Locomotion's encoding
+    std::string convertUnicodeToLoco(const std::u32string& unicodeString)
+    {
+        std::string out;
+        for (utf32_t unicodePoint : unicodeString)
+        {
+            out += convertUnicodeToLoco(unicodePoint);
+        }
         return out;
     }
 }

--- a/src/OpenLoco/src/Localisation/Conversion.h
+++ b/src/OpenLoco/src/Localisation/Conversion.h
@@ -7,8 +7,10 @@
 namespace OpenLoco::Localisation
 {
     utf32_t convertLocoToUnicode(uint8_t loco_char);
+    std::u32string convertLocoToUnicode32(const std::string& locoString);
     uint8_t convertUnicodeToLoco(utf32_t unicode);
     std::string convertUnicodeToLoco(const std::string& unicode_string);
+    std::string convertUnicodeToLoco(const std::u32string& unicode_string);
 
     namespace LocoChar
     {

--- a/src/OpenLoco/src/Ui/TextInput.cpp
+++ b/src/OpenLoco/src/Ui/TextInput.cpp
@@ -184,7 +184,7 @@ namespace OpenLoco::Ui::TextInput
                 }),
             buffer32.end());
     }
-    
+
     std::string InputSession::getLocoString() const
     {
         return Localisation::convertUnicodeToLoco(buffer32);

--- a/src/OpenLoco/src/Ui/TextInput.cpp
+++ b/src/OpenLoco/src/Ui/TextInput.cpp
@@ -13,7 +13,7 @@ namespace OpenLoco::Ui::TextInput
     {
         if ((charCode >= SDLK_SPACE && charCode < SDLK_DELETE) || (charCode >= 159))
         {
-            if (inputLenLimit > 0 && buffer32.length() == inputLenLimit)
+            if (inputLenLimit > 0 && buffer32.length() >= inputLenLimit)
             {
                 // Limit reached but we need to consume this input.
                 return true;

--- a/src/OpenLoco/src/Ui/TextInput.cpp
+++ b/src/OpenLoco/src/Ui/TextInput.cpp
@@ -1,6 +1,7 @@
 #include "Ui/TextInput.h"
 #include "Graphics/SoftwareDrawingEngine.h"
 #include "Graphics/TextRenderer.h"
+#include "Localisation/Conversion.h"
 #include "Localisation/Formatting.h"
 #include "Localisation/StringManager.h"
 
@@ -11,7 +12,9 @@ namespace OpenLoco::Ui::TextInput
     // Common code from 0x0044685C, 0x004CE910
     bool InputSession::handleInput(uint32_t charCode, uint32_t keyCode)
     {
-        if ((charCode >= SDLK_SPACE && charCode < SDLK_DELETE) || (charCode >= 159 && charCode <= 255))
+        uint8_t locoCharCode = Localisation::convertUnicodeToLoco(charCode);
+
+        if ((locoCharCode >= SDLK_SPACE && locoCharCode < SDLK_DELETE) || (locoCharCode >= 159))
         {
             if (inputLenLimit > 0 && buffer.length() == inputLenLimit)
             {
@@ -21,11 +24,11 @@ namespace OpenLoco::Ui::TextInput
 
             if (cursorPosition == buffer.length())
             {
-                buffer.append(1, (char)charCode);
+                buffer.append(1, locoCharCode);
             }
             else
             {
-                buffer.insert(cursorPosition, 1, (char)charCode);
+                buffer.insert(cursorPosition, 1, locoCharCode);
             }
             cursorPosition += 1;
         }

--- a/src/OpenLoco/src/Ui/TextInput.h
+++ b/src/OpenLoco/src/Ui/TextInput.h
@@ -2,9 +2,9 @@
 
 #include "Graphics/Gfx.h"
 
+#include <Localisation/Conversion.h>
 #include <cstdint>
 #include <string>
-#include <Localisation/Conversion.h>
 
 namespace OpenLoco::Ui::TextInput
 {
@@ -13,9 +13,9 @@ namespace OpenLoco::Ui::TextInput
     struct InputSession
     {
         std::u32string buffer32; // in UTF-32
-        size_t cursorPosition; // 0x01136FA2
-        int16_t xOffset;       // 0x01136FA4
-        uint8_t cursorFrame;   // 0x011370A9
+        size_t cursorPosition;   // 0x01136FA2
+        int16_t xOffset;         // 0x01136FA4
+        uint8_t cursorFrame;     // 0x011370A9
         uint32_t inputLenLimit;
 
         InputSession() = default;

--- a/src/OpenLoco/src/Ui/TextInput.h
+++ b/src/OpenLoco/src/Ui/TextInput.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <string>
+#include <Localisation/Conversion.h>
 
 namespace OpenLoco::Ui::TextInput
 {
@@ -11,17 +12,19 @@ namespace OpenLoco::Ui::TextInput
 
     struct InputSession
     {
-        std::string buffer;    // 0x011369A0
+        std::u32string buffer32; // in UTF-32
         size_t cursorPosition; // 0x01136FA2
         int16_t xOffset;       // 0x01136FA4
         uint8_t cursorFrame;   // 0x011370A9
         uint32_t inputLenLimit;
 
         InputSession() = default;
+
+        // initialString is in Locomotion's 8-bit encoding
         InputSession(const std::string initialString, uint32_t inputSize)
         {
-            buffer = initialString;
-            cursorPosition = buffer.length();
+            buffer32 = Localisation::convertLocoToUnicode32(initialString);
+            cursorPosition = buffer32.length();
             cursorFrame = 0;
             xOffset = 0;
             inputLenLimit = inputSize;
@@ -32,5 +35,6 @@ namespace OpenLoco::Ui::TextInput
         void calculateTextOffset(int16_t containerWidth);
         void clearInput();
         void sanitizeInput();
+        std::string getLocoString() const;
     };
 }

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -548,7 +548,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 continue;
             }
 
-            std::string_view pattern = inputSession.buffer;
+            std::string_view pattern = inputSession.getLocoString();
 
             if (!pattern.empty())
             {
@@ -1248,7 +1248,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     static void drawSearchBox(Window& self, Gfx::DrawingContext& drawingCtx)
     {
         char* textBuffer = (char*)StringManager::getString(StringIds::buffer_2039);
-        strncpy(textBuffer, inputSession.buffer.c_str(), 256);
+        strncpy(textBuffer, inputSession.getLocoString().c_str(), 256);
 
         auto& widget = _widgets[widx::searchBox];
         auto clipped = Gfx::clipRenderTarget(drawingCtx.currentRenderTarget(), Ui::Rect(self.x + widget.left, widget.top + 1 + self.y, widget.width() - 2, widget.height() - 2));

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -548,7 +548,8 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 continue;
             }
 
-            std::string_view pattern = inputSession.getLocoString();
+            const auto locoString = inputSession.getLocoString();
+            std::string_view pattern = locoString;
 
             if (!pattern.empty())
             {

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -406,7 +406,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     static void applyFilterToObjectList(FilterFlags filterFlags)
     {
-        std::string_view pattern = inputSession.getLocoString();
+        const auto locoString = inputSession.getLocoString();
+        std::string_view pattern = locoString;
         _numVisibleObjectsListed = 0;
         for (auto& entry : _tabObjectList)
         {

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -406,7 +406,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     static void applyFilterToObjectList(FilterFlags filterFlags)
     {
-        std::string_view pattern = inputSession.buffer;
+        std::string_view pattern = inputSession.getLocoString();
         _numVisibleObjectsListed = 0;
         for (auto& entry : _tabObjectList)
         {
@@ -941,7 +941,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static void drawSearchBox(Window& self, Gfx::DrawingContext& drawingCtx)
     {
         char* textBuffer = (char*)StringManager::getString(StringIds::buffer_2039);
-        strncpy(textBuffer, inputSession.buffer.c_str(), 256);
+        strncpy(textBuffer, inputSession.getLocoString().c_str(), 256);
 
         auto& widget = widgets[widx::textInput];
         const auto& rt = drawingCtx.currentRenderTarget();

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -890,7 +890,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     static void processFileForLoadSave(Window* self)
     {
         // Create full path to target file.
-        fs::path path = _currentDirectory / inputSession.getLocoString();
+        fs::path path = _currentDirectory / inputSession.buffer32;
 
         // Append extension to filename.
         path += getExtensionFromFileType(_fileType);

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -843,7 +843,8 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     static bool filenameContainsInvalidChars()
     {
         uint8_t numNonSpacesProcessed = 0;
-        for (const char chr : inputSession.getLocoString())
+        const auto buffer = inputSession.getLocoString();
+        for (const char chr : buffer)
         {
             if (chr != ' ')
             {

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -486,7 +486,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                 drawingCtx.pushRenderTarget(*clipped);
 
                 bool showCaret = Input::isFocused(window.type, window.number, widx::text_filename) && (inputSession.cursorFrame & 0x10) == 0;
-                drawTextInput(&window, drawingCtx, inputSession.buffer.c_str(), inputSession.cursorPosition, showCaret);
+                drawTextInput(&window, drawingCtx, inputSession.getLocoString().c_str(), inputSession.cursorPosition, showCaret);
 
                 drawingCtx.popRenderTarget();
             }
@@ -843,7 +843,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     static bool filenameContainsInvalidChars()
     {
         uint8_t numNonSpacesProcessed = 0;
-        for (const char chr : inputSession.buffer)
+        for (const char chr : inputSession.getLocoString())
         {
             if (chr != ' ')
             {
@@ -890,7 +890,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     static void processFileForLoadSave(Window* self)
     {
         // Create full path to target file.
-        fs::path path = _currentDirectory / inputSession.buffer;
+        fs::path path = _currentDirectory / inputSession.getLocoString();
 
         // Append extension to filename.
         path += getExtensionFromFileType(_fileType);

--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -243,7 +243,7 @@ namespace OpenLoco::Ui::Windows::TextInput
 
         drawingCtx.popRenderTarget();
 
-        const uint16_t numCharacters = static_cast<uint16_t>(inputSession.buffer.length());
+        const uint16_t numCharacters = static_cast<uint16_t>(inputSession.buffer32.length());
         const uint16_t maxNumCharacters = inputSession.inputLenLimit;
 
         {

--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -218,7 +218,7 @@ namespace OpenLoco::Ui::Windows::TextInput
         drawingCtx.pushRenderTarget(*clipped);
 
         char* drawnBuffer = (char*)StringManager::getString(StringIds::buffer_2039);
-        strcpy(drawnBuffer, inputSession.buffer.c_str());
+        strcpy(drawnBuffer, inputSession.getLocoString().c_str());
 
         {
             FormatArguments args{};
@@ -230,7 +230,7 @@ namespace OpenLoco::Ui::Windows::TextInput
 
         if ((inputSession.cursorFrame % 32) < 16)
         {
-            strncpy(drawnBuffer, inputSession.buffer.c_str(), inputSession.cursorPosition);
+            strncpy(drawnBuffer, inputSession.getLocoString().c_str(), inputSession.cursorPosition);
             drawnBuffer[inputSession.cursorPosition] = '\0';
 
             if (Input::isFocused(window.type, window.number, Widx::input))
@@ -270,7 +270,7 @@ namespace OpenLoco::Ui::Windows::TextInput
                 auto caller = WindowManager::find(_callingWindowType, _callingWindowNumber);
                 if (caller != nullptr)
                 {
-                    caller->callTextInput(_callingWidget, caller->widgets[_callingWidget].id, inputSession.buffer.c_str());
+                    caller->callTextInput(_callingWidget, caller->widgets[_callingWidget].id, inputSession.getLocoString().c_str());
                 }
                 WindowManager::close(&window);
                 break;


### PR DESCRIPTION
InputSession.buffer was previously encoded in the 8-bit encoding used by Locomotion. This replaces it with a 32-bit buffer encoded as UTF-32.

If UTF-8 is desired here instead, I think this works as a step towards it.

~~Includes the changes of #3356 (as their changes were essentially prerequisite for this) - you might want to review that pull on its own first.~~
Supersedes #3357.

Also allows you to name save files with characters that are unsupported by the game's font, and fixes writing save names with Polish characters resulting in incorrect file names on the host OS - i.e. typing "Łęłą" would result in "§æ÷Ý.SV5", now it results in "Łęłą.SV5" (note: they both display the same in the in-game browse prompt).

Also fixes #3354 because why not (`>=` instead of `==` in input session's length check).