### PR TITLE
Drop final loco_globals from Audio unit

### DIFF
--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -685,18 +685,6 @@ namespace OpenLoco::Audio
         }
     }
 
-    // 0x00401A05
-    static void stopChannel(ChannelId id)
-    {
-        Logging::verbose("stopChannel({})", static_cast<int>(id));
-
-        auto channel = getChannel(id);
-        if (channel != nullptr)
-        {
-            channel->stop();
-        }
-    }
-
     // 0x0048A268
     static void triggerVehicleSoundIfInView(Vehicles::VehicleSoundPlayer* v)
     {


### PR DESCRIPTION
Turns out there were two more `loco_global`s hiding inline after #3344.

`_unk_50D514` is an array of all-zeros, used in `shouldSoundLoop`. Not sure what its original purpose was, but it seems it's never updated to be non-zero. I've decided to just remove it.

`_50D5AC` used in `stopAmbientNoise` seems to be the vanilla channel playing check. This wasn't actually updated by our code, so I've replaced it with an actual channel query.

`stopChannel` was only used by this `stopAmbientNoise` function, so after my changes, it was no longer used. I've removed this as well.