### PR TITLE
Fix the player not being able to play the game at all

### DIFF
--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -40,9 +40,9 @@ namespace OpenLoco::Ui::WindowManager
 {
     static constexpr size_t kMaxWindows = 64;
 
-    static uint16_t _thousandthTickCounter; // 0x0052334E
-    static WindowType _currentModalType = WindowType::undefined;    // 0x005233B6
-    static int32_t _currentRotation;        // 0x00E3F0B8
+    static uint16_t _thousandthTickCounter;                      // 0x0052334E
+    static WindowType _currentModalType = WindowType::undefined; // 0x005233B6
+    static int32_t _currentRotation;                             // 0x00E3F0B8
 
     static sfl::static_vector<Window, kMaxWindows> _windows;
 


### PR DESCRIPTION
Oversight in #3376, probably. `_currentModalType` was not being initialised, which resulted in not being able to click thing on the main menu as the game thinks something modal is open.

No need for changelog as this bug is only on master.