### PR TITLE
Make text input length numbers turn red when character limit reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Change: [#3384] Music selection window is now resizable, sortable, and displays the time period associated with each track.
 - Change: [#3402] Text input windows now show the total characters used rather than the current character position.
+- Change: [#3404] Text input length numbers now turn red when the character limit is reached.
 - Fix: [#3313] Vehicle orders not being deleted correctly when the station is deallocated.
 - Fix: [#3395] Text input windows no longer show character limits.
 - Fix: [#3401] The character limit label is using the wrong text colour.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2442,3 +2442,4 @@ strings:
   2387: "-"
   2388: "{UINT16} music track selected"
   2389: "{UINT16} music tracks selected"
+  2390: "{COLOUR RED}{UINT16}/{UINT16}"

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -1926,7 +1926,7 @@ namespace OpenLoco::StringIds
     constexpr StringId object_selection_length = 2260;
     constexpr StringId stats_length = 2261;
     constexpr StringId vehicle_details_tooltip_length = 2262;
-    constexpr StringId num_characters_left_int_int = 2263;
+    constexpr StringId text_input_length = 2263;
     constexpr StringId menu_giant_screenshot = 2264;
     constexpr StringId object_selection_filename = 2265;
     constexpr StringId open_scenario_options = 2266;
@@ -2053,6 +2053,7 @@ namespace OpenLoco::StringIds
     constexpr StringId year_range_no_start_no_end = 2387;
     constexpr StringId status_music_tracks_selected_singular = 2388;
     constexpr StringId status_music_tracks_selected_plural = 2389;
+    constexpr StringId text_input_length_maxed = 2390;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -253,9 +253,15 @@ namespace OpenLoco::Ui::Windows::TextInput
             args.push<uint16_t>(numCharacters);
             args.push<uint16_t>(maxNumCharacters);
 
+            auto stringId = StringIds::text_input_length;
+            if (numCharacters >= maxNumCharacters)
+            {
+                stringId = StringIds::text_input_length_maxed;
+            }
+
             auto& buttonWidget = window.widgets[Widx::ok];
             auto point = Point(window.x + buttonWidget.left - 5, window.y + buttonWidget.top + 1);
-            tr.drawStringRight(point, Colour::black, StringIds::num_characters_left_int_int, args);
+            tr.drawStringRight(point, Colour::black, stringId, args);
         }
     }
 


### PR DESCRIPTION
~~Draft as this is made on top of #3397~~
Still a draft as I agree that this is not ideal in its current state.

<img width="330" height="90" alt="image" src="https://github.com/user-attachments/assets/03dca430-2de5-46d8-b6ec-d039d972c234" />
<img width="330" height="90" alt="image" src="https://github.com/user-attachments/assets/645ced1b-e135-4f51-9660-68270712fb6a" />
<img width="330" height="90" alt="image" src="https://github.com/user-attachments/assets/5f1459fd-cdff-4155-a8ba-9fbe4c708bb3" />
