### PR TITLE
CompanyAI Pathfinding remove unused globals

### DIFF
--- a/src/OpenLoco/src/World/CompanyAi/CompanyAiPathfinding.cpp
+++ b/src/OpenLoco/src/World/CompanyAi/CompanyAiPathfinding.cpp
@@ -47,7 +47,7 @@ namespace OpenLoco::CompanyAi
     static Interop::loco_global<uint32_t, 0x0112C364> _unk112C364;
     static Interop::loco_global<uint32_t, 0x0112C36C> _unk112C36C;
     static Interop::loco_global<uint32_t, 0x0112C35C> _unk112C35C;
-    static Interop::loco_global<uint32_t, 0x0112C34C> _unk112C34C; // currency_32t
+    static Interop::loco_global<uint32_t, 0x0112C34C> _unk112C34C;                 // currency_32t
     static Interop::loco_global<uint32_t, 0x0112C358> _maxTrackRoadWeightingLimit; // Limits the extent of the track/road placement search
     static Interop::loco_global<uint32_t, 0x0112C374> _createTrackRoadCommandAiUnkFlags;
     static Interop::loco_global<uint16_t, 0x0112C4D4> _unkTad112C4D4;


### PR DESCRIPTION
Seems i did all the work for these globals but forgot to delete the ref.