### PR TITLE
Fix broken text input format arguments

### DIFF
--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Localisation/FormatArguments.hpp"
 #include "Localisation/StringManager.h"
 #include "Window.h"
 #include <Map/Track/TrackModSection.h>
@@ -372,7 +373,7 @@ namespace OpenLoco::Ui::Windows
 
     namespace TextInput
     {
-        void openTextInput(Ui::Window* w, StringId title, StringId message, StringId value, int callingWidget, const void* valueArgs, uint32_t inputSize = StringManager::kUserStringSize - 1);
+        void openTextInput(Ui::Window* w, StringId title, StringId message, StringId value, int callingWidget, FormatArgumentsView valueArgs, uint32_t inputSize = StringManager::kUserStringSize - 1);
         void sub_4CE6C9(WindowType type, WindowNumber_t number);
         void cancel();
         void sub_4CE6FF();

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -314,7 +314,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 case widx::change_owner_name:
                 {
                     auto company = CompanyManager::get(CompanyId(self.number));
-                    TextInput::openTextInput(&self, StringIds::title_name_owner, StringIds::prompt_enter_new_name_for_owner, company->ownerName, widgetIndex, nullptr);
+                    TextInput::openTextInput(&self, StringIds::title_name_owner, StringIds::prompt_enter_new_name_for_owner, company->ownerName, widgetIndex, {});
                     break;
                 }
             }
@@ -2777,7 +2777,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void renameCompanyPrompt(Window* self, WidgetIndex_t widgetIndex)
         {
             auto company = CompanyManager::get(CompanyId(self->number));
-            TextInput::openTextInput(self, StringIds::title_name_company, StringIds::prompt_enter_new_company_name, company->name, widgetIndex, nullptr);
+            TextInput::openTextInput(self, StringIds::title_name_company, StringIds::prompt_enter_new_company_name, company->name, widgetIndex, {});
         }
 
         // 0x0043254F

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -799,7 +799,10 @@ namespace OpenLoco::Ui::Windows::Industry
             args.push(industry->name);
             args.push(industry->town);
 
-            TextInput::openTextInput(&self, StringIds::title_industry_name, StringIds::prompt_enter_new_industry_name, industry->name, widgetIndex, &industry->town);
+            FormatArgumentsBuffer buffer{};
+            auto args2 = FormatArguments(buffer);
+            args2.push(industry->town);
+            TextInput::openTextInput(&self, StringIds::title_industry_name, StringIds::prompt_enter_new_industry_name, industry->name, widgetIndex, args2);
         }
 
         // 0x00455CC7

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -2061,7 +2061,7 @@ namespace OpenLoco::Ui::Windows::Options
             strcpy(buffer, playerName);
             buffer[strlen(playerName)] = '\0';
 
-            TextInput::openTextInput(w, StringIds::preferred_owner_name, StringIds::enter_preferred_owner_name, StringIds::buffer_2039, Widx::usePreferredOwnerName, nullptr);
+            TextInput::openTextInput(w, StringIds::preferred_owner_name, StringIds::enter_preferred_owner_name, StringIds::buffer_2039, Widx::usePreferredOwnerName, {});
         }
 
         // 0x004C135F

--- a/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
@@ -1166,7 +1166,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     strncpy(buffer, Scenario::getOptions().scenarioName, 512);
                     auto inputSize = std::size(Scenario::getOptions().scenarioName) - 1;
 
-                    TextInput::openTextInput(&self, StringIds::scenario_name_title, StringIds::enter_name_for_scenario, StringIds::buffer_2039, widgetIndex, nullptr, inputSize);
+                    TextInput::openTextInput(&self, StringIds::scenario_name_title, StringIds::enter_name_for_scenario, StringIds::buffer_2039, widgetIndex, {}, inputSize);
                     break;
                 }
 
@@ -1176,7 +1176,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     strncpy(buffer, Scenario::getOptions().scenarioDetails, 512);
                     auto inputSize = std::size(Scenario::getOptions().scenarioDetails) - 1;
 
-                    TextInput::openTextInput(&self, StringIds::scenario_details_title, StringIds::enter_description_of_this_scenario, StringIds::buffer_2039, widgetIndex, nullptr, inputSize);
+                    TextInput::openTextInput(&self, StringIds::scenario_details_title, StringIds::enter_description_of_this_scenario, StringIds::buffer_2039, widgetIndex, {}, inputSize);
                     break;
                 }
             }

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -1392,7 +1392,10 @@ namespace OpenLoco::Ui::Windows::Station
             args.push(station->name);
             args.push(station->town);
 
-            TextInput::openTextInput(self, StringIds::title_station_name, StringIds::prompt_type_new_station_name, station->name, widgetIndex, &station->town);
+            FormatArgumentsBuffer buffer{};
+            auto args2 = FormatArguments(buffer);
+            args2.push(station->town);
+            TextInput::openTextInput(self, StringIds::title_station_name, StringIds::prompt_type_new_station_name, station->name, widgetIndex, args2);
         }
 
         // 0x0048E520

--- a/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
@@ -239,7 +239,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
         args.push(opponent->name);
 
         // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments
-        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::map_chat_menu, &args);
+        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::map_chat_menu, args);
     }
 
     // 0x0043A72F

--- a/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
@@ -367,7 +367,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     static void showMultiplayer(Window* window)
     {
         StringManager::setString(StringIds::buffer_2039, "");
-        TextInput::openTextInput(window, StringIds::enter_host_address, StringIds::enter_host_address_description, StringIds::buffer_2039, Widx::multiplayer_toggle_btn, nullptr);
+        TextInput::openTextInput(window, StringIds::enter_host_address, StringIds::enter_host_address_description, StringIds::buffer_2039, Widx::multiplayer_toggle_btn, {});
     }
 
     static void multiplayerConnect(std::string_view host)
@@ -405,7 +405,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
         args.push(StringIds::the_other_player);
 
         // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments
-        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::chat_btn, &args);
+        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::chat_btn, args);
     }
 
     static void sub_43918F(const char* string)

--- a/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
@@ -737,7 +737,7 @@ namespace OpenLoco::Ui::Windows::Town
             args.push(town->name);
             args.push(town->name);
 
-            TextInput::openTextInput(&self, StringIds::title_town_name, StringIds::prompt_type_new_town_name, town->name, widgetIndex, &args);
+            TextInput::openTextInput(&self, StringIds::title_town_name, StringIds::prompt_type_new_town_name, town->name, widgetIndex, args);
         }
 
         // 0x004991BC

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -4922,7 +4922,11 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 args.push(StringIds::getVehicleType(vehicle->vehicleType)); // 0
                 args.skip(6);
                 args.push(StringIds::getVehicleType(vehicle->vehicleType)); // 8
-                TextInput::openTextInput(&self, StringIds::title_name_vehicle, StringIds::prompt_enter_new_vehicle_name, vehicle->name, widgetIndex, &vehicle->ordinalNumber);
+
+                FormatArgumentsBuffer buffer{};
+                auto args2 = FormatArguments(buffer);
+                args2.push(vehicle->ordinalNumber);
+                TextInput::openTextInput(&self, StringIds::title_name_vehicle, StringIds::prompt_enter_new_vehicle_name, vehicle->name, widgetIndex, args2);
             }
         }
 


### PR DESCRIPTION
Text input was using the common format args buffer but was no longer referencing the buffer. Text input works v. odd. I can't quite work out why there are two sets of args needed.