### PR TITLE
Manually set up cache for vcpkg

### DIFF
--- a/src/OpenLoco/src/Version.cpp
+++ b/src/OpenLoco/src/Version.cpp
@@ -2,7 +2,7 @@
 
 // clang-format off
 
-#define OPENLOCO_NAME "OpenLoco TEST"
+#define OPENLOCO_NAME "OpenLoco"
 
 #if defined(__amd64__) || defined(_M_AMD64)
     #define OPENLOCO_ARCHITECTURE "x86-64"


### PR DESCRIPTION
See https://github.com/lukka/run-vcpkg/issues/251 for why the automatic cache is no longer working.