### PR TITLE
Added German translations for options

### DIFF
--- a/data/language/de-DE.yml
+++ b/data/language/de-DE.yml
@@ -2207,8 +2207,8 @@ strings:
   2325: "{SMALLFONT}{COLOUR BLACK}Unternehmen optionen"
   2326: "Optionen - Unternehmen"
   2327: "Gesicht des Unternehmen"
-  2328: "Bevorzugtes Gesicht der Unternehmen beim Spielstart verwenden"
-  2329: "{SMALLFONT}{COLOUR BLACK}Wählen Sie ob beim Start eines neuen Szenarios das bevorzugte Gesicht des Unternehmen verwendet werden soll."
+  2328: "Bevorzugtes Gesicht des Unternehmen beim Spielstart verwenden"
+  2329: "{SMALLFONT}{COLOUR BLACK}Wählen Sie, ob das bevorzugte Gesicht der Firma beim Start eines neuen Szenarios genutzt werden soll."
 
   2349: Optionsfenster anzeigen
 


### PR DESCRIPTION
I've noticed the options menu was missing a few German translations, and that there was a mixed term for companies was used, I corrected them to use `Unternehmen` instead of `Firma` consistently.