### PR TITLE
Refactor _availableObjects duplicate to use local variables

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -55,7 +55,6 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     static loco_global<uint8_t, 0x00F24948> _constructionArrowDirection;
 
     static loco_global<uint8_t, 0x0112C2E9> _alternateTrackObjectId; // set from GameCommands::createRoad
-    static loco_global<uint8_t[18], 0x0050A006> _availableObjects;   // top toolbar
 
     // TODO: move to ConstructionState when no longer a loco_global?
     static bool _isDragging = false;
@@ -190,17 +189,16 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             return;
         }
 
-        for (const auto objId : _availableObjects)
+        // Check if the alternate road object is available for the current company
+        auto availableRoads = companyGetAvailableRoads(CompanyManager::getControllingId());
+        auto targetId = _alternateTrackObjectId | (1 << 7);
+        for (const auto objId : availableRoads)
         {
-            if (objId == 0xFF)
+            if (objId == targetId)
             {
-                return;
-            }
-
-            if (objId == (_alternateTrackObjectId | (1 << 7)))
-            {
-                cState.trackType = _alternateTrackObjectId | (1 << 7);
+                cState.trackType = targetId;
                 Common::sub_4A3A50();
+                break;
             }
         }
     }

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -44,9 +44,9 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     static loco_global<uint32_t, 0x009C86F8> _zoomTicks;
     static loco_global<uint8_t, 0x009C870C> _lastTownOption;
     static loco_global<uint8_t, 0x009C870D> _lastPortOption;
-    static loco_global<uint8_t[18], 0x0050A006> _availableObjects;
-    // Replaces 0x0050A006
-    AvailableTracksAndRoads availableTracks;
+
+    // Temporary storage for railroad menu dropdown (populated in mouseDown, consumed in dropdown callback)
+    static AvailableTracksAndRoads _railroadMenuObjects;
 
     namespace Widx
     {
@@ -428,14 +428,9 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     {
         // Load dropdown objects removing any that are not unlocked.
         // Note: This is not using player company id! This looks odd.
-        availableTracks = companyGetAvailableRailTracks(GameCommands::getUpdatingCompanyId());
+        _railroadMenuObjects = companyGetAvailableRailTracks(GameCommands::getUpdatingCompanyId());
 
-        assert(std::size(_availableObjects) >= std::size(availableTracks));
-        // Legacy copy to available_objects remove when all users of 0x0050A006 accounted for
-        std::copy(std::begin(availableTracks), std::end(availableTracks), std::begin(_availableObjects));
-        _availableObjects[availableTracks.size()] = std::numeric_limits<uint8_t>::max();
-
-        if (availableTracks.size() == 0)
+        if (_railroadMenuObjects.size() == 0)
         {
             return;
         }
@@ -445,12 +440,12 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         // Add available objects to Dropdown.
         uint16_t highlightedItem = 0;
 
-        for (auto i = 0u; i < std::size(availableTracks); i++)
+        for (auto i = 0u; i < _railroadMenuObjects.size(); i++)
         {
             uint32_t objImage;
             StringId objStringId;
 
-            auto objIndex = availableTracks[i];
+            auto objIndex = _railroadMenuObjects[i];
             if ((objIndex & (1 << 7)) != 0)
             {
                 auto road = ObjectManager::get<RoadObject>(objIndex & 0x7F);
@@ -472,7 +467,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             }
         }
 
-        Dropdown::showBelow(window, widgetIndex, std::size(availableTracks), 25, (1 << 6));
+        Dropdown::showBelow(window, widgetIndex, _railroadMenuObjects.size(), 25, (1 << 6));
         Dropdown::setHighlightedItem(highlightedItem);
     }
 
@@ -489,7 +484,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             return;
         }
 
-        uint8_t objIndex = availableTracks[itemIndex];
+        uint8_t objIndex = _railroadMenuObjects[itemIndex];
         Construction::openWithFlags(objIndex);
     }
 


### PR DESCRIPTION
Eliminated the shared loco_global at 0x0050A006 by using local static variables for dropdown menu state in each file:
- ToolbarTop.cpp: Uses _railroadMenuObjects for railroad menu dropdown
- ToolbarTopCommon.cpp: Uses _roadMenuObjects for road menu dropdown
- ConstructionTab.cpp: Calls companyGetAvailableRoads() directly instead of reading shared global

Split off from #3288