### PR TITLE
Integrate remaining Vehicle window globals

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -311,7 +311,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         );
     }
 
-    static int32_t _1136264;                     // 0x01136264
+    static int32_t _ghostTrackProgress;          // 0x01136264
     static uint8_t _ghostAirportNode;            // 0x01136264
     static World::Pos3 _ghostVehiclePos;         // 0x0113625E
     static StationId _ghostAirportStationId;     // 0x0113625A
@@ -4258,7 +4258,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 auto flags = GameCommands::Flags::apply | GameCommands::Flags::noErrorWindow | GameCommands::Flags::ghost;
                 GameCommands::doCommand(gcArgs, flags);
             }
-            _1136264 = -1;
+            _ghostTrackProgress = -1;
         }
 
         // 0x004B2B9E
@@ -4272,7 +4272,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 return;
             }
 
-            if (_1136264 == 0 && _ghostVehiclePos == placementArgs->pos)
+            if (_ghostTrackProgress == 0 && _ghostVehiclePos == placementArgs->pos)
             {
                 return;
             }
@@ -4280,7 +4280,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             removeBoatGhost(head);
             if (GameCommands::doCommand(*placementArgs, GameCommands::Flags::apply | GameCommands::Flags::ghost | GameCommands::Flags::noErrorWindow) != GameCommands::FAILURE)
             {
-                _1136264 = 0;
+                _ghostTrackProgress = 0;
             }
         }
 
@@ -4641,7 +4641,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 args.head = head.id;
                 GameCommands::doCommand(args, GameCommands::Flags::apply | GameCommands::Flags::noErrorWindow | GameCommands::Flags::ghost);
             }
-            _1136264 = -1;
+            _ghostTrackProgress = -1;
         }
 
         // 0x004B2A1D
@@ -4655,7 +4655,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 return;
             }
 
-            if (_1136264 != -1 && _ghostLandTrackAndDirection == placementArgs->trackAndDirection && _ghostVehiclePos == placementArgs->pos && _1136264 == placementArgs->trackProgress)
+            if (_ghostTrackProgress != -1 && _ghostLandTrackAndDirection == placementArgs->trackAndDirection && _ghostVehiclePos == placementArgs->pos && _ghostTrackProgress == placementArgs->trackProgress)
             {
                 return;
             }
@@ -4665,7 +4665,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             {
                 _ghostLandTrackAndDirection = placementArgs->trackAndDirection;
                 _ghostVehiclePos = placementArgs->pos;
-                _1136264 = placementArgs->trackProgress;
+                _ghostTrackProgress = placementArgs->trackProgress;
             }
         }
 
@@ -4767,7 +4767,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 return;
             }
 
-            if (_1136264 == 0 && _ghostVehiclePos == placementArgs->pos)
+            if (_ghostTrackProgress == 0 && _ghostVehiclePos == placementArgs->pos)
             {
                 if (head.tileX != -1 && head.has38Flags(Vehicles::Flags38::isGhost))
                 {
@@ -4800,7 +4800,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 return;
             }
 
-            if (_ghostLandTrackAndDirection == placementArgs->trackAndDirection && _ghostVehiclePos == placementArgs->pos && _1136264 == placementArgs->trackProgress)
+            if (_ghostLandTrackAndDirection == placementArgs->trackAndDirection && _ghostVehiclePos == placementArgs->pos && _ghostTrackProgress == placementArgs->trackProgress)
             {
                 if (head.tileX != -1 && head.has38Flags(Vehicles::Flags38::isGhost))
                 {
@@ -4996,7 +4996,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 CursorId cursor = kTypeToToolCursor[static_cast<uint8_t>(head->vehicleType)][getGameState().pickupDirection != 0 ? 1 : 0];
                 if (ToolManager::toolSet(self, pickupWidx, cursor))
                 {
-                    _1136264 = -1;
+                    _ghostTrackProgress = -1;
                 }
                 return;
             }


### PR DESCRIPTION
This PR integrates the last remaining `loco_global`s in the Vehicle window.

Integrates:
* `0x01136264` _ghostTrackProgress (NB: was shared with below)
* `0x01136264` _ghostAirportNode (NB: was shared with above)
* `0x0113625E` _ghostVehiclePos
* `0x0113625A` _ghostAirportStationId (NB: was shared with below)
* `0x0113625A` _ghostLandTrackAndDirection (NB: was shared with above)