### PR TITLE
Localise menu key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix: [#2248, #3681] Newly placed signals can incorrectly update track network.
 - Fix: [#3173] Having multiple (station) vehicle lists open at once may cause duplicates and/or flashing listings.
 - Fix: [#3334] Auto order of cars with centrePosition flag incorrectly calculated.
+- Fix: [#3467] 'Menu' key is not localised in the keyboard shortcuts list.
 - Fix: [#3634] Invalidation issue when show AI planning is turned off.
 - Fix: [#3638] Loan can go negative.
 - Fix: [#3655] Incorrect scaffolding preview image in object selection window.

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -710,6 +710,8 @@ namespace OpenLoco::StringIds
     constexpr StringId keyboard_insert = 785;
     constexpr StringId keyboard_delete = 786;
 
+    constexpr StringId keyboard_menu = 833;
+
     constexpr StringId keyboard_numpad_0 = 836;
     constexpr StringId keyboard_numpad_1 = 837;
     constexpr StringId keyboard_numpad_2 = 838;

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -125,6 +125,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
             { SDLK_KP_PLUS, StringIds::keyboard_numpad_plus },
             { SDLK_NUMLOCKCLEAR, StringIds::keyboard_numlock },
             { SDLK_SCROLLLOCK, StringIds::keyboard_scroll },
+            { SDLK_MENU, StringIds::keyboard_menu },
         });
 
         auto match = keysToString.find(keyCode);


### PR DESCRIPTION
The menu key (key typically located between right ctrl and windows key) can be used for keyboard shortcuts in both OpenLoco and the original game. We already have localised strings for this key in a few languages (presumably inherited from the original game), but they went unused (unlike the strings for other keys such as scroll lock, insert, etc). This fixes this tiny oversight.

Note that there currently seems to be a mistake in the German localisation where it was confused for the windows key.