### PR TITLE
Fix inverted flag check for track/road placement

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -1959,7 +1959,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         {
             return;
         }
-        if (Common::hasGhostVisibilityFlag(GhostVisibilityFlags::track))
+        if (!Common::hasGhostVisibilityFlag(GhostVisibilityFlags::track))
         {
             auto& returnState = GameCommands::getLegacyReturnState();
             if (cState.trackType & (1 << 7))


### PR DESCRIPTION
This fixes the track/road buttons not updating correctly when editing existing track through the viewport.

Regression from #3383 (more specifically 79e20990e15ca652930e3015353521ad3b66b415)