### PR TITLE
Change fstream to ifstream for file reading for reading in translations

### DIFF
--- a/src/OpenLoco/src/Localisation/Languages.cpp
+++ b/src/OpenLoco/src/Localisation/Languages.cpp
@@ -32,7 +32,7 @@ namespace OpenLoco::Localisation
                 continue;
             }
 
-            std::fstream stream(filePath);
+            std::ifstream stream(filePath);
             if (!stream.is_open())
             {
                 continue;


### PR DESCRIPTION
Fixes #3477

Figured out that the fix likely works because all my installations are through a package manager which installs it systemwide, so I don't have writing rights. The fix changes from a rw requirement on the files to ro, which is why it works.