### PR TITLE
Don't skip drawing bridge supports underneath corners facing you

### DIFF
--- a/src/OpenLoco/src/Paint/PaintBridge.cpp
+++ b/src/OpenLoco/src/Paint/PaintBridge.cpp
@@ -986,10 +986,6 @@ namespace OpenLoco::Paint
         }
 
         const auto supportLengths = [&session, &bridgeEntry, &bridgeObj, pillarSpacing, supportLength, slope]() -> std::optional<SupportLengths> {
-            if ((bridgeEntry.edgesQuarters & ((1U << 5) | (1U << 4))) == ((1U << 5) | (1U << 4)))
-            {
-                return std::nullopt;
-            }
             if (pillarSpacing & (1U << 1))
             {
                 if (session.getSupportHeight(1).height == 0xFFFFU
@@ -1093,10 +1089,6 @@ namespace OpenLoco::Paint
         }
 
         const auto supportLengths = [&session, &bridgeEntry, &bridgeObj, pillarSpacing, supportLength, slope]() -> std::optional<SupportLengths> {
-            if ((bridgeEntry.edgesQuarters & ((1U << 6) | (1U << 5))) == ((1U << 6) | (1U << 5)))
-            {
-                return std::nullopt;
-            }
             if (pillarSpacing & (1U << 0))
             {
                 if (session.getSupportHeight(0).height == 0xFFFFU


### PR DESCRIPTION
<img width="322" height="322" alt="image-vanilla" src="https://github.com/user-attachments/assets/41defad3-f51e-4e98-b597-59ef94f54a28" /> <img width="322" height="322" alt="image-pr" src="https://github.com/user-attachments/assets/47ee6782-72bf-49fe-8086-b2df365cb55d" />

~~Fixes #2957 by deleting the vanilla feature that was bugged in OpenLoco.~~
~~PR #3479 is incompatible with this, obviously.~~