### PR TITLE
Header check rework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,27 @@ jobs:
         run: |
           ctest --test-dir build/linux/ --output-on-failure
 
+  header-checks:
+    name: Header Checks ${{ matrix.distro }} ${{ matrix.compiler }}
+    runs-on: ubuntu-latest
+    needs: check-code-formatting
+    container: ghcr.io/openloco/openloco:9-${{ matrix.distro }}32
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [clang++]
+        distro: [noble]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Validate Headers
+        run: |
+          cmake --preset linux -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DOPENLOCO_HEADER_CHECK=ON
+          cmake --build --preset linux-release --target all-headers-check
+
   fedora:
     name: Fedora shared=${{ matrix.build_shared_libs }} i686 MinGW32
     runs-on: ubuntu-latest

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -65,10 +65,6 @@
                 }
             },
             "cacheVariables": {
-                "OPENLOCO_HEADER_CHECK": {
-                    "type": "BOOL",
-                    "value": true
-                },
                 "OPENLOCO_USE_CCACHE": {
                     "type": "BOOL",
                     "value": false
@@ -95,10 +91,6 @@
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
                 "OPENLOCO_BUILD_TESTS": {
-                    "type": "BOOL",
-                    "value": false
-                },
-                "OPENLOCO_HEADER_CHECK": {
                     "type": "BOOL",
                     "value": false
                 },

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -46,4 +46,3 @@ target_link_libraries(Core
         fmt::fmt
         sfl::sfl
 )
-

--- a/src/Gfx/CMakeLists.txt
+++ b/src/Gfx/CMakeLists.txt
@@ -19,4 +19,3 @@ target_link_libraries(Gfx
         Diagnostics
         ${PNG_LIBRARY}
 )
-

--- a/src/Math/CMakeLists.txt
+++ b/src/Math/CMakeLists.txt
@@ -22,4 +22,3 @@ loco_add_library(Math STATIC
     TEST_FILES
         ${test_files}
 )
-

--- a/src/OpenLoco/CMakeLists.txt
+++ b/src/OpenLoco/CMakeLists.txt
@@ -768,7 +768,9 @@ set(OLOCO_HEADERS
 if (MINGW)
     loco_add_library(OpenLoco SHARED
         PRIVATE_FILES
-            ${OLOCO_SOURCES})
+            ${OLOCO_SOURCES}
+            ${OLOCO_HEADERS}
+        )
     target_link_libraries(OpenLoco winmm)
 else ()
     if (MSVC)
@@ -776,11 +778,13 @@ else ()
         loco_add_library(OpenLoco SHARED 
             PRIVATE_FILES
                 ${OLOCO_SOURCES}
-                ${OLOCO_HEADERS})
+                ${OLOCO_HEADERS}
+            )
     else ()
         loco_add_executable(OpenLoco 
             PRIVATE_FILES
                 ${OLOCO_SOURCES}
+                ${OLOCO_HEADERS}
         )
 
         if (TARGET SDL2::SDL2main)
@@ -887,30 +891,4 @@ if (APPLE)
         SOURCE ${BUNDLE_LANGUAGES}
         PROPERTY MACOSX_PACKAGE_LOCATION "Resources/language"
     )
-endif ()
-
-# Add headers check to verify all headers carry their dependencies.
-# Only valid for Clang for now:
-# - GCC 8 does not support -Wno-pragma-once-outside-header
-# - Other compilers status unknown
-if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    add_library(OpenLoco-headers-check OBJECT ${OLOCO_HEADERS})
-    set_target_properties(OpenLoco-headers-check PROPERTIES LINKER_LANGUAGE CXX)
-    set_source_files_properties(${OLOCO_HEADERS} PROPERTIES LANGUAGE CXX)
-    loco_target_compile_link_flags(OpenLoco-headers-check)
-    target_compile_options(OpenLoco-headers-check PUBLIC -x c++ -Wno-pragma-once-outside-header -Wno-unused-const-variable)
-    target_include_directories(OpenLoco-headers-check PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
-    target_link_libraries(OpenLoco-headers-check PUBLIC
-        Core
-        Diagnostics
-        Platform
-        Utility
-        Math
-        Engine
-        ${SDL2_LIB} # These libraries are used in some of our headers try to minimize doing this
-        yaml-cpp
-        )
-else ()
-    # Dummy target to ease invocation
-    add_custom_target(OpenLoco-headers-check)
 endif ()

--- a/src/Resources/CMakeLists.txt
+++ b/src/Resources/CMakeLists.txt
@@ -9,4 +9,5 @@ if (WIN32)
     loco_add_library(Resources OBJECT
         PUBLIC_FILES ${public_files}
         PRIVATE_FILES ${private_files})
+
 endif()

--- a/src/Utility/CMakeLists.txt
+++ b/src/Utility/CMakeLists.txt
@@ -16,4 +16,5 @@ loco_add_library(Utility STATIC
     PRIVATE_FILES
         ${private_files}
     TEST_FILES
-        ${test_files})
+        ${test_files}
+)


### PR DESCRIPTION
Instead of making it part of every build this is now its own specific job, I also refactored the cmake code and added a utility function to enable it for a target. I have decided to only do this on clang as we don't really need to check if every compiler has the same dependencies, this should be the same for all of them. This gets rid of having this target in the VS projects, entirely pointless, this check should only ever run on the CI but the user can activate it with OPENLOCO_HEADER_CHECK if he desires to, this option was also not used before but existed arleady.