### PR TITLE
Don't initialise text input when filename field is invisible

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -114,9 +114,6 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         const char* filter,
         StringId titleId)
     {
-        auto path = fs::u8path(savePath);
-        auto directory = getDirectory(path);
-
         TextInput::cancel();
 
         _type = type;
@@ -132,6 +129,8 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         }
         Utility::strlcpy(_filter, filter, std::size(_filter));
 
+        auto path = fs::u8path(savePath);
+        auto directory = getDirectory(path);
         changeDirectory(directory.make_preferred());
 
         auto window = WindowManager::createWindowCentred(


### PR DESCRIPTION
The `PromptBrowseWindow` was performing unnecessary invalidation for the cursor animation, even when the filename textbox was hidden.

Doesn't make a difference for the fps _yet_; the window is still going through the custom `promptTickLoop`.