### PR TITLE
Add vscode devcontainer to allow development and debugging on newer x64 linux hosts.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+  "name": "OpenLoco Development Container",
+  "dockerFile": "../Dockerfile",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools",
+        "twxs.cmake"
+      ],
+      "settings": {}
+    }
+  },
+  "workspaceMount": "source=${localWorkspaceFolder}/,target=/openloco,type=bind",
+  "workspaceFolder": "/openloco",
+  "remoteUser": "ubuntu",
+  "postCreateCommand": "",
+  "mounts": [
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.locomotion,target=/locomotion,type=bind"
+  ],
+  "runArgs": [
+    "--security-opt=label=disable",
+    "--device=/dev/dri",
+    "-e", "XDG_RUNTIME_DIR=/tmp",
+    "-e", "WAYLAND_DISPLAY=${env:WAYLAND_DISPLAY}",
+    "-v", "${env:XDG_RUNTIME_DIR}/${env:WAYLAND_DISPLAY}:/tmp/${env:WAYLAND_DISPLAY}"
+  ],
+  "containerEnv": {
+    "XDG_RUNTIME_DIR": "/tmp",
+    "WAYLAND_DISPLAY": "${env:WAYLAND_DISPLAY}"
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM ghcr.io/openloco/openloco:9-noble32
+
+RUN apt-get update && apt-get install -y \
+    gdb \
+    pkg-config \
+    libasound2-dev \
+    libudev-dev \
+    mesa-utils \
+    vulkan-tools \
+    libwayland-dev \
+    libxkbcommon-dev \
+    libvulkan1 \
+    libvulkan-dev \
+    libegl1-mesa-dev \
+    libgles2-mesa-dev \
+    libx11-dev \
+    libxcursor-dev \
+    libxrandr-dev \
+    libxi-dev \
+    libxcb1-dev \
+    libxcb-icccm4-dev \
+    libxcb-image0-dev \
+    libxcb-keysyms1-dev \
+    libxcb-randr0-dev \
+    libxcb-shape0-dev \
+    libxcb-xfixes0-dev \
+    libxcb-xkb-dev \
+    libgl1-mesa-dri \
+    libglu1-mesa-dev \
+    libglu1-mesa \
+    libgtk-3-0 \
+    alsa-utils \
+    acl \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG UID=1000
+ARG GID=1000
+
+# Set default shell
+SHELL ["/bin/bash", "-c"]
+
+# Create a non-root user (recommended for VS Code dev containers)
+USER ubuntu
+
+WORKDIR /openloco


### PR DESCRIPTION
This pull request adds a vscode devcontainer to streamline the development under non-windows environments as the necessary toolchain and libs seem older and won't be available on newer Linux machines.  This container is based of [this](https://github.com/OpenLoco/OpenLoco/issues/3364#issuecomment-3476360721) comment.
Closes #3364.

**Known issues**
- Only wayland is supported
- Sound isn't working when running the game inside the container right now.