### PR TITLE
Strip diacritics in language files on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 26.04+ (???)
 ------------------------------------------------------------------------
+- Change: [#3517] Letters with unsupported diacritics/accents are temporarily replaced with regular letters to keep e.g. Czech, Slovak readable.
 - Change: [#3710] The Build Vehicle window is now wider by default, moving the sorting options to a dedicated dropdown.
 - Change: [#3734] The Station Construction tab now lists accepted and produced cargo in full, with labels along the icons.
 - Fix: [#3651] Industry and town lists are not cleared immediately when generating a new landscape in the editor.

--- a/src/OpenLoco/src/Localisation/Conversion.cpp
+++ b/src/OpenLoco/src/Localisation/Conversion.cpp
@@ -217,15 +217,15 @@ namespace OpenLoco::Localisation
         }
 
         // Remove diacritics from letters that don't have an associated glyph yet
-        it = std::ranges::lower_bound(
+        auto it2 = std::ranges::lower_bound(
             kUnicodeTemporaryStrip,
             unicode,
             {},
             &EncodingConvertEntry::unicode);
 
-        if (it != kUnicodeTemporaryStrip.end() && it->unicode == unicode)
+        if (it2 != kUnicodeTemporaryStrip.end() && it2->unicode == unicode)
         {
-            return it->locoCode;
+            return it2->locoCode;
         }
 
         // Basic Latin characters

--- a/src/OpenLoco/src/Localisation/Conversion.cpp
+++ b/src/OpenLoco/src/Localisation/Conversion.cpp
@@ -53,8 +53,135 @@ namespace OpenLoco::Localisation
         { UnicodeChar::railway, LocoChar::railway },
     });
 
+    static constexpr auto kUnicodeTemporayStrip = std::to_array<EncodingConvertEntry>({
+        { 0x00C6, 'A' }, // Æ
+        { 0x00D0, 'D' }, // Ð
+        { 0x00D8, 'O' }, // Ø
+        { 0x00DD, 'Y' }, // Ý
+        { 0x00DE, 'T' }, // Þ
+        { 0x00E6, 'a' }, // æ
+        { 0x00F0, 'd' }, // ð
+        { 0x00F8, 'o' }, // ø
+        { 0x00FD, 'y' }, // ý
+        { 0x00FE, 't' }, // þ
+        { 0x00FF, 'y' }, // ÿ
+        { 0x0100, 'A' }, // Ā
+        { 0x0101, 'a' }, // ā
+        { 0x0102, 'A' }, // Ă
+        { 0x0103, 'a' }, // ă
+        { 0x0108, 'C' }, // Ĉ
+        { 0x0109, 'c' }, // ĉ
+        { 0x010A, 'C' }, // Ċ
+        { 0x010B, 'c' }, // ċ
+        { 0x010C, 'C' }, // Č
+        { 0x010D, 'c' }, // č
+        { 0x010E, 'D' }, // Ď
+        { 0x010F, 'd' }, // ď
+        { 0x0110, 'D' }, // Đ
+        { 0x0111, 'd' }, // đ
+        { 0x0112, 'E' }, // Ē
+        { 0x0113, 'e' }, // ē
+        { 0x0114, 'E' }, // Ĕ
+        { 0x0115, 'e' }, // ĕ
+        { 0x0116, 'E' }, // Ė
+        { 0x0117, 'e' }, // ė
+        { 0x011A, 'E' }, // Ě
+        { 0x011B, 'e' }, // ě
+        { 0x011C, 'G' }, // Ĝ
+        { 0x011D, 'g' }, // ĝ
+        { 0x011E, 'G' }, // Ğ
+        { 0x011F, 'g' }, // ğ
+        { 0x0120, 'G' }, // Ġ
+        { 0x0121, 'g' }, // ġ
+        { 0x0122, 'G' }, // Ģ
+        { 0x0123, 'g' }, // ģ
+        { 0x0124, 'H' }, // Ĥ
+        { 0x0125, 'h' }, // ĥ
+        { 0x0126, 'H' }, // Ħ
+        { 0x0127, 'h' }, // ħ
+        { 0x0128, 'I' }, // Ĩ
+        { 0x0129, 'i' }, // ĩ
+        { 0x012A, 'I' }, // Ī
+        { 0x012B, 'i' }, // ī
+        { 0x012C, 'I' }, // Ĭ
+        { 0x012D, 'i' }, // ĭ
+        { 0x012E, 'I' }, // Į
+        { 0x012F, 'i' }, // į
+        { 0x0130, 'I' }, // İ
+        { 0x0131, 'i' }, // ı
+        { 0x0132, 'I' }, // Ĳ
+        { 0x0133, 'i' }, // ĳ
+        { 0x0134, 'J' }, // Ĵ
+        { 0x0135, 'j' }, // ĵ
+        { 0x0136, 'K' }, // Ķ
+        { 0x0137, 'k' }, // ķ
+        { 0x0138, 'k' }, // ĸ
+        { 0x0139, 'L' }, // Ĺ
+        { 0x013A, 'l' }, // ĺ
+        { 0x013B, 'L' }, // Ļ
+        { 0x013C, 'l' }, // ļ
+        { 0x013D, 'L' }, // Ľ
+        { 0x013E, 'l' }, // ľ
+        { 0x013F, 'L' }, // Ŀ
+        { 0x0140, 'l' }, // ŀ
+        { 0x0145, 'N' }, // Ņ
+        { 0x0146, 'n' }, // ņ
+        { 0x0147, 'N' }, // Ň
+        { 0x0148, 'n' }, // ň
+        { 0x0149, 'n' }, // ŉ
+        { 0x014A, 'n' }, // Ŋ
+        { 0x014B, 'n' }, // ŋ
+        { 0x014C, 'O' }, // Ō
+        { 0x014D, 'o' }, // ō
+        { 0x014E, 'O' }, // Ŏ
+        { 0x014F, 'o' }, // ŏ
+        { 0x0150, 'O' }, // Ő
+        { 0x0151, 'o' }, // ő
+        { 0x0152, 'O' }, // Œ
+        { 0x0153, 'o' }, // œ
+        { 0x0154, 'R' }, // Ŕ
+        { 0x0155, 'r' }, // ŕ
+        { 0x0156, 'R' }, // Ŗ
+        { 0x0157, 'r' }, // ŗ
+        { 0x0158, 'R' }, // Ř
+        { 0x0159, 'r' }, // ř
+        { 0x015C, 'S' }, // Ŝ
+        { 0x015D, 's' }, // ŝ
+        { 0x015E, 'S' }, // Ş
+        { 0x015F, 's' }, // ş
+        { 0x0160, 'S' }, // Š
+        { 0x0161, 's' }, // š
+        { 0x0162, 'T' }, // Ţ
+        { 0x0163, 't' }, // ţ
+        { 0x0164, 'T' }, // Ť
+        { 0x0165, 't' }, // ť
+        { 0x0166, 'T' }, // Ŧ
+        { 0x0167, 't' }, // ŧ
+        { 0x0168, 'U' }, // Ũ
+        { 0x0169, 'u' }, // ũ
+        { 0x016A, 'U' }, // Ū
+        { 0x016B, 'u' }, // ū
+        { 0x016C, 'U' }, // Ŭ
+        { 0x016D, 'u' }, // ŭ
+        { 0x016E, 'U' }, // Ů
+        { 0x016F, 'u' }, // ů
+        { 0x0170, 'U' }, // Ű
+        { 0x0171, 'u' }, // ű
+        { 0x0172, 'U' }, // Ų
+        { 0x0173, 'u' }, // ų
+        { 0x0174, 'W' }, // Ŵ
+        { 0x0175, 'w' }, // ŵ
+        { 0x0176, 'Y' }, // Ŷ
+        { 0x0177, 'y' }, // ŷ
+        { 0x0178, 'Y' }, // Ÿ
+        { 0x017D, 'Z' }, // Ž
+        { 0x017E, 'z' }, // ž
+        { 0x017F, 's' }, // ſ
+    });
+
     // Ensure that the table is sorted by Unicode point.
     static_assert(std::ranges::is_sorted(kUnicodeToLocoTable, {}, &EncodingConvertEntry::unicode));
+    static_assert(std::ranges::is_sorted(kUnicodeTemporayStrip, {}, &EncodingConvertEntry::unicode));
 
     utf32_t convertLocoToUnicode(uint8_t locoCode)
     {
@@ -86,6 +213,17 @@ namespace OpenLoco::Localisation
         if (it != kUnicodeToLocoTable.end() && it->unicode == unicode)
         {
             return it->locoCode;
+        }
+
+        const auto it2 = std::ranges::lower_bound(
+            kUnicodeTemporayStrip,
+            unicode,
+            {},
+            &EncodingConvertEntry::unicode);
+
+        if (it2 != kUnicodeTemporayStrip.end() && it2->unicode == unicode)
+        {
+            return it2->locoCode;
         }
 
         if (unicode < 256)

--- a/src/OpenLoco/src/Localisation/Conversion.cpp
+++ b/src/OpenLoco/src/Localisation/Conversion.cpp
@@ -204,28 +204,24 @@ namespace OpenLoco::Localisation
 
     uint8_t convertUnicodeToLoco(utf32_t unicode)
     {
-        // Extended Latin characters that are supported by Locomotion as-is
-        auto it = std::ranges::lower_bound(
-            kUnicodeToLocoTable,
-            unicode,
-            {},
-            &EncodingConvertEntry::unicode);
+        auto tableLookup = [unicode](auto&& table) {
+            return std::ranges::lower_bound(
+                table,
+                unicode,
+                {},
+                &EncodingConvertEntry::unicode);
+        };
 
-        if (it != kUnicodeToLocoTable.end() && it->unicode == unicode)
+        // Extended Latin characters that are supported by Locomotion as-is
+        if (auto it = tableLookup(kUnicodeToLocoTable); it != kUnicodeToLocoTable.end() && it->unicode == unicode)
         {
             return it->locoCode;
         }
 
         // Remove diacritics from letters that don't have an associated glyph yet
-        auto it2 = std::ranges::lower_bound(
-            kUnicodeTemporaryStrip,
-            unicode,
-            {},
-            &EncodingConvertEntry::unicode);
-
-        if (it2 != kUnicodeTemporaryStrip.end() && it2->unicode == unicode)
+        if (auto it = tableLookup(kUnicodeTemporaryStrip); it != kUnicodeTemporaryStrip.end() && it->unicode == unicode)
         {
-            return it2->locoCode;
+            return it->locoCode;
         }
 
         // Basic Latin characters

--- a/src/OpenLoco/src/Localisation/Conversion.cpp
+++ b/src/OpenLoco/src/Localisation/Conversion.cpp
@@ -205,21 +205,24 @@ namespace OpenLoco::Localisation
     uint8_t convertUnicodeToLoco(utf32_t unicode)
     {
         auto tableLookup = [unicode](auto&& table) {
-            return std::ranges::lower_bound(
+            auto it = std::ranges::lower_bound(
                 table,
                 unicode,
                 {},
                 &EncodingConvertEntry::unicode);
+
+            // Handle edge case where iterator is valid, but mismatches the input
+            return it != table.end() && it->unicode == unicode ? it : table.end();
         };
 
         // Extended Latin characters that are supported by Locomotion as-is
-        if (auto it = tableLookup(kUnicodeToLocoTable); it != kUnicodeToLocoTable.end() && it->unicode == unicode)
+        if (auto it = tableLookup(kUnicodeToLocoTable); it != kUnicodeToLocoTable.end())
         {
             return it->locoCode;
         }
 
         // Remove diacritics from letters that don't have an associated glyph yet
-        if (auto it = tableLookup(kUnicodeTemporaryStrip); it != kUnicodeTemporaryStrip.end() && it->unicode == unicode)
+        if (auto it = tableLookup(kUnicodeTemporaryStrip); it != kUnicodeTemporaryStrip.end())
         {
             return it->locoCode;
         }


### PR DESCRIPTION
Rebased version of #3449. From that PR:

> This is meant to be temporarily solution, as talked about on #localisation in discord, before the full true type font support will be achieved in the code.
> 
> Temporarily solves inappropriate rendering of question marks in place of those letters, thus making existing Slovak and prepared Czech translation usable and playable without need to compromise language files written with full diacritics.
> 
> This as well opens a space to create new and actually usable translations for languages using theses letters with diacritics, including but not limited to languages such as Latvian or Lithuanian, Catalan, Esperanto, Hungarian...
> 
> To create a comprehensive table of stripping, a following were taken into consideration: [this discord post considering list of supported characters](https://discord.com/channels/689445672390361176/839549939197149204/1436965718213132369), existing [`static constexpr auto kUnicodeToLocoTable`](https://github.com/OpenLoco/OpenLoco/blob/bf64dc23ee5cd0277c0da7ad6b8779b06d2b84a4/src/OpenLoco/src/Localisation/Conversion.cpp#L16-L50) which defines support for (not only, but mainly) Polish characters which are supported and need no stripping. I have started by processing these with a simple script and I finished myself with a hand.

In the short term, I'd like us to rework the internal strings to use UTF-8, instead of the ISO 8859-1 dialect we use today. Moreover, rework text rendering to use TTF font recreations of the current sprite fonts. This will allow us to remove this workaround, and get these European languages to be rendered with all diacritics. Finally, it would let Chinese/Japanese/Korean glyphs to also be drawn correctly through alternative fonts.