### PR TITLE
Fix #3527: Crash when drawing trams, tracks

### DIFF
--- a/src/OpenLoco/src/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/src/Objects/ObjectManager.cpp
@@ -141,7 +141,16 @@ namespace OpenLoco::ObjectManager
 
     Object* getAny(const LoadedObjectHandle& handle)
     {
-        auto obj = getRepositoryItem(handle.type).objects[handle.id];
+        auto& ori = getRepositoryItem(handle.type);
+        if (handle.id >= ori.objects.size())
+        {
+            // We shouldn't get here but sometimes we pass null handles like 0xFF and
+            // accidentally get here. Ideally the call sites should be fixed so thats
+            // why we are asserting here.
+            assert(false);
+            return nullptr;
+        }
+        auto obj = ori.objects[handle.id];
         if (obj == (void*)-1)
         {
             obj = nullptr;

--- a/src/OpenLoco/src/Paint/PaintRoad.cpp
+++ b/src/OpenLoco/src/Paint/PaintRoad.cpp
@@ -559,6 +559,10 @@ namespace OpenLoco::Paint
         const auto ghostMods = Ui::Windows::Construction::getLastSelectedMods();
         for (auto mod = 0; mod < 2; ++mod)
         {
+            if (roadObj->mods[mod] == 0xFF)
+            {
+                continue;
+            }
             const auto* roadExtraObj = ObjectManager::get<RoadExtraObject>(roadObj->mods[mod]);
             ImageId roadExtraBaseImage{};
             if (elRoad.hasMod(mod))

--- a/src/OpenLoco/src/Paint/PaintTrack.cpp
+++ b/src/OpenLoco/src/Paint/PaintTrack.cpp
@@ -307,6 +307,10 @@ namespace OpenLoco::Paint
         const auto ghostMods = Ui::Windows::Construction::getLastSelectedMods();
         for (auto mod = 0; mod < 4; ++mod)
         {
+            if (trackObj->mods[mod] == 0xFF)
+            {
+                continue;
+            }
             const auto* trackExtraObj = ObjectManager::get<TrackExtraObject>(trackObj->mods[mod]);
             ImageId trackExtraBaseImage{};
             if (elTrack.hasMod(mod))


### PR DESCRIPTION
Fix #3527

After I switched to using spans for the objects it meant if you walked off the end of the span it would crash instead of return a garbage pointer of an object. I've fixed the two call sites causing the crash and switched to returning a nullptr when it would walk off the end of the array. Ideally we shouldn't ever get there though so I added an assert for our debug builds. (Mistake was added only a few commits ago so no change log required)