### PR TITLE
Fix Pre-existing name of town not displayed in text input window #3403

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -66,13 +66,11 @@ namespace OpenLoco::Ui::Windows::TextInput
         const char* messageStr = StringManager::getString(message);
         char formattedMsg[512] = {};
         strncat(formattedMsg, messageStr, 511);
-
         char* colonPos = strchr(formattedMsg, ':');
         if (colonPos != nullptr)
         {
-            *(colonPos+1) = '\0';
+            *(colonPos + 1) = '\0';
         }
-
         strncat(formattedMsg, " ", 511 - strlen(formattedMsg));
         strncat(formattedMsg, temp, 511 - strlen(formattedMsg));
         StringManager::setString(message, formattedMsg);


### PR DESCRIPTION
Created  new method that updates current message's string to contain the temp value.
Tested by updating business name, town name.

Fixes https://github.com/OpenLoco/OpenLoco/issues/3403