### PR TITLE
Fix crash in tryLoadInstalledFaceForName

### DIFF
--- a/src/OpenLoco/src/GameCommands/Company/RenameCompanyOwner.cpp
+++ b/src/OpenLoco/src/GameCommands/Company/RenameCompanyOwner.cpp
@@ -134,7 +134,9 @@ namespace OpenLoco::GameCommands
             // Copy the string as it needs some processing
             std::string objectName = object.object._name;
             // Not sure what ControlCodes::pop16 is doing in the object name but it is at the start of all the object names
-            objectName.erase(std::remove(std::begin(objectName), std::end(objectName), static_cast<char>(ControlCodes::pop16)));
+            auto newEndIterator = std::remove(std::begin(objectName), std::end(objectName), static_cast<char>(ControlCodes::pop16));
+            // Erase everything past the new end. If the new end is the same as the old end (because ControlCodes::pop16 is not present), this is a no-op
+            objectName.erase(newEndIterator, std::end(objectName));
 
             auto strcmpSpecial = [](const char* lhs, const char* rhs) {
                 while (*lhs && *rhs)


### PR DESCRIPTION
* the erase overload that takes just a single iterator on std::string erases a position, not everything after a position. std::remove rearranges things and then returns the off-the-end iterator for the remainder. So if the control code is not present (which seems to be the case at least sometimes on my system, not sure if that's expected or not) you get UB, and if you're lucky, a nice crash. With the particular pack of mods I have installed right now, it seems to be 100% reliable on my system. Instead, use the two-argument version. This removes *any* pop16 codes, regardless of position (whether or not that was the original intent, is not clear to me). 
* References for convenience: https://en.cppreference.com/w/cpp/string/basic_string/erase.html and https://en.cppreference.com/w/cpp/algorithm/remove.html
* Tested manually - any pop16 are removed, if no pop16 are present, it leaves the string alone (and no longer crashes / appears to no longer go out of bounds), and if the name used is the name of a competitor, the picture is automatically installed as it should be.
* Add a wider variety of vcpkg based build presets for convenient debugging. Happy to split that into another PR.
