### PR TITLE
Fix screenshot filename to work directly from current save file

### DIFF
--- a/src/OpenLoco/src/Ui/Screenshot.cpp
+++ b/src/OpenLoco/src/Ui/Screenshot.cpp
@@ -1,13 +1,13 @@
 #include "Screenshot.h"
 #include "Entities/EntityManager.h"
 #include "Environment.h"
+#include "GameState.h"
 #include "Graphics/Gfx.h"
 #include "Graphics/RenderTarget.h"
 #include "Graphics/SoftwareDrawingEngine.h"
 #include "Localisation/FormatArguments.hpp"
 #include "Localisation/StringIds.h"
 #include "Map/TileManager.h"
-#include "Scenario/ScenarioOptions.h"
 #include "Ui.h"
 #include "WindowManager.h"
 #include <OpenLoco/Core/Exception.hpp>
@@ -150,8 +150,8 @@ namespace OpenLoco::Ui
     {
         auto screenshotsFolderPath = Environment::getPathNoWarning(Environment::PathId::screenshots);
         Environment::autoCreateDirectory(screenshotsFolderPath);
-        std::string scenarioName = Scenario::getOptions().scenarioName;
 
+        std::string scenarioName = getGameState().scenarioName;
         if (scenarioName.length() == 0)
         {
             scenarioName = StringManager::getString(StringIds::screenshot_filename_template);


### PR DESCRIPTION
This changes the scenario filename template to work directly from the scenario name embedded in the current game state rather than whatever scenario was last loaded.

Thought about appending the current in-game year to the filename as well, but that wouldn't work well with scenarios that already have a year in their name, e.g. `North America (Mid) 1970`.