### PR TITLE
Fix owner name propagation to company name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix: [#3496] Incorrect (off by 1 quantity) building cargo tooltip displayed.
 - Fix: [#3503] Crash when placing airports or docks in a scenario with no track objects.
 - Fix: [#3544] Viewport panning (right-mouse click drag) is broken during tutorial playback.
+- Fix: [#3545] The initial company name is not set correctly when entering a custom name at scenario start.
 
 25.11 (2025-11-05)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -363,7 +363,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
                 args.bufferIndex = 0;
 
-                success = GameCommands::doCommand(args, GameCommands::Flags::apply);
+                success = GameCommands::doCommand(args, GameCommands::Flags::apply) != GameCommands::FAILURE;
             }
 
             // No need to propagate the name if it could not be set.


### PR DESCRIPTION
Fixes #3545. Must've been broken when we switched to the current struct-based game commands. So, for years. Clearly, we all seem to test with our preferred names set 😅 