### PR TITLE
Naming pathfinding related functions and variables, and a tiny bit of refactoring

### DIFF
--- a/src/OpenLoco/src/Map/RoadElement.h
+++ b/src/OpenLoco/src/Map/RoadElement.h
@@ -45,11 +45,11 @@ namespace OpenLoco::World
             _4 &= ~0x80;
             _4 |= hasBridge ? 0x80 : 0;
         }
-        uint8_t unk4u() const { return (_4 & 0x30) >> 4; }
-        void setUnk4u(uint8_t newUnk4u)
+        uint8_t laneOccupation() const { return (_4 & 0x30) >> 4; }
+        void setLaneOccupation(uint8_t newLaneOccupation)
         {
             _4 &= ~(0x30);
-            _4 |= (newUnk4u & 0x3) << 4;
+            _4 |= (newLaneOccupation & 0x3) << 4;
         }
         uint8_t roadObjectId() const { return _5 >> 4; } // _5u
         void setRoadObjectId(uint8_t objectId)

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -578,7 +578,7 @@ namespace OpenLoco::Vehicles
     // bp : trackAndDirection
     // ebp : bp | (setOccupied << 31)
     // returns dh : trackType
-    uint8_t VehicleBase::sub_47D959(const World::Pos3& loc, const TrackAndDirection::_RoadAndDirection rad, const bool setOccupied)
+    uint8_t VehicleBase::updateTileOccupancy(const World::Pos3& loc, const TrackAndDirection::_RoadAndDirection rad, const bool setOccupied)
     {
         auto roadType = getTrackType();
         auto tile = World::TileManager::get(loc);

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -611,14 +611,14 @@ namespace OpenLoco::Vehicles
                 continue;
             }
 
-            const auto newUnk4u = World::TrackData::getRoadOccupationMask(rad._data >> 2) >> 4;
+            const auto newLaneOccupation = World::TrackData::getRoadOccupationMask(rad._data >> 2) >> 4;
             if (setOccupied)
             {
-                elRoad->setUnk4u(elRoad->unk4u() | newUnk4u);
+                elRoad->setLaneOccupation(elRoad->laneOccupation() | newLaneOccupation);
             }
             else
             {
-                elRoad->setUnk4u(elRoad->unk4u() & (~newUnk4u));
+                elRoad->setLaneOccupation(elRoad->laneOccupation() & (~newLaneOccupation));
             }
 
             if (getTrackType() == 0xFF)

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -578,7 +578,7 @@ namespace OpenLoco::Vehicles
     // bp : trackAndDirection
     // ebp : bp | (setOccupied << 31)
     // returns dh : trackType
-    uint8_t VehicleBase::updateTileOccupancy(const World::Pos3& loc, const TrackAndDirection::_RoadAndDirection rad, const bool setOccupied)
+    uint8_t VehicleBase::updateRoadTileOccupancy(const World::Pos3& loc, const TrackAndDirection::_RoadAndDirection rad, const bool setOccupied)
     {
         auto roadType = getTrackType();
         auto tile = World::TileManager::get(loc);

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -325,7 +325,7 @@ namespace OpenLoco::Vehicles
         VehicleBase* previousVehicleComponent();
         void explodeComponent();
         void destroyTrain();
-        uint8_t sub_47D959(const World::Pos3& loc, const TrackAndDirection::_RoadAndDirection rad, const bool setOccupied);
+        uint8_t updateTileOccupancy(const World::Pos3& loc, const TrackAndDirection::_RoadAndDirection rad, const bool setOccupied);
         UpdateMotionResult updateTrackMotion(int32_t unk1, bool isVeh2UnkM15);
     };
     static_assert(sizeof(VehicleBase) <= sizeof(Entity));

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -325,7 +325,7 @@ namespace OpenLoco::Vehicles
         VehicleBase* previousVehicleComponent();
         void explodeComponent();
         void destroyTrain();
-        uint8_t updateTileOccupancy(const World::Pos3& loc, const TrackAndDirection::_RoadAndDirection rad, const bool setOccupied);
+        uint8_t updateRoadTileOccupancy(const World::Pos3& loc, const TrackAndDirection::_RoadAndDirection rad, const bool setOccupied);
         UpdateMotionResult updateTrackMotion(int32_t unk1, bool isVeh2UnkM15);
     };
     static_assert(sizeof(VehicleBase) <= sizeof(Entity));

--- a/src/OpenLoco/src/Vehicles/Vehicle1.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle1.cpp
@@ -344,7 +344,7 @@ namespace OpenLoco::Vehicles
 
         TrackAndDirection::_RoadAndDirection newRad(0, 0);
         newRad._data = routing & 0x1FFU;
-        veh1.sub_47D959(newPos, newRad, true);
+        veh1.updateTileOccupancy(newPos, newRad, true);
 
         veh1.routingHandle = newRoutingHandle;
         veh1.trackAndDirection.road = newRad;
@@ -773,7 +773,7 @@ namespace OpenLoco::Vehicles
             return RoadMotionNewPieceResult::noFurther;
         }
 
-        const auto newTrackType = component.sub_47D959(nextPos, newRad, true);
+        const auto newTrackType = component.updateTileOccupancy(nextPos, newRad, true);
 
         component.trackType = newTrackType;
         component.routingHandle = newRoutingHandle;

--- a/src/OpenLoco/src/Vehicles/Vehicle1.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle1.cpp
@@ -344,7 +344,7 @@ namespace OpenLoco::Vehicles
 
         TrackAndDirection::_RoadAndDirection newRad(0, 0);
         newRad._data = routing & 0x1FFU;
-        veh1.updateTileOccupancy(newPos, newRad, true);
+        veh1.updateRoadTileOccupancy(newPos, newRad, true);
 
         veh1.routingHandle = newRoutingHandle;
         veh1.trackAndDirection.road = newRad;
@@ -773,7 +773,7 @@ namespace OpenLoco::Vehicles
             return RoadMotionNewPieceResult::noFurther;
         }
 
-        const auto newTrackType = component.updateTileOccupancy(nextPos, newRad, true);
+        const auto newTrackType = component.updateRoadTileOccupancy(nextPos, newRad, true);
 
         component.trackType = newTrackType;
         component.routingHandle = newRoutingHandle;

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -1305,7 +1305,7 @@ namespace OpenLoco::Vehicles
         {
             if (mode == TransportMode::road)
             {
-                SignalTimeoutStatus bl = categoriseTimeElapsed();
+               auto bl = categoriseTimeElapsed();
                 if (bl == SignalTimeoutStatus::firstTimeout)
                 {
                     return sub_4A8DB7();
@@ -1582,7 +1582,7 @@ namespace OpenLoco::Vehicles
     // 0x004A8D8F
     bool VehicleHead::roadNormalMovementUpdate(uint8_t al, StationId nextStation)
     {
-        SignalTimeoutStatus bl = categoriseTimeElapsed();
+        auto bl = categoriseTimeElapsed();
         if (bl == SignalTimeoutStatus::firstTimeout)
         {
             return sub_4A8DB7();

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3898,7 +3898,7 @@ namespace OpenLoco::Vehicles
     }
 
     // 0x0047C722
-    static void sub_47C722(VehicleHead& head)
+    static void roadResetHead(VehicleHead& head)
     {
         head.var_38 |= Flags38::unk_2;
         auto train = Vehicle(head);
@@ -3935,7 +3935,7 @@ namespace OpenLoco::Vehicles
         if (mode == TransportMode::road)
         {
             // 0x0047C5B0
-            sub_47C722(*this);
+            roadResetHead(*this);
             var_38 |= Flags38::unk_2;
             veh1.var_38 |= Flags38::unk_2;
 
@@ -6173,7 +6173,7 @@ namespace OpenLoco::Vehicles
     {
         if (mode == TransportMode::road)
         {
-            sub_47C722(*this);
+            roadResetHead(*this);
             return;
         }
 

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -1305,7 +1305,7 @@ namespace OpenLoco::Vehicles
         {
             if (mode == TransportMode::road)
             {
-               auto bl = categoriseTimeElapsed();
+                auto bl = categoriseTimeElapsed();
                 if (bl == SignalTimeoutStatus::firstTimeout)
                 {
                     return sub_4A8DB7();
@@ -4390,34 +4390,34 @@ namespace OpenLoco::Vehicles
 
         const auto newRoutingCurvature = TrackData::getCurvatureDegree((newRouting & World::Track::AdditionalTaDFlags::basicTaDMask) >> 2);
 
-        int8_t minCurvature = curvatures[0];    // cl
-        int8_t maxCurvature = curvatures[0];    // ch
-        int8_t minAbsCurvature = curvatures[0]; // ah
+        int8_t minCurvature = curvatures[0];            // cl
+        int8_t maxCurvature = curvatures[0];            // ch
+        int8_t leastMagnitudeCurvature = curvatures[0]; // ah
         for (auto i = 1U; i < curvatures.size(); ++i)
         {
             const auto curvature = curvatures[i];
             minCurvature = std::min(minCurvature, curvature);
             maxCurvature = std::max(maxCurvature, curvature);
 
-            if (std::abs(curvature) < std::abs(minAbsCurvature))
+            if (std::abs(curvature) < std::abs(leastMagnitudeCurvature))
             {
-                minAbsCurvature = curvature;
+                leastMagnitudeCurvature = curvature;
             }
         }
 
         uint32_t lightStateFlags = 0x10;
-        if (minAbsCurvature != minCurvature)
+        if (leastMagnitudeCurvature != minCurvature)
         {
             lightStateFlags |= 1U << 30;
-            if (newRoutingCurvature < minAbsCurvature)
+            if (newRoutingCurvature < leastMagnitudeCurvature)
             {
                 lightStateFlags |= 1U << 28;
             }
         }
-        if (minAbsCurvature != maxCurvature)
+        if (leastMagnitudeCurvature != maxCurvature)
         {
             lightStateFlags |= 1U << 29;
-            if (newRoutingCurvature > minAbsCurvature)
+            if (newRoutingCurvature > leastMagnitudeCurvature)
             {
                 lightStateFlags |= 1U << 27;
             }

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -4390,8 +4390,8 @@ namespace OpenLoco::Vehicles
 
         const auto newRoutingCurvature = TrackData::getCurvatureDegree((newRouting & World::Track::AdditionalTaDFlags::basicTaDMask) >> 2);
 
-        int8_t minCurvature = curvatures[0]; // cl
-        int8_t maxCurvature = curvatures[0]; // ch
+        int8_t minCurvature = curvatures[0];    // cl
+        int8_t maxCurvature = curvatures[0];    // ch
         int8_t minAbsCurvature = curvatures[0]; // ah
         for (auto i = 1U; i < curvatures.size(); ++i)
         {

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -4398,11 +4398,8 @@ namespace OpenLoco::Vehicles
             const auto curvature = curvatures[i];
             minCurvature = std::min(minCurvature, curvature);
             maxCurvature = std::max(maxCurvature, curvature);
-            const auto absCurvature = std::abs(curvature);
 
-            // Note: this std::abs is not redundant, since minAbsCurvature stores both sign and value, not just magnitude
-            const auto currMinAbsCurvature = std::abs(minAbsCurvature);
-            if (absCurvature < currMinAbsCurvature)
+            if (std::abs(curvature) < std::abs(minAbsCurvature))
             {
                 minAbsCurvature = curvature;
             }

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3950,7 +3950,7 @@ namespace OpenLoco::Vehicles
 
                 if (handle != veh2.routingHandle)
                 {
-                    veh2.sub_47D959(pos, tad, false);
+                    veh2.updateTileOccupancy(pos, tad, false);
                 }
 
                 pos += World::TrackData::getUnkRoad(tad.basicRad()).pos;
@@ -6403,7 +6403,7 @@ namespace OpenLoco::Vehicles
                 const auto routing = RoutingManager::getRouting(handle);
                 TrackAndDirection::_RoadAndDirection tad{ 0, 0 };
                 tad._data = routing & World::Track::AdditionalTaDFlags::basicTaDMask;
-                sub_47D959(routingPos, tad, false);
+                updateTileOccupancy(routingPos, tad, false);
                 routingPos += World::TrackData::getUnkRoad(tad.basicRad()).pos;
             }
 
@@ -6617,7 +6617,7 @@ namespace OpenLoco::Vehicles
         if (mode == TransportMode::road)
         {
             newTad.road._data &= World::Track::AdditionalTaDFlags::basicTaDMask;
-            sub_47D959(newPos, newTad.road, true);
+            updateTileOccupancy(newPos, newTad.road, true);
         }
 
         auto& moveInfo = mode == TransportMode::road ? World::TrackData::getRoadSubPositon(trackAndDirection.road._data)[subPosition]

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3950,7 +3950,7 @@ namespace OpenLoco::Vehicles
 
                 if (handle != veh2.routingHandle)
                 {
-                    veh2.updateTileOccupancy(pos, tad, false);
+                    veh2.updateRoadTileOccupancy(pos, tad, false);
                 }
 
                 pos += World::TrackData::getUnkRoad(tad.basicRad()).pos;
@@ -6405,7 +6405,7 @@ namespace OpenLoco::Vehicles
                 const auto routing = RoutingManager::getRouting(handle);
                 TrackAndDirection::_RoadAndDirection tad{ 0, 0 };
                 tad._data = routing & World::Track::AdditionalTaDFlags::basicTaDMask;
-                updateTileOccupancy(routingPos, tad, false);
+                updateRoadTileOccupancy(routingPos, tad, false);
                 routingPos += World::TrackData::getUnkRoad(tad.basicRad()).pos;
             }
 
@@ -6619,7 +6619,7 @@ namespace OpenLoco::Vehicles
         if (mode == TransportMode::road)
         {
             newTad.road._data &= World::Track::AdditionalTaDFlags::basicTaDMask;
-            updateTileOccupancy(newPos, newTad.road, true);
+            updateRoadTileOccupancy(newPos, newTad.road, true);
         }
 
         auto& moveInfo = mode == TransportMode::road ? World::TrackData::getRoadSubPositon(trackAndDirection.road._data)[subPosition]

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -1305,7 +1305,7 @@ namespace OpenLoco::Vehicles
         {
             if (mode == TransportMode::road)
             {
-                SignalTimeoutStatus bl = categorizeTimeElapsed();
+                SignalTimeoutStatus bl = categoriseTimeElapsed();
                 if (bl == SignalTimeoutStatus::firstTimeout)
                 {
                     return sub_4A8DB7();
@@ -1384,7 +1384,7 @@ namespace OpenLoco::Vehicles
     // 0: None of the below
     // 1: reached first timeout at signal
     // 2: give up and reverse at signal
-    SignalTimeoutStatus VehicleHead::categorizeTimeElapsed()
+    SignalTimeoutStatus VehicleHead::categoriseTimeElapsed()
     {
         Vehicle train(head);
         if (train.veh2->routingHandle != train.veh1->routingHandle || train.veh2->subPosition != train.veh1->subPosition)
@@ -1582,7 +1582,7 @@ namespace OpenLoco::Vehicles
     // 0x004A8D8F
     bool VehicleHead::roadNormalMovementUpdate(uint8_t al, StationId nextStation)
     {
-        SignalTimeoutStatus bl = categorizeTimeElapsed();
+        SignalTimeoutStatus bl = categoriseTimeElapsed();
         if (bl == SignalTimeoutStatus::firstTimeout)
         {
             return sub_4A8DB7();

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -1305,12 +1305,12 @@ namespace OpenLoco::Vehicles
         {
             if (mode == TransportMode::road)
             {
-                uint8_t bl = sub_4AA36A();
-                if (bl == 1)
+                SignalTimeoutStatus bl = categorizeTimeElapsed();
+                if (bl == SignalTimeoutStatus::firstTimeout)
                 {
                     return sub_4A8DB7();
                 }
-                else if (bl == 2)
+                else if (bl == SignalTimeoutStatus::turnaroundAtSignalTimeout)
                 {
                     return tryReverse();
                 }
@@ -1384,13 +1384,13 @@ namespace OpenLoco::Vehicles
     // 0: None of the below
     // 1: reached first timeout at signal
     // 2: give up and reverse at signal
-    uint8_t VehicleHead::sub_4AA36A()
+    SignalTimeoutStatus VehicleHead::categorizeTimeElapsed()
     {
         Vehicle train(head);
         if (train.veh2->routingHandle != train.veh1->routingHandle || train.veh2->subPosition != train.veh1->subPosition)
         {
             train.veh1->timeAtSignal = 0;
-            return 0;
+            return SignalTimeoutStatus::ok;
         }
 
         auto param1 = 160;
@@ -1418,16 +1418,16 @@ namespace OpenLoco::Vehicles
         train.veh1->timeAtSignal++;
         if (train.veh1->timeAtSignal == param1)
         {
-            return 1;
+            return SignalTimeoutStatus::firstTimeout;
         }
 
         if (train.veh1->timeAtSignal == turnaroundAtSignalTimeout)
         {
             var_5C = 40;
-            return 2;
+            return SignalTimeoutStatus::turnaroundAtSignalTimeout;
         }
 
-        return 0;
+        return SignalTimeoutStatus::ok;
     }
 
     // 0x004A8DB7
@@ -1582,12 +1582,12 @@ namespace OpenLoco::Vehicles
     // 0x004A8D8F
     bool VehicleHead::roadNormalMovementUpdate(uint8_t al, StationId nextStation)
     {
-        uint8_t bl = sub_4AA36A();
-        if (bl == 1)
+        SignalTimeoutStatus bl = categorizeTimeElapsed();
+        if (bl == SignalTimeoutStatus::firstTimeout)
         {
             return sub_4A8DB7();
         }
-        else if (bl == 2)
+        else if (bl == SignalTimeoutStatus::turnaroundAtSignalTimeout)
         {
             return tryReverse();
         }

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -1305,12 +1305,12 @@ namespace OpenLoco::Vehicles
         {
             if (mode == TransportMode::road)
             {
-                auto bl = categoriseTimeElapsed();
-                if (bl == SignalTimeoutStatus::firstTimeout)
+                auto timeoutStatus = categoriseTimeElapsed(); // bl
+                if (timeoutStatus == SignalTimeoutStatus::firstTimeout)
                 {
                     return sub_4A8DB7();
                 }
-                else if (bl == SignalTimeoutStatus::turnaroundAtSignalTimeout)
+                else if (timeoutStatus == SignalTimeoutStatus::turnaroundAtSignalTimeout)
                 {
                     return tryReverse();
                 }
@@ -1582,12 +1582,12 @@ namespace OpenLoco::Vehicles
     // 0x004A8D8F
     bool VehicleHead::roadNormalMovementUpdate(uint8_t al, StationId nextStation)
     {
-        auto bl = categoriseTimeElapsed();
-        if (bl == SignalTimeoutStatus::firstTimeout)
+        auto timeoutStatus = categoriseTimeElapsed(); // bl
+        if (timeoutStatus == SignalTimeoutStatus::firstTimeout)
         {
             return sub_4A8DB7();
         }
-        else if (bl == SignalTimeoutStatus::turnaroundAtSignalTimeout)
+        else if (timeoutStatus == SignalTimeoutStatus::turnaroundAtSignalTimeout)
         {
             return tryReverse();
         }

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -4382,14 +4382,13 @@ namespace OpenLoco::Vehicles
     {
         TrackAndDirection::_TrackAndDirection tad{ 0, 0 };
         tad._data = targetRouting & World::Track::AdditionalTaDFlags::basicTaDMask;
-        // unk113621F
-        sfl::static_vector<int8_t, 16> curvatures;
+        sfl::static_vector<int8_t, 16> curvatures; // unk113621F
         for (const auto& otherConnection : tc.connections)
         {
             curvatures.push_back(TrackData::getCurvatureDegree((otherConnection & World::Track::AdditionalTaDFlags::basicTaDMask) >> 2));
         }
 
-        const auto curUnk = TrackData::getCurvatureDegree((newRouting & World::Track::AdditionalTaDFlags::basicTaDMask) >> 2);
+        const auto newRoutingCurvature = TrackData::getCurvatureDegree((newRouting & World::Track::AdditionalTaDFlags::basicTaDMask) >> 2);
 
         int8_t minCurvature = curvatures[0]; // cl
         int8_t maxCurvature = curvatures[0]; // ch
@@ -4413,7 +4412,7 @@ namespace OpenLoco::Vehicles
         if (minAbsCurvature != minCurvature)
         {
             lightStateFlags |= 1U << 30;
-            if (curUnk < minAbsCurvature)
+            if (newRoutingCurvature < minAbsCurvature)
             {
                 lightStateFlags |= 1U << 28;
             }
@@ -4421,7 +4420,7 @@ namespace OpenLoco::Vehicles
         if (minAbsCurvature != maxCurvature)
         {
             lightStateFlags |= 1U << 29;
-            if (curUnk > minAbsCurvature)
+            if (newRoutingCurvature > minAbsCurvature)
             {
                 lightStateFlags |= 1U << 27;
             }

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -1318,7 +1318,7 @@ namespace OpenLoco::Vehicles
 
             if (hasVehicleFlags(VehicleFlags::commandStop))
             {
-                return sub_4A8CB6();
+                return stoppingUpdate();
             }
             else if (hasVehicleFlags(VehicleFlags::manualControl))
             {
@@ -1365,7 +1365,7 @@ namespace OpenLoco::Vehicles
                     }
                     else
                     {
-                        return sub_4A8CB6();
+                        return stoppingUpdate();
                     }
                 }
                 else
@@ -1375,7 +1375,7 @@ namespace OpenLoco::Vehicles
             }
             else
             {
-                return sub_4A8CB6();
+                return stoppingUpdate();
             }
         }
     }
@@ -1461,7 +1461,7 @@ namespace OpenLoco::Vehicles
     }
 
     // 0x004A8CB6
-    bool VehicleHead::sub_4A8CB6()
+    bool VehicleHead::stoppingUpdate()
     {
         Vehicle train(head);
 
@@ -1503,7 +1503,7 @@ namespace OpenLoco::Vehicles
         auto foundStationId = manualFindTrainStationAtLocation();
         if (foundStationId == StationId::null)
         {
-            return sub_4A8CB6();
+            return stoppingUpdate();
         }
         stationId = foundStationId;
         setStationVisitedTypes();
@@ -1511,7 +1511,7 @@ namespace OpenLoco::Vehicles
         updateLastJourneyAverageSpeed();
         beginUnloading();
 
-        return sub_4A8CB6();
+        return stoppingUpdate();
     }
 
     // 0x004A8FAC

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -4393,23 +4393,22 @@ namespace OpenLoco::Vehicles
 
         int8_t minCurvature = curvatures[0]; // cl
         int8_t maxCurvature = curvatures[0]; // ch
-        uint32_t iMinAbsCurvature = 0; // ebp
+        int8_t minAbsCurvature = curvatures[0]; // ah
         for (auto i = 1U; i < curvatures.size(); ++i)
         {
             const auto curvature = curvatures[i];
             minCurvature = std::min(minCurvature, curvature);
             maxCurvature = std::max(maxCurvature, curvature);
             const auto absCurvature = std::abs(curvature);
-            const auto currMinAbsCurvature = std::abs(curvatures[iMinAbsCurvature]);
+
+            // Note: this std::abs is not redundant, since minAbsCurvature stores both sign and value, not just magnitude
+            const auto currMinAbsCurvature = std::abs(minAbsCurvature);
             if (absCurvature < currMinAbsCurvature)
             {
-                iMinAbsCurvature = i;
+                minAbsCurvature = curvature;
             }
         }
-        
-        // Note: this is the actual curvature, not the absolute value of it
-        // Hence the index tracking above.
-        const auto minAbsCurvature = curvatures[iMinAbsCurvature]; // ah
+
         uint32_t lightStateFlags = 0x10;
         if (minAbsCurvature != minCurvature)
         {

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -4969,7 +4969,7 @@ namespace OpenLoco::Vehicles
                     }
 
                     const uint8_t lane = isBackToFront ^ isOverLap ? 0b10 : 0b01;
-                    if (!(elRoad->unk4u() & lane))
+                    if (!(elRoad->laneOccupation() & lane))
                     {
                         continue;
                     }
@@ -5029,7 +5029,7 @@ namespace OpenLoco::Vehicles
                             res |= RoadOccupationFlags::isLevelCrossingClosed;
                         }
                     }
-                    if (elRoad->unk4u() & 0b01)
+                    if (elRoad->laneOccupation() & 0b01)
                     {
                         res |= RoadOccupationFlags::isLaneOccupied;
                     }
@@ -5050,7 +5050,7 @@ namespace OpenLoco::Vehicles
                             res |= RoadOccupationFlags::isLevelCrossingClosed;
                         }
                     }
-                    if (elRoad->unk4u() & 0b10)
+                    if (elRoad->laneOccupation() & 0b10)
                     {
                         res |= RoadOccupationFlags::isLaneOccupied;
                     }

--- a/src/OpenLoco/src/Vehicles/VehicleHead.h
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.h
@@ -157,7 +157,7 @@ namespace OpenLoco::Vehicles
         Status sub_427BF2();
         void produceLeavingDockSound();
         void produceTouchdownAirportSound();
-        SignalTimeoutStatus categorizeTimeElapsed();
+        SignalTimeoutStatus categoriseTimeElapsed();
         bool sub_4AC1C2();
         bool opposingTrainAtSignal();
         bool pathingShouldReverse();

--- a/src/OpenLoco/src/Vehicles/VehicleHead.h
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.h
@@ -116,7 +116,7 @@ namespace OpenLoco::Vehicles
         bool updateLand();
         bool sub_4A8DB7();
         bool tryReverse();
-        bool sub_4A8CB6();
+        bool stoppingUpdate();
         bool sub_4A8C81();
         bool landTryBeginUnloading();
         bool landLoadingUpdate();

--- a/src/OpenLoco/src/Vehicles/VehicleHead.h
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.h
@@ -33,6 +33,13 @@ namespace OpenLoco::Vehicles
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(WaterMotionFlags);
 
+    enum class SignalTimeoutStatus : uint32_t
+    {
+        ok = 0U,
+        firstTimeout = 1U,
+        turnaroundAtSignalTimeout = 2U,
+    };
+
     struct VehicleStatus
     {
         StringId status1;
@@ -150,7 +157,7 @@ namespace OpenLoco::Vehicles
         Status sub_427BF2();
         void produceLeavingDockSound();
         void produceTouchdownAirportSound();
-        uint8_t sub_4AA36A();
+        SignalTimeoutStatus categorizeTimeElapsed();
         bool sub_4AC1C2();
         bool opposingTrainAtSignal();
         bool pathingShouldReverse();

--- a/src/OpenLoco/src/Vehicles/VehicleTail.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleTail.cpp
@@ -93,7 +93,7 @@ namespace OpenLoco::Vehicles
 
         if (mode == TransportMode::road)
         {
-            sub_47D959(_oldTilePos, trackAndDir.road, false);
+            updateTileOccupancy(_oldTilePos, trackAndDir.road, false);
         }
         else
         {
@@ -131,7 +131,7 @@ namespace OpenLoco::Vehicles
                 const auto routing = RoutingManager::getRouting(handle);
                 auto tad = TrackAndDirection::_RoadAndDirection(0, 0);
                 tad._data = routing & Track::AdditionalTaDFlags::basicTaDMask;
-                tail.sub_47D959(pos, tad, false);
+                tail.updateTileOccupancy(pos, tad, false);
 
                 pos += World::TrackData::getUnkRoad(tad.basicRad()).pos;
             }

--- a/src/OpenLoco/src/Vehicles/VehicleTail.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleTail.cpp
@@ -93,7 +93,7 @@ namespace OpenLoco::Vehicles
 
         if (mode == TransportMode::road)
         {
-            updateTileOccupancy(_oldTilePos, trackAndDir.road, false);
+            updateRoadTileOccupancy(_oldTilePos, trackAndDir.road, false);
         }
         else
         {
@@ -131,7 +131,7 @@ namespace OpenLoco::Vehicles
                 const auto routing = RoutingManager::getRouting(handle);
                 auto tad = TrackAndDirection::_RoadAndDirection(0, 0);
                 tad._data = routing & Track::AdditionalTaDFlags::basicTaDMask;
-                tail.updateTileOccupancy(pos, tad, false);
+                tail.updateRoadTileOccupancy(pos, tad, false);
 
                 pos += World::TrackData::getUnkRoad(tad.basicRad()).pos;
             }


### PR DESCRIPTION
Each commit is self-contained (except for the formatting, which is in a final commit on the end). Happy to pull pieces out if desired
* Try to give meaningful names to a number of subroutines
* Name some variables too from context
* Simplify updateJunctionSignalLights a bit since it's clearer what it was doing now. the min and max bits could be pulled out into a std::minmax_element call if we wanted, but not sure that'd perform any better.