### PR TITLE
Feature: Drag & drop files and folders into game window when using browse prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.03.1+ (???)
 ------------------------------------------------------------------------
 - Feature: [#1438] Add basic blueprint feature for copy, paste and rotate railroad track.
+- Feature: [#3568] Can now drag & drop files and folders into the game window to load them when using the browse prompt.
 - Feature: [#3591] Cheat to keep cargo when picking up a vehicle or modifying a vehicle's components.
 - Feature: [#3639] The Locomotion title screen music can now be listened to during scenario play.
 - Change: [#3594] More sorting options when building vehicles.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2491,3 +2491,4 @@ strings:
   2436: '{SMALLFONT}{COLOUR BLACK}When enabled, cargo will not be cleared from the entire vehicle when adding cars, moving cars or picking up the vehicle'
   2437: "Error: not a regular file or directory"
   2438: "Error: incorrect file type"
+  2439: "Error importing file"

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2489,3 +2489,5 @@ strings:
   2434: 'Vehicle cargo'
   2435: 'Keep vehicle cargo on modify or pickup'
   2436: '{SMALLFONT}{COLOUR BLACK}When enabled, cargo will not be cleared from the entire vehicle when adding cars, moving cars or picking up the vehicle'
+  2437: "Error: not a regular file or directory"
+  2438: "Error: incorrect file type"

--- a/src/OpenLoco/src/Input.cpp
+++ b/src/OpenLoco/src/Input.cpp
@@ -209,17 +209,15 @@ namespace OpenLoco::Input
                     enqueueText(e.text.text);
                     break;
 
-                case SDL_DROPFILE:
+                case SDL_EVENT_DROP_FILE:
                 {
-                    auto droppedFilePath = e.drop.file;
+                    auto droppedFilePath = e.drop.data;
 
                     auto browsePromptWindow = Ui::WindowManager::find(Ui::WindowType::fileBrowserPrompt);
                     if (browsePromptWindow != nullptr)
                     {
                         Ui::Windows::PromptBrowse::onDropFile(*browsePromptWindow, droppedFilePath);
                     }
-
-                    SDL_free(droppedFilePath);
                     break;
                 }
             }

--- a/src/OpenLoco/src/Input.cpp
+++ b/src/OpenLoco/src/Input.cpp
@@ -211,15 +211,15 @@ namespace OpenLoco::Input
 
                 case SDL_DROPFILE:
                 {
-                    auto droppedFileDir = e.drop.file;
+                    auto droppedFilePath = e.drop.file;
 
                     auto browsePromptWindow = Ui::WindowManager::find(Ui::WindowType::fileBrowserPrompt);
                     if (browsePromptWindow != nullptr)
                     {
-                        Ui::Windows::PromptBrowse::onDropFile(*browsePromptWindow, droppedFileDir);
+                        Ui::Windows::PromptBrowse::onDropFile(*browsePromptWindow, droppedFilePath);
                     }
 
-                    SDL_free(droppedFileDir);
+                    SDL_free(droppedFilePath);
                     break;
                 }
             }

--- a/src/OpenLoco/src/Input.cpp
+++ b/src/OpenLoco/src/Input.cpp
@@ -208,6 +208,20 @@ namespace OpenLoco::Input
                 case SDL_EVENT_TEXT_INPUT:
                     enqueueText(e.text.text);
                     break;
+
+                case SDL_DROPFILE:
+                {
+                    auto droppedFileDir = e.drop.file;
+
+                    auto browsePromptWindow = Ui::WindowManager::find(Ui::WindowType::fileBrowserPrompt);
+                    if (browsePromptWindow != nullptr)
+                    {
+                        Ui::Windows::PromptBrowse::onDropFile(*browsePromptWindow, droppedFileDir);
+                    }
+
+                    SDL_free(droppedFileDir);
+                    break;
+                }
             }
         }
 

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -2152,6 +2152,7 @@ namespace OpenLoco::StringIds
     constexpr StringId tooltip_keep_cargo_modify_pickup = 2436;
     constexpr StringId error_not_regular_file_nor_directory = 2437;
     constexpr StringId error_incorrect_file_type = 2438;
+    constexpr StringId error_importing_file = 2439;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -2150,6 +2150,8 @@ namespace OpenLoco::StringIds
     constexpr StringId cheat_vehicle_cargo = 2434;
     constexpr StringId cheat_keep_cargo_modify_pickup = 2435;
     constexpr StringId tooltip_keep_cargo_modify_pickup = 2436;
+    constexpr StringId error_not_regular_file_nor_directory = 2437;
+    constexpr StringId error_incorrect_file_type = 2438;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -319,7 +319,7 @@ namespace OpenLoco::Ui::Windows
             save = 2
         };
         std::optional<std::string> open(browse_type type, std::string_view path, const char* filter, StringId titleId);
-        void onDropFile(Window& window, const char* droppedFileDirectory);
+        void onDropFile(Window& window, const char* droppedFilePath);
     }
 
     namespace PromptOkCancel

--- a/src/OpenLoco/src/Ui/WindowManager.h
+++ b/src/OpenLoco/src/Ui/WindowManager.h
@@ -319,6 +319,7 @@ namespace OpenLoco::Ui::Windows
             save = 2
         };
         std::optional<std::string> open(browse_type type, std::string_view path, const char* filter, StringId titleId);
+        void onDropFile(Window& window, const char* droppedFileDirectory);
     }
 
     namespace PromptOkCancel

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -184,25 +184,25 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         return std::nullopt;
     }
 
-    void onDropFile(Window& window, const char* droppedFileDirectory)
+    void onDropFile(Window& window, const char* droppedFilePath)
     {
-        fs::path droppedPath = droppedFileDirectory;
+        auto path = fs::canonical(droppedFilePath);
 
-        if (fs::is_directory(droppedPath))
+        if (fs::is_directory(path))
         {
-            changeDirectory(droppedPath);
+            changeDirectory(path);
             return;
         }
 
-        if (!fs::is_regular_file(droppedPath))
+        if (!fs::is_regular_file(path))
         {
             Error::open(StringIds::error_not_regular_file_nor_directory);
             return;
         }
 
-        // Check file extention against filter
+        // Check file extension against filter
         {
-            auto extension = droppedPath.extension().u8string();
+            auto extension = path.extension().u8string();
 
             // All our filters are probably *.something so just truncate the *
             // and treat as an extension filter
@@ -219,8 +219,8 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             }
         }
 
-        changeDirectory(droppedPath.parent_path()); // Not necessary but is nice
-        processFileForLoadSave(&window, droppedPath);
+        changeDirectory(path.parent_path()); // Not necessary but is nice
+        processFileForLoadSave(&window, path);
     }
 
     // 0x00447174

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -807,19 +807,10 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             {
                 for (const auto& file : fs::directory_iterator(_currentDirectory, fs::directory_options::skip_permission_denied))
                 {
-                    // Only list directories and normal files
-                    if (!(file.is_regular_file() || file.is_directory()))
+                    // Only list directories and normal files that match the filter of this browse prompt
+                    if (!(file.is_regular_file() && matchesFilter(file.path()) || file.is_directory()))
                     {
                         continue;
-                    }
-
-                    // Filter files by extension
-                    if (file.is_regular_file())
-                    {
-                        if (!matchesFilter(file.path()))
-                        {
-                            continue;
-                        }
                     }
 
                     _files.emplace_back(file.path());

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -88,6 +88,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
 
     static fs::path getDirectory(const fs::path& path);
     static std::string getBasename(const fs::path& path);
+    static bool matchesFilter(fs::path path);
 
     static void drawSavePreview(Ui::Window& window, Gfx::DrawingContext& drawingCtx, int32_t x, int32_t y, int32_t width, int32_t height, const S5::SaveDetails& saveInfo);
     static void drawLandscapePreview(Ui::Window& window, Gfx::DrawingContext& drawingCtx, int32_t x, int32_t y, int32_t width, int32_t height);
@@ -200,23 +201,10 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             return;
         }
 
-        // Check file extension against filter
+        if (!matchesFilter(path))
         {
-            auto extension = path.extension().u8string();
-
-            // All our filters are probably *.something so just truncate the *
-            // and treat as an extension filter
-            auto filterExtension = std::string(_filter);
-            if (filterExtension[0] == '*')
-            {
-                filterExtension = filterExtension.substr(1);
-            }
-
-            if (!Utility::iequals(extension, filterExtension))
-            {
-                Error::open(StringIds::error_incorrect_file_type);
-                return;
-            }
+            Error::open(StringIds::error_incorrect_file_type);
+            return;
         }
 
         changeDirectory(path.parent_path()); // Not necessary but is nice
@@ -788,8 +776,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         return baseName;
     }
 
-    // 0x00446A93
-    static void refreshDirectoryList()
+    static bool matchesFilter(fs::path path)
     {
         // All our filters are probably *.something so just truncate the *
         // and treat as an extension filter
@@ -799,6 +786,14 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             filterExtension = filterExtension.substr(1);
         }
 
+        auto extension = path.extension().u8string();
+
+        return Utility::iequals(extension, filterExtension);
+    }
+
+    // 0x00446A93
+    static void refreshDirectoryList()
+    {
         _files.clear();
         if (_currentDirectory.empty())
         {
@@ -821,8 +816,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                     // Filter files by extension
                     if (file.is_regular_file())
                     {
-                        auto extension = file.path().extension().u8string();
-                        if (!Utility::iequals(extension, filterExtension))
+                        if (!matchesFilter(file.path()))
                         {
                             continue;
                         }

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -184,6 +184,45 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         return std::nullopt;
     }
 
+    void onDropFile(Window& window, const char* droppedFileDirectory)
+    {
+        fs::path droppedPath = droppedFileDirectory;
+
+        if (fs::is_directory(droppedPath))
+        {
+            changeDirectory(droppedPath);
+            return;
+        }
+
+        if (!fs::is_regular_file(droppedPath))
+        {
+            Error::open(StringIds::error_not_regular_file_nor_directory);
+            return;
+        }
+
+        // Check file extention against filter
+        {
+            auto extension = droppedPath.extension().u8string();
+
+            // All our filters are probably *.something so just truncate the *
+            // and treat as an extension filter
+            auto filterExtension = std::string(_filter);
+            if (filterExtension[0] == '*')
+            {
+                filterExtension = filterExtension.substr(1);
+            }
+
+            if (!Utility::iequals(extension, filterExtension))
+            {
+                Error::open(StringIds::error_incorrect_file_type);
+                return;
+            }
+        }
+
+        changeDirectory(droppedPath.parent_path()); // Not necessary but is nice
+        processFileForLoadSave(&window, droppedPath);
+    }
+
     // 0x00447174
     static void freeFileDetails()
     {


### PR DESCRIPTION
Adds the ability to drag and drop files and directories (e.g. from Windows File Explorer) into the game window when the browse prompt is open to load them. This of course applies no matter if you are loading (or saving) a game, a landscape, or a PNG heightmap.

If the file extension does not match the browse prompt's filter, an "error" message will be shown to the player instead.

**Video examples**
Dragging a save file into the Load Game prompt:

https://github.com/user-attachments/assets/ad7fb40f-683b-4061-8f42-54e62e9c6524

Dragging a folder into the Load Game prompt:

https://github.com/user-attachments/assets/f2434266-859c-428b-8baf-0fcd21a265e0

