### PR TITLE
Identify and name road object flags

### DIFF
--- a/src/OpenLoco/src/GameCommands/Road/CreateRoad.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/CreateRoad.cpp
@@ -287,8 +287,8 @@ namespace OpenLoco::GameCommands
         }
 
         const auto& gs = getGameState();
-        if (!(gs.roadObjectIdIsFlag7 & (1U << elRoad.roadObjectId()))
-            || !(gs.roadObjectIdIsFlag7 & (1U << args.roadObjectId)))
+        if (!(gs.roadObjectIdIsUsableByAllCompanies & (1U << elRoad.roadObjectId()))
+            || !(gs.roadObjectIdIsUsableByAllCompanies & (1U << args.roadObjectId)))
         {
             if (!sub_431E6A(elRoad.owner(), reinterpret_cast<const World::TileElement*>(&elRoad)))
             {

--- a/src/OpenLoco/src/GameCommands/Road/CreateRoad.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/CreateRoad.cpp
@@ -849,7 +849,7 @@ namespace OpenLoco::GameCommands
                     newElRoad->setMod(i, true);
                 }
             }
-            if ((getGameState().roadObjectIdIsNotTram & (1U << args.roadObjectId)) && companyId != CompanyId::neutral)
+            if ((getGameState().roadObjectIdIsAnyRoadTypeCompatible & (1U << args.roadObjectId)) && companyId != CompanyId::neutral)
             {
                 newElRoad->setUnk7_40(true);
             }

--- a/src/OpenLoco/src/GameCommands/Road/CreateRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/CreateRoadStation.cpp
@@ -456,7 +456,7 @@ namespace OpenLoco::GameCommands
                         return FAILURE;
                     }
                     if (roadObj2->hasFlags(RoadObjectFlags::unk_03)
-                        || roadObj2->hasFlags(RoadObjectFlags::unk_07)
+                        || roadObj2->hasFlags(RoadObjectFlags::allowUseByAllCompanies)
                         || sub_431E6A(elRoad->owner(), &el))
                     {
                         unk112C7F4 = true;

--- a/src/OpenLoco/src/GameCommands/Road/CreateRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/CreateRoadStation.cpp
@@ -455,7 +455,7 @@ namespace OpenLoco::GameCommands
                         setErrorText(StringIds::station_not_compatible_with_string_id);
                         return FAILURE;
                     }
-                    if (roadObj2->hasFlags(RoadObjectFlags::unk_03)
+                    if (roadObj2->hasFlags(RoadObjectFlags::anyRoadTypeCompatible)
                         || roadObj2->hasFlags(RoadObjectFlags::allowUseByAllCompanies)
                         || sub_431E6A(elRoad->owner(), &el))
                     {

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoad.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoad.cpp
@@ -143,7 +143,7 @@ namespace OpenLoco::GameCommands
         }
 
         // Check mod removal costs
-        if (!roadObj->hasFlags(RoadObjectFlags::unk_03))
+        if (!roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
         {
             for (auto i = 0U; i < 2; i++)
             {

--- a/src/OpenLoco/src/GameCommands/Vehicles/VehiclePlace.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/VehiclePlace.cpp
@@ -96,7 +96,7 @@ namespace OpenLoco::GameCommands
             return false;
         }
 
-        if (!(getGameState().roadObjectIdIsFlag7 & (1 << elRoad->roadObjectId())))
+        if (!(getGameState().roadObjectIdIsUsableByAllCompanies & (1 << elRoad->roadObjectId())))
         {
             if (!sub_431E6A(elRoad->owner(), reinterpret_cast<const World::TileElement*>(elRoad)))
             {

--- a/src/OpenLoco/src/GameCommands/Vehicles/VehiclePlace.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/VehiclePlace.cpp
@@ -63,7 +63,7 @@ namespace OpenLoco::GameCommands
                     {
                         continue;
                     }
-                    if (!(getGameState().roadObjectIdIsNotTram & (1 << elRoad->roadObjectId())))
+                    if (!(getGameState().roadObjectIdIsAnyRoadTypeCompatible & (1 << elRoad->roadObjectId())))
                     {
                         continue;
                     }

--- a/src/OpenLoco/src/GameSaveCompare.cpp
+++ b/src/OpenLoco/src/GameSaveCompare.cpp
@@ -441,7 +441,7 @@ namespace OpenLoco::GameSaveCompare
         foundDivergence |= isLoggedDivergentGameStateField("lastLandOption", 0, gameState1.general.lastLandOption, gameState2.general.lastLandOption);
         foundDivergence |= isLoggedDivergentGameStateField("maxCompetingCompanies", 0, gameState1.general.maxCompetingCompanies, gameState2.general.maxCompetingCompanies);
         foundDivergence |= isLoggedDivergentGameStateField("orderTableLength", 0, gameState1.general.orderTableLength, gameState2.general.orderTableLength);
-        foundDivergence |= isLoggedDivergentGameStateField("roadObjectIdIsNotTram", 0, gameState1.general.roadObjectIdIsNotTram, gameState2.general.roadObjectIdIsNotTram);
+        foundDivergence |= isLoggedDivergentGameStateField("roadObjectIdIsAnyRoadTypeCompatible", 0, gameState1.general.roadObjectIdIsAnyRoadTypeCompatible, gameState2.general.roadObjectIdIsAnyRoadTypeCompatible);
         foundDivergence |= isLoggedDivergentGameStateField("roadObjectIdIsUsableByAllCompanies", 0, gameState1.general.roadObjectIdIsUsableByAllCompanies, gameState2.general.roadObjectIdIsUsableByAllCompanies);
         foundDivergence |= isLoggedDivergentGameStateField("currentDefaultLevelCrossingType", 0, gameState1.general.currentDefaultLevelCrossingType, gameState2.general.currentDefaultLevelCrossingType);
         foundDivergence |= isLoggedDivergentGameStateField("lastTrackTypeOption", 0, gameState1.general.lastTrackTypeOption, gameState2.general.lastTrackTypeOption);

--- a/src/OpenLoco/src/GameSaveCompare.cpp
+++ b/src/OpenLoco/src/GameSaveCompare.cpp
@@ -442,7 +442,7 @@ namespace OpenLoco::GameSaveCompare
         foundDivergence |= isLoggedDivergentGameStateField("maxCompetingCompanies", 0, gameState1.general.maxCompetingCompanies, gameState2.general.maxCompetingCompanies);
         foundDivergence |= isLoggedDivergentGameStateField("orderTableLength", 0, gameState1.general.orderTableLength, gameState2.general.orderTableLength);
         foundDivergence |= isLoggedDivergentGameStateField("roadObjectIdIsNotTram", 0, gameState1.general.roadObjectIdIsNotTram, gameState2.general.roadObjectIdIsNotTram);
-        foundDivergence |= isLoggedDivergentGameStateField("roadObjectIdIsFlag7", 0, gameState1.general.roadObjectIdIsFlag7, gameState2.general.roadObjectIdIsFlag7);
+        foundDivergence |= isLoggedDivergentGameStateField("roadObjectIdIsUsableByAllCompanies", 0, gameState1.general.roadObjectIdIsUsableByAllCompanies, gameState2.general.roadObjectIdIsUsableByAllCompanies);
         foundDivergence |= isLoggedDivergentGameStateField("currentDefaultLevelCrossingType", 0, gameState1.general.currentDefaultLevelCrossingType, gameState2.general.currentDefaultLevelCrossingType);
         foundDivergence |= isLoggedDivergentGameStateField("lastTrackTypeOption", 0, gameState1.general.lastTrackTypeOption, gameState2.general.lastTrackTypeOption);
         foundDivergence |= isLoggedDivergentGameStateField("loanInterestRate", 0, gameState1.general.loanInterestRate, gameState2.general.loanInterestRate);

--- a/src/OpenLoco/src/GameState.h
+++ b/src/OpenLoco/src/GameState.h
@@ -62,7 +62,7 @@ namespace OpenLoco
         uint8_t lastLandOption;                                                  // 0x00019E (0x00525FB6)
         uint8_t maxCompetingCompanies;                                           // 0x00019F (0x00525FB7)
         uint32_t orderTableLength;                                               // 0x0001A0 (0x00525FB8)
-        uint32_t roadObjectIdIsNotTram;                                          // 0x0001A4 (0x00525FBC)
+        uint32_t roadObjectIdIsAnyRoadTypeCompatible;                            // 0x0001A4 (0x00525FBC)
         uint32_t roadObjectIdIsUsableByAllCompanies;                             // 0x0001A8 (0x00525FC0)
         uint8_t currentDefaultLevelCrossingType;                                 // 0x0001AC (0x00525FC4)
         uint8_t lastTrackTypeOption;                                             // 0x0001AD (0x00525FC5)

--- a/src/OpenLoco/src/GameState.h
+++ b/src/OpenLoco/src/GameState.h
@@ -63,7 +63,7 @@ namespace OpenLoco
         uint8_t maxCompetingCompanies;                                           // 0x00019F (0x00525FB7)
         uint32_t orderTableLength;                                               // 0x0001A0 (0x00525FB8)
         uint32_t roadObjectIdIsNotTram;                                          // 0x0001A4 (0x00525FBC)
-        uint32_t roadObjectIdIsFlag7;                                            // 0x0001A8 (0x00525FC0)
+        uint32_t roadObjectIdIsUsableByAllCompanies;                             // 0x0001A8 (0x00525FC0)
         uint8_t currentDefaultLevelCrossingType;                                 // 0x0001AC (0x00525FC4)
         uint8_t lastTrackTypeOption;                                             // 0x0001AD (0x00525FC5)
         uint8_t loanInterestRate;                                                // 0x0001AE (0x00525FC6)

--- a/src/OpenLoco/src/Map/RoadElement.cpp
+++ b/src/OpenLoco/src/Map/RoadElement.cpp
@@ -34,7 +34,7 @@ namespace OpenLoco::World
             return true;
         }
 
-        if (!(getGameState().roadObjectIdIsNotTram & (1 << roadObjectId())))
+        if (!(getGameState().roadObjectIdIsAnyRoadTypeCompatible & (1 << roadObjectId())))
         {
             return true;
         }
@@ -80,7 +80,7 @@ namespace OpenLoco::World
                 continue;
             }
 
-            if (!(getGameState().roadObjectIdIsNotTram & (1 << roadEl->roadObjectId())))
+            if (!(getGameState().roadObjectIdIsAnyRoadTypeCompatible & (1 << roadEl->roadObjectId())))
             {
                 continue;
             }

--- a/src/OpenLoco/src/Map/TileManager.cpp
+++ b/src/OpenLoco/src/Map/TileManager.cpp
@@ -1584,7 +1584,7 @@ namespace OpenLoco::World::TileManager
     // 0x0047AB9B
     void updateYearly()
     {
-        const auto isObjectNotTram = getGameState().roadObjectIdIsNotTram;
+        const auto isObjectAnyRoadTypeCompatible = getGameState().roadObjectIdIsAnyRoadTypeCompatible;
         for (const auto& tilePos : getWorldRange())
         {
             auto tile = get(tilePos);
@@ -1601,7 +1601,7 @@ namespace OpenLoco::World::TileManager
                 }
                 // This is a much cheaper tram checker
                 // compared to getting the object
-                if (isObjectNotTram & (1U << elRoad->roadObjectId()))
+                if (isObjectAnyRoadTypeCompatible & (1U << elRoad->roadObjectId()))
                 {
                     elRoad->setUnk7_80(elRoad->hasUnk7_40());
                     elRoad->setUnk7_40(false);

--- a/src/OpenLoco/src/Map/Track/Track.cpp
+++ b/src/OpenLoco/src/Map/Track/Track.cpp
@@ -51,7 +51,7 @@ namespace OpenLoco::World::Track
                 {
                     continue;
                 }
-                if (!(getGameState().roadObjectIdIsNotTram & (1 << elRoad->roadObjectId())))
+                if (!(getGameState().roadObjectIdIsAnyRoadTypeCompatible & (1 << elRoad->roadObjectId())))
                 {
                     continue;
                 }

--- a/src/OpenLoco/src/Map/Track/Track.cpp
+++ b/src/OpenLoco/src/Map/Track/Track.cpp
@@ -37,7 +37,7 @@ namespace OpenLoco::World::Track
                 continue;
             }
 
-            if (!(getGameState().roadObjectIdIsFlag7 & (1 << elRoad->roadObjectId())))
+            if (!(getGameState().roadObjectIdIsUsableByAllCompanies & (1 << elRoad->roadObjectId())))
             {
                 if (elRoad->owner() != company)
                 {

--- a/src/OpenLoco/src/Objects/ObjectIndex.cpp
+++ b/src/OpenLoco/src/Objects/ObjectIndex.cpp
@@ -970,7 +970,7 @@ namespace OpenLoco::ObjectManager
                     }
 
                     auto* roadObj = get<RoadObject>(elRoad->roadObjectId());
-                    if (!roadObj->hasFlags(RoadObjectFlags::unk_03))
+                    if (!roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
                     {
                         for (auto i = 0U; i < 2; ++i)
                         {
@@ -1261,7 +1261,7 @@ namespace OpenLoco::ObjectManager
                         return false;
                     }
                     auto* roadObj = reinterpret_cast<RoadObject*>(getTemporaryObject());
-                    if (!roadObj->hasFlags(RoadObjectFlags::unk_03))
+                    if (!roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
                     {
                         freeTemporaryObject();
                         return false;

--- a/src/OpenLoco/src/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/src/Objects/ObjectManager.cpp
@@ -960,7 +960,7 @@ namespace OpenLoco::ObjectManager
     void updateRoadObjectIdFlags()
     {
         uint32_t roadObjectIdIsNotTram = 0;
-        uint32_t roadObjectIdIsFlag7 = 0;
+        uint32_t roadObjectIdIsUsableByAllCompanies = 0;
 
         for (size_t index = 0; index < ObjectManager::getMaxObjects(ObjectType::road); ++index)
         {
@@ -971,14 +971,14 @@ namespace OpenLoco::ObjectManager
                 {
                     roadObjectIdIsNotTram |= (1u << index);
                 }
-                if (roadObject->hasFlags(RoadObjectFlags::unk_07))
+                if (roadObject->hasFlags(RoadObjectFlags::allowUseByAllCompanies))
                 {
-                    roadObjectIdIsFlag7 |= (1u << index);
+                    roadObjectIdIsUsableByAllCompanies |= (1u << index);
                 }
             }
         }
         getGameState().roadObjectIdIsNotTram = roadObjectIdIsNotTram;
-        getGameState().roadObjectIdIsFlag7 = roadObjectIdIsFlag7;
+        getGameState().roadObjectIdIsUsableByAllCompanies = roadObjectIdIsUsableByAllCompanies;
     }
 
     // 0x004796A9

--- a/src/OpenLoco/src/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/src/Objects/ObjectManager.cpp
@@ -959,7 +959,7 @@ namespace OpenLoco::ObjectManager
     // 0x0047966E
     void updateRoadObjectIdFlags()
     {
-        uint32_t roadObjectIdIsNotTram = 0;
+        uint32_t roadObjectIdIsAnyRoadTypeCompatible = 0;
         uint32_t roadObjectIdIsUsableByAllCompanies = 0;
 
         for (size_t index = 0; index < ObjectManager::getMaxObjects(ObjectType::road); ++index)
@@ -969,7 +969,7 @@ namespace OpenLoco::ObjectManager
             {
                 if (roadObject->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
                 {
-                    roadObjectIdIsNotTram |= (1u << index);
+                    roadObjectIdIsAnyRoadTypeCompatible |= (1u << index);
                 }
                 if (roadObject->hasFlags(RoadObjectFlags::allowUseByAllCompanies))
                 {
@@ -977,7 +977,7 @@ namespace OpenLoco::ObjectManager
                 }
             }
         }
-        getGameState().roadObjectIdIsNotTram = roadObjectIdIsNotTram;
+        getGameState().roadObjectIdIsAnyRoadTypeCompatible = roadObjectIdIsAnyRoadTypeCompatible;
         getGameState().roadObjectIdIsUsableByAllCompanies = roadObjectIdIsUsableByAllCompanies;
     }
 

--- a/src/OpenLoco/src/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/src/Objects/ObjectManager.cpp
@@ -967,7 +967,7 @@ namespace OpenLoco::ObjectManager
             auto roadObject = ObjectManager::get<RoadObject>(index);
             if (roadObject != nullptr)
             {
-                if (roadObject->hasFlags(RoadObjectFlags::unk_03))
+                if (roadObject->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
                 {
                     roadObjectIdIsNotTram |= (1u << index);
                 }
@@ -1176,7 +1176,7 @@ namespace OpenLoco::ObjectManager
             auto roadObject = ObjectManager::get<RoadObject>(index);
             if (roadObject != nullptr)
             {
-                if (roadObject->hasFlags(RoadObjectFlags::unk_03) && !roadObject->hasFlags(RoadObjectFlags::isOneWay))
+                if (roadObject->hasFlags(RoadObjectFlags::anyRoadTypeCompatible) && !roadObject->hasFlags(RoadObjectFlags::isOneWay))
                 {
                     if (largestTownSize <= roadObject->targetTownSize)
                     {

--- a/src/OpenLoco/src/Objects/RoadObject.cpp
+++ b/src/OpenLoco/src/Objects/RoadObject.cpp
@@ -52,7 +52,7 @@ namespace OpenLoco
         {
             return false;
         }
-        if (hasFlags(RoadObjectFlags::unk_03))
+        if (hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
         {
             return numMods == 0;
         }

--- a/src/OpenLoco/src/Objects/RoadObject.h
+++ b/src/OpenLoco/src/Objects/RoadObject.h
@@ -27,7 +27,7 @@ namespace OpenLoco
         isOneWay = 1U << 0,
         isRailTransport = 1U << 1, // controls if the object appears in the tracks menu instead of the road menu
         unk_02 = 1U << 2,
-        unk_03 = 1U << 3, // Likely isTram
+        anyRoadTypeCompatible = 1U << 3,   // when used can't have mods
         noSlipSurface = 1U << 4, // if set vehicles can't start slipping
         unk_05 = 1U << 5,
         isRoad = 1U << 6, // If not set this is tram track

--- a/src/OpenLoco/src/Objects/RoadObject.h
+++ b/src/OpenLoco/src/Objects/RoadObject.h
@@ -27,12 +27,12 @@ namespace OpenLoco
         isOneWay = 1U << 0,
         isRailTransport = 1U << 1, // controls if the object appears in the tracks menu instead of the road menu
         unk_02 = 1U << 2,
-        anyRoadTypeCompatible = 1U << 3,   // when used can't have mods
-        noSlipSurface = 1U << 4, // if set vehicles can't start slipping
+        anyRoadTypeCompatible = 1U << 3, // when used can't have mods
+        noSlipSurface = 1U << 4,         // if set vehicles can't start slipping
         unk_05 = 1U << 5,
-        isRoad = 1U << 6, // If not set this is tram track
+        isRoad = 1U << 6,                 // If not set this is tram track
         allowUseByAllCompanies = 1U << 7, // allow use by companies other than the owner
-        canHaveStreetLights = 1U << 8, // allow streets to have street lights added by towns
+        canHaveStreetLights = 1U << 8,    // allow streets to have street lights added by towns
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(RoadObjectFlags);
 

--- a/src/OpenLoco/src/Objects/RoadObject.h
+++ b/src/OpenLoco/src/Objects/RoadObject.h
@@ -31,7 +31,7 @@ namespace OpenLoco
         unk_04 = 1U << 4,
         unk_05 = 1U << 5,
         isRoad = 1U << 6, // If not set this is tram track
-        unk_07 = 1U << 7,
+        allowUseByAllCompanies = 1U << 7, // allow use by companies other than the owner
         canHaveStreetLights = 1U << 8, // allow streets to have street lights added by towns
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(RoadObjectFlags);

--- a/src/OpenLoco/src/Objects/RoadObject.h
+++ b/src/OpenLoco/src/Objects/RoadObject.h
@@ -28,7 +28,7 @@ namespace OpenLoco
         isRailTransport = 1U << 1, // controls if the object appears in the tracks menu instead of the road menu
         unk_02 = 1U << 2,
         unk_03 = 1U << 3, // Likely isTram
-        unk_04 = 1U << 4,
+        noSlipSurface = 1U << 4, // if set vehicles can't start slipping
         unk_05 = 1U << 5,
         isRoad = 1U << 6, // If not set this is tram track
         allowUseByAllCompanies = 1U << 7, // allow use by companies other than the owner

--- a/src/OpenLoco/src/Objects/RoadObject.h
+++ b/src/OpenLoco/src/Objects/RoadObject.h
@@ -32,7 +32,7 @@ namespace OpenLoco
         unk_05 = 1U << 5,
         isRoad = 1U << 6, // If not set this is tram track
         unk_07 = 1U << 7,
-        unk_08 = 1U << 8,
+        canHaveStreetLights = 1U << 8, // allow streets to have street lights added by towns
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(RoadObjectFlags);
 

--- a/src/OpenLoco/src/Objects/RoadObject.h
+++ b/src/OpenLoco/src/Objects/RoadObject.h
@@ -25,7 +25,7 @@ namespace OpenLoco
     {
         none = 0U,
         isOneWay = 1U << 0,
-        unk_01 = 1U << 1,
+        isRailTransport = 1U << 1, // controls if the object appears in the tracks menu instead of the road menu
         unk_02 = 1U << 2,
         unk_03 = 1U << 3, // Likely isTram
         unk_04 = 1U << 4,

--- a/src/OpenLoco/src/Objects/RoadObject.h
+++ b/src/OpenLoco/src/Objects/RoadObject.h
@@ -25,7 +25,7 @@ namespace OpenLoco
     {
         none = 0U,
         isOneWay = 1U << 0,
-        isRailTransport = 1U << 1, // controls if the object appears in the tracks menu instead of the road menu
+        isRail = 1U << 1, // controls if the object appears in the tracks menu instead of the road menu
         unk_02 = 1U << 2,
         anyRoadTypeCompatible = 1U << 3, // when used can't have mods
         noSlipSurface = 1U << 4,         // if set vehicles can't start slipping

--- a/src/OpenLoco/src/Paint/PaintRoad.cpp
+++ b/src/OpenLoco/src/Paint/PaintRoad.cpp
@@ -551,7 +551,7 @@ namespace OpenLoco::Paint
             paintLevelCrossing(session, baseRoadImageColour, elRoad, rotation);
         }
 
-        if (session.getRenderTarget()->zoomLevel > 0 || roadObj->hasFlags(RoadObjectFlags::unk_03))
+        if (session.getRenderTarget()->zoomLevel > 0 || roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
         {
             return;
         }

--- a/src/OpenLoco/src/S5/S5GameState.cpp
+++ b/src/OpenLoco/src/S5/S5GameState.cpp
@@ -66,7 +66,7 @@ namespace OpenLoco::S5
         dst.lastLandOption = src.lastLandOption;
         dst.maxCompetingCompanies = src.maxCompetingCompanies;
         dst.orderTableLength = src.orderTableLength;
-        dst.roadObjectIdIsNotTram = src.roadObjectIdIsNotTram;
+        dst.roadObjectIdIsAnyRoadTypeCompatible = src.roadObjectIdIsAnyRoadTypeCompatible;
         dst.roadObjectIdIsUsableByAllCompanies = src.roadObjectIdIsUsableByAllCompanies;
         dst.currentDefaultLevelCrossingType = src.currentDefaultLevelCrossingType;
         dst.lastTrackTypeOption = src.lastTrackTypeOption;
@@ -270,7 +270,7 @@ namespace OpenLoco::S5
         dst.lastLandOption = src.lastLandOption;
         dst.maxCompetingCompanies = src.maxCompetingCompanies;
         dst.orderTableLength = src.orderTableLength;
-        dst.roadObjectIdIsNotTram = src.roadObjectIdIsNotTram;
+        dst.roadObjectIdIsAnyRoadTypeCompatible = src.roadObjectIdIsAnyRoadTypeCompatible;
         dst.roadObjectIdIsUsableByAllCompanies = src.roadObjectIdIsUsableByAllCompanies;
         dst.currentDefaultLevelCrossingType = src.currentDefaultLevelCrossingType;
         dst.lastTrackTypeOption = src.lastTrackTypeOption;

--- a/src/OpenLoco/src/S5/S5GameState.cpp
+++ b/src/OpenLoco/src/S5/S5GameState.cpp
@@ -67,7 +67,7 @@ namespace OpenLoco::S5
         dst.maxCompetingCompanies = src.maxCompetingCompanies;
         dst.orderTableLength = src.orderTableLength;
         dst.roadObjectIdIsNotTram = src.roadObjectIdIsNotTram;
-        dst.roadObjectIdIsFlag7 = src.roadObjectIdIsFlag7;
+        dst.roadObjectIdIsUsableByAllCompanies = src.roadObjectIdIsUsableByAllCompanies;
         dst.currentDefaultLevelCrossingType = src.currentDefaultLevelCrossingType;
         dst.lastTrackTypeOption = src.lastTrackTypeOption;
         dst.loanInterestRate = src.loanInterestRate;
@@ -271,7 +271,7 @@ namespace OpenLoco::S5
         dst.maxCompetingCompanies = src.maxCompetingCompanies;
         dst.orderTableLength = src.orderTableLength;
         dst.roadObjectIdIsNotTram = src.roadObjectIdIsNotTram;
-        dst.roadObjectIdIsFlag7 = src.roadObjectIdIsFlag7;
+        dst.roadObjectIdIsUsableByAllCompanies = src.roadObjectIdIsUsableByAllCompanies;
         dst.currentDefaultLevelCrossingType = src.currentDefaultLevelCrossingType;
         dst.lastTrackTypeOption = src.lastTrackTypeOption;
         dst.loanInterestRate = src.loanInterestRate;

--- a/src/OpenLoco/src/S5/S5GameState.h
+++ b/src/OpenLoco/src/S5/S5GameState.h
@@ -76,7 +76,7 @@ namespace OpenLoco::S5
         uint8_t lastLandOption;                             // 0x00019E (0x00525FB6)
         uint8_t maxCompetingCompanies;                      // 0x00019F (0x00525FB7)
         uint32_t orderTableLength;                          // 0x0001A0 (0x00525FB8)
-        uint32_t roadObjectIdIsNotTram;                     // 0x0001A4 (0x00525FBC)
+        uint32_t roadObjectIdIsAnyRoadTypeCompatible;       // 0x0001A4 (0x00525FBC)
         uint32_t roadObjectIdIsUsableByAllCompanies;        // 0x0001A8 (0x00525FC0)
         uint8_t currentDefaultLevelCrossingType;            // 0x0001AC (0x00525FC4)
         uint8_t lastTrackTypeOption;                        // 0x0001AD (0x00525FC5)

--- a/src/OpenLoco/src/S5/S5GameState.h
+++ b/src/OpenLoco/src/S5/S5GameState.h
@@ -77,7 +77,7 @@ namespace OpenLoco::S5
         uint8_t maxCompetingCompanies;                      // 0x00019F (0x00525FB7)
         uint32_t orderTableLength;                          // 0x0001A0 (0x00525FB8)
         uint32_t roadObjectIdIsNotTram;                     // 0x0001A4 (0x00525FBC)
-        uint32_t roadObjectIdIsFlag7;                       // 0x0001A8 (0x00525FC0)
+        uint32_t roadObjectIdIsUsableByAllCompanies;        // 0x0001A8 (0x00525FC0)
         uint8_t currentDefaultLevelCrossingType;            // 0x0001AC (0x00525FC4)
         uint8_t lastTrackTypeOption;                        // 0x0001AD (0x00525FC5)
         uint8_t loanInterestRate;                           // 0x0001AE (0x00525FC6)

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -1354,7 +1354,7 @@ namespace OpenLoco::Ui::ViewportInteraction
                     auto owner = road->owner();
 
                     auto roadObject = ObjectManager::get<RoadObject>(road->roadObjectId());
-                    if (owner == CompanyManager::getControllingId() || owner == CompanyId::neutral || roadObject->hasFlags(RoadObjectFlags::unk_03))
+                    if (owner == CompanyManager::getControllingId() || owner == CompanyId::neutral || roadObject->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
                     {
                         Ui::Windows::Construction::openAtRoad(*window, road, interaction.pos);
                     }

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -493,7 +493,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         {
             auto trackIdx = trackType & ~(1 << 7);
             auto roadObj = ObjectManager::get<RoadObject>(trackIdx);
-            if (roadObj->hasFlags(RoadObjectFlags::unk_03))
+            if (roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
             {
                 trackType = 0xFE;
             }

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -1708,7 +1708,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         if (isRoad)
         {
             auto road_obj = ObjectManager::get<RoadObject>(trackType);
-            if (road_obj && road_obj->hasFlags(RoadObjectFlags::isRailTransport))
+            if (road_obj && road_obj->hasFlags(RoadObjectFlags::isRail))
             {
                 setRail = true;
             }

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -1708,7 +1708,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         if (isRoad)
         {
             auto road_obj = ObjectManager::get<RoadObject>(trackType);
-            if (road_obj && road_obj->hasFlags(RoadObjectFlags::unk_01))
+            if (road_obj && road_obj->hasFlags(RoadObjectFlags::isRailTransport))
             {
                 setRail = true;
             }

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -1262,7 +1262,7 @@ namespace OpenLoco::Ui::Windows::Construction
             {
                 newTrackType &= ~(1 << 7);
                 auto roadObj = ObjectManager::get<RoadObject>(newTrackType);
-                if (!roadObj->hasFlags(RoadObjectFlags::unk_01))
+                if (!roadObj->hasFlags(RoadObjectFlags::isRailTransport))
                 {
                     getGameState().lastRoadOption = trackType;
                 }

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -431,7 +431,7 @@ namespace OpenLoco::Ui::Windows::Construction
 
         cState.lastSelectedMods = 0;
         auto* roadObj = ObjectManager::get<RoadObject>(cState.trackType & ~(1ULL << 7));
-        if (!roadObj->hasFlags(RoadObjectFlags::unk_03))
+        if (!roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
         {
             cState.lastSelectedMods = copyElement->mods();
         }
@@ -468,14 +468,14 @@ namespace OpenLoco::Ui::Windows::Construction
                 auto trackType = flags & ~(1 << 7);
                 auto roadObj = ObjectManager::get<RoadObject>(trackType);
 
-                if (roadObj->hasFlags(RoadObjectFlags::unk_03))
+                if (roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
                 {
                     if (cState.trackType & (1 << 7))
                     {
                         trackType = cState.trackType & ~(1 << 7);
                         roadObj = ObjectManager::get<RoadObject>(trackType);
 
-                        if (roadObj->hasFlags(RoadObjectFlags::unk_03))
+                        if (roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
                         {
                             cState.trackType = static_cast<uint8_t>(flags);
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -1262,7 +1262,7 @@ namespace OpenLoco::Ui::Windows::Construction
             {
                 newTrackType &= ~(1 << 7);
                 auto roadObj = ObjectManager::get<RoadObject>(newTrackType);
-                if (!roadObj->hasFlags(RoadObjectFlags::isRailTransport))
+                if (!roadObj->hasFlags(RoadObjectFlags::isRail))
                 {
                     getGameState().lastRoadOption = trackType;
                 }

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -171,12 +171,12 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         }
 
         auto* alternativeRoadObj = ObjectManager::get<RoadObject>(alternateRoadObjId);
-        if (!alternativeRoadObj->hasFlags(RoadObjectFlags::unk_03))
+        if (!alternativeRoadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
         {
             return;
         }
         auto* curRoadObj = ObjectManager::get<RoadObject>(cState.trackType & ~(1 << 7));
-        if (!curRoadObj->hasFlags(RoadObjectFlags::unk_03))
+        if (!curRoadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
         {
             return;
         }

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -377,7 +377,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                             }
 
                             auto* roadObj = ObjectManager::get<RoadObject>(roadEl->roadObjectId());
-                            if (roadObj->hasFlags(RoadObjectFlags::isRailTransport))
+                            if (roadObj->hasFlags(RoadObjectFlags::isRail))
                             {
                                 colour0 = colourFlash0 = PaletteIndex::black7;
                                 if (_flashingItems & (1 << 3))

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -377,7 +377,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
                             }
 
                             auto* roadObj = ObjectManager::get<RoadObject>(roadEl->roadObjectId());
-                            if (roadObj->hasFlags(RoadObjectFlags::unk_01))
+                            if (roadObj->hasFlags(RoadObjectFlags::isRailTransport))
                             {
                                 colour0 = colourFlash0 = PaletteIndex::black7;
                                 if (_flashingItems & (1 << 3))

--- a/src/OpenLoco/src/Vehicles/Vehicle.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle.cpp
@@ -623,7 +623,7 @@ namespace OpenLoco::Vehicles
 
             if (getTrackType() == 0xFF)
             {
-                if (getGameState().roadObjectIdIsNotTram & (1 << elRoad->roadObjectId()))
+                if (getGameState().roadObjectIdIsAnyRoadTypeCompatible & (1 << elRoad->roadObjectId()))
                 {
                     elRoad->setUnk7_40(true);
                     roadType = elRoad->roadObjectId();

--- a/src/OpenLoco/src/Vehicles/Vehicle2.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle2.cpp
@@ -101,7 +101,7 @@ namespace OpenLoco::Vehicles
                 return false;
             }
             const auto* roadObj = ObjectManager::get<RoadObject>(frontBogie.trackType);
-            if (roadObj->hasFlags(RoadObjectFlags::unk_04))
+            if (roadObj->hasFlags(RoadObjectFlags::noSlipSurface))
             {
                 return false;
             }

--- a/src/OpenLoco/src/World/Company.cpp
+++ b/src/OpenLoco/src/World/Company.cpp
@@ -399,7 +399,7 @@ namespace OpenLoco
 
         std::copy_if(std::begin(roads), std::end(roads), std::back_inserter(result), [](uint8_t trackIdx) {
             const auto* trackObj = ObjectManager::get<RoadObject>(trackIdx & ~(1 << 7));
-            return trackObj->hasFlags(RoadObjectFlags::isRailTransport);
+            return trackObj->hasFlags(RoadObjectFlags::isRail);
         });
 
         return result;
@@ -445,7 +445,7 @@ namespace OpenLoco
 
         std::copy_if(std::begin(roads), std::end(roads), std::back_inserter(result), [](uint8_t roadId) {
             const auto* roadObj = ObjectManager::get<RoadObject>(roadId & ~(1U << 7));
-            return !roadObj->hasFlags(RoadObjectFlags::isRailTransport);
+            return !roadObj->hasFlags(RoadObjectFlags::isRail);
         });
 
         sfl::static_unordered_set<uint8_t, Limits::kMaxTrackObjects> tracks;

--- a/src/OpenLoco/src/World/Company.cpp
+++ b/src/OpenLoco/src/World/Company.cpp
@@ -399,7 +399,7 @@ namespace OpenLoco
 
         std::copy_if(std::begin(roads), std::end(roads), std::back_inserter(result), [](uint8_t trackIdx) {
             const auto* trackObj = ObjectManager::get<RoadObject>(trackIdx & ~(1 << 7));
-            return trackObj->hasFlags(RoadObjectFlags::unk_01);
+            return trackObj->hasFlags(RoadObjectFlags::isRailTransport);
         });
 
         return result;

--- a/src/OpenLoco/src/World/Company.cpp
+++ b/src/OpenLoco/src/World/Company.cpp
@@ -391,7 +391,7 @@ namespace OpenLoco
                 continue;
             }
 
-            if (roadObj->hasFlags(RoadObjectFlags::unk_03))
+            if (roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
             {
                 roads.insert(i | (1 << 7));
             }
@@ -437,7 +437,7 @@ namespace OpenLoco
                 continue;
             }
 
-            if (roadObj->hasFlags(RoadObjectFlags::unk_03))
+            if (roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
             {
                 roads.insert(i | (1U << 7));
             }
@@ -445,7 +445,7 @@ namespace OpenLoco
 
         std::copy_if(std::begin(roads), std::end(roads), std::back_inserter(result), [](uint8_t roadId) {
             const auto* roadObj = ObjectManager::get<RoadObject>(roadId & ~(1U << 7));
-            return !roadObj->hasFlags(RoadObjectFlags::unk_01);
+            return !roadObj->hasFlags(RoadObjectFlags::isRailTransport);
         });
 
         sfl::static_unordered_set<uint8_t, Limits::kMaxTrackObjects> tracks;

--- a/src/OpenLoco/src/World/CompanyAi/CompanyAi.cpp
+++ b/src/OpenLoco/src/World/CompanyAi/CompanyAi.cpp
@@ -1606,18 +1606,18 @@ namespace OpenLoco
                         auto* elRoad = el.as<World::RoadElement>();
                         if (elRoad != nullptr)
                         {
-                            const bool targetIsNotTram = getGameState().roadObjectIdIsNotTram & (1U << (thought.trackObjId & ~(1U << 7)));
-                            const bool elIsNotTram = getGameState().roadObjectIdIsNotTram & (1U << elRoad->roadObjectId());
-                            if (targetIsNotTram)
+                            const bool targetIsAnyRoadTypeCompatible = getGameState().roadObjectIdIsAnyRoadTypeCompatible & (1U << (thought.trackObjId & ~(1U << 7)));
+                            const bool elIsAnyRoadTypeCompatible = getGameState().roadObjectIdIsAnyRoadTypeCompatible & (1U << elRoad->roadObjectId());
+                            if (targetIsAnyRoadTypeCompatible)
                             {
-                                if (!elIsNotTram)
+                                if (!elIsAnyRoadTypeCompatible)
                                 {
                                     continue;
                                 }
                             }
                             else
                             {
-                                if (elIsNotTram)
+                                if (elIsAnyRoadTypeCompatible)
                                 {
                                     continue;
                                 }

--- a/src/OpenLoco/src/World/CompanyAi/CompanyAi.cpp
+++ b/src/OpenLoco/src/World/CompanyAi/CompanyAi.cpp
@@ -757,7 +757,7 @@ namespace OpenLoco
             trackType &= ~(1U << 7);
             mode = TransportMode::road;
             auto* roadObj = ObjectManager::get<RoadObject>(trackType);
-            if (roadObj->hasFlags(RoadObjectFlags::unk_03))
+            if (roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
             {
                 trackType = 0xFFU;
             }
@@ -1628,7 +1628,7 @@ namespace OpenLoco
                             }
                             existingMods = 0U;
                             auto* roadObj = ObjectManager::get<RoadObject>(elRoad->roadObjectId());
-                            if (!roadObj->hasFlags(RoadObjectFlags::unk_03))
+                            if (!roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
                             {
                                 for (auto i = 0U; i < 2; ++i)
                                 {
@@ -3541,7 +3541,7 @@ namespace OpenLoco
 
             auto* roadObj = ObjectManager::get<RoadObject>(roadObjId & ~(1U << 7));
             using enum RoadObjectFlags;
-            if ((roadObj->flags & (unk_07 | isRoad | unk_03 | unk_02)) != (unk_07 | isRoad | unk_03 | unk_02))
+            if ((roadObj->flags & (allowUseByAllCompanies | isRoad | anyRoadTypeCompatible | unk_02)) != (allowUseByAllCompanies | isRoad | anyRoadTypeCompatible | unk_02))
             {
                 continue;
             }
@@ -3583,7 +3583,7 @@ namespace OpenLoco
 
             auto* roadObj = ObjectManager::get<RoadObject>(roadObjId & ~(1U << 7));
             using enum RoadObjectFlags;
-            if (roadObj->hasFlags(unk_07 | isRoad | unk_03 | isOneWay))
+            if (roadObj->hasFlags(allowUseByAllCompanies | isRoad | anyRoadTypeCompatible | isOneWay))
             {
                 continue;
             }
@@ -4660,7 +4660,7 @@ namespace OpenLoco
         }
 
         bool isTram = false;
-        if (!roadObj->hasFlags(RoadObjectFlags::unk_03))
+        if (!roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
         {
             isTram = true;
             if (thoughtTypeHasFlags(thought.type, ThoughtTypeFlags::unk6))
@@ -5756,11 +5756,11 @@ namespace OpenLoco
                 if (elRoad->roadObjectId() != roadObjectId)
                 {
                     auto* existingRoadObj = ObjectManager::get<RoadObject>(elRoad->roadObjectId());
-                    if (!existingRoadObj->hasFlags(RoadObjectFlags::unk_03))
+                    if (!existingRoadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
                     {
                         continue;
                     }
-                    if (!newRoadObj->hasFlags(RoadObjectFlags::unk_03))
+                    if (!newRoadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
                     {
                         continue;
                     }
@@ -5818,7 +5818,7 @@ namespace OpenLoco
         const auto existingRoadObjId = elRoad->roadObjectId();
         auto* existingRoadObj = ObjectManager::get<RoadObject>(existingRoadObjId);
         uint8_t mods = 0;
-        if (!existingRoadObj->hasFlags(RoadObjectFlags::unk_03))
+        if (!existingRoadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
         {
             mods = elRoad->mods();
         }
@@ -6172,7 +6172,7 @@ namespace OpenLoco
                 const auto requiredMods = 0U;
                 const auto roadObjId = thought.trackObjId & ~(1U << 7);
                 auto* roadObj = ObjectManager::get<RoadObject>(roadObjId);
-                auto compatRoadObjId = roadObj->hasFlags(RoadObjectFlags::unk_03) ? 0xFFU : roadObjId;
+                auto compatRoadObjId = roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible) ? 0xFFU : roadObjId;
 
                 auto [nextPos, nextRotation] = Track::getRoadConnectionEnd(pos, tad);
                 auto rc = Track::getRoadConnectionsAiAllocated(nextPos, nextRotation, company.id(), compatRoadObjId, requiredMods, queryMods);
@@ -6448,7 +6448,7 @@ namespace OpenLoco
     {
         using enum TrackRoadRemoveQueryFlags;
         auto* roadObj = ObjectManager::get<RoadObject>(roadObjId);
-        if (roadObj->hasFlags(RoadObjectFlags::unk_03))
+        if (roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
         {
             return roadTypeShouldNotBeRemoved;
         }
@@ -6638,7 +6638,7 @@ namespace OpenLoco
         }
 
         auto* roadObj = ObjectManager::get<RoadObject>(roadObjId);
-        if (!roadObj->hasFlags(RoadObjectFlags::unk_03))
+        if (!roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
         {
             using enum TrackRoadRemoveQueryFlags;
             if ((queryRoadForRemoval(pos, (0 << 3) | rotation, roadObjId, companyId) & (malformed | roadTypeShouldNotBeRemoved)) == none)

--- a/src/OpenLoco/src/World/CompanyAi/CompanyAiPathfinding.cpp
+++ b/src/OpenLoco/src/World/CompanyAi/CompanyAiPathfinding.cpp
@@ -145,7 +145,7 @@ namespace OpenLoco::CompanyAi
 
             auto* roadObj = ObjectManager::get<RoadObject>(thought.trackObjId & ~(1U << 7));
             _createTrackRoadCommandAiUnkFlags |= (1U << 21);
-            if (roadObj->hasFlags(RoadObjectFlags::unk_03))
+            if (roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
             {
                 _createTrackRoadCommandAiUnkFlags = _createTrackRoadCommandAiUnkFlags & ~(1U << 21);
                 _createTrackRoadCommandAiUnkFlags |= (1U << 20);
@@ -995,7 +995,7 @@ namespace OpenLoco::CompanyAi
         const auto nextRot = World::kReverseRotation[rot];
         auto adjustedRoadObjId = roadObjId;
         auto* roadObj = ObjectManager::get<RoadObject>(roadObjId);
-        if (roadObj->hasFlags(RoadObjectFlags::unk_03))
+        if (roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
         {
             adjustedRoadObjId = 0xFFU;
         }
@@ -1311,7 +1311,7 @@ namespace OpenLoco::CompanyAi
                 const auto cost = (roadBaseCost * roadIdCostFactor) / 256;
                 totalCost += cost;
             }
-            if (!roadObj->hasFlags(RoadObjectFlags::unk_03))
+            if (!roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
             {
                 for (auto i = 0U; i < 2; ++i)
                 {
@@ -2284,7 +2284,7 @@ namespace OpenLoco::CompanyAi
             const auto nextRot = World::kReverseRotation[rotationBegin];
             uint8_t matchRoadObjId = roadObjId;
             auto* roadObj = ObjectManager::get<RoadObject>(roadObjId);
-            if (roadObj->hasFlags(RoadObjectFlags::unk_03))
+            if (roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
             {
                 matchRoadObjId = 0xFFU; // any road object
             }

--- a/src/OpenLoco/src/World/CompanyAi/CompanyAiPlaceVehicle.cpp
+++ b/src/OpenLoco/src/World/CompanyAi/CompanyAiPlaceVehicle.cpp
@@ -114,7 +114,7 @@ namespace OpenLoco::CompanyAi
             }
             if (roadObjectId == 0xFFU)
             {
-                if (!(getGameState().roadObjectIdIsNotTram & (1U << elRoad->roadObjectId())))
+                if (!(getGameState().roadObjectIdIsAnyRoadTypeCompatible & (1U << elRoad->roadObjectId())))
                 {
                     continue;
                 }
@@ -193,7 +193,7 @@ namespace OpenLoco::CompanyAi
                     }
                     if (elRoad->roadObjectId() != roadObjectId)
                     {
-                        if (!(getGameState().roadObjectIdIsNotTram & (1U << elRoad->roadObjectId())))
+                        if (!(getGameState().roadObjectIdIsAnyRoadTypeCompatible & (1U << elRoad->roadObjectId())))
                         {
                             continue;
                         }

--- a/src/OpenLoco/src/World/Station.cpp
+++ b/src/OpenLoco/src/World/Station.cpp
@@ -1156,7 +1156,7 @@ namespace OpenLoco
                             continue;
                         }
                         auto* roadObj = ObjectManager::get<RoadObject>(elRoad->roadObjectId());
-                        station->flags |= roadObj->hasFlags(RoadObjectFlags::unk_01)
+                        station->flags |= roadObj->hasFlags(RoadObjectFlags::isRailTransport)
                             ? StationFlags::transportModeRail
                             : StationFlags::transportModeRoad;
                     }

--- a/src/OpenLoco/src/World/Station.cpp
+++ b/src/OpenLoco/src/World/Station.cpp
@@ -1156,7 +1156,7 @@ namespace OpenLoco
                             continue;
                         }
                         auto* roadObj = ObjectManager::get<RoadObject>(elRoad->roadObjectId());
-                        station->flags |= roadObj->hasFlags(RoadObjectFlags::isRailTransport)
+                        station->flags |= roadObj->hasFlags(RoadObjectFlags::isRail)
                             ? StationFlags::transportModeRail
                             : StationFlags::transportModeRoad;
                     }

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -351,7 +351,7 @@ namespace OpenLoco
             {
                 continue;
             }
-            if (!(getGameState().roadObjectIdIsNotTram & (1U << elRoad->roadObjectId())))
+            if (!(getGameState().roadObjectIdIsAnyRoadTypeCompatible & (1U << elRoad->roadObjectId())))
             {
                 continue;
             }
@@ -540,7 +540,7 @@ namespace OpenLoco
             {
                 continue;
             }
-            if (!(getGameState().roadObjectIdIsNotTram & (1U << elRoad->roadObjectId())))
+            if (!(getGameState().roadObjectIdIsAnyRoadTypeCompatible & (1U << elRoad->roadObjectId())))
             {
                 continue;
             }

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -274,7 +274,7 @@ namespace OpenLoco
             {
                 continue;
             }
-            if (!roadObj->hasFlags(RoadObjectFlags::unk_03))
+            if (!roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
             {
                 continue;
             }
@@ -842,7 +842,7 @@ namespace OpenLoco
                     continue;
                 }
                 auto* roadObj = ObjectManager::get<RoadObject>(elRoad->roadObjectId());
-                if (!roadObj->hasFlags(RoadObjectFlags::unk_03))
+                if (!roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
                 {
                     continue;
                 }
@@ -931,7 +931,7 @@ namespace OpenLoco
                 }
 
                 auto* roadObj = ObjectManager::get<RoadObject>(elRoad->roadObjectId());
-                if (!roadObj->hasFlags(RoadObjectFlags::unk_03))
+                if (!roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
                 {
                     continue;
                 }
@@ -1556,7 +1556,7 @@ namespace OpenLoco
                     continue;
                 }
                 auto* roadObj = ObjectManager::get<RoadObject>(elRoad->roadObjectId());
-                if (!roadObj->hasFlags(RoadObjectFlags::unk_03))
+                if (!roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
                 {
                     continue;
                 }

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -864,7 +864,7 @@ namespace OpenLoco
     static uint32_t getStreetLightStyle(uint8_t roadObjId, uint8_t townDensity)
     {
         auto* roadObj = ObjectManager::get<RoadObject>(roadObjId);
-        if (!roadObj->hasFlags(RoadObjectFlags::unk_08) || townDensity == 0)
+        if (!roadObj->hasFlags(RoadObjectFlags::canHaveStreetLights) || townDensity == 0)
         {
             return 0;
         }


### PR DESCRIPTION
Identify and name the flags used in road objects.  
  
- `RoadObjectFlags::unk_01` renamed to `isRailTransport`
  This flag controls if the road object appears in the tracks/rails menu instead of the road menu. It is also used to check if the object should be considered a rail instead of a standard road in several places.  
  Only ROADTRAM has this flag set, all other roads do not have it.  
- `RoadObjectFlags::unk_03` renamed to `anyRoadTypeCompatible`  
  Towns will only use roads with this flag set. Without it, vehicles won't enter the road from another road type. Road object will not appear in menu if no vehicles for this specific road are not available (vehicles with anyRoadType set will not work on this road.    
- `RoadObjectFlags::unk_04` renamed to `noSlipSurface`  
  This flag controls if a vehicle can start slipping on it. If set, the vehicle can't start slipping.  
- `RoadObjectFlags::unk_07` renamed to `allowUseByAllCompanies`  
  If this flag is set, roads/trams built by one company can be used by all other companies in a game. If this flag is not set, the road/tram can't be used by anyone other than the owner company. If the flag is not set on a town owned road, road can't be used by companies.  
- `RoadObjectFlags::unk_08` renamed to `canHaveStreetLights`  
  This flag is only used in the function that determines what street lights style to use. If the flag is not set, street lights are not allowed.  
