### PR TITLE
Fix "not starting for x months" using wrong variable for plural check

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -364,7 +364,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             // Delayed start for competing companies
             args = FormatArguments();
             args.push<uint16_t>(scenarioInfo->competingCompanyDelay);
-            competitionStringId = scenarioInfo->numCompetingCompanies == 1 ? StringIds::competition_not_starting_for_month : StringIds::competition_not_starting_for_months;
+            competitionStringId = scenarioInfo->competingCompanyDelay == 1 ? StringIds::competition_not_starting_for_month : StringIds::competition_not_starting_for_months;
             tr.drawStringLeft(Point(x, y), Colour::black, competitionStringId, args);
         }
     }


### PR DESCRIPTION
The operation for deciding whether the string for "(not starting for x month(s))" should be a plural was using the number of competing companies instead of the actual number of months.

Before:
<img width="170" height="246" alt="image" src="https://github.com/user-attachments/assets/9cc36aa0-9f2d-425c-9047-6c2c8d52dbd8" /> <img width="165" height="241" alt="image" src="https://github.com/user-attachments/assets/0410213c-34e4-4965-9648-15909e5396ea" />

After:
<img width="164" height="240" alt="image" src="https://github.com/user-attachments/assets/f147dc28-7191-4006-9522-422b9c10da79" /> <img width="158" height="246" alt="image" src="https://github.com/user-attachments/assets/6e382a27-cfaf-4329-9f2e-d396447a953c" />

