### PR TITLE
Rename initialiseViewports to resetSubsystems

### DIFF
--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -57,7 +57,7 @@ namespace OpenLoco::EditorController
         gameState.lastMapWindowAttributes.flags = WindowFlags::none;
 
         WindowManager::closeAllFloatingWindows();
-        initialiseViewports();
+        resetSubsystems();
         MessageManager::reset();
         Audio::pauseSound();
         Audio::unpauseSound();

--- a/src/OpenLoco/src/Intro.cpp
+++ b/src/OpenLoco/src/Intro.cpp
@@ -45,7 +45,7 @@ namespace OpenLoco::Intro
         _state = State::none;
         Gfx::loadDefaultPalette();
         Gfx::invalidateScreen();
-        initialiseViewports();
+        resetSubsystems();
         Gui::init();
         Title::reset();
     }

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -155,7 +155,7 @@ namespace OpenLoco
     }
 
     // 0x004C57C0
-    void initialiseViewports()
+    void resetSubsystems()
     {
         Ui::Windows::MapToolTip::reset();
 
@@ -193,7 +193,7 @@ namespace OpenLoco
 
         Ui::initialise();
         Ui::initialiseCursors();
-        initialiseViewports();
+        resetSubsystems();
         Gui::init();
 
         MessageManager::reset();

--- a/src/OpenLoco/src/OpenLoco.h
+++ b/src/OpenLoco/src/OpenLoco.h
@@ -18,7 +18,7 @@ namespace OpenLoco
     }
 
     void* hInstance();
-    void initialiseViewports();
+    void resetSubsystems();
     void simulateGame(const fs::path& path, int32_t ticks);
 
     void sub_431695(uint16_t var_F253A0);

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -686,7 +686,7 @@ namespace OpenLoco::S5
             if (!hasLoadFlags(flags, LoadFlags::titleSequence))
             {
                 SceneManager::removeSceneFlags(SceneManager::Flags::title);
-                initialiseViewports();
+                resetSubsystems();
                 Audio::resetMusic();
                 if (hasLoadFlags(flags, LoadFlags::landscape))
                 {

--- a/src/OpenLoco/src/Scenario/Scenario.cpp
+++ b/src/OpenLoco/src/Scenario/Scenario.cpp
@@ -305,7 +305,7 @@ namespace OpenLoco::Scenario
         WindowManager::closeAllFloatingWindows();
 
         SceneManager::removeSceneFlags(SceneManager::Flags::title);
-        initialiseViewports();
+        resetSubsystems();
         Gui::init();
         Audio::resetMusic();
 

--- a/src/OpenLoco/src/Title.cpp
+++ b/src/OpenLoco/src/Title.cpp
@@ -146,7 +146,7 @@ namespace OpenLoco::Title
         ObjectManager::reloadAll();
         Scenario::sub_4748D4();
         Scenario::reset();
-        initialiseViewports();
+        resetSubsystems();
         MessageManager::reset();
         Gui::init();
         reset();


### PR DESCRIPTION
This PR renames the `initialiseViewports` to `resetSubsystems`. Naming things is hard, but this function call many other init functions, including `ViewportManager::init`. Clearly, it desperately needs another, less confusing name.