### PR TITLE
Update the version info when the branch changes

### DIFF
--- a/cmake/OpenLocoVersion.cmake
+++ b/cmake/OpenLocoVersion.cmake
@@ -47,6 +47,11 @@ if (Git_FOUND)
     set(OPENLOCO_VERSION_TAG "${OPENLOCO_VERSION_TAG}")
     set(OPENLOCO_BRANCH "${OPENLOCO_BRANCH}")
     set(OPENLOCO_COMMIT_SHA1_SHORT "${OPENLOCO_COMMIT_SHA1_SHORT}")
+    
+    # Reconfigure when branch changes
+    if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git/HEAD")
+        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/.git/HEAD")
+    endif()
 else()
     message(WARNING "Git not found, version information will be limited.")
 


### PR DESCRIPTION
This will trigger a cmake configure when branches are switched, one unfortunate side effect is that the project most likely rebuilds even when only a couple of files changed, I however want to avoid adding any complex logic, this is the most simple way I can think off. The alternative is we don't care about what the version info says for local builds.

The only reason we have cmake variables for the version info is the macOS bundling, if there is a way around doing that then we can move it to build time but I don't have macOS and I'm not going to ever get one.