### PR TITLE
Fix getting a refund for removing bridges owned by towns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#2825] Drawing the viewport canvas now uses parallel processing where possible.
 - Change: [#3577] PNG heightmaps of any size are now supported and use interpolation when the image size differs from the map size.
+- Fix: [#3268] Removing bridges built by towns gives you a refund.
 - Fix: [#3577] Crash loading PNGs with unexpected color formats or channel configurations as heightmaps.
 - Fix: [#3581] Remove sprite drawing limit that caused visual artifacts on high resolution displays and complex maps.
 

--- a/src/OpenLoco/src/GameCommands/Road/RemoveRoad.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/RemoveRoad.cpp
@@ -293,7 +293,7 @@ namespace OpenLoco::GameCommands
         // 0x00477A10
         totalRemovalCost += pieceRemovalCost;
 
-        // Add on bridge refund if applicable
+        // Add on bridge refund if applicable (Absent from vanilla)
         if (removeRoadBridge && roadOwner != CompanyId::neutral)
         {
             const auto* bridgeObj = ObjectManager::get<BridgeObject>(roadBridgeId);


### PR DESCRIPTION
Fixes #3268

Checks that the road is not town owned before adding on the refund for the bridge.