### PR TITLE
Cheat: Keep cargo on pickup/modify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.03.1+ (???)
 ------------------------------------------------------------------------
 - Feature: [#1438] Add basic blueprint feature for copy, paste and rotate railroad track.
+- Feature: [#3591] Cheat to keep cargo when picking up a vehicle or modifying a vehicle's components.
 - Feature: [#3639] The Locomotion title screen music can now be listened to during scenario play.
 - Change: [#3594] More sorting options when building vehicles.
 - Change: [#3702, #3703, #3704, #3705] Improved performance for vehicle, industry, town, station, and company lists.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2488,4 +2488,4 @@ strings:
   2433: "Sort by obsolescence"
   2434: 'Vehicle cargo'
   2435: 'Keep vehicle cargo on modify or pickup'
-  2436: '{SMALLFONT}{COLOUR BLACK}When enabled, cargo will not be cleared from the entire vehicle when picking it up or modifying its cars'
+  2436: '{SMALLFONT}{COLOUR BLACK}When enabled, cargo will not be cleared from the entire vehicle when adding cars, moving cars or picking up the vehicle'

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2486,3 +2486,6 @@ strings:
   2431: "Descending order"
   2432: "Sort by capacity"
   2433: "Sort by obsolescence"
+  2434: 'Vehicle cargo'
+  2435: 'Keep vehicle cargo on modify or pickup'
+  2436: '{SMALLFONT}{COLOUR BLACK}When enabled, cargo will not be cleared from the entire vehicle when picking it up or modifying its cars'

--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -181,6 +181,7 @@ namespace OpenLoco::Config
         _config.trainsReverseAtSignals = config["trainsReverseAtSignals"].as<bool>(false);
         _config.disableStationSizeLimit = config["disableStationSizeLimit"].as<bool>(false);
         _config.showAiPlanningAsGhosts = config["showAiPlanningAsGhosts"].as<bool>(false);
+        _config.keepCargoModifyPickup = config["keepCargoModifyPickup"].as<bool>(false);
 
         // Preferred owner
         _config.preferredOwnerName = config["preferredOwnerName"].as<std::string>("");
@@ -315,6 +316,7 @@ namespace OpenLoco::Config
         node["trainsReverseAtSignals"] = _config.trainsReverseAtSignals;
         node["disableStationSizeLimit"] = _config.disableStationSizeLimit;
         node["showAiPlanningAsGhosts"] = _config.showAiPlanningAsGhosts;
+        node["keepCargoModifyPickup"] = _config.keepCargoModifyPickup;
 
         // Preferred owner
         node["preferredOwnerName"] = _config.preferredOwnerName;

--- a/src/OpenLoco/src/Config.h
+++ b/src/OpenLoco/src/Config.h
@@ -208,6 +208,7 @@ namespace OpenLoco::Config
         bool trainsReverseAtSignals = true;
         bool disableStationSizeLimit = false;
         bool showAiPlanningAsGhosts = false;
+        bool keepCargoModifyPickup = false;
 
         bool usePreferredOwnerName = false;
         std::string preferredOwnerName;

--- a/src/OpenLoco/src/GameCommands/Vehicles/VehiclePickupAir.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/VehiclePickupAir.cpp
@@ -1,5 +1,5 @@
-#include "Config.h"
 #include "VehiclePickupAir.h"
+#include "Config.h"
 #include "Entities/EntityManager.h"
 #include "GameCommands/GameCommands.h"
 #include "Vehicles/Vehicle.h"

--- a/src/OpenLoco/src/GameCommands/Vehicles/VehiclePickupAir.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/VehiclePickupAir.cpp
@@ -1,3 +1,4 @@
+#include "Config.h"
 #include "VehiclePickupAir.h"
 #include "Entities/EntityManager.h"
 #include "GameCommands/GameCommands.h"
@@ -64,11 +65,14 @@ namespace OpenLoco::GameCommands
             component.var_38 &= ~(Vehicles::Flags38::isGhost);
         });
 
-        for (auto& car : train.cars)
+        if (!Config::get().keepCargoModifyPickup)
         {
-            for (auto& component : car)
+            for (auto& car : train.cars)
             {
-                removeAllCargo(component);
+                for (auto& component : car)
+                {
+                    removeAllCargo(component);
+                }
             }
         }
 

--- a/src/OpenLoco/src/GameCommands/Vehicles/VehiclePickupWater.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/VehiclePickupWater.cpp
@@ -1,5 +1,5 @@
-#include "Config.h"
 #include "VehiclePickupWater.h"
+#include "Config.h"
 #include "Entities/EntityManager.h"
 #include "GameCommands/GameCommands.h"
 #include "Map/StationElement.h"

--- a/src/OpenLoco/src/GameCommands/Vehicles/VehiclePickupWater.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/VehiclePickupWater.cpp
@@ -1,3 +1,4 @@
+#include "Config.h"
 #include "VehiclePickupWater.h"
 #include "Entities/EntityManager.h"
 #include "GameCommands/GameCommands.h"
@@ -79,11 +80,14 @@ namespace OpenLoco::GameCommands
         });
 
         train.head->vehicleFlags |= VehicleFlags::commandStop;
-        for (auto& car : train.cars)
+        if (!Config::get().keepCargoModifyPickup)
         {
-            for (auto& component : car)
+            for (auto& car : train.cars)
             {
-                removeAllCargo(component);
+                for (auto& component : car)
+                {
+                    removeAllCargo(component);
+                }
             }
         }
         return 0;

--- a/src/OpenLoco/src/GameCommands/Vehicles/VehicleRearrange.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/VehicleRearrange.cpp
@@ -1,5 +1,5 @@
-#include "Config.h"
 #include "VehicleRearrange.h"
+#include "Config.h"
 #include "Economy/Expenditures.h"
 #include "Entities/EntityManager.h"
 #include "VehiclePickupAir.h"

--- a/src/OpenLoco/src/GameCommands/Vehicles/VehicleRearrange.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/VehicleRearrange.cpp
@@ -1,3 +1,4 @@
+#include "Config.h"
 #include "VehicleRearrange.h"
 #include "Economy/Expenditures.h"
 #include "Entities/EntityManager.h"
@@ -83,16 +84,16 @@ namespace OpenLoco::GameCommands
             Vehicles::Vehicle sourceTrain(*sourceHead);
             Vehicles::Vehicle destTrain(*destHead);
 
-            if (sourceHead != destHead)
+            if (sourceHead != destHead && !Config::get().keepCargoModifyPickup)
             {
                 [&train = sourceTrain, &targetBogie = *sourceBogie]() {
                     for (auto& car : train.cars)
                     {
-                        for (auto& carComponet : car)
+                        for (auto& carComponent : car)
                         {
-                            if (carComponet.front == &targetBogie)
+                            if (carComponent.front == &targetBogie)
                             {
-                                Vehicles::removeAllCargo(carComponet);
+                                Vehicles::removeAllCargo(carComponent);
                                 return;
                             }
                         }

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -2145,6 +2145,9 @@ namespace OpenLoco::StringIds
     constexpr StringId sortDescendingOrder = 2431;
     constexpr StringId sortByCapacity = 2432;
     constexpr StringId sortByObsolete = 2433;
+    constexpr StringId cheat_vehicle_cargo = 2434;
+    constexpr StringId cheat_keep_cargo_modify_pickup = 2435;
+    constexpr StringId tooltip_keep_cargo_modify_pickup = 2436;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Ui/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Cheats.cpp
@@ -617,8 +617,7 @@ namespace OpenLoco::Ui::Windows::Cheats
             Widgets::Checkbox({ 10, 116 }, { 200, 12 }, WindowColour::secondary, StringIds::display_locked_vehicles, StringIds::tooltip_display_locked_vehicles),
             Widgets::Checkbox({ 25, 130 }, { 200, 12 }, WindowColour::secondary, StringIds::allow_building_locked_vehicles, StringIds::tooltip_build_locked_vehicles),
             Widgets::GroupBox({ 4, 152 }, { kWindowSize.width - 8, 30 }, WindowColour::secondary, StringIds::cheat_vehicle_cargo),
-            Widgets::Checkbox({ 10, 166 }, { 200, 12 }, WindowColour::secondary, StringIds::cheat_keep_cargo_modify_pickup, StringIds::tooltip_keep_cargo_modify_pickup)
-        );
+            Widgets::Checkbox({ 10, 166 }, { 200, 12 }, WindowColour::secondary, StringIds::cheat_keep_cargo_modify_pickup, StringIds::tooltip_keep_cargo_modify_pickup));
 
         static void prepareDraw(Window& self)
         {

--- a/src/OpenLoco/src/Ui/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Cheats.cpp
@@ -591,7 +591,7 @@ namespace OpenLoco::Ui::Windows::Cheats
 
     namespace Vehicles
     {
-        static constexpr Ui::Size kWindowSize = { 250, 152 };
+        static constexpr Ui::Size kWindowSize = { 250, 188 };
 
         namespace Widx
         {
@@ -603,6 +603,8 @@ namespace OpenLoco::Ui::Windows::Cheats
                 vehicle_locked_group,
                 checkbox_display_locked_vehicles,
                 checkbox_build_locked_vehicles,
+                vehicle_cargo_group,
+                checkbox_keep_cargo_modify_pickup,
             };
         }
 
@@ -613,8 +615,9 @@ namespace OpenLoco::Ui::Windows::Cheats
             Widgets::Button({ 10, 78 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_reliability_hundred),
             Widgets::GroupBox({ 4, 102 }, { kWindowSize.width - 8, 45 }, WindowColour::secondary, StringIds::cheat_build_vehicle_window),
             Widgets::Checkbox({ 10, 116 }, { 200, 12 }, WindowColour::secondary, StringIds::display_locked_vehicles, StringIds::tooltip_display_locked_vehicles),
-            Widgets::Checkbox({ 25, 130 }, { 200, 12 }, WindowColour::secondary, StringIds::allow_building_locked_vehicles, StringIds::tooltip_build_locked_vehicles)
-
+            Widgets::Checkbox({ 25, 130 }, { 200, 12 }, WindowColour::secondary, StringIds::allow_building_locked_vehicles, StringIds::tooltip_build_locked_vehicles),
+            Widgets::GroupBox({ 4, 152 }, { kWindowSize.width - 8, 30 }, WindowColour::secondary, StringIds::cheat_vehicle_cargo),
+            Widgets::Checkbox({ 10, 166 }, { 200, 12 }, WindowColour::secondary, StringIds::cheat_keep_cargo_modify_pickup, StringIds::tooltip_keep_cargo_modify_pickup)
         );
 
         static void prepareDraw(Window& self)
@@ -639,6 +642,15 @@ namespace OpenLoco::Ui::Windows::Cheats
             else
             {
                 self.activatedWidgets &= ~(1 << Widx::checkbox_build_locked_vehicles);
+            }
+
+            if (Config::get().keepCargoModifyPickup)
+            {
+                self.activatedWidgets |= (1 << Widx::checkbox_keep_cargo_modify_pickup);
+            }
+            else
+            {
+                self.activatedWidgets &= ~(1 << Widx::checkbox_keep_cargo_modify_pickup);
             }
         }
 
@@ -703,6 +715,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                         self.disabledWidgets |= (1 << Widx::checkbox_build_locked_vehicles);
                     }
 
+                    Config::write();
                     WindowManager::invalidateWidget(self.type, self.number, Widx::checkbox_build_locked_vehicles);
                     WindowManager::invalidateWidget(self.type, self.number, Widx::checkbox_display_locked_vehicles);
                     WindowManager::invalidate(WindowType::buildVehicle);
@@ -714,9 +727,18 @@ namespace OpenLoco::Ui::Windows::Cheats
                     if (Config::get().displayLockedVehicles)
                     {
                         Config::get().buildLockedVehicles = !Config::get().buildLockedVehicles;
+                        Config::write();
                         WindowManager::invalidateWidget(self.type, self.number, Widx::checkbox_build_locked_vehicles);
                         WindowManager::invalidate(WindowType::buildVehicle);
                     }
+                    break;
+                }
+
+                case Widx::checkbox_keep_cargo_modify_pickup:
+                {
+                    Config::get().keepCargoModifyPickup = !Config::get().keepCargoModifyPickup;
+                    Config::write();
+                    WindowManager::invalidateWidget(self.type, self.number, Widx::checkbox_keep_cargo_modify_pickup);
                     break;
                 }
             }

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -137,7 +137,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             return veh;
         }
 
-        static bool needsComponentChangeConfirm(EntityId id)
+        static bool needsComponentChangeConfirm(EntityId id, const bool checkKeepCargoCheat)
         {
             auto* vehBase = EntityManager::get<Vehicles::VehicleBase>(id);
             if (vehBase == nullptr)
@@ -156,9 +156,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 return false;
             }
 
-            if (Config::get().keepCargoModifyPickup)
+            if (checkKeepCargoCheat && Config::get().keepCargoModifyPickup)
             {
-                return true;
+                return false;
             }
 
             if (head->getCarCount() > 0 && CompanyManager::getControllingId() == head->owner)
@@ -169,9 +169,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
             return false;
         }
 
-        static bool confirmComponentChange(const EntityId id, const OpenLoco::StringId windowTitle, const OpenLoco::StringId windowMessage, const OpenLoco::StringId windowConfirm)
+        static bool confirmComponentChange(const EntityId id, const OpenLoco::StringId windowTitle, const OpenLoco::StringId windowMessage, const OpenLoco::StringId windowConfirm, const bool checkKeepCargoCheat = true)
         {
-            if (!needsComponentChangeConfirm(id))
+            if (!needsComponentChangeConfirm(id, checkKeepCargoCheat))
             {
                 return true;
             }
@@ -180,9 +180,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
             return Windows::PromptOkCancel::open(windowTitle, windowMessage, format, windowConfirm);
         }
 
-        static bool confirmComponentChange(const EntityId srcId, const EntityId destId, const OpenLoco::StringId windowTitle, const OpenLoco::StringId windowMessage, const OpenLoco::StringId windowConfirm)
+        static bool confirmComponentChange(const EntityId srcId, const EntityId destId, const OpenLoco::StringId windowTitle, const OpenLoco::StringId windowMessage, const OpenLoco::StringId windowConfirm, const bool checkKeepCargoCheat = true)
         {
-            if (!needsComponentChangeConfirm(srcId) && !needsComponentChangeConfirm(destId))
+            if (!needsComponentChangeConfirm(srcId, checkKeepCargoCheat) && !needsComponentChangeConfirm(destId, checkKeepCargoCheat))
             {
                 return true;
             }
@@ -2444,7 +2444,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     args.head = static_cast<EntityId>(self.number);
                     args.cargoType = Dropdown::getItemArgument(dropdownIndex, 3);
 
-                    if (Common::confirmComponentChange(args.head, StringIds::confirm_vehicle_component_refit_cargo_warning_title, StringIds::confirm_vehicle_component_refit_cargo_warning_message, StringIds::confirm_vehicle_component_refit_cargo_warning_confirm))
+                    if (Common::confirmComponentChange(args.head, StringIds::confirm_vehicle_component_refit_cargo_warning_title, StringIds::confirm_vehicle_component_refit_cargo_warning_message, StringIds::confirm_vehicle_component_refit_cargo_warning_confirm, false))
                     {
                         GameCommands::setErrorTitle(StringIds::cant_refit_vehicle);
                         GameCommands::doCommand(args, GameCommands::Flags::apply);

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -156,6 +156,11 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 return false;
             }
 
+            if (Config::get().keepCargoModifyPickup)
+            {
+                return true;
+            }
+
             if (head->getCarCount() > 0 && CompanyManager::getControllingId() == head->owner)
             {
                 return true;

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -7086,11 +7086,14 @@ namespace OpenLoco::Vehicles
             veh.moveTo(World::Pos3(static_cast<int16_t>(0x8000), 0, 0));
         });
 
-        for (auto& car : train.cars)
+        if (!Config::get().keepCargoModifyPickup)
         {
-            for (auto& component : car)
+            for (auto& car : train.cars)
             {
-                removeAllCargo(component);
+                for (auto& component : car)
+                {
+                    removeAllCargo(component);
+                }
             }
         }
 


### PR DESCRIPTION
This adds a cheat to the vehicle cheats menu that keeps the cargo in the vehicle when moving components, adding components, selling components, or picking up the entire vehicle. Refitting still clears cargo. Closes #2499

~This PR also adds a new confirmation (when the cheat is disabled) when a car is moved within a train/between trains to the confirm delete cargo prompts added in 25.11. I can separate this into a different PR if desired~

https://github.com/user-attachments/assets/6514d7d0-3b28-4eb9-8b06-bb4c0dce21c8