### PR TITLE
Add more sorting options when building vehicles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#2825] Drawing the viewport canvas now uses parallel processing where possible.
 - Change: [#3577] PNG heightmaps of any size are now supported and use interpolation when the image size differs from the map size.
+- Change: [#3594] More sorting options when building vehicles.
 - Fix: [#3577] Crash loading PNGs with unexpected color formats or channel configurations as heightmaps.
 - Fix: [#3581] Remove sprite drawing limit that caused visual artifacts on high resolution displays and complex maps.
 

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2455,3 +2455,5 @@ strings:
   2407: "Sort by length"
   2408: "Ascending order"
   2409: "Descending order"
+  2410: "Sort by capacity"
+  2411: "Sort by obsolescence"

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -2114,6 +2114,8 @@ namespace OpenLoco::StringIds
     constexpr StringId sortByLength = 2407;
     constexpr StringId sortAscendingOrder = 2408;
     constexpr StringId sortDescendingOrder = 2409;
+    constexpr StringId sortByCapacity = 2410;
+    constexpr StringId sortByObsolete = 2411;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;


### PR DESCRIPTION
Sometimes in a pinch you need the most bang for your buck when it comes to cost and power, these additional options make it easier to find what you need

<img width="828" height="631" alt="image" src="https://github.com/user-attachments/assets/9179b7d8-1226-4656-8035-f91a9e58c1c3" />

Note: Perhaps being able to define sort order is unnecessary? Should defaults just be ascending for all (Except possibly for power and max speed, force descending instead?)