### PR TITLE
Fix toolbar widget boundaries

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -923,22 +923,19 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             window.widgets[Common::Widx::audio_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_audio_active, window.getColour(WindowColour::primary).c());
         }
 
-        if (Config::get().cheatsMenuEnabled)
-        {
-            window.widgets[Widx::cheats_menu].hidden = false;
-            auto& baseWidget = window.widgets[Widx::cheats_menu];
-            window.widgets[Common::Widx::zoom_menu].left = baseWidget.left + 14 + (baseWidget.width() * 1);
-            window.widgets[Common::Widx::rotate_menu].left = baseWidget.left + 14 + (baseWidget.width() * 2);
-            window.widgets[Common::Widx::view_menu].left = baseWidget.left + 14 + (baseWidget.width() * 3);
-        }
-        else
-        {
-            window.widgets[Widx::cheats_menu].hidden = true;
-            auto& baseWidget = window.widgets[Common::Widx::audio_menu];
-            window.widgets[Common::Widx::zoom_menu].left = baseWidget.left + 14 + (baseWidget.width() * 1);
-            window.widgets[Common::Widx::rotate_menu].left = baseWidget.left + 14 + (baseWidget.width() * 2);
-            window.widgets[Common::Widx::view_menu].left = baseWidget.left + 14 + (baseWidget.width() * 3);
-        }
+        const bool cheatsOn = Config::get().cheatsMenuEnabled;
+        window.widgets[Widx::cheats_menu].hidden = !cheatsOn;
+
+        const auto& refWidget = window.widgets[cheatsOn ? enumValue(Widx::cheats_menu) : enumValue(Common::Widx::audio_menu)];
+        const auto offsetWidget = [&window, refWidget](uint8_t widgetIndex, uint8_t index) {
+            auto& widget = window.widgets[widgetIndex];
+            widget.left = refWidget.left + 14 + (refWidget.width() * index);
+            widget.right = widget.left + refWidget.width() - 1;
+        };
+
+        offsetWidget(Common::Widx::zoom_menu, 1);
+        offsetWidget(Common::Widx::rotate_menu, 2);
+        offsetWidget(Common::Widx::view_menu, 3);
 
         if (_lastPortOption == 0
             && getGameState().lastAirport == 0xFF


### PR DESCRIPTION
Widget boundaries were incorrect for part of the toolbar buttons, but only when cheats were disabled. In other words, in the default state, but one that we devs rarely test.

Before:
<img width="350" height="68" alt="Boulder Breakers (3)" src="https://github.com/user-attachments/assets/a711c5dc-38d0-47e3-8757-76f5b54b6fb8" />

After:
<img width="350" height="60" alt="Boulder Breakers (4)" src="https://github.com/user-attachments/assets/428642ea-a121-4210-825f-c22735623105" />
