### PR TITLE
Add forEachLoaded<T> helper function for object iteration

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,6 +18,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * LeeSpork
 * Kelson Blakewood (spacek531)
 * luciditee
+* killerdevildog
 
 ## Bugfixes
 * seifer7

--- a/src/OpenLoco/include/OpenLoco/Objects/ObjectManager.h
+++ b/src/OpenLoco/include/OpenLoco/Objects/ObjectManager.h
@@ -5,6 +5,7 @@
 #include <OpenLoco/Engine/Ui/Point.hpp>
 #include <optional>
 #include <span>
+#include <type_traits>
 #include <vector>
 
 namespace OpenLoco
@@ -87,6 +88,40 @@ namespace OpenLoco::ObjectManager
     {
         static_assert(getMaxObjects(T::kObjectType) != 1);
         return reinterpret_cast<T*>(getAny({ T::kObjectType, static_cast<LoadedObjectId>(id) }));
+    }
+
+    // Calls function for each loaded object of type T
+    // Function signature can be:
+    //   void(const T&)           - just the object
+    //   void(T&)                 - mutable object reference
+    //   void(LoadedObjectId, const T&) - index and object
+    //   void(LoadedObjectId, T&) - index and mutable object
+    template<typename T, typename Function>
+    void forEachLoaded(Function&& func)
+    {
+        for (LoadedObjectId i = 0U; i < getMaxObjects(T::kObjectType); ++i)
+        {
+            auto* obj = get<T>(i);
+            if (obj != nullptr)
+            {
+                if constexpr (std::is_invocable_v<Function, LoadedObjectId, T&>)
+                {
+                    func(i, *const_cast<T*>(obj));
+                }
+                else if constexpr (std::is_invocable_v<Function, LoadedObjectId, const T&>)
+                {
+                    func(i, *obj);
+                }
+                else if constexpr (std::is_invocable_v<Function, T&>)
+                {
+                    func(*const_cast<T*>(obj));
+                }
+                else
+                {
+                    func(*obj);
+                }
+            }
+        }
     }
 
 #pragma pack(push, 1)

--- a/src/OpenLoco/include/OpenLoco/Objects/ObjectManager.h
+++ b/src/OpenLoco/include/OpenLoco/Objects/ObjectManager.h
@@ -92,10 +92,8 @@ namespace OpenLoco::ObjectManager
 
     // Calls function for each loaded object of type T
     // Function signature can be:
-    //   void(const T&)           - just the object
-    //   void(T&)                 - mutable object reference
-    //   void(LoadedObjectId, const T&) - index and object
-    //   void(LoadedObjectId, T&) - index and mutable object
+    //   void(const T&)                  - just the object
+    //   void(LoadedObjectId, const T&)  - index and object
     template<typename T, typename Function>
     void forEachLoaded(Function&& func)
     {
@@ -104,17 +102,9 @@ namespace OpenLoco::ObjectManager
             auto* obj = get<T>(i);
             if (obj != nullptr)
             {
-                if constexpr (std::is_invocable_v<Function, LoadedObjectId, T&>)
-                {
-                    func(i, *const_cast<T*>(obj));
-                }
-                else if constexpr (std::is_invocable_v<Function, LoadedObjectId, const T&>)
+                if constexpr (std::is_invocable_v<Function, LoadedObjectId, const T&>)
                 {
                     func(i, *obj);
-                }
-                else if constexpr (std::is_invocable_v<Function, T&>)
-                {
-                    func(*const_cast<T*>(obj));
                 }
                 else
                 {

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -2255,20 +2255,13 @@ namespace OpenLoco::Ui::Windows::MapWindow
         }
 
         // Then, assign surface texture colours
-        for (auto i = 0U; i < ObjectManager::getMaxObjects(ObjectType::land); i++)
-        {
-            auto landObj = ObjectManager::get<LandObject>(i);
-            if (landObj == nullptr)
-            {
-                continue;
-            }
-
-            auto landPixel = Gfx::getG1Element(landObj->mapPixelImage)->offset[0];
+        ObjectManager::forEachLoaded<LandObject>([&availableColours](const LandObject& landObj) {
+            auto landPixel = Gfx::getG1Element(landObj.mapPixelImage)->offset[0];
             availableColours = checkIndustryColours(landPixel, availableColours);
 
-            landPixel = Gfx::getG1Element(landObj->mapPixelImage)->offset[1];
+            landPixel = Gfx::getG1Element(landObj.mapPixelImage)->offset[1];
             availableColours = checkIndustryColours(landPixel, availableColours);
-        }
+        });
 
         availableColours = checkIndustryColours(PaletteIndex::mutedDarkRed2, availableColours);
         availableColours = checkIndustryColours(PaletteIndex::black2, availableColours);
@@ -2281,41 +2274,27 @@ namespace OpenLoco::Ui::Windows::MapWindow
         }
 
         // Assign preferred industry colours, if possible
-        for (auto i = 0U; i < ObjectManager::getMaxObjects(ObjectType::industry); i++)
-        {
-            auto industryObj = ObjectManager::get<IndustryObject>(i);
-            if (industryObj == nullptr)
-            {
-                continue;
-            }
-
+        ObjectManager::forEachLoaded<IndustryObject>([&availableColours](LoadedObjectId i, const IndustryObject& industryObj) {
             // Preferred colour still available?
-            auto preferredColour = enumValue(industryObj->mapColour);
+            auto preferredColour = enumValue(industryObj.mapColour);
             if (availableColours & (1U << preferredColour))
             {
                 _assignedIndustryColours[i] = preferredColour;
                 availableColours &= ~(1U << preferredColour);
             }
-        }
+        });
 
         // Assign alternative industry colours if needed
-        for (auto i = 0U; i < ObjectManager::getMaxObjects(ObjectType::industry); i++)
-        {
-            auto industryObj = ObjectManager::get<IndustryObject>(i);
-            if (industryObj == nullptr)
-            {
-                continue;
-            }
-
+        ObjectManager::forEachLoaded<IndustryObject>([&availableColours](LoadedObjectId i, [[maybe_unused]] const IndustryObject& industryObj) {
             if (_assignedIndustryColours[i] != 0xFF)
             {
-                continue;
+                return;
             }
 
             auto freeColour = std::max(0, Numerics::bitScanForward(availableColours));
             availableColours &= ~(1U << freeColour);
             _assignedIndustryColours[i] = freeColour;
-        }
+        });
     }
 
     // 0x0046CED0
@@ -2335,20 +2314,13 @@ namespace OpenLoco::Ui::Windows::MapWindow
         }
 
         // Then, assign surface texture colours
-        for (auto i = 0U; i < ObjectManager::getMaxObjects(ObjectType::land); i++)
-        {
-            auto landObj = ObjectManager::get<LandObject>(i);
-            if (landObj == nullptr)
-            {
-                continue;
-            }
-
-            auto landPixel = Gfx::getG1Element(landObj->mapPixelImage)->offset[0];
+        ObjectManager::forEachLoaded<LandObject>([&availableColours](const LandObject& landObj) {
+            auto landPixel = Gfx::getG1Element(landObj.mapPixelImage)->offset[0];
             availableColours = checkIndustryColours(landPixel, availableColours);
 
-            landPixel = Gfx::getG1Element(landObj->mapPixelImage)->offset[1];
+            landPixel = Gfx::getG1Element(landObj.mapPixelImage)->offset[1];
             availableColours = checkIndustryColours(landPixel, availableColours);
-        }
+        });
 
         availableColours = checkIndustryColours(PaletteIndex::mutedDarkRed2, availableColours);
         availableColours = checkIndustryColours(PaletteIndex::orange8, availableColours);


### PR DESCRIPTION
Implements a templated helper function that simplifies the common pattern of iterating over all loaded objects of a specific type. This reduces boilerplate code and improves readability.

The helper supports multiple callback signatures:
- void(const T&)              - object only (const)
- void(T&)                    - object only (mutable)
- void(LoadedObjectId, const T&) - index and object (const)
- void(LoadedObjectId, T&)    - index and object (mutable)

Applied the helper to MapWindow.cpp as an initial demonstration, replacing manual loops for LandObject and IndustryObject iteration.

Closes #2948