### PR TITLE
Name the awaitingCargoTransfer flag

### DIFF
--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -61,7 +61,11 @@ namespace OpenLoco::Vehicles
     enum class BreakdownFlags : uint8_t
     {
         none = 0U,
-        unk_0 = 1U << 0,
+
+        // Indicates a vehicle component is waiting for a cargo transfer.
+        // When placed on the VehicleHead component it indicates that the vehicle
+        // cannot wait at the station for further loading. (TODO: Introduce a different flag for that)
+        awaitingCargoTransfer = 1U << 0,
         breakdownPending = 1U << 1,
         brokenDown = 1U << 2,
         journeyStarted = 1U << 3, // The journey start meta data has been filled in

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -2788,13 +2788,15 @@ namespace OpenLoco::Vehicles
     // 0x004B99E1
     void VehicleHead::beginUnloading()
     {
-        breakdownFlags &= ~BreakdownFlags::unk_0;
+        // See note on flag
+        breakdownFlags &= ~BreakdownFlags::awaitingCargoTransfer;
+
         status = Status::unloading;
         cargoTransferTimeout = 10;
         var_58 = 0;
 
         Vehicle train(head);
-        train.cars.applyToComponents([](auto& component) { component.breakdownFlags |= BreakdownFlags::unk_0; });
+        train.cars.applyToComponents([](auto& component) { component.breakdownFlags |= BreakdownFlags::awaitingCargoTransfer; });
     }
 
     // 0x00426CA4
@@ -3091,7 +3093,8 @@ namespace OpenLoco::Vehicles
                     auto* roadStationObj = ObjectManager::get<RoadStationObject>(elStation->objectId());
                     if (!roadStationObj->hasFlags(RoadStationFlags::roadEnd))
                     {
-                        breakdownFlags |= BreakdownFlags::unk_0;
+                        // Set on the vehicleHead awaitingCargoTransfer see note on flag
+                        breakdownFlags |= BreakdownFlags::awaitingCargoTransfer;
                     }
                     loadingModifier = kMinVehiclePastStationPenalty;
                 }
@@ -3256,7 +3259,7 @@ namespace OpenLoco::Vehicles
         cargoTransferTimeout = 10;
 
         Vehicle train(head);
-        train.cars.applyToComponents([](auto& component) { component.breakdownFlags |= BreakdownFlags::unk_0; });
+        train.cars.applyToComponents([](auto& component) { component.breakdownFlags |= BreakdownFlags::awaitingCargoTransfer; });
     }
     // 0x004B9A2A
     void VehicleHead::updateUnloadCargo()
@@ -3272,9 +3275,9 @@ namespace OpenLoco::Vehicles
         {
             for (auto& carComponent : car)
             {
-                if (carComponent.front->hasBreakdownFlags(BreakdownFlags::unk_0))
+                if (carComponent.front->hasBreakdownFlags(BreakdownFlags::awaitingCargoTransfer))
                 {
-                    carComponent.front->breakdownFlags &= ~BreakdownFlags::unk_0;
+                    carComponent.front->breakdownFlags &= ~BreakdownFlags::awaitingCargoTransfer;
                     if (carComponent.front->secondaryCargo.type == 0xFF)
                     {
                         return;
@@ -3282,14 +3285,14 @@ namespace OpenLoco::Vehicles
                     updateUnloadCargoComponent(carComponent.front->secondaryCargo, carComponent.front);
                     return;
                 }
-                else if (carComponent.back->hasBreakdownFlags(BreakdownFlags::unk_0))
+                else if (carComponent.back->hasBreakdownFlags(BreakdownFlags::awaitingCargoTransfer))
                 {
-                    carComponent.back->breakdownFlags &= ~BreakdownFlags::unk_0;
+                    carComponent.back->breakdownFlags &= ~BreakdownFlags::awaitingCargoTransfer;
                     return;
                 }
-                else if (carComponent.body->hasBreakdownFlags(BreakdownFlags::unk_0))
+                else if (carComponent.body->hasBreakdownFlags(BreakdownFlags::awaitingCargoTransfer))
                 {
-                    carComponent.body->breakdownFlags &= ~BreakdownFlags::unk_0;
+                    carComponent.body->breakdownFlags &= ~BreakdownFlags::awaitingCargoTransfer;
                     if (carComponent.body->primaryCargo.type == 0xFF)
                     {
                         return;
@@ -3506,9 +3509,9 @@ namespace OpenLoco::Vehicles
         {
             for (auto& carComponent : car)
             {
-                if (carComponent.front->hasBreakdownFlags(BreakdownFlags::unk_0))
+                if (carComponent.front->hasBreakdownFlags(BreakdownFlags::awaitingCargoTransfer))
                 {
-                    carComponent.front->breakdownFlags &= ~BreakdownFlags::unk_0;
+                    carComponent.front->breakdownFlags &= ~BreakdownFlags::awaitingCargoTransfer;
                     if (carComponent.front->secondaryCargo.type == 0xFF)
                     {
                         return true;
@@ -3516,14 +3519,14 @@ namespace OpenLoco::Vehicles
                     updateLoadCargoComponent(carComponent.front->secondaryCargo, carComponent.front);
                     return true;
                 }
-                else if (carComponent.back->hasBreakdownFlags(BreakdownFlags::unk_0))
+                else if (carComponent.back->hasBreakdownFlags(BreakdownFlags::awaitingCargoTransfer))
                 {
-                    carComponent.back->breakdownFlags &= ~BreakdownFlags::unk_0;
+                    carComponent.back->breakdownFlags &= ~BreakdownFlags::awaitingCargoTransfer;
                     return true;
                 }
-                else if (carComponent.body->hasBreakdownFlags(BreakdownFlags::unk_0))
+                else if (carComponent.body->hasBreakdownFlags(BreakdownFlags::awaitingCargoTransfer))
                 {
-                    carComponent.body->breakdownFlags &= ~BreakdownFlags::unk_0;
+                    carComponent.body->breakdownFlags &= ~BreakdownFlags::awaitingCargoTransfer;
                     if (carComponent.body->primaryCargo.type == 0xFF)
                     {
                         return true;
@@ -3559,7 +3562,8 @@ namespace OpenLoco::Vehicles
                 {
                     if (carComponent.front->secondaryCargo.type == waitFor->getCargo() && carComponent.front->secondaryCargo.maxQty != carComponent.front->secondaryCargo.qty)
                     {
-                        if (!hasBreakdownFlags(BreakdownFlags::unk_0))
+                        // Look at the vehicleHead awaitingCargoTransfer see note on flag
+                        if (!hasBreakdownFlags(BreakdownFlags::awaitingCargoTransfer))
                         {
                             beginLoading();
                             return true;
@@ -3573,7 +3577,8 @@ namespace OpenLoco::Vehicles
                     }
                     if (carComponent.body->primaryCargo.type == waitFor->getCargo() && carComponent.body->primaryCargo.maxQty != carComponent.body->primaryCargo.qty)
                     {
-                        if (!hasBreakdownFlags(BreakdownFlags::unk_0))
+                        // Look at the vehicleHead awaitingCargoTransfer see note on flag
+                        if (!hasBreakdownFlags(BreakdownFlags::awaitingCargoTransfer))
                         {
                             beginLoading();
                             return true;


### PR DESCRIPTION
Eventually I'd like to move cargo loading into something the station update manages (this will allow for different distribution setups). To be able to do that though we first need to fully understand how it currently works.