### PR TITLE
Micro optimization and code refactoring

### DIFF
--- a/src/OpenLoco/src/Paint/Paint.cpp
+++ b/src/OpenLoco/src/Paint/Paint.cpp
@@ -1287,7 +1287,7 @@ namespace OpenLoco::Paint
     }
 
     // 0x0045ED91
-    [[nodiscard]] InteractionArg PaintSession::getNormalInteractionInfo(const InteractionItemFlags flags)
+    [[nodiscard]] InteractionArg PaintSession::getNormalInteractionInfo(const InteractionItemFlags flags) const
     {
         InteractionArg info{};
 
@@ -1331,7 +1331,7 @@ namespace OpenLoco::Paint
     }
 
     // 0x0048DDE4
-    [[nodiscard]] InteractionArg PaintSession::getStationNameInteractionInfo(const InteractionItemFlags flags)
+    [[nodiscard]] InteractionArg PaintSession::getStationNameInteractionInfo(const InteractionItemFlags flags) const
     {
         InteractionArg interaction{};
 
@@ -1363,7 +1363,7 @@ namespace OpenLoco::Paint
     }
 
     // 0x0049773D
-    [[nodiscard]] InteractionArg PaintSession::getTownNameInteractionInfo(const InteractionItemFlags flags)
+    [[nodiscard]] InteractionArg PaintSession::getTownNameInteractionInfo(const InteractionItemFlags flags) const
     {
         InteractionArg interaction{};
 
@@ -1512,7 +1512,7 @@ namespace OpenLoco::Paint
             case 3:
                 return _tunnels3;
         }
-        return std::span<TunnelEntry>();
+        return {};
     }
 
     bool showAiPlanningGhosts()

--- a/src/OpenLoco/src/Paint/Paint.h
+++ b/src/OpenLoco/src/Paint/Paint.h
@@ -240,47 +240,47 @@ namespace OpenLoco::Paint
         void drawStructs(Gfx::DrawingContext& drawingCtx);
         void drawStringStructs(Gfx::DrawingContext& drawingCtx);
 
-        [[nodiscard]] Ui::ViewportInteraction::InteractionArg getNormalInteractionInfo(const Ui::ViewportInteraction::InteractionItemFlags flags);
-        [[nodiscard]] Ui::ViewportInteraction::InteractionArg getStationNameInteractionInfo(const Ui::ViewportInteraction::InteractionItemFlags flags);
-        [[nodiscard]] Ui::ViewportInteraction::InteractionArg getTownNameInteractionInfo(const Ui::ViewportInteraction::InteractionItemFlags flags);
-        const Gfx::RenderTarget* getRenderTarget() { return _renderTarget; }
-        uint8_t getRotation() { return currentRotation; }
+        [[nodiscard]] Ui::ViewportInteraction::InteractionArg getNormalInteractionInfo(const Ui::ViewportInteraction::InteractionItemFlags flags) const;
+        [[nodiscard]] Ui::ViewportInteraction::InteractionArg getStationNameInteractionInfo(const Ui::ViewportInteraction::InteractionItemFlags flags) const;
+        [[nodiscard]] Ui::ViewportInteraction::InteractionArg getTownNameInteractionInfo(const Ui::ViewportInteraction::InteractionItemFlags flags) const;
+        const Gfx::RenderTarget* getRenderTarget() const { return _renderTarget; }
+        uint8_t getRotation() const { return currentRotation; }
         void setRotation(uint8_t rotation) { currentRotation = rotation; }
-        int16_t getMaxHeight() { return _maxHeight; }
-        uint32_t getRoadExits() { return _roadMergeExits; }
+        int16_t getMaxHeight() const { return _maxHeight; }
+        uint32_t getRoadExits() const { return _roadMergeExits; }
         void setRoadExits(uint32_t value) { _roadMergeExits = value; }
-        uint32_t getMergeRoadBaseImage() { return _roadMergeBaseImage; }
+        uint32_t getMergeRoadBaseImage() const { return _roadMergeBaseImage; }
         void setMergeRoadBaseImage(uint32_t value) { _roadMergeBaseImage = value; }
-        int16_t getMergeRoadHeight() { return _roadMergeHeight; }
+        int16_t getMergeRoadHeight() const { return _roadMergeHeight; }
         void setMergeRoadHeight(int16_t value) { _roadMergeHeight = value; }
-        uint16_t getMergeRoadStreetlight() { return _roadMergeStreetlightType; }
+        uint16_t getMergeRoadStreetlight() const { return _roadMergeStreetlightType; }
         void setMergeRoadStreetlight(uint16_t value) { _roadMergeStreetlightType = value; }
-        int16_t getAdditionSupportHeight() { return _trackRoadAdditionSupports.height; }
-        const TrackRoadAdditionSupports& getAdditionSupport() { return _trackRoadAdditionSupports; }
+        int16_t getAdditionSupportHeight() const { return _trackRoadAdditionSupports.height; }
+        const TrackRoadAdditionSupports& getAdditionSupport() const { return _trackRoadAdditionSupports; }
         void setAdditionSupport(const TrackRoadAdditionSupports& newValue) { _trackRoadAdditionSupports = newValue; }
-        const SupportHeight& getGeneralSupportHeight() { return _support; }
-        const SupportHeight& getSupportHeight(uint8_t segment) { return _supportSegments[segment]; }
-        const BridgeEntry& getBridgeEntry() { return _bridgeEntry; }
-        SegmentFlags get525CF8() { return _525CF8; }
-        int16_t getWaterHeight() { return _waterHeight; }
-        int16_t getWaterHeight2() { return _waterHeight2; }
-        int16_t getSurfaceHeight() { return _surfaceHeight; }
-        uint8_t getSurfaceSlope() { return _surfaceSlope; }
-        SegmentFlags getOccupiedAdditionSupportSegments() { return _trackRoadAdditionSupports.occupiedSegments; }
-        World::Pos2 getUnkPosition()
+        const SupportHeight& getGeneralSupportHeight() const { return _support; }
+        const SupportHeight& getSupportHeight(uint8_t segment) const { return _supportSegments[segment]; }
+        const BridgeEntry& getBridgeEntry() const { return _bridgeEntry; }
+        SegmentFlags get525CF8() const { return _525CF8; }
+        int16_t getWaterHeight() const { return _waterHeight; }
+        int16_t getWaterHeight2() const { return _waterHeight2; }
+        int16_t getSurfaceHeight() const { return _surfaceHeight; }
+        uint8_t getSurfaceSlope() const { return _surfaceSlope; }
+        SegmentFlags getOccupiedAdditionSupportSegments() const { return _trackRoadAdditionSupports.occupiedSegments; }
+        World::Pos2 getUnkPosition() const
         {
             return World::Pos2{ _unkPositionX, _unkPositionY };
         }
-        World::Pos2 getSpritePosition()
+        World::Pos2 getSpritePosition() const
         {
             return World::Pos2{ _spritePositionX, _spritePositionY };
         }
-        Ui::ViewportFlags getViewFlags() { return _viewFlags; }
+        Ui::ViewportFlags getViewFlags() const { return _viewFlags; }
         // TileElement or Entity
         void setCurrentItem(void* item) { _currentItem = item; }
-        void* getCurrentItem() { return _currentItem; }
+        void* getCurrentItem() const { return _currentItem; }
         void setItemType(const Ui::ViewportInteraction::InteractionItem type) { _itemType = type; }
-        Ui::ViewportInteraction::InteractionItem getItemType() { return _itemType; }
+        Ui::ViewportInteraction::InteractionItem getItemType() const { return _itemType; }
         void setTrackModId(const uint8_t mod) { _trackModId = mod; }
         void setEntityPosition(const World::Pos2& pos);
         void setMapPosition(const World::Pos2& pos);

--- a/src/OpenLoco/src/Paint/PaintSurface.cpp
+++ b/src/OpenLoco/src/Paint/PaintSurface.cpp
@@ -1346,7 +1346,7 @@ namespace OpenLoco::Paint
     }
 
     template<std::size_t TDirection>
-    static inline TileDescriptor getTileDescriptor(PaintSession& session, const uint8_t rotation, const CornerHeight& selfCornerHeight)
+    static inline TileDescriptor getTileDescriptor(const PaintSession& session, const uint8_t rotation, const CornerHeight& selfCornerHeight)
     {
         const auto& offset = kNeighbourOffsets[rotation][TDirection];
         const auto position = session.getSpritePosition() + offset;


### PR DESCRIPTION
I noticed this during profiling that the array was always zero initialized and then everything got overwritten, turns out MSVC isn't smart enough to alias the memory correctly to turn the zero initialization into dead stores, I also eliminated the for loop now it its unfolded and it can generate better code, it's not going to give any major boosts but on my test file the average jumped from 32 to 33 (checked via multiple runs), so 1 FPS gain on my end and also checked the disassembly, definitely better than the for loop.