### PR TITLE
Add pause on lost focus option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.03.1+ (???)
 ------------------------------------------------------------------------
 - Feature: [#1438] Add basic blueprint feature for copy, paste and rotate railroad track.
+- Feature: [#2055] Option to pause the game on lost focus.
 - Feature: [#3591] Cheat to keep cargo when picking up a vehicle or modifying a vehicle's components.
 - Feature: [#3639] The Locomotion title screen music can now be listened to during scenario play.
 - Change: [#3594] More sorting options when building vehicles.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2489,3 +2489,5 @@ strings:
   2434: 'Vehicle cargo'
   2435: 'Keep vehicle cargo on modify or pickup'
   2436: '{SMALLFONT}{COLOUR BLACK}When enabled, cargo will not be cleared from the entire vehicle when adding cars, moving cars or picking up the vehicle'
+  2437: "Pause on lost focus"
+  2438: "{SMALLFONT}{COLOUR BLACK}Suspends game updates and pauses audio when the OpenLoo window loses focus."

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -335,15 +335,10 @@ namespace OpenLoco::Audio
     {
         stopVehicleNoise();
         stopAmbientNoise();
-        if (!SceneManager::isTitleMode())
-        {
-            pauseMusic();
-        }
     }
 
     void unpauseSound()
     {
-        unpauseMusic();
     }
 
     static const SoundObject* getSoundObject(SoundId id)

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -568,4 +568,42 @@ namespace OpenLoco::Audio
     {
         return _audioIsEnabled;
     }
+
+    void toggleAudioLostFocus(bool pause)
+    {
+        static bool soundsWerePlaying = false;
+        static bool musicWasPlaying = false;
+
+        if (pause)
+        {
+            // Pause audio
+
+            soundsWerePlaying = !_audioIsPaused;
+            if (soundsWerePlaying)
+            {
+                pauseSound();
+            }
+
+            auto* channel = getChannel(ChannelId::music);
+            musicWasPlaying = (_audioIsInitialised && channel != nullptr && channel->isPlaying());
+            if (musicWasPlaying)
+            {
+                pauseMusic();
+            }
+        }
+        else
+        {
+            // Unpause audio
+
+            if (soundsWerePlaying)
+            {
+                unpauseSound();
+            }
+
+            if (musicWasPlaying)
+            {
+                unpauseMusic();
+            }
+        }
+    }
 }

--- a/src/OpenLoco/src/Audio/Audio.h
+++ b/src/OpenLoco/src/Audio/Audio.h
@@ -106,6 +106,8 @@ namespace OpenLoco::Audio
 
     void resetSoundObjects();
 
+    void toggleAudioLostFocus(bool pause);
+
     std::optional<BufferId> loadMusicSample(Environment::PathId asset);
 
     int32_t calculatePan(const coord_t coord, const int32_t screenSize);

--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -163,6 +163,7 @@ namespace OpenLoco::Config
         _config.edgeScrollingSpeed = config["edgeScrollingSpeed"].as<int32_t>(12);
         _config.windowFrameStyle = config["windowFrameStyle"].as<WindowFrameStyle>(WindowFrameStyle::background);
         _config.zoomToCursor = config["zoom_to_cursor"].as<bool>(true);
+        _config.pauseOnLostFocus = config["pauseOnLostFocus"].as<bool>(false);
 
         // Saving and autosaves
         _config.autosaveAmount = config["autosave_amount"].as<int32_t>(12);
@@ -298,6 +299,7 @@ namespace OpenLoco::Config
         node["edgeScrollingSpeed"] = _config.edgeScrollingSpeed;
         node["windowFrameStyle"] = _config.windowFrameStyle;
         node["zoom_to_cursor"] = _config.zoomToCursor;
+        node["pauseOnLostFocus"] = _config.pauseOnLostFocus;
 
         // Saving and autosaves
         node["autosave_amount"] = _config.autosaveAmount;

--- a/src/OpenLoco/src/Config.h
+++ b/src/OpenLoco/src/Config.h
@@ -218,6 +218,8 @@ namespace OpenLoco::Config
         int32_t scenarioSelectedTab;
 
         std::map<Input::Shortcut, KeyboardShortcut> shortcuts;
+
+        bool pauseOnLostFocus;
     };
 
     Config& get();

--- a/src/OpenLoco/src/Input.cpp
+++ b/src/OpenLoco/src/Input.cpp
@@ -53,6 +53,7 @@ namespace OpenLoco::Input
         // TODO check config
 
         _isLostFocusPaused = true;
+        Audio::toggleAudioLostFocus(true);
     }
 
     static void focusGained()
@@ -63,6 +64,7 @@ namespace OpenLoco::Input
         }
 
         _isLostFocusPaused = false;
+        Audio::toggleAudioLostFocus(false);
     }
 
     bool isLostFocusPaused()

--- a/src/OpenLoco/src/Input.cpp
+++ b/src/OpenLoco/src/Input.cpp
@@ -15,6 +15,7 @@ namespace OpenLoco::Input
     static Ui::Point _cursorDragStart;
     static uint32_t _cursorDragState;
     static bool _exitRequested = false;
+    static bool _isLostFocusPaused = false;
 
     void init()
     {
@@ -45,6 +46,28 @@ namespace OpenLoco::Input
     void state(State state)
     {
         _state = state;
+    }
+
+    static void focusLost()
+    {
+        // TODO check config
+
+        _isLostFocusPaused = true;
+    }
+
+    static void focusGained()
+    {
+        if (!_isLostFocusPaused)
+        {
+            return;
+        }
+
+        _isLostFocusPaused = false;
+    }
+
+    bool isLostFocusPaused()
+    {
+        return _isLostFocusPaused;
     }
 
     // 0x00407218
@@ -129,6 +152,12 @@ namespace OpenLoco::Input
 
                 case SDL_EVENT_WINDOW_MOVED:
                     Ui::windowPositionChanged(e.window.data1, e.window.data2);
+                    break;
+                case SDL_WINDOWEVENT_FOCUS_LOST:
+                    focusLost();
+                    break;
+                case SDL_WINDOWEVENT_FOCUS_GAINED:
+                    focusGained();
                     break;
                 case SDL_EVENT_WINDOW_RESIZED:
                 case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:

--- a/src/OpenLoco/src/Input.cpp
+++ b/src/OpenLoco/src/Input.cpp
@@ -50,7 +50,10 @@ namespace OpenLoco::Input
 
     static void focusLost()
     {
-        // TODO check config
+        if (!Config::get().pauseOnLostFocus)
+        {
+            return;
+        }
 
         _isLostFocusPaused = true;
         Audio::toggleAudioLostFocus(true);

--- a/src/OpenLoco/src/Input.h
+++ b/src/OpenLoco/src/Input.h
@@ -67,6 +67,8 @@ namespace OpenLoco::Input
     bool processMessages();
     bool processMessagesMini();
 
+    bool isLostFocusPaused();
+
     Ui::Point getMouseLocation();
     Ui::Point getMouseLocation2();
     bool isHovering(Ui::WindowType);

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -2150,6 +2150,8 @@ namespace OpenLoco::StringIds
     constexpr StringId cheat_vehicle_cargo = 2434;
     constexpr StringId cheat_keep_cargo_modify_pickup = 2435;
     constexpr StringId tooltip_keep_cargo_modify_pickup = 2436;
+    constexpr StringId pause_on_lost_focus = 2437;
+    constexpr StringId pause_on_lost_focus_tip = 2438;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -735,6 +735,12 @@ namespace OpenLoco
 
         while (Input::processMessages())
         {
+
+            if (Input::isLostFocusPaused())
+            {
+                continue;
+            }
+
             update();
         }
 

--- a/src/OpenLoco/src/SceneManager.cpp
+++ b/src/OpenLoco/src/SceneManager.cpp
@@ -112,12 +112,18 @@ namespace OpenLoco::SceneManager
     static void onPause()
     {
         Audio::pauseSound();
+        // Do not pause title screen music
+        if (!isTitleMode())
+        {
+            Audio::pauseMusic();
+        }
         Ui::Windows::TimePanel::invalidateFrame();
     }
 
     static void onUnpause()
     {
         Audio::unpauseSound();
+        Audio::unpauseMusic();
         Ui::Windows::TimePanel::invalidateFrame();
     }
 

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -2177,7 +2177,7 @@ namespace OpenLoco::Ui::Windows::Options
 
     namespace Misc
     {
-        static constexpr Ui::Size kWindowSize = { 420, 266 };
+        static constexpr Ui::Size kWindowSize = { 420, 281 };
 
         namespace Widx
         {
@@ -2203,6 +2203,8 @@ namespace OpenLoco::Ui::Windows::Options
                 autosave_amount_down_btn,
                 autosave_amount_up_btn,
                 export_plugin_objects,
+
+                pauseOnLostFocus,
             };
         }
 
@@ -2231,7 +2233,9 @@ namespace OpenLoco::Ui::Windows::Options
             Widgets::Label({ 10, 226 }, { 200, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::autosave_amount),
             Widgets::stepperWidgets({ 250, 226 }, { 156, 12 }, WindowColour::secondary, StringIds::empty),
 
-            Widgets::Checkbox({ 10, 241 }, { 400, 12 }, WindowColour::secondary, StringIds::export_plugin_objects, StringIds::export_plugin_objects_tip)
+            Widgets::Checkbox({ 10, 241 }, { 400, 12 }, WindowColour::secondary, StringIds::export_plugin_objects, StringIds::export_plugin_objects_tip),
+
+            Widgets::Checkbox({ 10, 266 }, { 400, 12 }, WindowColour::secondary, StringIds::pause_on_lost_focus, StringIds::pause_on_lost_focus_tip)
 
         );
 
@@ -2241,6 +2245,7 @@ namespace OpenLoco::Ui::Windows::Options
         static void disableAICompaniesMouseUp(Window& self);
         static void disableTownExpansionMouseUp(Window& self);
         static void exportPluginObjectsMouseUp(Window& self);
+        static void pauseOnLostFocus(Window& self);
 
         // 0x004C11B7
         static void prepareDraw(Window& self)
@@ -2290,6 +2295,11 @@ namespace OpenLoco::Ui::Windows::Options
             }
 
             self.widgets[Widx::export_plugin_objects].hidden = !ObjectManager::getCustomObjectsInIndexStatus();
+
+            if (Config::get().pauseOnLostFocus)
+            {
+                self.activatedWidgets |= (1ULL << Widx::pauseOnLostFocus);
+            }
         }
 
         static void drawDropdownContent(const Window& self, Gfx::DrawingContext& drawingCtx, WidgetIndex_t widgetIndex, StringId stringId, int32_t value)
@@ -2459,6 +2469,10 @@ namespace OpenLoco::Ui::Windows::Options
                 case Widx::export_plugin_objects:
                     exportPluginObjectsMouseUp(self);
                     break;
+
+                case Widx::pauseOnLostFocus:
+                    pauseOnLostFocus(self);
+                    break;
             }
         }
 
@@ -2533,6 +2547,15 @@ namespace OpenLoco::Ui::Windows::Options
         {
             auto& cfg = Config::get();
             cfg.exportObjectsWithSaves ^= true;
+            Config::write();
+
+            self.invalidate();
+        }
+
+        static void pauseOnLostFocus(Window& self)
+        {
+            auto& cfg = Config::get();
+            cfg.pauseOnLostFocus ^= true;
             Config::write();
 
             self.invalidate();


### PR DESCRIPTION
Closes #2055.

Note that I chose to make that the way it pauses be completely separate from the existing pause system.

Marked as a draft because this was broken in a rebase and I'm not sure if I still believe in these changes.
