### PR TITLE
Fix #3636: Match vanilla UI frame drawing

### DIFF
--- a/src/OpenLoco/src/Ui/Widgets/FrameWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/FrameWidget.cpp
@@ -48,7 +48,7 @@ namespace OpenLoco::Ui::Widgets
 
         uint8_t shade;
         const auto* window = widgetState.window;
-        if (window->hasFlags(WindowFlags::lighterFrame))
+        if (!window->hasFlags(WindowFlags::lighterFrame))
         {
             shade = Colours::getShade(widgetState.colour.c(), 3);
         }


### PR DESCRIPTION
About the second commit I'm not entirely sure if I'm correct there, maybe the shade value is wrong? This seems to now match the original drawing.

@LeeSpork please have a look if this is now all correct.

Closes #3636