### PR TITLE
Fix warning for deprecated user defined literal syntax

### DIFF
--- a/src/OpenLoco/src/Speed.hpp
+++ b/src/OpenLoco/src/Speed.hpp
@@ -100,7 +100,7 @@ namespace OpenLoco
     namespace Literals
     {
         // Note: Only valid for 5 decimal places.
-        constexpr Speed32 operator"" _mph(long double speedMph)
+        constexpr Speed32 operator""_mph(long double speedMph)
         {
             const auto wholeNumber = static_cast<uint32_t>(speedMph);
             const auto fraction = static_cast<uint64_t>((speedMph - wholeNumber) * 100000);


### PR DESCRIPTION
Seems this syntax is now deprecated where there is a space between the "" and the _