### PR TITLE
Retroactive changelog corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,8 +86,8 @@
 
 25.08 (2025-08-26)
 ------------------------------------------------------------------------
-- Feature: [#3052] Add refund for removing bridges.
 - Change: [#1682, #3216] Scroll widgets now support much larger sizes.
+- Change: [#3052] Add refund for removing bridges.
 - Change: [#3104] Landscape generation confirmation prompts now prevent you from clicking other windows until a choice is made.
 - Change: [#3193] The minimum size of the map window was changed to accommodate all elements.
 - Fix: [#3019] Mouse getting stuck on edges of monitor when right mouse dragging scroll views.


### PR DESCRIPTION
Context:

- [#3032](https://github.com/OpenLoco/OpenLoco/issues/3032) should have been marked as an original bug (tested on the Steam version of the original Locomotion).

- [#3052](https://github.com/OpenLoco/OpenLoco/pull/3052) added refunds for bridges, which was not present in previous versions of OpenLoco, nor the original game. As mentioned in https://github.com/OpenLoco/OpenLoco/pull/3052#discussion_r2365944055

- The station (spread) size limit removal was attributed to the wrong issue in the changelog by [#2306](https://github.com/OpenLoco/OpenLoco/pull/2306), as discussed in https://github.com/OpenLoco/OpenLoco/issues/358#issuecomment-2763066959


Do let me know if changing old changelog entries is considered bad practise.
I last edited old changelog entries in #3051.