### PR TITLE
Use UTF-8 in InputSession

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,13 +9,13 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Michał Janiszewski (janisozaur) - CI, Linux management
 * Benjamin Sutas (LeftofZen)
 * Matthias Moninger (ZehMatt)
+* LeeSpork
 
 ## Additional implementation
 * Richard Jenkins (rwjuk)
 * Hielke Morsink (Broxzier)
 * Peter Gaál (petergaal)
 * Joe Bloomfield (Svelbeard)
-* LeeSpork
 * Kelson Blakewood (spacek531)
 * luciditee
 * killerdevildog

--- a/src/OpenLoco/include/OpenLoco/Localisation/Conversion.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/Conversion.h
@@ -7,6 +7,7 @@
 namespace OpenLoco::Localisation
 {
     utf32_t convertLocoToUnicode(uint8_t loco_char);
+    std::string convertLocoToUnicode(const std::string& locoString);
     uint8_t convertUnicodeToLoco(utf32_t unicode);
     std::string convertUnicodeToLoco(const std::string& unicode_string);
 

--- a/src/OpenLoco/include/OpenLoco/Localisation/Unicode.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/Unicode.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace OpenLoco::Localisation
 {
@@ -8,4 +9,5 @@ namespace OpenLoco::Localisation
     using utf32_t = uint32_t;
 
     utf32_t readCodePoint(const utf8_t** string);
+    std::string codepointToUtf8(utf32_t codepoint);
 }

--- a/src/OpenLoco/include/OpenLoco/Localisation/Unicode.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/Unicode.h
@@ -10,4 +10,7 @@ namespace OpenLoco::Localisation
 
     utf32_t readCodePoint(const utf8_t** string);
     std::string codepointToUtf8(utf32_t codepoint);
+    size_t utf8Length(const std::string& string);
+    void utf8Insert(std::string& stringToModify, size_t characterPosition, const std::string& insertion);
+    void utf8Delete(std::string& stringToModify, size_t characterPosition);
 }

--- a/src/OpenLoco/include/OpenLoco/Ui/TextInput.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/TextInput.h
@@ -2,6 +2,7 @@
 
 #include "Graphics/Gfx.h"
 
+#include <Localisation/Conversion.h>
 #include <cstdint>
 #include <string>
 
@@ -11,17 +12,19 @@ namespace OpenLoco::Ui::TextInput
 
     struct InputSession
     {
-        std::string buffer;    // 0x011369A0
+        std::string buffer;    // in UTF-8
         size_t cursorPosition; // 0x01136FA2
         int16_t xOffset;       // 0x01136FA4
         uint8_t cursorFrame;   // 0x011370A9
         uint32_t inputLenLimit;
 
         InputSession() = default;
+
+        // initialString is in Locomotion's encoding
         InputSession(const std::string initialString, uint32_t inputSize)
         {
-            buffer = initialString;
-            cursorPosition = buffer.length();
+            buffer = Localisation::convertLocoToUnicode(initialString);
+            cursorPosition = length();
             cursorFrame = 0;
             xOffset = 0;
             inputLenLimit = inputSize;
@@ -31,6 +34,8 @@ namespace OpenLoco::Ui::TextInput
         bool needsReoffsetting(int16_t containerWidth);
         void calculateTextOffset(int16_t containerWidth);
         void clearInput();
-        void sanitizeInput();
+        std::string loco() const; // Returns the inputted text in Locomotion's encoding
+        std::string utf8() const; // Returns the inputted text in UTF-8 encoding
+        size_t length() const;
     };
 }

--- a/src/OpenLoco/include/OpenLoco/Ui/TextInput.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/TextInput.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "Graphics/Gfx.h"
+#include "Localisation/Conversion.h"
 
-#include <Localisation/Conversion.h>
 #include <cstdint>
 #include <string>
 

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -15,7 +15,6 @@
 #include "Ui/WindowManager.h"
 #include "Vehicles/Vehicle.h"
 #include "World/CompanyManager.h"
-#include <Localisation/Conversion.h>
 #include <Localisation/Unicode.h>
 #include <OpenLoco/Core/BitSet.hpp>
 #include <OpenLoco/Engine/Input/ShortcutManager.h>
@@ -230,7 +229,7 @@ namespace OpenLoco::Input
 
         uint32_t index = _keyQueueLastWrite;
         auto unsignedText = reinterpret_cast<const uint8_t*>(text);
-        _keyQueue[index].charCode = convertUnicodeToLoco(readCodePoint(&unsignedText));
+        _keyQueue[index].charCode = readCodePoint(&unsignedText);
     }
 
     // 0x00407028

--- a/src/OpenLoco/src/Localisation/Conversion.cpp
+++ b/src/OpenLoco/src/Localisation/Conversion.cpp
@@ -206,6 +206,16 @@ namespace OpenLoco::Localisation
         return locoCode;
     }
 
+    std::string convertLocoToUnicode(const std::string& locoString)
+    {
+        std::string out;
+        for (uint8_t locoCode : locoString)
+        {
+            out += codepointToUtf8(convertLocoToUnicode(locoCode));
+        }
+        return out;
+    }
+
     uint8_t convertUnicodeToLoco(utf32_t unicode)
     {
         auto tableLookup = [unicode](auto&& table) {

--- a/src/OpenLoco/src/Localisation/Unicode.cpp
+++ b/src/OpenLoco/src/Localisation/Unicode.cpp
@@ -68,32 +68,50 @@ namespace OpenLoco::Localisation
         return string;
     }
 
+    static size_t utf8CharacterLength(const std::string& string, size_t cursor = 0)
+    {
+        if ((string[cursor] & 0b1000'0000) == 0)
+        {
+            return 1;
+        }
+        else if ((string[cursor] & 0b1110'0000) == 0b1100'0000)
+        {
+            return 2;
+        }
+        else if ((string[cursor] & 0b1111'0000) == 0b1110'0000)
+        {
+            return 3;
+        }
+        else if ((string[cursor] & 0b1111'1000) == 0b1111'0000)
+        {
+            return 4;
+        }
+        throw Exception::RuntimeError("Invalid UTF-8 string");
+    }
+
+    static size_t nextUtf8CodePointPosition(const std::string& string, size_t cursor)
+    {
+        return cursor + utf8CharacterLength(string, cursor);
+    }
+
+    static size_t utf8CharacterPosition(const std::string& str, size_t characterPosition)
+    {
+        size_t cursor = 0;
+        for (size_t i = 0; i < characterPosition; i++)
+        {
+            cursor = nextUtf8CodePointPosition(str, cursor);
+        }
+        return cursor;
+    }
+
     size_t utf8Length(const std::string& string)
     {
         size_t count = 0;
-        size_t i = 0;
-        while (i < string.length())
+        size_t cursor = 0;
+
+        while (cursor < string.length())
         {
-            if ((string[i] & 0b1000'0000) == 0)
-            {
-                i += 1;
-            }
-            else if ((string[i] & 0b1110'0000) == 0b1100'0000)
-            {
-                i += 2;
-            }
-            else if ((string[i] & 0b1111'0000) == 0b1110'0000)
-            {
-                i += 3;
-            }
-            else if ((string[i] & 0b1111'1000) == 0b1111'0000)
-            {
-                i += 4;
-            }
-            else
-            {
-                throw Exception::RuntimeError("Invalid UTF-8 string");
-            }
+            cursor = nextUtf8CodePointPosition(string, cursor);
             count++;
         }
         return count;
@@ -101,82 +119,14 @@ namespace OpenLoco::Localisation
 
     void utf8Insert(std::string& stringToModify, size_t characterPosition, const std::string& insertion)
     {
-        // Get byte position
-        size_t i = 0;
-        for (size_t j = 0; j < characterPosition; j++)
-        {
-            if ((stringToModify[i] & 0b1000'0000) == 0)
-            {
-                i += 1;
-            }
-            else if ((stringToModify[i] & 0b1110'0000) == 0b1100'0000)
-            {
-                i += 2;
-            }
-            else if ((stringToModify[i] & 0b1111'0000) == 0b1110'0000)
-            {
-                i += 3;
-            }
-            else if ((stringToModify[i] & 0b1111'1000) == 0b1111'0000)
-            {
-                i += 4;
-            }
-            else
-            {
-                throw Exception::RuntimeError("Invalid UTF-8 string");
-            }
-        }
-
-        stringToModify.insert(i, insertion);
+        auto cursor = utf8CharacterPosition(stringToModify, characterPosition);
+        stringToModify.insert(cursor, insertion);
     }
 
     void utf8Delete(std::string& stringToModify, size_t characterPosition)
     {
-        // Get byte position
-        size_t i = 0;
-        for (size_t j = 0; j < characterPosition; j++)
-        {
-            if ((stringToModify[i] & 0b1000'0000) == 0)
-            {
-                i += 1;
-            }
-            else if ((stringToModify[i] & 0b1110'0000) == 0b1100'0000)
-            {
-                i += 2;
-            }
-            else if ((stringToModify[i] & 0b1111'0000) == 0b1110'0000)
-            {
-                i += 3;
-            }
-            else if ((stringToModify[i] & 0b1111'1000) == 0b1111'0000)
-            {
-                i += 4;
-            }
-            else
-            {
-                throw Exception::RuntimeError("Invalid UTF-8 string");
-            }
-        }
-
-        // Get length of target character
-        uint8_t bytes = 0;
-        if ((stringToModify[i] & 0b1000'0000) == 0)
-        {
-            bytes = 1;
-        }
-        else if ((stringToModify[i] & 0b1110'0000) == 0b1100'0000)
-        {
-            bytes = 2;
-        }
-        else if ((stringToModify[i] & 0b1111'0000) == 0b1110'0000)
-        {
-            bytes = 3;
-        }
-        else if ((stringToModify[i] & 0b1111'1000) == 0b1111'0000)
-        {
-            bytes = 4;
-        }
-
-        stringToModify.erase(i, bytes);
+        auto cursor = utf8CharacterPosition(stringToModify, characterPosition);
+        auto length = utf8CharacterLength(stringToModify, cursor);
+        stringToModify.erase(cursor, length);
     }
 }

--- a/src/OpenLoco/src/Localisation/Unicode.cpp
+++ b/src/OpenLoco/src/Localisation/Unicode.cpp
@@ -10,25 +10,25 @@ namespace OpenLoco::Localisation
 
         const utf8_t* ptr = *string;
 
-        if ((ptr[0] & 0b10000000) == 0)
+        if ((ptr[0] & 0b1000'0000) == 0)
         {
             read = ptr[0];
             *string += 1;
         }
-        else if ((ptr[0] & 0b11100000) == 0b11000000)
+        else if ((ptr[0] & 0b1110'0000) == 0b1100'0000)
         {
-            read = ((ptr[0] & 0b11111) << 6) | (ptr[1] & 0b111111);
+            read = ((ptr[0] & 0b1'1111) << 6) | (ptr[1] & 0b11'1111);
             *string += 2;
         }
-        else if ((ptr[0] & 0b11110000) == 0b11100000)
+        else if ((ptr[0] & 0b1111'0000) == 0b1110'0000)
         {
-            read = ((ptr[0] & 0b1111) << 12) | ((ptr[1] & 0b111111) << 6) | (ptr[2] & 0b111111);
+            read = ((ptr[0] & 0b1111) << 12) | ((ptr[1] & 0b11'1111) << 6) | (ptr[2] & 0b11'1111);
             *string += 3;
         }
-        else if ((ptr[0] & 0b11111000) == 0b11110000)
+        else if ((ptr[0] & 0b1111'1000) == 0b1111'0000)
         {
-            read = ((ptr[0] & 0b111) << 18) | ((ptr[1] & 0b111111) << 12) | ((ptr[2] & 0b111111) << 6)
-                | (ptr[3] & 0b111111);
+            read = ((ptr[0] & 0b111) << 18) | ((ptr[1] & 0b11'1111) << 12) | ((ptr[2] & 0b11'1111) << 6)
+                | (ptr[3] & 0b11'1111);
             *string += 4;
         }
 
@@ -44,21 +44,21 @@ namespace OpenLoco::Localisation
         }
         else if (codepoint < 0x800)
         {
-            string += 0b11000000 + ((codepoint & 0b111111000000) >> 6);
-            string += 0b10000000 + (codepoint & 0b111111);
+            string += 0b1100'0000 + ((codepoint & 0b111'11100'0000) >> 6);
+            string += 0b1000'0000 + (codepoint & 0b11'1111);
         }
         else if (codepoint < 0x10000)
         {
-            string += 0b11100000 + ((codepoint & 0b1111000000000000) >> 12);
-            string += 0b10000000 + ((codepoint & 0b1111111000000) >> 6);
-            string += 0b10000000 + (codepoint & 0b111111);
+            string += 0b1110'0000 + ((codepoint & 0b1111'0000'0000'0000) >> 12);
+            string += 0b1000'0000 + ((codepoint & 0b1'1111'1100'0000) >> 6);
+            string += 0b1000'0000 + (codepoint & 0b11'1111);
         }
         else if (codepoint < 0x110000)
         {
-            string += 0b11100000 + ((codepoint & 0b111000000000000000000) >> 18);
-            string += 0b10000000 + ((codepoint & 0b111111000000000000) >> 12);
-            string += 0b10000000 + ((codepoint & 0b1111111000000) >> 6);
-            string += 0b10000000 + (codepoint & 0b111111);
+            string += 0b1110'0000 + ((codepoint & 0b1'1100'0000'0000'0000'0000) >> 18);
+            string += 0b1000'0000 + ((codepoint & 0b11'1111'0000'0000'0000) >> 12);
+            string += 0b1000'0000 + ((codepoint & 0b1'1111'1100'0000) >> 6);
+            string += 0b1000'0000 + (codepoint & 0b11'1111);
         }
         else
         {
@@ -74,19 +74,19 @@ namespace OpenLoco::Localisation
         size_t i = 0;
         while (i < string.length())
         {
-            if ((string[i] & 0b10000000) == 0)
+            if ((string[i] & 0b1000'0000) == 0)
             {
                 i += 1;
             }
-            else if ((string[i] & 0b11100000) == 0b11000000)
+            else if ((string[i] & 0b1110'0000) == 0b1100'0000)
             {
                 i += 2;
             }
-            else if ((string[i] & 0b11110000) == 0b11100000)
+            else if ((string[i] & 0b1111'0000) == 0b1110'0000)
             {
                 i += 3;
             }
-            else if ((string[i] & 0b11111000) == 0b11110000)
+            else if ((string[i] & 0b1111'1000) == 0b1111'0000)
             {
                 i += 4;
             }
@@ -105,19 +105,19 @@ namespace OpenLoco::Localisation
         size_t i = 0;
         for (size_t j = 0; j < characterPosition; j++)
         {
-            if ((stringToModify[i] & 0b10000000) == 0)
+            if ((stringToModify[i] & 0b1000'0000) == 0)
             {
                 i += 1;
             }
-            else if ((stringToModify[i] & 0b11100000) == 0b11000000)
+            else if ((stringToModify[i] & 0b1110'0000) == 0b1100'0000)
             {
                 i += 2;
             }
-            else if ((stringToModify[i] & 0b11110000) == 0b11100000)
+            else if ((stringToModify[i] & 0b1111'0000) == 0b1110'0000)
             {
                 i += 3;
             }
-            else if ((stringToModify[i] & 0b11111000) == 0b11110000)
+            else if ((stringToModify[i] & 0b1111'1000) == 0b1111'0000)
             {
                 i += 4;
             }
@@ -136,19 +136,19 @@ namespace OpenLoco::Localisation
         size_t i = 0;
         for (size_t j = 0; j < characterPosition; j++)
         {
-            if ((stringToModify[i] & 0b10000000) == 0)
+            if ((stringToModify[i] & 0b1000'0000) == 0)
             {
                 i += 1;
             }
-            else if ((stringToModify[i] & 0b11100000) == 0b11000000)
+            else if ((stringToModify[i] & 0b1110'0000) == 0b1100'0000)
             {
                 i += 2;
             }
-            else if ((stringToModify[i] & 0b11110000) == 0b11100000)
+            else if ((stringToModify[i] & 0b1111'0000) == 0b1110'0000)
             {
                 i += 3;
             }
-            else if ((stringToModify[i] & 0b11111000) == 0b11110000)
+            else if ((stringToModify[i] & 0b1111'1000) == 0b1111'0000)
             {
                 i += 4;
             }
@@ -160,19 +160,19 @@ namespace OpenLoco::Localisation
 
         // Get length of target character
         uint8_t bytes = 0;
-        if ((stringToModify[i] & 0b10000000) == 0)
+        if ((stringToModify[i] & 0b1000'0000) == 0)
         {
             bytes = 1;
         }
-        else if ((stringToModify[i] & 0b11100000) == 0b11000000)
+        else if ((stringToModify[i] & 0b1110'0000) == 0b1100'0000)
         {
             bytes = 2;
         }
-        else if ((stringToModify[i] & 0b11110000) == 0b11100000)
+        else if ((stringToModify[i] & 0b1111'0000) == 0b1110'0000)
         {
             bytes = 3;
         }
-        else if ((stringToModify[i] & 0b11111000) == 0b11110000)
+        else if ((stringToModify[i] & 0b1111'1000) == 0b1111'0000)
         {
             bytes = 4;
         }

--- a/src/OpenLoco/src/Localisation/Unicode.cpp
+++ b/src/OpenLoco/src/Localisation/Unicode.cpp
@@ -53,7 +53,7 @@ namespace OpenLoco::Localisation
             string += 0b10000000 + ((codepoint & 0b1111111000000) >> 6);
             string += 0b10000000 + (codepoint & 0b111111);
         }
-        else if (codepoint < 110000)
+        else if (codepoint < 0x110000)
         {
             string += 0b11100000 + ((codepoint & 0b111000000000000000000) >> 18);
             string += 0b10000000 + ((codepoint & 0b111111000000000000) >> 12);

--- a/src/OpenLoco/src/Localisation/Unicode.cpp
+++ b/src/OpenLoco/src/Localisation/Unicode.cpp
@@ -33,4 +33,37 @@ namespace OpenLoco::Localisation
 
         return read;
     }
+
+    std::string codepointToUtf8(utf32_t codepoint)
+    {
+        std::string string;
+        if (codepoint < 0x80)
+        {
+            string += codepoint;
+        }
+        else if (codepoint < 0x800)
+        {
+            string += 0b11000000 + ((codepoint & 0b111111000000) >> 6);
+            string += 0b10000000 + (codepoint & 0b111111);
+        }
+        else if (codepoint < 0x10000)
+        {
+            string += 0b11100000 + ((codepoint & 0b1111000000000000) >> 12);
+            string += 0b10000000 + ((codepoint & 0b1111111000000) >> 6);
+            string += 0b10000000 + (codepoint & 0b111111);
+        }
+        else if (codepoint < 110000)
+        {
+            string += 0b11100000 + ((codepoint & 0b111000000000000000000) >> 18);
+            string += 0b10000000 + ((codepoint & 0b111111000000000000) >> 12);
+            string += 0b10000000 + ((codepoint & 0b1111111000000) >> 6);
+            string += 0b10000000 + (codepoint & 0b111111);
+        }
+        else
+        {
+            // Invalid
+            string += "�";
+        }
+        return string;
+    }
 }

--- a/src/OpenLoco/src/Localisation/Unicode.cpp
+++ b/src/OpenLoco/src/Localisation/Unicode.cpp
@@ -1,4 +1,5 @@
 #include "Localisation/Unicode.h"
+#include <OpenLoco/Core/Exception.hpp>
 #include <cstdint>
 
 namespace OpenLoco::Localisation
@@ -65,5 +66,117 @@ namespace OpenLoco::Localisation
             string += "�";
         }
         return string;
+    }
+
+    size_t utf8Length(const std::string& string)
+    {
+        size_t count = 0;
+        size_t i = 0;
+        while (i < string.length())
+        {
+            if ((string[i] & 0b10000000) == 0)
+            {
+                i += 1;
+            }
+            else if ((string[i] & 0b11100000) == 0b11000000)
+            {
+                i += 2;
+            }
+            else if ((string[i] & 0b11110000) == 0b11100000)
+            {
+                i += 3;
+            }
+            else if ((string[i] & 0b11111000) == 0b11110000)
+            {
+                i += 4;
+            }
+            else
+            {
+                throw Exception::RuntimeError("Invalid UTF-8 string");
+            }
+            count++;
+        }
+        return count;
+    }
+
+    void utf8Insert(std::string& stringToModify, size_t characterPosition, const std::string& insertion)
+    {
+        // Get byte position
+        size_t i = 0;
+        for (size_t j = 0; j < characterPosition; j++)
+        {
+            if ((stringToModify[i] & 0b10000000) == 0)
+            {
+                i += 1;
+            }
+            else if ((stringToModify[i] & 0b11100000) == 0b11000000)
+            {
+                i += 2;
+            }
+            else if ((stringToModify[i] & 0b11110000) == 0b11100000)
+            {
+                i += 3;
+            }
+            else if ((stringToModify[i] & 0b11111000) == 0b11110000)
+            {
+                i += 4;
+            }
+            else
+            {
+                throw Exception::RuntimeError("Invalid UTF-8 string");
+            }
+        }
+
+        stringToModify.insert(i, insertion);
+    }
+
+    void utf8Delete(std::string& stringToModify, size_t characterPosition)
+    {
+        // Get byte position
+        size_t i = 0;
+        for (size_t j = 0; j < characterPosition; j++)
+        {
+            if ((stringToModify[i] & 0b10000000) == 0)
+            {
+                i += 1;
+            }
+            else if ((stringToModify[i] & 0b11100000) == 0b11000000)
+            {
+                i += 2;
+            }
+            else if ((stringToModify[i] & 0b11110000) == 0b11100000)
+            {
+                i += 3;
+            }
+            else if ((stringToModify[i] & 0b11111000) == 0b11110000)
+            {
+                i += 4;
+            }
+            else
+            {
+                throw Exception::RuntimeError("Invalid UTF-8 string");
+            }
+        }
+
+        // Get length of target character
+        uint8_t bytes = 0;
+        if ((stringToModify[i] & 0b10000000) == 0)
+        {
+            bytes = 1;
+        }
+        else if ((stringToModify[i] & 0b11100000) == 0b11000000)
+        {
+            bytes = 2;
+        }
+        else if ((stringToModify[i] & 0b11110000) == 0b11100000)
+        {
+            bytes = 3;
+        }
+        else if ((stringToModify[i] & 0b11111000) == 0b11110000)
+        {
+            bytes = 4;
+        }
+
+        stringToModify.erase(i, bytes);
     }
 }

--- a/src/OpenLoco/src/Ui/TextInput.cpp
+++ b/src/OpenLoco/src/Ui/TextInput.cpp
@@ -2,6 +2,7 @@
 #include "Graphics/TextRenderer.h"
 #include "Localisation/Formatting.h"
 #include "Localisation/StringManager.h"
+#include "Localisation/Unicode.h"
 
 #include <SDL3/SDL_keycode.h>
 
@@ -10,21 +11,23 @@ namespace OpenLoco::Ui::TextInput
     // Common code from 0x0044685C, 0x004CE910
     bool InputSession::handleInput(uint32_t charCode, uint32_t keyCode)
     {
-        if ((charCode >= SDLK_SPACE && charCode < SDLK_DELETE) || (charCode >= 159 && charCode <= 255))
+        if ((charCode >= SDLK_SPACE && charCode < SDLK_DELETE) || (charCode >= 159))
         {
-            if (inputLenLimit > 0 && buffer.length() >= inputLenLimit)
+            if (inputLenLimit > 0 && length() >= inputLenLimit)
             {
                 // Limit reached but we need to consume this input.
                 return true;
             }
 
-            if (cursorPosition == buffer.length())
+            auto character = Localisation::codepointToUtf8(charCode);
+
+            if (cursorPosition == length())
             {
-                buffer.append(1, (char)charCode);
+                buffer.append(character);
             }
             else
             {
-                buffer.insert(cursorPosition, 1, (char)charCode);
+                Localisation::utf8Insert(buffer, cursorPosition, character);
             }
             cursorPosition += 1;
         }
@@ -36,18 +39,18 @@ namespace OpenLoco::Ui::TextInput
                 return true;
             }
 
-            buffer.erase(cursorPosition - 1, 1);
+            Localisation::utf8Delete(buffer, cursorPosition - 1);
             cursorPosition -= 1;
         }
         else if (keyCode == SDLK_DELETE)
         {
-            if (cursorPosition == buffer.length())
+            if (cursorPosition == length())
             {
                 // Cursor is at end. No change required, but consume input
                 return true;
             }
 
-            buffer.erase(cursorPosition, 1);
+            Localisation::utf8Delete(buffer, cursorPosition);
         }
         else if (keyCode == SDLK_HOME)
         {
@@ -55,7 +58,7 @@ namespace OpenLoco::Ui::TextInput
         }
         else if (keyCode == SDLK_END)
         {
-            cursorPosition = buffer.length();
+            cursorPosition = length();
         }
         else if (keyCode == SDLK_LEFT)
         {
@@ -69,7 +72,7 @@ namespace OpenLoco::Ui::TextInput
         }
         else if (keyCode == SDLK_RIGHT)
         {
-            if (cursorPosition == buffer.length())
+            if (cursorPosition == length())
             {
                 // Cursor is at end. No change required, but consume input
                 return true;
@@ -84,10 +87,11 @@ namespace OpenLoco::Ui::TextInput
 
     bool InputSession::needsReoffsetting(int16_t containerWidth)
     {
-        std::string cursorStr = buffer.substr(0, cursorPosition);
+        const auto locoString = loco();
+        std::string cursorStr = locoString.substr(0, cursorPosition);
 
         const auto font = Gfx::Font::medium_bold;
-        const auto stringWidth = Gfx::TextRenderer::getStringWidth(font, buffer.c_str());
+        const auto stringWidth = Gfx::TextRenderer::getStringWidth(font, locoString.c_str());
         const auto cursorX = Gfx::TextRenderer::getStringWidth(font, cursorStr.c_str());
 
         const int x = xOffset + cursorX;
@@ -117,10 +121,11 @@ namespace OpenLoco::Ui::TextInput
      */
     void InputSession::calculateTextOffset(int16_t containerWidth)
     {
-        std::string cursorStr = buffer.substr(0, cursorPosition);
+        const auto locoString = loco();
+        std::string cursorStr = locoString.substr(0, cursorPosition);
 
         const auto font = Gfx::Font::medium_bold;
-        const auto stringWidth = Gfx::TextRenderer::getStringWidth(font, buffer.c_str());
+        const auto stringWidth = Gfx::TextRenderer::getStringWidth(font, locoString.c_str());
         const auto cursorX = Gfx::TextRenderer::getStringWidth(font, cursorStr.c_str());
 
         const auto midX = containerWidth / 2;
@@ -148,37 +153,18 @@ namespace OpenLoco::Ui::TextInput
         xOffset = 0;
     }
 
-    // 0x004CEBFB
-    void InputSession::sanitizeInput()
+    std::string InputSession::loco() const
     {
-        buffer.erase(
-            std::remove_if(
-                buffer.begin(),
-                buffer.end(),
-                [](unsigned char chr) {
-                    if (chr < ' ')
-                    {
-                        return true;
-                    }
-                    else if (chr <= 'z')
-                    {
-                        return false;
-                    }
-                    else if (chr == 171)
-                    {
-                        return false;
-                    }
-                    else if (chr == 187)
-                    {
-                        return false;
-                    }
-                    else if (chr >= 191)
-                    {
-                        return false;
-                    }
+        return Localisation::convertUnicodeToLoco(buffer);
+    }
 
-                    return true;
-                }),
-            buffer.end());
+    std::string InputSession::utf8() const
+    {
+        return buffer;
+    }
+
+    size_t InputSession::length() const
+    {
+        return Localisation::utf8Length(buffer);
     }
 }

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -615,7 +615,8 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 continue;
             }
 
-            std::string_view pattern = inputSession.buffer;
+            const auto locoString = inputSession.loco();
+            std::string_view pattern = locoString;
 
             if (!pattern.empty())
             {
@@ -1419,7 +1420,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     static void drawSearchBox(Window& self, Gfx::DrawingContext& drawingCtx)
     {
         char* textBuffer = StringManager::getBufferString(StringIds::buffer_2039);
-        strncpy(textBuffer, inputSession.buffer.c_str(), 256);
+        strncpy(textBuffer, inputSession.loco().c_str(), 256);
 
         auto& widget = _widgets[widx::searchBox];
         if (!drawingCtx.pushClip(Ui::Rect(widget.left, widget.top + 1, widget.width() - 2, widget.height() - 2)))

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -443,7 +443,8 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     static void applyFilterToObjectList(FilterFlags filterFlags)
     {
-        std::string_view pattern = inputSession.buffer;
+        const auto locoString = inputSession.loco();
+        std::string_view pattern = locoString;
         _numVisibleObjectsListed = 0;
         for (auto& entry : _tabObjectList)
         {
@@ -998,7 +999,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static void drawSearchBox(Window& self, Gfx::DrawingContext& drawingCtx)
     {
         char* textBuffer = StringManager::getBufferString(StringIds::buffer_2039);
-        strncpy(textBuffer, inputSession.buffer.c_str(), 256);
+        strncpy(textBuffer, inputSession.loco().c_str(), 256);
 
         auto& widget = widgets[widx::textInput];
         if (!drawingCtx.pushClip(Ui::Rect(widget.left + 1, widget.top + 1, widget.width() - 2, widget.height() - 2)))

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -518,7 +518,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             if (drawingCtx.pushClip(Ui::Rect(filenameBox.left + 1, filenameBox.top + 1, filenameBox.right - filenameBox.left - 1, filenameBox.bottom - filenameBox.top - 1)))
             {
                 bool showCaret = Input::isFocused(window.type, window.number, widx::text_filename) && (inputSession.cursorFrame & 0x10) == 0;
-                drawTextInput(&window, drawingCtx, inputSession.buffer.c_str(), static_cast<int32_t>(inputSession.cursorPosition), showCaret);
+                drawTextInput(&window, drawingCtx, inputSession.loco().c_str(), static_cast<int32_t>(inputSession.cursorPosition), showCaret);
 
                 drawingCtx.popClip();
             }
@@ -896,7 +896,9 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     static bool filenameContainsInvalidChars()
     {
         uint8_t numNonSpacesProcessed = 0;
-        for (const char chr : inputSession.buffer)
+        // To do: not convert to Locomotion encoding here, as we convert character not supported by it to '?'
+        const auto buffer = inputSession.loco();
+        for (const char chr : buffer)
         {
             if (chr != ' ')
             {
@@ -943,7 +945,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     static void processFileForLoadSave(Window* self)
     {
         // Create full path to target file.
-        fs::path path = _currentDirectory / inputSession.buffer;
+        fs::path path = _currentDirectory / fs::u8path(inputSession.utf8());
 
         // Append extension to filename.
         path += getExtensionFromFileType(_fileType);

--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -263,40 +263,10 @@ namespace OpenLoco::Ui::Windows::TextInput
                 WindowManager::close(&window);
                 break;
             case Widx::kOk:
-                auto buffer = inputSession.loco();
-                buffer.erase(
-                    std::remove_if(
-                        buffer.begin(),
-                        buffer.end(),
-                        [](uint32_t chr) {
-                            if (chr < ' ')
-                            {
-                                return true;
-                            }
-                            else if (chr <= 'z')
-                            {
-                                return false;
-                            }
-                            else if (chr == 171)
-                            {
-                                return false;
-                            }
-                            else if (chr == 187)
-                            {
-                                return false;
-                            }
-                            else if (chr >= 191)
-                            {
-                                return false;
-                            }
-
-                            return true;
-                        }),
-                    buffer.end());
                 auto caller = WindowManager::find(_callingWindowType, _callingWindowNumber);
                 if (caller != nullptr)
                 {
-                    caller->callTextInput(_callingWidget, caller->widgets[_callingWidget].id, buffer.c_str());
+                    caller->callTextInput(_callingWidget, caller->widgets[_callingWidget].id, inputSession.loco().c_str());
                 }
                 WindowManager::close(&window);
                 break;

--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -263,6 +263,9 @@ namespace OpenLoco::Ui::Windows::TextInput
                 WindowManager::close(&window);
                 break;
             case Widx::kOk:
+                // inputSession.sanitizeInput() was previously called here.
+                // We are currently converting to Locomotion's encoding here, which effectively does sanitisation.
+                // TODO: once we are not converting to 'Loco', consider ensuring inputSession cannot give us any unwanted UTF-8 characters here.
                 auto caller = WindowManager::find(_callingWindowType, _callingWindowNumber);
                 if (caller != nullptr)
                 {

--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -193,7 +193,7 @@ namespace OpenLoco::Ui::Windows::TextInput
         self.widgets[widx::title].text = _title;
         memcpy(self.widgets[widx::title].textArgs.data(), _formatArgs.data(), 16);
 
-        const uint16_t numCharacters = static_cast<uint16_t>(inputSession.buffer.length());
+        const uint16_t numCharacters = static_cast<uint16_t>(inputSession.length());
         const uint16_t maxNumCharacters = inputSession.inputLenLimit;
 
         FormatArguments args{ self.widgets[widx::charLimit].textArgs };
@@ -227,7 +227,7 @@ namespace OpenLoco::Ui::Windows::TextInput
         if (drawingCtx.pushClip(Ui::Rect(inputWidget.left + 1, inputWidget.top + 1, inputWidget.width() - 2, inputWidget.height() - 2)))
         {
             char* drawnBuffer = StringManager::getBufferString(StringIds::buffer_2039);
-            strcpy(drawnBuffer, inputSession.buffer.c_str());
+            strcpy(drawnBuffer, inputSession.loco().c_str());
 
             {
                 FormatArguments args{};
@@ -239,7 +239,7 @@ namespace OpenLoco::Ui::Windows::TextInput
 
             if ((inputSession.cursorFrame % 32) < 16)
             {
-                strncpy(drawnBuffer, inputSession.buffer.c_str(), inputSession.cursorPosition);
+                strncpy(drawnBuffer, inputSession.loco().c_str(), inputSession.cursorPosition);
                 drawnBuffer[inputSession.cursorPosition] = '\0';
 
                 if (Input::isFocused(window.type, window.number, widx::input))
@@ -263,11 +263,40 @@ namespace OpenLoco::Ui::Windows::TextInput
                 WindowManager::close(&window);
                 break;
             case Widx::kOk:
-                inputSession.sanitizeInput();
+                auto buffer = inputSession.loco();
+                buffer.erase(
+                    std::remove_if(
+                        buffer.begin(),
+                        buffer.end(),
+                        [](uint32_t chr) {
+                            if (chr < ' ')
+                            {
+                                return true;
+                            }
+                            else if (chr <= 'z')
+                            {
+                                return false;
+                            }
+                            else if (chr == 171)
+                            {
+                                return false;
+                            }
+                            else if (chr == 187)
+                            {
+                                return false;
+                            }
+                            else if (chr >= 191)
+                            {
+                                return false;
+                            }
+
+                            return true;
+                        }),
+                    buffer.end());
                 auto caller = WindowManager::find(_callingWindowType, _callingWindowNumber);
                 if (caller != nullptr)
                 {
-                    caller->callTextInput(_callingWidget, caller->widgets[_callingWidget].id, inputSession.buffer.c_str());
+                    caller->callTextInput(_callingWidget, caller->widgets[_callingWidget].id, buffer.c_str());
                 }
                 WindowManager::close(&window);
                 break;


### PR DESCRIPTION
I had to implement the conversion to and handling of UTF-8 strings to make this happen, and I am doubtful that I did this properly (although it appears to be correct).

The only player facing change should be that the actual file names of saved files will now be correct when non-ASCII characters are typed in the browse prompt (e.g. if typing "Łęłą" when saving a game, it will now be written to "Łęłą.SV5" instead of "§æ÷Ý.SV5").


This is an updated redo of changes I previously proposed in #3365
