### PR TITLE
Raise the threshold for the timer test

### DIFF
--- a/src/Core/tests/TimerTest.cpp
+++ b/src/Core/tests/TimerTest.cpp
@@ -28,5 +28,5 @@ TEST(TimerTest, TestReset)
     timer.reset();
 
     // Should be close to zero at this point.
-    EXPECT_NEAR(timer.elapsed(), 0.0f, 0.001f);
+    EXPECT_NEAR(timer.elapsed(), 0.0f, 0.1f);
 }


### PR DESCRIPTION
The CI sometimes fails because of this test, since those runners share the CPU let's be more lenient on the time, elapsed returns milliseconds as a float so I think 0.1ms should be fair, we just want to know if the reset actually did reset and not check its accuracy in this test.

For reference, this is what it reported on a failed CI run:
```
D:\a\OpenLoco\OpenLoco\src\Core\tests\TimerTest.cpp(31): error: The difference between timer.elapsed() and 0.0f is 0.053500000387430191, which exceeds 0.001f, where
timer.elapsed() evaluates to 0.053500000387430191,
```