### PR TITLE
Add default values to newsSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 26.02+ (???)
 ------------------------------------------------------------------------
+- Fix: [#3657] All news settings default to disabled instead of newspaper style.
 - Fix: [#3659] Using relative paths as Locomotion path causes certain data not to load.
 
 26.02 (2026-02-28)

--- a/src/OpenLoco/src/Config.h
+++ b/src/OpenLoco/src/Config.h
@@ -144,7 +144,14 @@ namespace OpenLoco::Config
         WindowFrameStyle windowFrameStyle = WindowFrameStyle::background;
         bool zoomToCursor = true;
 
-        NewsType newsSettings[kMessageCriticalityCount];
+        NewsType newsSettings[kMessageCriticalityCount] = {
+            NewsType::newsWindow,
+            NewsType::newsWindow,
+            NewsType::newsWindow,
+            NewsType::newsWindow,
+            NewsType::newsWindow,
+            NewsType::newsWindow
+        };
 
         int32_t autosaveAmount = 12;
         int32_t autosaveFrequency = 1;


### PR DESCRIPTION
Fixes #3657. Setting defaults in `Config::read()` is skipped if no config file is encountered!