### PR TITLE
fix: always reset newspaper content position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 26.02+ (???)
 ------------------------------------------------------------------------
-- Fix: [#3657] All news settings default to disabled instead of newspaper style.
 - Fix: [#3597] Single-image newspaper not staying centered when viewing consecutive news items.
+- Fix: [#3657] All news settings default to disabled instead of newspaper style.
 - Fix: [#3659] Using relative paths as Locomotion path causes certain data not to load.
 
 26.02 (2026-02-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.02+ (???)
 ------------------------------------------------------------------------
 - Fix: [#3657] All news settings default to disabled instead of newspaper style.
+- Fix: [#3597] Single-image newspaper not staying centered when viewing consecutive news items.
 - Fix: [#3659] Using relative paths as Locomotion path causes certain data not to load.
 
 26.02 (2026-02-28)

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -329,24 +329,24 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 self.widgets[Common::widx::viewport1Button].hidden = false;
             }
 
+            self.widgets[Common::widx::viewport1].left = 6;
+            self.widgets[Common::widx::viewport1].right = 353;
+            self.widgets[Common::widx::viewport1Button].left = 4;
+            self.widgets[Common::widx::viewport1Button].right = 355;
+
+            if (mtd.hasFlag(MessageTypeFlags::hasSecondItem))
+            {
+                self.widgets[Common::widx::viewport1].left = 6;
+                self.widgets[Common::widx::viewport1].right = 173;
+                self.widgets[Common::widx::viewport1Button].left = 4;
+                self.widgets[Common::widx::viewport1Button].right = 175;
+            }
+
             if (_nState.savedView[0] != view)
             {
                 _nState.savedView[0] = view;
                 self.viewportRemove(0);
                 self.invalidate();
-
-                self.widgets[Common::widx::viewport1].left = 6;
-                self.widgets[Common::widx::viewport1].right = 353;
-                self.widgets[Common::widx::viewport1Button].left = 4;
-                self.widgets[Common::widx::viewport1Button].right = 355;
-
-                if (mtd.hasFlag(MessageTypeFlags::hasSecondItem))
-                {
-                    self.widgets[Common::widx::viewport1].left = 6;
-                    self.widgets[Common::widx::viewport1].right = 173;
-                    self.widgets[Common::widx::viewport1Button].left = 4;
-                    self.widgets[Common::widx::viewport1Button].right = 175;
-                }
 
                 if (!view.isEmpty())
                 {
@@ -424,16 +424,16 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 self.widgets[Common::widx::viewport2Button].hidden = false;
             }
 
+            self.widgets[Common::widx::viewport2].left = 186;
+            self.widgets[Common::widx::viewport2].right = 353;
+            self.widgets[Common::widx::viewport2Button].left = 184;
+            self.widgets[Common::widx::viewport2Button].right = 355;
+
             if (_nState.savedView[1] != view)
             {
                 _nState.savedView[1] = view;
                 self.viewportRemove(1);
                 self.invalidate();
-
-                self.widgets[Common::widx::viewport2].left = 186;
-                self.widgets[Common::widx::viewport2].right = 353;
-                self.widgets[Common::widx::viewport2Button].left = 184;
-                self.widgets[Common::widx::viewport2Button].right = 355;
 
                 if (!view.isEmpty())
                 {

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -342,11 +342,12 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 self.widgets[Common::widx::viewport1Button].right = 175;
             }
 
+            self.invalidate();
+
             if (_nState.savedView[0] != view)
             {
                 _nState.savedView[0] = view;
                 self.viewportRemove(0);
-                self.invalidate();
 
                 if (!view.isEmpty())
                 {
@@ -429,11 +430,12 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             self.widgets[Common::widx::viewport2Button].left = 184;
             self.widgets[Common::widx::viewport2Button].right = 355;
 
+            self.invalidate();
+
             if (_nState.savedView[1] != view)
             {
                 _nState.savedView[1] = view;
                 self.viewportRemove(1);
-                self.invalidate();
 
                 if (!view.isEmpty())
                 {


### PR DESCRIPTION
The viewport widget positions in initViewport0 and initViewport1 were only updated when the saved view changed. 

When viewing consecutive newspapers, the saved view might show a stale layout.

Moved the widget positioning code outside the savedView change check so it always runs.

Fixes: #3597 