### PR TITLE
Fix crash when deselecting last built track/road type

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -827,19 +827,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             {
                 ebx = ebx & ~(1 << 7);
                 auto obj = ObjectManager::get<RoadObject>(ebx);
-                if (obj == nullptr)
-                {
-                    return;
-                }
                 fg_image = Gfx::recolour(obj->image, companyColour);
             }
             else
             {
                 auto obj = ObjectManager::get<TrackObject>(ebx);
-                if (obj == nullptr)
-                {
-                    return;
-                }
                 fg_image = Gfx::recolour(obj->image + TrackObj::ImageIds::kUiPreviewImage0, companyColour);
             }
 

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
@@ -66,19 +66,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
             if (isRoad)
             {
                 auto obj = ObjectManager::get<RoadObject>(lastRoadOption & ~(1 << 7));
-                if (obj == nullptr)
-                {
-                    return;
-                }
                 fgImage = Gfx::recolour(obj->image, companyColour);
             }
             else
             {
                 auto obj = ObjectManager::get<TrackObject>(lastRoadOption);
-                if (obj == nullptr)
-                {
-                    return;
-                }
                 fgImage = Gfx::recolour(obj->image + TrackObj::ImageIds::kUiPreviewImage0, companyColour);
             }
 


### PR DESCRIPTION
Fixes #3034

When you open Object Selection and deselect a type that was available on the toolbar and selected as last used, the object gets unloaded from memory but the stored reference in the toolbar isn't cleared. So on the next redraw, it crashes.

Fix: When the Object Selection window closes, we now call `updatePlayerInfrastructureOptions()` to rebuild the list and reset any stale references. I also added null checks in the toolbar draw code as a safety net.