### PR TITLE
fix: loan going negative when holding repay button

### DIFF
--- a/src/OpenLoco/src/GameCommands/Company/ChangeLoan.cpp
+++ b/src/OpenLoco/src/GameCommands/Company/ChangeLoan.cpp
@@ -13,9 +13,10 @@ namespace OpenLoco::GameCommands
         GameCommands::setExpenditureType(ExpenditureType::LoanInterest);
 
         auto* company = CompanyManager::get(GameCommands::getUpdatingCompanyId());
-        const currency32_t loanDifference = company->currentLoan - newLoan;
+        const auto clampedLoan = std::max<currency32_t>(newLoan, 0);
+        const currency32_t loanDifference = company->currentLoan - clampedLoan;
 
-        if (company->currentLoan > newLoan)
+        if (company->currentLoan > clampedLoan)
         {
             if (company->cash < loanDifference)
             {
@@ -26,7 +27,7 @@ namespace OpenLoco::GameCommands
         else
         {
             const auto maxLoan = Economy::getInflationAdjustedCost(CompanyManager::getMaxLoanSize(), 0, 8);
-            if (newLoan > maxLoan)
+            if (clampedLoan > maxLoan)
             {
                 GameCommands::setErrorText(StringIds::bank_refuses_to_increase_loan);
                 return FAILURE;
@@ -35,7 +36,7 @@ namespace OpenLoco::GameCommands
 
         if (flags & Flags::apply)
         {
-            company->currentLoan = newLoan;
+            company->currentLoan = clampedLoan;
             company->cash -= loanDifference;
             Ui::WindowManager::invalidate(Ui::WindowType::company, static_cast<uint16_t>(GameCommands::getUpdatingCompanyId()));
             if (CompanyManager::getControllingId() == GameCommands::getUpdatingCompanyId())


### PR DESCRIPTION
When holding the repay button, the step size accelerates and can overshoot past zero.

Clamp newLoan to zero so the final repayment always brings the loan to exactly zero instead of going negative.

Fixes #3638 