### PR TITLE
fix: ImageButton hover drawing and restore terraform scroll wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 26.02+ (???)
 ------------------------------------------------------------------------
+- Fix: [#2983] Terraform tool size +/- buttons show incorrect hover highlight and scroll wheel does not work.
 - Fix: [#3657] All news settings default to disabled instead of newspaper style.
 - Fix: [#3659] Using relative paths as Locomotion path causes certain data not to load.
 

--- a/src/OpenLoco/src/Ui/Widget.h
+++ b/src/OpenLoco/src/Ui/Widget.h
@@ -191,6 +191,8 @@ namespace OpenLoco::Ui
         WidgetType type{};
         ContentAlign contentAlign{ ContentAlign::left };
         WindowColour windowColour{};
+        bool hoverTranslucent{};
+        bool hoverInset{ true };
 
         int32_t midX() const;
         int32_t midY() const;

--- a/src/OpenLoco/src/Ui/Widgets/ImageButtonWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ImageButtonWidget.cpp
@@ -8,7 +8,7 @@
 namespace OpenLoco::Ui::Widgets
 {
     // 0x004CADE8
-    static void drawImage(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
+    static void drawImage(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState, int32_t indexOffset = 0)
     {
         auto* window = widgetState.window;
 
@@ -16,6 +16,10 @@ namespace OpenLoco::Ui::Widgets
 
         const bool isColourSet = widget.image & Widget::kImageIdColourSet;
         ImageId imageId = ImageId::fromUInt32(widget.image & ~Widget::kImageIdColourSet);
+        if (indexOffset != 0)
+        {
+            imageId = imageId.withIndexOffset(indexOffset);
+        }
 
         auto colour = widgetState.colour;
         if (widgetState.disabled)
@@ -85,13 +89,25 @@ namespace OpenLoco::Ui::Widgets
             return;
         }
 
+        if (!widget.hoverInset)
+        {
+            // No hover effect — draw image normally, with pressed sprite on click.
+            if (widget.content == Widget::kContentNull)
+            {
+                return;
+            }
+
+            drawImage(drawingCtx, widget, widgetState, widgetState.activated ? 1 : 0);
+            return;
+        }
+
         if (window->hasFlags(WindowFlags::framedWidgets))
         {
             drawingCtx.fillRect(pos, size, enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
         }
 
-        // TODO: Add a setting to decide if it should be translucent or not, for now it seems all ImageButton's require this.
-        drawingCtx.fillRectInset(pos, size, widgetState.colour.translucent(), flags);
+        const auto colour = widget.hoverTranslucent ? widgetState.colour.translucent() : widgetState.colour;
+        drawingCtx.fillRectInset(pos, size, colour, flags);
 
         if (widget.content == Widget::kContentNull)
         {

--- a/src/OpenLoco/src/Ui/Widgets/ImageButtonWidget.h
+++ b/src/OpenLoco/src/Ui/Widgets/ImageButtonWidget.h
@@ -20,6 +20,20 @@ namespace OpenLoco::Ui::Widgets
         {
         }
 
+        constexpr ImageButton withHoverTranslucent() const
+        {
+            ImageButton copy = *this;
+            copy.hoverTranslucent = true;
+            return copy;
+        }
+
+        constexpr ImageButton withNoHoverInset() const
+        {
+            ImageButton copy = *this;
+            copy.hoverInset = false;
+            return copy;
+        }
+
         static void draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState);
     };
 

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -1210,6 +1210,11 @@ namespace OpenLoco::Ui::WindowManager
                 return reverseIndex;
             }
 
+            if (isStepperGroup(w, reverseIndex, WidgetType::buttonWithImage))
+            {
+                return reverseIndex;
+            }
+
             if (isStepperGroup(w, reverseIndex, WidgetType::button))
             {
                 return reverseIndex;

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -138,7 +138,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             Common::makeCommonWidgets(270, 182, StringIds::title_company),
             Widgets::Label({ 3, 160 }, { 242, 21 }, WindowColour::secondary, ContentAlign::center),
             Widgets::Viewport({ 3, 44 }, { 96, 120 }, WindowColour::secondary, Widget::kContentUnk),
-            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this),
+            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this).withHoverTranslucent(),
             Widgets::ImageButton({ 178, 57 }, { 66, 66 }, WindowColour::secondary, Widget::kContentNull),
             Widgets::ImageButton({ 154, 124 }, { 112, 22 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_change_owner_name)
 
@@ -697,7 +697,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             Widgets::Viewport({ 219, 54 }, { 96, 120 }, WindowColour::secondary, Widget::kContentUnk),
             Widgets::ImageButton({ 315, 92 }, { 24, 24 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_build_or_move_headquarters),
             Widgets::ImageButton({ 315, 92 + 26 }, { 24, 24 }, WindowColour::secondary, ImageIds::rotate_object, StringIds::rotate_object_90),
-            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this)
+            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this).withHoverTranslucent()
 
         );
 

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -95,7 +95,7 @@ namespace OpenLoco::Ui::Windows::Industry
             Common::makeCommonWidgets(223, 137, StringIds::title_town),
             Widgets::Viewport({ 3, 44 }, { 195, 80 }, WindowColour::secondary, Widget::kContentUnk),
             Widgets::Label({ 3, 115 }, { 195, 21 }, WindowColour::secondary, ContentAlign::center),
-            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this),
+            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this).withHoverTranslucent(),
             Widgets::ImageButton({ 198, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::rubbish_bin, StringIds::demolish_this_industry)
 
         );

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -125,7 +125,7 @@ namespace OpenLoco::Ui::Windows::Station
             Common::makeCommonWidgets(223, 136),
             Widgets::Viewport({ 3, 44 }, { 195, 80 }, WindowColour::secondary, Widget::kContentUnk),
             Widgets::Label({ 3, 115 }, { 195, 21 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid),
-            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this)
+            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this).withHoverTranslucent()
 
         );
 

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -982,8 +982,8 @@ namespace OpenLoco::Ui::Windows::Terraform
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(130, 105, StringIds::clear_area),
             Widgets::Wt3Widget({ 33 + 16, 45 }, { 64, 44 }, WindowColour::secondary, ImageIds::tool_area, StringIds::tooltip_clear_area),
-            Widgets::ImageButton({ 34 + 16, 46 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_clear_area),
-            Widgets::ImageButton({ 80 + 16, 72 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_clear_area)
+            Widgets::ImageButton({ 34 + 16, 46 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_clear_area).withNoHoverInset(),
+            Widgets::ImageButton({ 80 + 16, 72 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_clear_area).withNoHoverInset()
 
         );
 
@@ -1223,8 +1223,8 @@ namespace OpenLoco::Ui::Windows::Terraform
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(130, 105, StringIds::title_adjust_land),
             Widgets::Wt3Widget({ 49, 45 }, { 64, 44 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_adjust_land_tool),
-            Widgets::ImageButton({ 50, 46 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_adjust_land_area),
-            Widgets::ImageButton({ 96, 72 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_adjust_land_area),
+            Widgets::ImageButton({ 50, 46 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_adjust_land_area).withNoHoverInset(),
+            Widgets::ImageButton({ 96, 72 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_adjust_land_area).withNoHoverInset(),
             Widgets::ImageButton({ 57, 92 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_slope_up, StringIds::mountainModeTooltip),
             Widgets::ImageButton({ 83, 92 }, { 24, 24 }, WindowColour::secondary, ImageIds::paintbrush, StringIds::tooltip_paint_landscape_tool),
             Widgets::ImageButton({ 112, 94 }, { 20, 20 }, WindowColour::primary)
@@ -1904,8 +1904,8 @@ namespace OpenLoco::Ui::Windows::Terraform
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(130, 105, StringIds::title_adjust_water),
             Widgets::Wt3Widget({ 33 + 16, 45 }, { 64, 44 }, WindowColour::secondary, ImageIds::tool_area, StringIds::tooltip_adjust_water_tool),
-            Widgets::ImageButton({ 34 + 16, 46 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_adjust_water_area),
-            Widgets::ImageButton({ 80 + 16, 72 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_adjust_water_area)
+            Widgets::ImageButton({ 34 + 16, 46 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_adjust_water_area).withNoHoverInset(),
+            Widgets::ImageButton({ 80 + 16, 72 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_adjust_water_area).withNoHoverInset()
 
         );
 

--- a/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
@@ -87,7 +87,7 @@ namespace OpenLoco::Ui::Windows::Town
             Common::makeCommonWidgets(223, 161, StringIds::title_town),
             Widgets::Viewport({ 3, 44 }, { 195, 104 }, WindowColour::secondary, Widget::kContentUnk),
             Widgets::Label({ 3, 139 }, { 195, 21 }, WindowColour::secondary, ContentAlign::center),
-            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this),
+            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this).withHoverTranslucent(),
             Widgets::ImageButton({ 198, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::town_expand, StringIds::expand_this_town),
             Widgets::ImageButton({ 198, 68 }, { 24, 24 }, WindowColour::secondary, ImageIds::rubbish_bin, StringIds::demolish_this_town)
 

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -367,7 +367,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             Widgets::ImageButton({ 240, 68 }, { 24, 24 }, WindowColour::secondary, ImageIds::null, StringIds::tooltip_remove_from_track),
             Widgets::ImageButton({ 240, 92 }, { 24, 24 }, WindowColour::secondary, ImageIds::pass_signal, StringIds::tooltip_pass_signal_at_danger),
             Widgets::ImageButton({ 240, 116 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_right_turnaround, StringIds::tooltip_change_direction),
-            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this)
+            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this).withHoverTranslucent()
 
         );
 


### PR DESCRIPTION
Created new hover settings on ImageButton, resolving a regression from #2860 where all ImageButton hover states were made translucent.
Also reintroduced image offset for the +/- buttons, fixing their behaviour.

- Added hoverTranslucent flag for arrow buttons in the company/station/vehicle windows
- Added hoverInset flag for buttons that should not draw a hover background, using the pressed sprite (index+1) on click
- Added buttonWithImage to stepper group widget detection so scroll wheel works now
- Marked terraform +/- buttons with .withNoHoverInset() and arrow buttons with .withHoverTranslucent()

Also relates to #3147 by making the translucent hover a choice per widget rather than globally applied

Fixes #2983