### PR TITLE
Fix crash caused by deleting a station that a vehicle is approaching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix: [#3312] Dragging around vehicles leaves pixels on-screen from the preview.
 - Fix: [#3657] All news settings default to disabled instead of newspaper style.
 - Fix: [#3659] Using relative paths as Locomotion path causes certain data not to load.
+- Fix: [#3672] Crash when a vehicle arrives at the location of a station that was deallocated whilst the vehicle was approaching it.
 
 26.02 (2026-02-28)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -2681,6 +2681,10 @@ namespace OpenLoco::Vehicles
     // 0x004B996F
     void VehicleHead::setStationVisitedTypes()
     {
+        if (stationId == StationId::null)
+        {
+            return;
+        }
         auto station = StationManager::get(stationId);
         station->var_3B2 |= (1 << static_cast<uint8_t>(vehicleType));
     }


### PR DESCRIPTION
Fixes #3672.

In addition to the save file linked in that issue, the situation that caused this crash could also be reproduced from a new game with the following steps:
1. Construct a long road with a passenger stop or terminus at or near one end, and a WMC Bus (which does not need orders) at the other end.
2. Start the bus, and watch its window. When you see the bus's status switch to "approaching [station]", quickly remove the station (by right-clicking it with the build stations tool).

By the time it reaches the location of the station, the station will have been deallocated. In vanilla, (and now in OpenLoco with this PR), the bus will stop where the station was, but it will then continuing on without crashing the game.
