### PR TITLE
Configurable scenario path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 26.02+ (???)
 ------------------------------------------------------------------------
+- Feature: [#3677] Scenarios can be placed in sub folders in new custom scenario folder.
 - Fix: [#3657] All news settings default to disabled instead of newspaper style.
 - Fix: [#3659] Using relative paths as Locomotion path causes certain data not to load.
 

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2456,3 +2456,4 @@ strings:
   2401: "Move component"
   2402: "Moving this vehicle component will remove all cargo aboard the entire vehicle. Continue?"
   2403: "Moving this vehicle component will remove all cargo aboard both vehicles. Continue?"
+  2404: "{COLOUR WINDOW_2} Filename: {COLOUR BLACK}{STRINGID}"

--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -103,6 +103,7 @@ namespace OpenLoco::Config
         _config.locoInstallPath = config["loco_install_path"].as<std::string>("");
         _config.lastSavePath = config["last_save_path"].as<std::string>("");
         _config.lastLandscapePath = config["last_landscape_path"].as<std::string>("");
+        _config.lastScenarioPath = config["last_scenario_path"].as<std::string>("");
 
         // Regional
         _config.language = config["language"].as<std::string>("en-GB");
@@ -242,6 +243,7 @@ namespace OpenLoco::Config
         node["loco_install_path"] = _config.locoInstallPath;
         node["last_save_path"] = _config.lastSavePath;
         node["last_landscape_path"] = _config.lastLandscapePath;
+        node["last_scenario_path"] = _config.lastScenarioPath;
 
         // Regional
         node["language"] = _config.language;

--- a/src/OpenLoco/src/Config.h
+++ b/src/OpenLoco/src/Config.h
@@ -118,6 +118,7 @@ namespace OpenLoco::Config
         std::string locoInstallPath;
         std::string lastSavePath;
         std::string lastLandscapePath;
+        std::string lastScenarioPath;
 
         std::string language = "en-GB";
         MeasurementFormat measurementFormat;

--- a/src/OpenLoco/src/Environment.cpp
+++ b/src/OpenLoco/src/Environment.cpp
@@ -19,6 +19,7 @@ namespace OpenLoco::Environment
         fs::path install;
         fs::path saves;
         fs::path landscapes;
+        fs::path scenarios;
     };
 
     static ConfigurablePaths _configurablePaths;
@@ -193,6 +194,10 @@ namespace OpenLoco::Environment
         {
             return _configurablePaths.landscapes;
         }
+        else if (id == PathId::customScenarios)
+        {
+            return _configurablePaths.scenarios;
+        }
         else
         {
             return getDefaultPathNoWarning(id);
@@ -266,7 +271,12 @@ namespace OpenLoco::Environment
         auto configLastLandscapePath = fs::u8path(Config::get().lastLandscapePath);
         _configurablePaths.landscapes = tryPathOrDefault(configLastLandscapePath, PathId::landscape);
 
+        // Figure out what scenario directory to default to
+        auto configLastScenarioPath = fs::u8path(Config::get().lastScenarioPath);
+        _configurablePaths.scenarios = tryPathOrDefault(configLastScenarioPath, PathId::customScenarios);
+
         autoCreateDirectory(getPath(PathId::customObjects));
+        autoCreateDirectory(getPath(PathId::customScenarios));
     }
 
     class ThousandsSepFacet : public std::numpunct<char>
@@ -307,6 +317,7 @@ namespace OpenLoco::Environment
             case PathId::landscape:
             case PathId::heightmap:
             case PathId::customObjects:
+            case PathId::customScenarios:
             case PathId::screenshots:
                 return Platform::getUserDirectory();
             case PathId::languageFiles:
@@ -323,7 +334,7 @@ namespace OpenLoco::Environment
 
     static fs::path getSubPath(PathId id)
     {
-        static constexpr std::array<const char*, 60> kPaths = {
+        static constexpr std::array<const char*, 61> kPaths = {
             "Data/g1.DAT",
             "plugin.dat",
             "plugin2.dat",
@@ -384,6 +395,7 @@ namespace OpenLoco::Environment
             "objects",
             "objects",
             "screenshots",
+            "scenarios",
         };
 
         size_t index = (size_t)id;
@@ -392,5 +404,26 @@ namespace OpenLoco::Environment
             throw Exception::RuntimeError("Invalid PathId: " + std::to_string((int32_t)id));
         }
         return kPaths[(size_t)id];
+    }
+
+    std::vector<fs::path> getAllScenarioPaths()
+    {
+        std::vector<fs::path> paths;
+
+        // User configurable scenarios path
+        const auto& userPath = _configurablePaths.scenarios;
+        if (fs::is_directory(userPath))
+        {
+            paths.push_back(userPath);
+        }
+
+        // Install path scenarios
+        auto installPath = (_configurablePaths.install / getSubPath(PathId::vanillaScenarios)).lexically_normal();
+        if (fs::is_directory(installPath) && installPath != userPath)
+        {
+            paths.push_back(installPath);
+        }
+
+        return paths;
     }
 }

--- a/src/OpenLoco/src/Environment.h
+++ b/src/OpenLoco/src/Environment.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <OpenLoco/Core/FileSystem.hpp>
+#include <vector>
 
 namespace OpenLoco::Environment
 {
@@ -61,16 +62,18 @@ namespace OpenLoco::Environment
         landscape,
         _1tmp,
         vanillaObjects,
-        scenarios,
+        vanillaScenarios,
         heightmap,
         customObjects,
         objects,
         screenshots,
+        customScenarios,
     };
 
     void autoCreateDirectory(const fs::path& path);
     fs::path getPath(PathId id);
     fs::path getPathNoWarning(PathId id);
+    std::vector<fs::path> getAllScenarioPaths();
     void resolvePaths();
     void setLocale();
 }

--- a/src/OpenLoco/src/Game.cpp
+++ b/src/OpenLoco/src/Game.cpp
@@ -85,7 +85,7 @@ namespace OpenLoco::Game
     // 0x004418DB
     [[nodiscard]] std::optional<std::string> saveScenarioOpen()
     {
-        auto path = Environment::getPath(Environment::PathId::scenarios) / Scenario::getOptions().scenarioName;
+        auto path = Environment::getPath(Environment::PathId::customScenarios) / Scenario::getOptions().scenarioName;
         auto savePath = path.u8string() + S5::extensionSC5;
 
         return openBrowsePrompt(savePath, StringIds::title_prompt_save_scenario, browse_type::save, S5::filterSC5);

--- a/src/OpenLoco/src/Localisation/StringIds.h
+++ b/src/OpenLoco/src/Localisation/StringIds.h
@@ -2115,6 +2115,7 @@ namespace OpenLoco::StringIds
     constexpr StringId confirm_vehicle_component_move_cargo_warning_confirm = 2401;
     constexpr StringId confirm_vehicle_component_move_cargo_warning_message = 2402;
     constexpr StringId confirm_vehicle_component_move_cargo_multiple_vehicles_warning_message = 2403;
+    constexpr StringId scenario_selection_filename = 2404;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Scenario/Scenario.cpp
+++ b/src/OpenLoco/src/Scenario/Scenario.cpp
@@ -288,7 +288,7 @@ namespace OpenLoco::Scenario
         fs::path fullPath = path;
         if (!fullPath.has_root_path())
         {
-            auto scenarioPath = Environment::getPath(Environment::PathId::scenarios);
+            auto scenarioPath = Environment::getPath(Environment::PathId::vanillaScenarios);
             fullPath = scenarioPath / path;
         }
 

--- a/src/OpenLoco/src/Scenario/Scenario.cpp
+++ b/src/OpenLoco/src/Scenario/Scenario.cpp
@@ -284,13 +284,7 @@ namespace OpenLoco::Scenario
         WindowManager::closeConstructionWindows();
         WindowManager::closeAllFloatingWindows();
 
-        // Resolve filenames to base game scenario directory
-        fs::path fullPath = path;
-        if (!fullPath.has_root_path())
-        {
-            auto scenarioPath = Environment::getPath(Environment::PathId::vanillaScenarios);
-            fullPath = scenarioPath / path;
-        }
+        auto fullPath = ScenarioManager::resolveScenarioPath(path).value_or(path);
 
         Audio::pauseSound();
 

--- a/src/OpenLoco/src/Scenario/ScenarioManager.cpp
+++ b/src/OpenLoco/src/Scenario/ScenarioManager.cpp
@@ -289,6 +289,29 @@ namespace OpenLoco::ScenarioManager
         return std::nullopt;
     }
 
+    std::optional<fs::path> resolveScenarioPath(const fs::path& path)
+    {
+        if (path.has_root_path())
+        {
+            if (fs::exists(path))
+            {
+                return path;
+            }
+            return std::nullopt;
+        }
+
+        for (const auto& scenarioPath : Environment::getAllScenarioPaths())
+        {
+            auto fullPath = (scenarioPath / path).lexically_normal();
+            if (fs::exists(fullPath))
+            {
+                return fullPath;
+            }
+        }
+
+        return std::nullopt;
+    }
+
     // 0x004447DF
     static void createIndex(const ScenarioFolderState& currentState)
     {

--- a/src/OpenLoco/src/Scenario/ScenarioManager.cpp
+++ b/src/OpenLoco/src/Scenario/ScenarioManager.cpp
@@ -149,15 +149,17 @@ namespace OpenLoco::ScenarioManager
     static ScenarioFolderState getCurrentScenarioFolderState()
     {
         ScenarioFolderState currentState;
-        const auto scenarioPath = Environment::getPathNoWarning(Environment::PathId::scenarios);
-        for (const auto& file : fs::directory_iterator(scenarioPath, fs::directory_options::skip_permission_denied))
+        for (const auto& scenarioPath : Environment::getAllScenarioPaths())
         {
-            if (!file.is_regular_file())
+            for (const auto& file : fs::directory_iterator(scenarioPath, fs::directory_options::skip_permission_denied))
             {
-                continue;
+                if (!file.is_regular_file())
+                {
+                    continue;
+                }
+                currentState.numFiles++;
+                currentState.totalFileSize += file.file_size();
             }
-            currentState.numFiles++;
-            currentState.totalFileSize += file.file_size();
         }
         return currentState;
     }
@@ -301,78 +303,84 @@ namespace OpenLoco::ScenarioManager
             entry.flags &= ~ScenarioIndexFlags::flag_0;
         }
 
-        const auto scenarioPath = Environment::getPathNoWarning(Environment::PathId::scenarios);
+        const auto scenarioPaths = Environment::getAllScenarioPaths();
         auto numScenariosDetected = 0;
-        for (const auto& file : fs::directory_iterator(scenarioPath, fs::directory_options::skip_permission_denied))
+        for (const auto& scenarioPath : scenarioPaths)
         {
-            if (!file.is_regular_file())
+            for (const auto& file : fs::directory_iterator(scenarioPath, fs::directory_options::skip_permission_denied))
             {
-                continue;
-            }
-            if (!Utility::iequals(file.path().extension().u8string(), ".sc5"))
-            {
-                continue;
-            }
+                if (!file.is_regular_file())
+                {
+                    continue;
+                }
+                if (!Utility::iequals(file.path().extension().u8string(), ".sc5"))
+                {
+                    continue;
+                }
 
-            numScenariosDetected++;
+                numScenariosDetected++;
+            }
         }
 
         auto currentScenarioOffset = 0;
-        for (const auto& file : fs::directory_iterator(scenarioPath, fs::directory_options::skip_permission_denied))
+        for (const auto& scenarioPath : scenarioPaths)
         {
-            if (!file.is_regular_file())
+            for (const auto& file : fs::directory_iterator(scenarioPath, fs::directory_options::skip_permission_denied))
             {
-                continue;
-            }
-            if (!Utility::iequals(file.path().extension().u8string(), ".sc5"))
-            {
-                continue;
-            }
+                if (!file.is_regular_file())
+                {
+                    continue;
+                }
+                if (!Utility::iequals(file.path().extension().u8string(), ".sc5"))
+                {
+                    continue;
+                }
 
-            Input::processMessagesMini();
+                Input::processMessagesMini();
 
-            currentScenarioOffset++;
-            auto currentScenarioProgress = currentScenarioOffset * 225 / numScenariosDetected;
-            Ui::ProgressBar::setProgress(currentScenarioProgress);
+                currentScenarioOffset++;
+                auto currentScenarioProgress = currentScenarioOffset * 225 / numScenariosDetected;
+                Ui::ProgressBar::setProgress(currentScenarioProgress);
 
-            const auto u8FileName = file.path().filename().u8string();
-            auto foundId = findScenario(u8FileName);
+                const auto u8FileName = file.path().filename().u8string();
+                auto foundId = findScenario(u8FileName);
 
-            const auto options = S5::readScenarioOptions(file.path());
-            if (options == nullptr)
-            {
-                continue;
+                const auto options = S5::readScenarioOptions(file.path());
+                if (options == nullptr)
+                {
+                    continue;
+                }
+                if (options->editorStep != EditorController::Step::null)
+                {
+                    continue;
+                }
+                if (!foundId.has_value())
+                {
+                    // This is a new entry so we will need to clear fields and add to the list
+                    ScenarioIndexEntry entry{};
+                    std::strcpy(entry.filename, u8FileName.c_str());
+                    foundId = static_cast<uint32_t>(_scenarioList.size());
+                    _scenarioList.push_back(entry);
+                    _scenarioHeader.numScenarios++;
+                }
+                ScenarioIndexEntry& entry = _scenarioList[foundId.value()];
+
+                entry.flags |= ScenarioIndexFlags::flag_0;
+                entry.category = options->difficulty;
+                entry.flags &= ~ScenarioIndexFlags::hasPreviewImage;
+                if ((options->scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) != Scenario::ScenarioFlags::none)
+                {
+                    entry.flags |= ScenarioIndexFlags::hasPreviewImage;
+                    std::copy(&options->preview[0][0], &options->preview[0][0] + sizeof(options->preview), &entry.preview[0][0]);
+                }
+                entry.startYear = options->scenarioStartYear;
+                entry.numCompetingCompanies = options->maxCompetingCompanies;
+                entry.competingCompanyDelay = options->competitorStartDelay;
+                entry.currency = options->currency;
+
+                loadScenarioProgress(entry, *options);
+                loadScenarioDetails(entry, *options);
             }
-            if (options->editorStep != EditorController::Step::null)
-            {
-                continue;
-            }
-            if (!foundId.has_value())
-            {
-                // This is a new entry so we will need to clear fields and add to the list
-                ScenarioIndexEntry entry{};
-                std::strcpy(entry.filename, u8FileName.c_str());
-                foundId = static_cast<uint32_t>(_scenarioList.size());
-                _scenarioList.push_back(entry);
-                _scenarioHeader.numScenarios++;
-            }
-            ScenarioIndexEntry& entry = _scenarioList[foundId.value()];
-
-            entry.flags |= ScenarioIndexFlags::flag_0;
-            entry.category = options->difficulty;
-            entry.flags &= ~ScenarioIndexFlags::hasPreviewImage;
-            if ((options->scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) != Scenario::ScenarioFlags::none)
-            {
-                entry.flags |= ScenarioIndexFlags::hasPreviewImage;
-                std::copy(&options->preview[0][0], &options->preview[0][0] + sizeof(options->preview), &entry.preview[0][0]);
-            }
-            entry.startYear = options->scenarioStartYear;
-            entry.numCompetingCompanies = options->maxCompetingCompanies;
-            entry.competingCompanyDelay = options->competitorStartDelay;
-            entry.currency = options->currency;
-
-            loadScenarioProgress(entry, *options);
-            loadScenarioDetails(entry, *options);
         }
 
         std::ranges::sort(_scenarioList, [](const ScenarioIndexEntry& lhs, const ScenarioIndexEntry& rhs) {

--- a/src/OpenLoco/src/Scenario/ScenarioManager.h
+++ b/src/OpenLoco/src/Scenario/ScenarioManager.h
@@ -2,8 +2,8 @@
 
 #include "Objects/Object.h"
 #include "Types.hpp"
-#include <OpenLoco/Core/FileSystem.hpp>
 #include <OpenLoco/Core/EnumFlags.hpp>
+#include <OpenLoco/Core/FileSystem.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <optional>

--- a/src/OpenLoco/src/Scenario/ScenarioManager.h
+++ b/src/OpenLoco/src/Scenario/ScenarioManager.h
@@ -2,9 +2,11 @@
 
 #include "Objects/Object.h"
 #include "Types.hpp"
+#include <OpenLoco/Core/FileSystem.hpp>
 #include <OpenLoco/Core/EnumFlags.hpp>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 namespace OpenLoco::Scenario
 {
@@ -55,6 +57,7 @@ namespace OpenLoco::ScenarioManager
     bool hasScenarioInCategory(uint8_t category, ScenarioIndexEntry* scenario);
     uint16_t getScenarioCountByCategory(uint8_t category);
     ScenarioIndexEntry* getNthScenarioFromCategory(uint8_t category, uint8_t index);
+    std::optional<fs::path> resolveScenarioPath(const fs::path& path);
     void loadIndex(const bool forceReload = false);
     void saveNewScore(Scenario::ObjectiveProgress& progress, const CompanyId companyId);
 

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -23,6 +23,7 @@
 #include "Ui/Widgets/TabWidget.h"
 #include "Ui/Widgets/Wt3Widget.h"
 #include "Ui/WindowManager.h"
+#include <OpenLoco/Core/FileSystem.hpp>
 
 using namespace OpenLoco::Diagnostics;
 
@@ -388,8 +389,20 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 
             // Filename
             {
+                const auto fullScenarioPath = ScenarioManager::resolveScenarioPath(fs::u8path(scenarioInfo->filename));
+                std::string filename;
+                if (fullScenarioPath.has_value())
+                {
+                    auto preferredPath = *fullScenarioPath;
+                    filename = preferredPath.make_preferred().u8string();
+                }
+                else
+                {
+                    filename = scenarioInfo->filename;
+                }
+
                 auto filenameStr = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
-                strncpy(filenameStr, scenarioInfo->filename, std::size(scenarioInfo->filename));
+                strncpy(filenameStr, filename.c_str(), filename.length() + 1);
 
                 args = FormatArguments();
                 args.push<StringId>(StringIds::buffer_1250);

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -314,57 +314,90 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             x = baseX;
             y = baseY + 150;
 
-            // Description
-            auto str = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
-            strncpy(str, scenarioInfo->description, std::size(scenarioInfo->description));
-
+            char* str{};
             FormatArguments args{};
-            args.push(StringIds::buffer_2039);
+            constexpr const int kSpacing = 10;
 
-            auto point = tr.drawStringLeftWrapped(Point(x, y), 170, Colour::black, StringIds::black_stringid, args);
-            y = point.y;
+            // Description
+            {
+                str = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+                strncpy(str, scenarioInfo->description, std::size(scenarioInfo->description));
+                args.push(StringIds::buffer_2039);
+
+                auto point = tr.drawStringLeftWrapped(Point(x, y), 170, Colour::black, StringIds::black_stringid, args);
+                y = point.y;
+            }
+            y += kSpacing;
 
             // Challenge header
-            y += 5;
-            tr.drawStringLeft(Point(x, y), Colour::black, StringIds::challenge_label);
+            {
+                auto point = tr.drawStringLeft(Point(x, y), Colour::black, StringIds::challenge_label);
+                y = point.y;
+            }
+            y += kSpacing;
 
-            // Challenge text
-            str = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
-            strncpy(str, scenarioInfo->objective, std::size(scenarioInfo->objective));
+            // Challenge description
+            {
+                str = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
+                strncpy(str, scenarioInfo->objective, std::size(scenarioInfo->objective));
 
-            y += 10;
-            args = FormatArguments();
-            args.push(StringIds::buffer_1250);
+                args = FormatArguments();
+                args.push(StringIds::buffer_1250);
 
-            point = tr.drawStringLeftWrapped(Point(x, y), 170, Colour::black, StringIds::challenge_value, args);
-            y = point.y;
+                auto point = tr.drawStringLeftWrapped(Point(x, y), 170, Colour::black, StringIds::challenge_value, args);
+                y = point.y;
+            }
+            y += kSpacing;
 
             // Start year
-            y += 5;
-            args = FormatArguments();
-            args.push(scenarioInfo->startYear);
+            {
+                args = FormatArguments();
+                args.push(scenarioInfo->startYear);
 
-            tr.drawStringLeft(Point(x, y), Colour::black, StringIds::challenge_start_date, args);
+                auto point = tr.drawStringLeft(Point(x, y), Colour::black, StringIds::challenge_start_date, args);
+                y = point.y;
+                y += kSpacing; // no idea why this second spacing is needed, but it is
+            }
+            y += kSpacing;
 
             // Competing companies
-            y += 10;
-            args = FormatArguments();
-            args.push<uint16_t>(scenarioInfo->numCompetingCompanies);
-            StringId competitionStringId = scenarioInfo->numCompetingCompanies == 0 ? StringIds::challenge_competing_companies_none : StringIds::challenge_competing_companies_up_to;
-
-            point = tr.drawStringLeftWrapped(Point(x, y), 170, Colour::black, competitionStringId, args);
-            y = point.y;
-
-            if (scenarioInfo->numCompetingCompanies == 0 || scenarioInfo->competingCompanyDelay == 0)
+            if (scenarioInfo->numCompetingCompanies > 0)
             {
-                return;
-            }
+                {
+                    args = FormatArguments();
+                    args.push<uint16_t>(scenarioInfo->numCompetingCompanies);
+                    StringId competitionStringId = scenarioInfo->numCompetingCompanies == 0 ? StringIds::challenge_competing_companies_none : StringIds::challenge_competing_companies_up_to;
 
-            // Delayed start for competing companies
-            args = FormatArguments();
-            args.push<uint16_t>(scenarioInfo->competingCompanyDelay);
-            competitionStringId = scenarioInfo->competingCompanyDelay == 1 ? StringIds::competition_not_starting_for_month : StringIds::competition_not_starting_for_months;
-            tr.drawStringLeft(Point(x, y), Colour::black, competitionStringId, args);
+                    auto point = tr.drawStringLeftWrapped(Point(x, y), 170, Colour::black, competitionStringId, args);
+                    y = point.y;
+                }
+
+                // Delayed start for competing companies
+                if (scenarioInfo->competingCompanyDelay > 0)
+                {
+                    args = FormatArguments();
+                    args.push<uint16_t>(scenarioInfo->competingCompanyDelay);
+                    StringId competitionStringId = scenarioInfo->competingCompanyDelay == 1 ? StringIds::competition_not_starting_for_month : StringIds::competition_not_starting_for_months;
+
+                    auto point = tr.drawStringLeft(Point(x, y), Colour::black, competitionStringId, args);
+                    y = point.y;
+                    y += kSpacing;
+                }
+            }
+            y += kSpacing;
+
+            // Filename
+            {
+                auto filenameStr = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
+                strncpy(filenameStr, scenarioInfo->filename, std::size(scenarioInfo->filename));
+
+                args = FormatArguments();
+                args.push<StringId>(StringIds::buffer_1250);
+
+                auto point = tr.drawStringLeftWrapped(Point(x, y), 170, Colour::black, StringIds::scenario_selection_filename, args);
+                y = point.y;
+            }
+            y += kSpacing;
         }
     }
 


### PR DESCRIPTION
Adds a user/custom scenario path to allow users to put scenarios inside their openloco appdata folder, in the same manner as they do with custom objects, save games, heightmaps, etc.

I've also added a UI section to draw the filename of the scenario when the mouse is hovered over it, as well as improving the spacing of the items in the scenario overview.