### PR TITLE
Add "Home" button to browse prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 26.05+ (???)
 ------------------------------------------------------------------------
-- Feature: [#3768] Add tab to town window to show delivered cargo last month.
 - Feature: [#3569] Add a "home" button to the browse prompt window.
+- Feature: [#3768] Add tab to town window to show delivered cargo last month.
 - Change: [#3740] Options that interfere with tutorial operation are temporarily disabled options during playback.
 
 26.05 (2026-05-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.05+ (???)
 ------------------------------------------------------------------------
 - Feature: [#3768] Add tab to town window to show delivered cargo last month.
+- Feature: [#3569] Add a "home" button to the browse prompt window.
 - Change: [#3740] Options that interfere with tutorial operation are temporarily disabled options during playback.
 
 26.05 (2026-05-30)

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2499,3 +2499,4 @@ strings:
   2444: Can't change company name...
   2445: "{STRINGID} has no nearby transit companies"
   2446: "{STRINGID} has not received any deliveries last month"
+  2447: "{SMALLFONT}{COLOUR BLACK}Navigate back to the home folder for this item type"

--- a/src/OpenLoco/include/OpenLoco/Environment.h
+++ b/src/OpenLoco/include/OpenLoco/Environment.h
@@ -69,6 +69,7 @@ namespace OpenLoco::Environment
     };
 
     void autoCreateDirectory(const fs::path& path);
+    fs::path getDefaultPathNoWarning(PathId id);
     fs::path getPath(PathId id);
     fs::path getPathNoWarning(PathId id);
     void resolvePaths();

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -2160,6 +2160,7 @@ namespace OpenLoco::StringIds
     constexpr StringId cannot_change_company_name = 2444;
     constexpr StringId town_not_served = 2445;
     constexpr StringId town_no_deliveries = 2446;
+    constexpr StringId window_browse_home_folder_tooltip = 2447;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Environment.cpp
+++ b/src/OpenLoco/src/Environment.cpp
@@ -175,7 +175,7 @@ namespace OpenLoco::Environment
         return result;
     }
 
-    static fs::path getDefaultPathNoWarning(PathId id)
+    fs::path getDefaultPathNoWarning(PathId id)
     {
         auto basePath = getBasePath(id);
         auto subPath = getSubPath(id);

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -22,6 +22,7 @@
 #include "Ui/Widgets/CaptionWidget.h"
 #include "Ui/Widgets/FrameWidget.h"
 #include "Ui/Widgets/ImageButtonWidget.h"
+#include "Ui/Widgets/LabelWidget.h"
 #include "Ui/Widgets/PanelWidget.h"
 #include "Ui/Widgets/ScrollViewWidget.h"
 #include "Ui/Widgets/TextBoxWidget.h"
@@ -51,6 +52,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         caption,
         close_button,
         panel,
+        folder_path,
         parent_button,
         text_filename,
         ok_button,
@@ -62,6 +64,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         Widgets::Caption({ 1, 1 }, { 498, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::empty),
         Widgets::ImageButton({ 485, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
         Widgets::Panel({ 0, 15 }, { 500, 365 }, WindowColour::secondary),
+        Widgets::Label({ 3, 18 }, { 470, 24 }, WindowColour::secondary, ContentAlign::left, StringIds::window_browse_folder),
         Widgets::ImageButton({ 473, 18 }, { 24, 24 }, WindowColour::secondary, ImageIds::icon_parent_folder, StringIds::window_browse_parent_folder_tooltip),
         Widgets::TextBox({ 88, 348 }, { 408, 14 }, WindowColour::secondary),
         Widgets::Button({ 426, 364 }, { 70, 12 }, WindowColour::secondary, StringIds::label_button_ok),
@@ -361,6 +364,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
 
         self.widgets[widx::parent_button].left = self.width - 26;
         self.widgets[widx::parent_button].right = self.width - 3;
+        self.widgets[widx::folder_path].right = self.widgets[widx::parent_button].left;
 
         // Get width of the base 'Folder:' string
         char folderBuffer[256]{};
@@ -371,7 +375,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         const auto folderLabelWidth = Gfx::TextRenderer::getStringWidth(Gfx::Font::medium_bold, folderBuffer);
 
         // We'll ensure the folder width does not reach the parent button.
-        const uint16_t maxWidth = self.widgets[widx::parent_button].left - folderLabelWidth - 10;
+        const uint16_t maxWidth = self.widgets[widx::folder_path].width() - folderLabelWidth;
         auto nameBuffer = _currentDirectory.u8string();
         nameBuffer = Localisation::convertUnicodeToLoco(nameBuffer);
         strncpy(&_displayFolderBuffer[0], nameBuffer.c_str(), 512);
@@ -423,9 +427,9 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
 
         {
             auto folder = &_displayFolderBuffer[0];
-            auto args = getStringPtrFormatArgs(folder);
-            auto point = Point(window.x + 3, window.y + window.widgets[widx::parent_button].top + 6);
-            tr.drawStringLeft(point, Colour::black, StringIds::window_browse_folder, args);
+            FormatArguments args{ window.widgets[widx::folder_path].textArgs };
+            args.push(StringIds::stringptr);
+            args.push(folder);
         }
 
         auto selectedIndex = window.var_85A;

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -54,6 +54,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         panel,
         folder_path,
         parent_button,
+        home_button,
         text_filename,
         ok_button,
         scrollview,
@@ -64,8 +65,9 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         Widgets::Caption({ 1, 1 }, { 498, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::empty),
         Widgets::ImageButton({ 485, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
         Widgets::Panel({ 0, 15 }, { 500, 365 }, WindowColour::secondary),
-        Widgets::Label({ 3, 18 }, { 470, 24 }, WindowColour::secondary, ContentAlign::left, StringIds::window_browse_folder),
-        Widgets::ImageButton({ 473, 18 }, { 24, 24 }, WindowColour::secondary, ImageIds::icon_parent_folder, StringIds::window_browse_parent_folder_tooltip),
+        Widgets::Label({ 3, 18 }, { 447, 24 }, WindowColour::secondary, ContentAlign::left, StringIds::window_browse_folder),
+        Widgets::ImageButton({ 449, 18 }, { 24, 24 }, WindowColour::secondary, ImageIds::icon_parent_folder, StringIds::window_browse_parent_folder_tooltip),
+        Widgets::ImageButton({ 473, 18 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_left_turnaround, StringIds::window_browse_home_folder_tooltip),
         Widgets::TextBox({ 88, 348 }, { 408, 14 }, WindowColour::secondary),
         Widgets::Button({ 426, 364 }, { 70, 12 }, WindowColour::secondary, StringIds::label_button_ok),
         Widgets::ScrollView({ 3, 45 }, { 494, 323 }, WindowColour::secondary, Scrollbars::vertical)
@@ -96,6 +98,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     static void drawLandscapePreview(Ui::Window& window, Gfx::DrawingContext& drawingCtx, int32_t x, int32_t y, int32_t width, int32_t height);
     static void drawTextInput(Ui::Window* window, Gfx::DrawingContext& drawingCtx, const char* text, int32_t caret, bool showCaret);
     static void upOneLevel();
+    static void defaultDirectory();
     static void changeDirectory(const fs::path& path);
     static void processFileForLoadSave(Window* window);
     static void processFileForLoadSave(Window* window, fs::path& entry);
@@ -218,6 +221,12 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                 break;
             case widx::parent_button:
                 upOneLevel();
+                window.var_85A = -1;
+                window.initScrollWidgets();
+                window.invalidate();
+                break;
+            case widx::home_button:
+                defaultDirectory();
                 window.var_85A = -1;
                 window.initScrollWidgets();
                 window.invalidate();
@@ -362,8 +371,12 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             self.widgets[widx::scrollview].right += 122;
         }
 
-        self.widgets[widx::parent_button].left = self.width - 26;
-        self.widgets[widx::parent_button].right = self.width - 3;
+        self.widgets[widx::home_button].right = self.width - 3;
+        self.widgets[widx::home_button].left = self.widgets[widx::home_button].right - 24;
+
+        self.widgets[widx::parent_button].right = self.widgets[widx::home_button].left;
+        self.widgets[widx::parent_button].left = self.widgets[widx::parent_button].right - 24;
+
         self.widgets[widx::folder_path].right = self.widgets[widx::parent_button].left;
 
         // Get width of the base 'Folder:' string
@@ -834,6 +847,27 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
 #endif
         // Going up one level (compensating for trailing slashes).
         changeDirectory(_currentDirectory.parent_path().parent_path());
+    }
+
+    static void defaultDirectory()
+    {
+        Environment::PathId pathId;
+        switch (_fileType)
+        {
+            case savedGame:
+                pathId = Environment::PathId::save;
+                break;
+            case landscape:
+                pathId = Environment::PathId::landscape;
+                break;
+            case heightmap:
+                pathId = Environment::PathId::heightmap;
+                break;
+            default:
+                throw Exception::RuntimeError("Unknown BrowseFileType.");
+        }
+        auto path = getDefaultPathNoWarning(pathId);
+        changeDirectory(path);
     }
 
     // 0x00446E62


### PR DESCRIPTION
Adds a button that navigates to the default directory for the file type that is being browsed (saves, landscapes, heightmaps). Closes #3569.

Re-uses an icon already present in g1.dat. This should be replaced with a new, purpose-made icon in the future.

The folder path was also changed to use a label widget instead of directly drawing the text.

**Before:**
<img width="500" height="380" alt="Before screenshot" src="https://github.com/user-attachments/assets/3de0009c-04a1-4348-8529-2d22fdd37f68" />

**After:**
<img width="500" height="380" alt="After screenshot" src="https://github.com/user-attachments/assets/4b786220-ff14-415e-a096-57c64d836f34" />


Other buttons that I am thinking about adding:
- Create new folder
- Open in Explorer
