### PR TITLE
Bump actions/checkout to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup cache directories
         run: mkdir ${{ env.VCPKG_DEFAULT_BINARY_CACHE }} | Out-Null
       - name: Set up binary cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
           key: ${{ runner.os }}-64-vcpkg-binary-cache-${{ hashFiles('vcpkg*.json') }}
@@ -120,7 +120,7 @@ jobs:
       - name: Setup cache directories
         run: mkdir ${{ env.VCPKG_DEFAULT_BINARY_CACHE }} | Out-Null
       - name: Set up binary cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
           key: ${{ runner.os }}-32-vcpkg-binary-cache-${{ hashFiles('vcpkg*.json') }}
@@ -271,7 +271,7 @@ jobs:
       - name: Setup cache directories
         run: mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
       - name: Set up binary cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
           key: ${{ runner.os }}-vcpkg-binary-cache-${{ hashFiles('vcpkg*.json') }}
@@ -311,7 +311,7 @@ jobs:
       - name: Setup cache directories
         run: mkdir -p ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
       - name: Set up binary cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
           key: ${{ runner.os }}-vcpkg-binary-cache-${{ hashFiles('vcpkg*.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       image: openrct2/openrct2-build:17-format
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run clang-format
         run: scripts/check-code-formatting.sh
   check-changelog-formatting:
@@ -22,7 +22,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run check-changelog-formatting
         run: scripts/check-changelog-formatting
   windows:
@@ -34,7 +34,7 @@ jobs:
       POWERSHELL_TELEMETRY_OPTOUT: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true
@@ -77,7 +77,7 @@ jobs:
           if-no-files-found: warn
       - name: Checkout Assets
         if: ${{ github.repository == 'OpenLoco/OpenLoco' && env.ASSETS_SSH_KEY != null }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ssh-key: ${{ env.ASSETS_SSH_KEY }}
           repository: OpenLoco/LocomotionAssets
@@ -85,7 +85,7 @@ jobs:
           path: LocomotionAssets
       - name: Checkout Test Data
         if: ${{ github.repository == 'OpenLoco/OpenLoco' && env.ASSETS_SSH_KEY != null }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: OpenLoco/TestData
           ref: b21e716f7158f5f6a3dad6df6905ad5a376501b9
@@ -110,7 +110,7 @@ jobs:
       POWERSHELL_TELEMETRY_OPTOUT: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true
@@ -168,7 +168,7 @@ jobs:
         distro: [26.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true
@@ -193,7 +193,7 @@ jobs:
         distro: [26.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true
@@ -219,7 +219,7 @@ jobs:
         distro: [26.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true
@@ -239,7 +239,7 @@ jobs:
         build_shared_libs: [on, off]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true
@@ -257,7 +257,7 @@ jobs:
     container: ghcr.io/openloco/openloco:11-ubuntu26.04.vcpkg
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true
@@ -299,7 +299,7 @@ jobs:
     needs: check-code-formatting
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: true


### PR DESCRIPTION
From CI:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/