### PR TITLE
Bump up sfl, refactor lookup tables

### DIFF
--- a/src/OpenLoco/src/GameCommands/Vehicles/RenameVehicle.cpp
+++ b/src/OpenLoco/src/GameCommands/Vehicles/RenameVehicle.cpp
@@ -10,8 +10,8 @@
 #include "Vehicles/Vehicle.h"
 #include "Vehicles/VehicleHead.h"
 
+#include <OpenLoco/Utility/LookupTable.hpp>
 #include <array>
-#include <unordered_map>
 
 namespace OpenLoco::GameCommands
 {
@@ -94,14 +94,14 @@ namespace OpenLoco::GameCommands
                 return 0;
             }
 
-            static const std::unordered_map<VehicleType, StringId> defaultVehicleStringIdMap = {
+            static constexpr auto defaultVehicleStringIdMap = Utility::buildLookupTable<VehicleType, StringId>({
                 { VehicleType::train, StringIds::train_number },
                 { VehicleType::bus, StringIds::bus_number },
                 { VehicleType::truck, StringIds::truck_number },
                 { VehicleType::tram, StringIds::tram_number },
                 { VehicleType::aircraft, StringIds::aircraft_number },
-                { VehicleType::ship, StringIds::ship_number }
-            };
+                { VehicleType::ship, StringIds::ship_number },
+            });
             allocatedStringId = defaultVehicleStringIdMap.at(vehicleHead->vehicleType);
         }
 

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -29,7 +29,7 @@
 #include "World/StationManager.h"
 #include "World/TownManager.h"
 
-#include <map>
+#include <OpenLoco/Utility/LookupTable.hpp>
 #include <queue>
 
 using namespace OpenLoco::Ui;
@@ -101,7 +101,7 @@ namespace OpenLoco::Input
 
     static int32_t _cursorWheel;
 
-    static const std::map<Ui::ScrollPart, StringId> kScrollWidgetTooltips = {
+    static constexpr auto kScrollWidgetTooltips = Utility::buildLookupTable<Ui::ScrollPart, StringId>({
         { Ui::ScrollPart::hscrollbarButtonLeft, StringIds::tooltip_scroll_left },
         { Ui::ScrollPart::hscrollbarButtonRight, StringIds::tooltip_scroll_right },
         { Ui::ScrollPart::hscrollbarTrackLeft, StringIds::tooltip_scroll_left_fast },
@@ -112,7 +112,7 @@ namespace OpenLoco::Input
         { Ui::ScrollPart::vscrollbarTrackTop, StringIds::tooltip_scroll_up_fast },
         { Ui::ScrollPart::vscrollbarTrackBottom, StringIds::tooltip_scroll_down_fast },
         { Ui::ScrollPart::vscrollbarThumb, StringIds::tooltip_scroll_up_down },
-    };
+    });
 
     constexpr int32_t kDropdownItemUndefined = -1;
 

--- a/src/OpenLoco/src/Localisation/Formatting.cpp
+++ b/src/OpenLoco/src/Localisation/Formatting.cpp
@@ -10,7 +10,9 @@
 #include "StringIds.h"
 #include "StringManager.h"
 #include "World/TownManager.h"
+
 #include <OpenLoco/Core/Exception.hpp>
+#include <OpenLoco/Utility/LookupTable.hpp>
 #include <cassert>
 #include <cmath>
 #include <cstring>
@@ -22,7 +24,7 @@ using namespace OpenLoco::Diagnostics;
 
 namespace OpenLoco::StringManager
 {
-    static const std::map<int32_t, StringId> kDayToString = {
+    static constexpr auto kDayToString = Utility::buildLookupTable<int32_t, StringId>({
         { 1, StringIds::day_1st },
         { 2, StringIds::day_2nd },
         { 3, StringIds::day_3rd },
@@ -54,9 +56,9 @@ namespace OpenLoco::StringManager
         { 29, StringIds::day_29th },
         { 30, StringIds::day_30th },
         { 31, StringIds::day_31st },
-    };
+    });
 
-    static const std::map<MonthId, std::pair<StringId, StringId>> kMonthToStringMap = {
+    static constexpr auto kMonthToStringMap = Utility::buildLookupTable<MonthId, std::pair<StringId, StringId>>({
         { MonthId::january, { StringIds::month_short_january, StringIds::month_long_january } },
         { MonthId::february, { StringIds::month_short_february, StringIds::month_long_february } },
         { MonthId::march, { StringIds::month_short_march, StringIds::month_long_march } },
@@ -69,7 +71,7 @@ namespace OpenLoco::StringManager
         { MonthId::october, { StringIds::month_short_october, StringIds::month_long_october } },
         { MonthId::november, { StringIds::month_short_november, StringIds::month_long_november } },
         { MonthId::december, { StringIds::month_short_december, StringIds::month_long_december } },
-    };
+    });
 
     std::pair<StringId, StringId> monthToString(MonthId month)
     {

--- a/src/OpenLoco/src/Localisation/LanguageFiles.cpp
+++ b/src/OpenLoco/src/Localisation/LanguageFiles.cpp
@@ -8,8 +8,10 @@
 #include "StringManager.h"
 #include "Ui.h"
 #include "Unicode.h"
+
 #include <OpenLoco/Core/Exception.hpp>
 #include <OpenLoco/Platform/Platform.h>
+#include <OpenLoco/Utility/LookupTable.hpp>
 #include <cassert>
 #include <iostream>
 #include <stdexcept>
@@ -21,7 +23,7 @@ namespace OpenLoco::Localisation
 {
     static std::vector<std::unique_ptr<char[]>> _stringsOwner;
 
-    static const std::map<std::string, uint8_t, std::less<>> kBasicCommands = {
+    static constexpr auto kBasicCommands = Utility::buildLookupTable<std::string_view, uint8_t>({
         { "INT16_1DP", ControlCodes::int16_decimals },
         { "INT32_2DP", ControlCodes::int32_decimals },
         { "INT16", ControlCodes::int16_grouped },
@@ -38,9 +40,9 @@ namespace OpenLoco::Localisation
         { "STRING", ControlCodes::string_ptr },
         { "POP16", ControlCodes::pop16 },
         { "POWER", ControlCodes::power },
-    };
+    });
 
-    static const std::map<std::string, uint8_t, std::less<>> kTextColourNames = {
+    static constexpr auto kTextColourNames = Utility::buildLookupTable<std::string_view, uint8_t>({
         { "BLACK", ControlCodes::Colour::black },
         { "WINDOW_1", ControlCodes::windowColour1 },
         { "WINDOW_2", ControlCodes::windowColour2 },
@@ -51,7 +53,7 @@ namespace OpenLoco::Localisation
         { "TOPAZ", ControlCodes::Colour::topaz },
         { "RED", ControlCodes::Colour::red },
         { "GREEN", ControlCodes::Colour::green },
-    };
+    });
 
     static std::unique_ptr<char[]> readString(const char* value, size_t size)
     {

--- a/src/OpenLoco/src/Paint/PaintEffectEntity.cpp
+++ b/src/OpenLoco/src/Paint/PaintEffectEntity.cpp
@@ -17,8 +17,8 @@
 #include "Paint.h"
 #include "World/CompanyManager.h"
 
+#include <array>
 #include <cassert>
-#include <unordered_map>
 
 namespace OpenLoco::Paint
 {
@@ -117,13 +117,14 @@ namespace OpenLoco::Paint
             return;
         }
 
-        static const std::unordered_map<int, const std::array<uint32_t, 12>> kVehicleCrashParticleImageIds = {
-            { 0, { ImageIds::vehicle_crash_0_00, ImageIds::vehicle_crash_0_01, ImageIds::vehicle_crash_0_02, ImageIds::vehicle_crash_0_03, ImageIds::vehicle_crash_0_04, ImageIds::vehicle_crash_0_05, ImageIds::vehicle_crash_0_06, ImageIds::vehicle_crash_0_07, ImageIds::vehicle_crash_0_08, ImageIds::vehicle_crash_0_09, ImageIds::vehicle_crash_0_10, ImageIds::vehicle_crash_0_11 } },
-            { 1, { ImageIds::vehicle_crash_1_00, ImageIds::vehicle_crash_1_01, ImageIds::vehicle_crash_1_02, ImageIds::vehicle_crash_1_03, ImageIds::vehicle_crash_1_04, ImageIds::vehicle_crash_1_05, ImageIds::vehicle_crash_1_06, ImageIds::vehicle_crash_1_07, ImageIds::vehicle_crash_1_08, ImageIds::vehicle_crash_1_09, ImageIds::vehicle_crash_1_10, ImageIds::vehicle_crash_1_11 } },
-            { 2, { ImageIds::vehicle_crash_2_00, ImageIds::vehicle_crash_2_01, ImageIds::vehicle_crash_2_02, ImageIds::vehicle_crash_2_03, ImageIds::vehicle_crash_2_04, ImageIds::vehicle_crash_2_05, ImageIds::vehicle_crash_2_06, ImageIds::vehicle_crash_2_07, ImageIds::vehicle_crash_2_08, ImageIds::vehicle_crash_2_09, ImageIds::vehicle_crash_2_10, ImageIds::vehicle_crash_2_11 } },
-            { 3, { ImageIds::vehicle_crash_3_00, ImageIds::vehicle_crash_3_01, ImageIds::vehicle_crash_3_02, ImageIds::vehicle_crash_3_03, ImageIds::vehicle_crash_3_04, ImageIds::vehicle_crash_3_05, ImageIds::vehicle_crash_3_06, ImageIds::vehicle_crash_3_07, ImageIds::vehicle_crash_3_08, ImageIds::vehicle_crash_3_09, ImageIds::vehicle_crash_3_10, ImageIds::vehicle_crash_3_11 } },
-            { 4, { ImageIds::vehicle_crash_4_00, ImageIds::vehicle_crash_4_01, ImageIds::vehicle_crash_4_02, ImageIds::vehicle_crash_4_03, ImageIds::vehicle_crash_4_04, ImageIds::vehicle_crash_4_05, ImageIds::vehicle_crash_4_06, ImageIds::vehicle_crash_4_07, ImageIds::vehicle_crash_4_08, ImageIds::vehicle_crash_4_09, ImageIds::vehicle_crash_4_10, ImageIds::vehicle_crash_4_11 } }
-        };
+        static constexpr auto kVehicleCrashParticleImageIds = std::to_array<std::array<uint32_t, 12>>(
+            {
+                { ImageIds::vehicle_crash_0_00, ImageIds::vehicle_crash_0_01, ImageIds::vehicle_crash_0_02, ImageIds::vehicle_crash_0_03, ImageIds::vehicle_crash_0_04, ImageIds::vehicle_crash_0_05, ImageIds::vehicle_crash_0_06, ImageIds::vehicle_crash_0_07, ImageIds::vehicle_crash_0_08, ImageIds::vehicle_crash_0_09, ImageIds::vehicle_crash_0_10, ImageIds::vehicle_crash_0_11 },
+                { ImageIds::vehicle_crash_1_00, ImageIds::vehicle_crash_1_01, ImageIds::vehicle_crash_1_02, ImageIds::vehicle_crash_1_03, ImageIds::vehicle_crash_1_04, ImageIds::vehicle_crash_1_05, ImageIds::vehicle_crash_1_06, ImageIds::vehicle_crash_1_07, ImageIds::vehicle_crash_1_08, ImageIds::vehicle_crash_1_09, ImageIds::vehicle_crash_1_10, ImageIds::vehicle_crash_1_11 },
+                { ImageIds::vehicle_crash_2_00, ImageIds::vehicle_crash_2_01, ImageIds::vehicle_crash_2_02, ImageIds::vehicle_crash_2_03, ImageIds::vehicle_crash_2_04, ImageIds::vehicle_crash_2_05, ImageIds::vehicle_crash_2_06, ImageIds::vehicle_crash_2_07, ImageIds::vehicle_crash_2_08, ImageIds::vehicle_crash_2_09, ImageIds::vehicle_crash_2_10, ImageIds::vehicle_crash_2_11 },
+                { ImageIds::vehicle_crash_3_00, ImageIds::vehicle_crash_3_01, ImageIds::vehicle_crash_3_02, ImageIds::vehicle_crash_3_03, ImageIds::vehicle_crash_3_04, ImageIds::vehicle_crash_3_05, ImageIds::vehicle_crash_3_06, ImageIds::vehicle_crash_3_07, ImageIds::vehicle_crash_3_08, ImageIds::vehicle_crash_3_09, ImageIds::vehicle_crash_3_10, ImageIds::vehicle_crash_3_11 },
+                { ImageIds::vehicle_crash_4_00, ImageIds::vehicle_crash_4_01, ImageIds::vehicle_crash_4_02, ImageIds::vehicle_crash_4_03, ImageIds::vehicle_crash_4_04, ImageIds::vehicle_crash_4_05, ImageIds::vehicle_crash_4_06, ImageIds::vehicle_crash_4_07, ImageIds::vehicle_crash_4_08, ImageIds::vehicle_crash_4_09, ImageIds::vehicle_crash_4_10, ImageIds::vehicle_crash_4_11 },
+            });
 
         assert(static_cast<size_t>(particle->frame / 256) < 12);
         assert((particle->crashedSpriteBase) < 5);

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -17,6 +17,7 @@
 #include "Ui/Widgets/ScrollViewWidget.h"
 #include "Ui/WindowManager.h"
 #include <OpenLoco/Engine/Input/ShortcutManager.h>
+#include <OpenLoco/Utility/LookupTable.hpp>
 #include <SDL3/SDL_keyboard.h>
 #include <unordered_map>
 
@@ -88,7 +89,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
 
     static void getBindingString(uint32_t keyCode, char* buffer, const size_t bufferLength)
     {
-        static const std::unordered_map<uint32_t, StringId> keysToString = { {
+        static constexpr auto keysToString = Utility::buildLookupTable<uint32_t, StringId>({
             { SDLK_BACKSPACE, StringIds::keyboard_backspace },
             { SDLK_TAB, StringIds::keyboard_tab },
             { SDLK_RETURN, StringIds::keyboard_return },
@@ -124,7 +125,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
             { SDLK_KP_PLUS, StringIds::keyboard_numpad_plus },
             { SDLK_NUMLOCKCLEAR, StringIds::keyboard_numlock },
             { SDLK_SCROLLLOCK, StringIds::keyboard_scroll },
-        } };
+        });
 
         auto match = keysToString.find(keyCode);
         if (match != keysToString.end())

--- a/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
@@ -47,6 +47,8 @@
 #include "World/CompanyManager.h"
 #include "World/Industry.h"
 #include "World/Station.h"
+
+#include <OpenLoco/Utility/LookupTable.hpp>
 #include <map>
 
 using namespace OpenLoco::World;
@@ -205,7 +207,7 @@ namespace OpenLoco::Ui::Windows::TileInspector
 
     static StringId getElementTypeName(const TileElement& element)
     {
-        static const std::map<ElementType, StringId> typeToString = {
+        static constexpr auto kTypeToString = Utility::buildLookupTable<ElementType, StringId>({
             { ElementType::surface, StringIds::tile_inspector_element_type_surface },
             { ElementType::track, StringIds::tile_inspector_element_type_track },
             { ElementType::station, StringIds::tile_inspector_element_type_station },
@@ -215,9 +217,9 @@ namespace OpenLoco::Ui::Windows::TileInspector
             { ElementType::wall, StringIds::tile_inspector_element_type_wall },
             { ElementType::road, StringIds::tile_inspector_element_type_road },
             { ElementType::industry, StringIds::tile_inspector_element_type_industry },
-        };
+        });
 
-        return typeToString.at(element.type());
+        return kTypeToString.at(element.type());
     }
 
     static StringId getObjectName(const TileElement& element)

--- a/src/OpenLoco/src/Ui/Windows/ToolbarBottomEditor.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarBottomEditor.cpp
@@ -7,7 +7,8 @@
 #include "Ui/Widget.h"
 #include "Ui/Widgets/ImageButtonWidget.h"
 #include "Ui/Widgets/Wt3Widget.h"
-#include <map>
+
+#include <OpenLoco/Utility/LookupTable.hpp>
 
 namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
 {
@@ -29,12 +30,12 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
 
     );
 
-    static std::map<EditorController::Step, StringId> _stepNames = {
+    static constexpr auto kStepNames = Utility::buildLookupTable<EditorController::Step, StringId>({
         { EditorController::Step::objectSelection, StringIds::editor_step_object_selection },
         { EditorController::Step::landscapeEditor, StringIds::editor_step_landscape },
         { EditorController::Step::scenarioOptions, StringIds::editor_step_options },
         { EditorController::Step::saveScenario, StringIds::editor_step_save },
-    };
+    });
 
     // 0x0043CE21
     static void prepareDraw(Window& self)
@@ -83,7 +84,7 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
         drawingCtx.drawRectInset(next.left + self.x + 1, next.top + self.y + 1, next.width() - 2, next.height() - 2, self.getColour(WindowColour::secondary), Gfx::RectInsetFlags::borderInset | Gfx::RectInsetFlags::fillNone);
 
         auto point = Point((previous.right + next.left) / 2 + self.x, self.y + self.height - 12);
-        tr.drawStringCentred(point, self.getColour(WindowColour::tertiary).opaque().outline(), _stepNames[EditorController::getCurrentStep()]);
+        tr.drawStringCentred(point, self.getColour(WindowColour::tertiary).opaque().outline(), kStepNames.at(EditorController::getCurrentStep()));
 
         if (EditorController::canGoBack())
         {
@@ -100,7 +101,7 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
             tr.drawStringCentred(point, textColour, StringIds::editor_previous_step);
 
             point = Point(self.x + x, self.y + y + 10);
-            tr.drawStringCentred(point, textColour, _stepNames[EditorController::getPreviousStep()]);
+            tr.drawStringCentred(point, textColour, kStepNames.at(EditorController::getPreviousStep()));
         }
         drawingCtx.drawImage(self.x + next.right - 29, self.y + next.top + 4, ImageIds::step_forward);
         int x = next.left + (next.width() - 31) / 2;
@@ -115,7 +116,7 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
         tr.drawStringCentred(point, textColour, StringIds::editor_next_step);
 
         point = Point(self.x + x, self.y + y + 10);
-        tr.drawStringCentred(point, textColour, _stepNames[EditorController::getNextStep()]);
+        tr.drawStringCentred(point, textColour, kStepNames.at(EditorController::getNextStep()));
     }
 
     // 0x0043D0ED

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -35,7 +35,8 @@
 #include "World/CompanyManager.h"
 #include "World/StationManager.h"
 #include "World/TownManager.h"
-#include <map>
+
+#include <OpenLoco/Utility/LookupTable.hpp>
 
 namespace OpenLoco::Ui::Windows::ToolbarTop::Game
 {
@@ -548,14 +549,14 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     };
 
     // clang-format off
-    static const std::map<VehicleType, VehicleTypeInterfaceParam> VehicleTypeInterfaceParameters{
+    static constexpr auto kVehicleTypeInterfaceParameters = Utility::buildLookupTable<VehicleType, VehicleTypeInterfaceParam>({
         { VehicleType::bus,      { InterfaceSkin::ImageIds::vehicle_buses_frame_0,      InterfaceSkin::ImageIds::build_vehicle_bus_frame_0,      StringIds::build_buses,    StringIds::num_buses_singular,     StringIds::num_buses_plural } },
         { VehicleType::aircraft, { InterfaceSkin::ImageIds::vehicle_aircraft_frame_0, InterfaceSkin::ImageIds::build_vehicle_aircraft_frame_0, StringIds::build_aircraft, StringIds::num_aircrafts_singular, StringIds::num_aircrafts_plural } },
         { VehicleType::ship,     { InterfaceSkin::ImageIds::vehicle_ships_frame_0,     InterfaceSkin::ImageIds::build_vehicle_ship_frame_0,     StringIds::build_ships,    StringIds::num_ships_singular,     StringIds::num_ships_plural } },
         { VehicleType::train,    { InterfaceSkin::ImageIds::vehicle_train_frame_0,    InterfaceSkin::ImageIds::build_vehicle_train_frame_0,    StringIds::build_trains,   StringIds::num_trains_singular,    StringIds::num_trains_plural } },
         { VehicleType::tram,     { InterfaceSkin::ImageIds::vehicle_trams_frame_0,     InterfaceSkin::ImageIds::build_vehicle_tram_frame_0,     StringIds::build_trams,    StringIds::num_trams_singular,     StringIds::num_trams_plural } },
         { VehicleType::truck,    { InterfaceSkin::ImageIds::vehicle_trucks_frame_0,    InterfaceSkin::ImageIds::build_vehicle_truck_frame_0,    StringIds::build_trucks,   StringIds::num_trucks_singular,    StringIds::num_trucks_plural } },
-    };
+    });
     // clang-format on
 
     // 0x0043AD1F
@@ -575,7 +576,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                 continue;
             }
 
-            auto& interface_param = VehicleTypeInterfaceParameters.at(static_cast<VehicleType>(vehicleType));
+            auto& interface_param = kVehicleTypeInterfaceParameters.at(static_cast<VehicleType>(vehicleType));
 
             uint32_t vehicle_image = Gfx::recolour(interface_param.buildImage, companyColour);
 
@@ -643,7 +644,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                 continue;
             }
 
-            auto& interfaceParam = VehicleTypeInterfaceParameters.at(static_cast<VehicleType>(vehicleType));
+            auto& interfaceParam = kVehicleTypeInterfaceParameters.at(static_cast<VehicleType>(vehicleType));
 
             uint32_t vehicleImage = Gfx::recolour(interfaceParam.image, companyColour);
             uint16_t vehicle_count = vehicle_counts[vehicleType];

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -84,8 +84,9 @@
 #include "ViewportManager.h"
 #include "World/CompanyManager.h"
 #include "World/StationManager.h"
+
 #include <OpenLoco/Math/Trigonometry.hpp>
-#include <map>
+#include <OpenLoco/Utility/LookupTable.hpp>
 #include <sfl/static_vector.hpp>
 #include <sstream>
 
@@ -1600,14 +1601,14 @@ namespace OpenLoco::Ui::Windows::Vehicle
             return CursorId::openHand;
         }
 
-        static const std::map<VehicleType, uint32_t> additionalVehicleButtonByVehicleType{
+        static constexpr auto kAdditionalVehicleButtonByVehicleType = Utility::buildLookupTable<VehicleType, uint32_t>({
             { VehicleType::train, InterfaceSkin::ImageIds::build_additional_train },
             { VehicleType::bus, InterfaceSkin::ImageIds::build_additional_bus },
             { VehicleType::truck, InterfaceSkin::ImageIds::build_additional_truck },
             { VehicleType::tram, InterfaceSkin::ImageIds::build_additional_tram },
             { VehicleType::aircraft, InterfaceSkin::ImageIds::build_additional_aircraft },
             { VehicleType::ship, InterfaceSkin::ImageIds::build_additional_ship },
-        };
+        });
 
         constexpr auto kVehicleDetailsOffset = 2;
         constexpr auto kVehicleDetailsLineHeight = 12;
@@ -1708,7 +1709,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
 
             auto skin = ObjectManager::get<InterfaceSkinObject>();
-            auto buildImage = skin->img + additionalVehicleButtonByVehicleType.at(head->vehicleType);
+            auto buildImage = skin->img + kAdditionalVehicleButtonByVehicleType.at(head->vehicleType);
 
             self.widgets[widx::buildNew].image = Gfx::recolour(buildImage, CompanyManager::getCompanyColour(self.owner)) | Widget::kImageIdColourSet;
 
@@ -5127,14 +5128,14 @@ namespace OpenLoco::Ui::Windows::Vehicle
             uint8_t frameSpeed;
         };
 
-        static const std::map<VehicleType, TabIcons> tabIconByVehicleType{
+        static constexpr auto kTabIconByVehicleType = Utility::buildLookupTable<VehicleType, TabIcons>({
             { VehicleType::train, { InterfaceSkin::ImageIds::tab_vehicle_train_frame0, 1 } },
             { VehicleType::bus, { InterfaceSkin::ImageIds::tab_vehicle_bus_frame0, 1 } },
             { VehicleType::truck, { InterfaceSkin::ImageIds::tab_vehicle_truck_frame0, 1 } },
             { VehicleType::tram, { InterfaceSkin::ImageIds::tab_vehicle_tram_frame0, 1 } },
             { VehicleType::aircraft, { InterfaceSkin::ImageIds::tab_vehicle_aircraft_frame0, 2 } },
             { VehicleType::ship, { InterfaceSkin::ImageIds::tab_vehicle_ship_frame0, 3 } },
-        };
+        });
 
         // 0x004B5F0D
         static void drawTabs(Window& self, Gfx::DrawingContext& drawingCtx)
@@ -5148,7 +5149,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
             auto vehicleType = vehicle->vehicleType;
 
-            auto mainTab = tabIconByVehicleType.at(vehicleType);
+            auto mainTab = kTabIconByVehicleType.at(vehicleType);
             int frame = 0;
             if (self.currentTab == 0)
             {

--- a/src/OpenLoco/src/World/Company.cpp
+++ b/src/OpenLoco/src/World/Company.cpp
@@ -33,11 +33,12 @@
 #include "Vehicles/VehicleHead.h"
 #include "Vehicles/VehicleManager.h"
 #include "ViewportManager.h"
+
 #include <OpenLoco/Core/Numerics.hpp>
 #include <OpenLoco/Math/Bound.hpp>
+#include <OpenLoco/Utility/LookupTable.hpp>
 #include <algorithm>
 #include <array>
-#include <map>
 #include <sfl/static_unordered_set.hpp>
 
 namespace OpenLoco
@@ -231,7 +232,7 @@ namespace OpenLoco
         return static_cast<CorporateRating>(std::min(9, performanceIndex / 100));
     }
 
-    static std::map<CorporateRating, StringId> _ratingNames = {
+    static constexpr auto kRatingNames = Utility::buildLookupTable<CorporateRating, StringId>({
         { CorporateRating::platelayer, StringIds::corporate_rating_platelayer },
         { CorporateRating::engineer, StringIds::corporate_rating_engineer },
         { CorporateRating::trafficManager, StringIds::corporate_rating_traffic_manager },
@@ -242,12 +243,12 @@ namespace OpenLoco
         { CorporateRating::chairman, StringIds::corporate_rating_chairman },
         { CorporateRating::president, StringIds::corporate_rating_president },
         { CorporateRating::tycoon, StringIds::corporate_rating_tycoon },
-    };
+    });
 
     StringId getCorporateRatingAsStringId(CorporateRating rating)
     {
-        auto it = _ratingNames.find(rating);
-        if (it != _ratingNames.end())
+        auto it = kRatingNames.find(rating);
+        if (it != kRatingNames.end())
         {
             return it->second;
         }

--- a/src/Utility/CMakeLists.txt
+++ b/src/Utility/CMakeLists.txt
@@ -8,11 +8,11 @@ set(private_files
 )
 
 set(test_files
+    "${CMAKE_CURRENT_SOURCE_DIR}/tests/LookupTableTests.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/StringTests.cpp"
 )
 
 set(public_link_libraries
-    sfl::sfl
 )
 
 loco_add_library(Utility STATIC

--- a/src/Utility/CMakeLists.txt
+++ b/src/Utility/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(public_files
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Utility/LookupTable.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/OpenLoco/Utility/String.hpp"
 )
 
@@ -10,6 +11,10 @@ set(test_files
     "${CMAKE_CURRENT_SOURCE_DIR}/tests/StringTests.cpp"
 )
 
+set(public_link_libraries
+    sfl::sfl
+)
+
 loco_add_library(Utility STATIC
     PUBLIC_FILES
         ${public_files}
@@ -17,4 +22,6 @@ loco_add_library(Utility STATIC
         ${private_files}
     TEST_FILES
         ${test_files}
+    PUBLIC_LINK_LIBRARIES
+        ${public_link_libraries}
 )

--- a/src/Utility/include/OpenLoco/Utility/LookupTable.hpp
+++ b/src/Utility/include/OpenLoco/Utility/LookupTable.hpp
@@ -1,14 +1,91 @@
 #pragma once
 
-#include <sfl/static_flat_map.hpp>
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
 
 namespace OpenLoco::Utility
 {
+    // Simplified version of sfl::static_flat_map, it has constexpr issues.
+    // Switch back to sfl::static_flat_map for when that is resolved.
+    template<typename K, typename V, std::size_t N>
+    class LookupTable
+    {
+        std::array<std::pair<K, V>, N> _data{};
+        std::size_t _size{};
+
+    public:
+        using value_type = std::pair<K, V>;
+        using const_iterator = typename std::array<value_type, N>::const_iterator;
+
+        template<typename... Args>
+        constexpr LookupTable(Args&&... args)
+            : _data{ std::forward<Args>(args)... }
+            , _size(sizeof...(Args))
+        {
+            std::sort(_data.begin(), _data.end(), [](const value_type& a, const value_type& b) {
+                return a.first < b.first;
+            });
+        }
+
+        constexpr const_iterator begin() const
+        {
+            return _data.begin();
+        }
+
+        constexpr const_iterator end() const
+        {
+            return _data.begin() + _size;
+        }
+
+        constexpr std::size_t size() const
+        {
+            return _size;
+        }
+
+        constexpr const_iterator find(const K& key) const
+        {
+            auto it = std::lower_bound(begin(), end(), key, [](const value_type& entry, const K& k) {
+                return entry.first < k;
+            });
+            if (it != end() && !(key < it->first))
+            {
+                return it;
+            }
+            return end();
+        }
+
+        constexpr bool contains(const K& key) const
+        {
+            return find(key) != end();
+        }
+
+        constexpr const V& at(const K& key) const
+        {
+            auto it = find(key);
+            if (it == end())
+            {
+                throw std::out_of_range("LookupTable::at");
+            }
+            return it->second;
+        }
+    };
+
+    namespace Detail
+    {
+        template<typename K, typename V, std::size_t N, std::size_t... I>
+        constexpr auto buildLookupTableImpl(std::pair<K, V> const (&arr)[N], std::index_sequence<I...>)
+        {
+            return LookupTable<K, V, N>{ arr[I]... };
+        }
+    }
 
     template<typename K, typename V, std::size_t N>
     constexpr auto buildLookupTable(std::pair<K, V> const (&arr)[N])
     {
-        return sfl::static_flat_map<K, V, N>{ std::begin(arr), std::end(arr) };
+        return Detail::buildLookupTableImpl(arr, std::make_index_sequence<N>{});
     }
 
 }

--- a/src/Utility/include/OpenLoco/Utility/LookupTable.hpp
+++ b/src/Utility/include/OpenLoco/Utility/LookupTable.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <sfl/static_flat_map.hpp>
+
+namespace OpenLoco::Utility
+{
+
+    template<typename K, typename V, std::size_t N>
+    constexpr auto buildLookupTable(std::pair<K, V> const (&arr)[N])
+    {
+        return sfl::static_flat_map<K, V, N>{ std::begin(arr), std::end(arr) };
+    }
+
+}

--- a/src/Utility/tests/LookupTableTests.cpp
+++ b/src/Utility/tests/LookupTableTests.cpp
@@ -1,0 +1,85 @@
+#include <OpenLoco/Utility/LookupTable.hpp>
+#include <gtest/gtest.h>
+
+using namespace OpenLoco;
+
+TEST(LookupTableTests, buildLookupTable)
+{
+    constexpr auto table = Utility::buildLookupTable<int, int>({
+        { 3, 30 },
+        { 1, 10 },
+        { 2, 20 },
+    });
+
+    EXPECT_EQ(table.size(), 3);
+}
+
+TEST(LookupTableTests, sortedOrder)
+{
+    constexpr auto table = Utility::buildLookupTable<int, int>({
+        { 3, 30 },
+        { 1, 10 },
+        { 2, 20 },
+    });
+
+    auto it = table.begin();
+    EXPECT_EQ(it->first, 1);
+    ++it;
+    EXPECT_EQ(it->first, 2);
+    ++it;
+    EXPECT_EQ(it->first, 3);
+}
+
+TEST(LookupTableTests, find)
+{
+    constexpr auto table = Utility::buildLookupTable<int, int>({
+        { 5, 50 },
+        { 3, 30 },
+        { 1, 10 },
+    });
+
+    auto it = table.find(3);
+    ASSERT_NE(it, table.end());
+    EXPECT_EQ(it->second, 30);
+
+    EXPECT_EQ(table.find(99), table.end());
+}
+
+TEST(LookupTableTests, contains)
+{
+    constexpr auto table = Utility::buildLookupTable<int, int>({
+        { 1, 10 },
+        { 2, 20 },
+    });
+
+    EXPECT_TRUE(table.contains(1));
+    EXPECT_TRUE(table.contains(2));
+    EXPECT_FALSE(table.contains(3));
+}
+
+TEST(LookupTableTests, at)
+{
+    constexpr auto table = Utility::buildLookupTable<int, int>({
+        { 1, 10 },
+        { 2, 20 },
+    });
+
+    EXPECT_EQ(table.at(1), 10);
+    EXPECT_EQ(table.at(2), 20);
+    EXPECT_THROW(table.at(99), std::out_of_range);
+}
+
+TEST(LookupTableTests, constexprEvaluation)
+{
+    constexpr auto table = Utility::buildLookupTable<int, int>({
+        { 2, 20 },
+        { 1, 10 },
+    });
+
+    static_assert(table.size() == 2);
+    static_assert(table.contains(1));
+    static_assert(table.contains(2));
+    static_assert(!table.contains(3));
+    static_assert(table.at(1) == 10);
+    static_assert(table.at(2) == 20);
+}

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -75,7 +75,7 @@ if ( NOT sfl_FOUND )
     FetchContent_Declare(
         sfl
         GIT_REPOSITORY      https://github.com/slavenf/sfl-library
-        GIT_TAG             2.1.1
+        GIT_TAG             2.2.0
         GIT_SHALLOW         ON
         EXCLUDE_FROM_ALL
     )


### PR DESCRIPTION
Raises the sfl version which added constexpr support allowing us to build lookup tables at compile time. I introduced a new header in the Utility library that has buildLookupTable to simplify creating those tables, it helps out with not having to specify the exact fixed storage size, it uses sfl::static_flat_map container, it is essentially a sorted static vector so lookups will be O(log n) and since the tables are usually not that big this is the best fit. Also changed some of the names to use k prefix.