### PR TITLE
Fix 3634: Invalidation issue with track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#3639] The Locomotion title screen music can now be listened to during scenario play.
 - Fix: [#3334] Auto order of cars with centrePosition flag incorrectly calculated.
+- Fix: [#3634] Invalidation issue when show AI planning is turned off.
 - Fix: [#3638] Loan can go negative.
 
 26.03.1 (2026-04-01)

--- a/src/OpenLoco/src/GameCommands/GameCommands.cpp
+++ b/src/OpenLoco/src/GameCommands/GameCommands.cpp
@@ -619,6 +619,6 @@ namespace OpenLoco::GameCommands
     // TODO: Maybe move this somewhere else used by multiple game commands
     bool shouldInvalidateTile(uint8_t flags)
     {
-        return !(flags & Flags::aiAllocated) && Config::get().showAiPlanningAsGhosts;
+        return !(flags & Flags::aiAllocated) || Config::get().showAiPlanningAsGhosts;
     }
 }


### PR DESCRIPTION
Mistake from #3270.

`!(flags & Flags::aiAllocated) || Config::get().showAiPlanningAsGhosts;`

We want to invalidate always if ai planning as ghosts is on. If its off we only invalidate if we are not ai allocating.