### PR TITLE
Fix #2248: New signals not correctly updating network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#1438] Add basic blueprint feature for copy, paste and rotate railroad track.
 - Feature: [#3639] The Locomotion title screen music can now be listened to during scenario play.
+- Fix: [#2248, #3681] Newly placed signals can incorrectly update track network.
 - Fix: [#3334] Auto order of cars with centrePosition flag incorrectly calculated.
 - Fix: [#3634] Invalidation issue when show AI planning is turned off.
 - Fix: [#3638] Loan can go negative.

--- a/src/OpenLoco/src/GameCommands/Track/CreateSignal.cpp
+++ b/src/OpenLoco/src/GameCommands/Track/CreateSignal.cpp
@@ -292,7 +292,7 @@ namespace OpenLoco::GameCommands
             {
                 const uint16_t tad = args.rotation | (args.trackId << 3);
                 {
-                    auto [nextLoc, nextRotation] = World::Track::getTrackConnectionEnd(args.pos, tad);
+                    auto [nextLoc, nextRotation] = World::Track::getTrackConnectionEnd(trackStart, tad);
                     auto tc = World::Track::getTrackConnections(nextLoc, nextRotation, getUpdatingCompanyId(), args.trackObjType, 0, 0);
                     if (!tc.connections.empty())
                     {
@@ -303,7 +303,7 @@ namespace OpenLoco::GameCommands
                 }
 
                 auto& trackSize = World::TrackData::getUnkTrack(tad);
-                auto nextTrackStart = args.pos + trackSize.pos;
+                auto nextTrackStart = trackStart + trackSize.pos;
                 if (trackSize.rotationEnd < 12)
                 {
                     nextTrackStart -= World::Pos3{ World::kRotationOffset[trackSize.rotationEnd], 0 };


### PR DESCRIPTION
There may be other places where this goes wrong but this solves one of them thanks @LeeSpork for the reproduction steps.

Issue was when there is a multi tile track piece and you place a signal on a piece that isn't piece 0 it wouldn't update the track network at all. There must be another area similar though causing the other issue #2248 mentions.

Fix #3681