### PR TITLE
Fix #3694: Crash when starting bus behind bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix: [#3634] Invalidation issue when show AI planning is turned off.
 - Fix: [#3638] Loan can go negative.
 - Fix: [#3655] Incorrect scaffolding preview image in object selection window.
+- Fix: [#3694] Crash when starting bus/truck immediately behind another bus/truck (original bug).
 
 26.03.1 (2026-04-01)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Vehicles/Vehicle1.cpp
+++ b/src/OpenLoco/src/Vehicles/Vehicle1.cpp
@@ -634,10 +634,17 @@ namespace OpenLoco::Vehicles
                 }
             }
             // 0x0047CFB5
-            const auto& roadObj = ObjectManager::get<RoadObject>(veh1.trackType);
-            if (!roadObj->hasFlags(RoadObjectFlags::isRoad))
+            // Note: Vanilla would not perform this check leading to
+            // invalid memory access. Unsure if we should perform something
+            // different but this should at least be safe to do (its not like
+            // you would have track type of 0xff unless you were on a road)
+            if (veh1.trackType != 0xFFU)
             {
-                return LookaheadResult{ LookaheadType::none, 0 };
+                const auto& roadObj = ObjectManager::get<RoadObject>(veh1.trackType);
+                if (!roadObj->hasFlags(RoadObjectFlags::isRoad))
+                {
+                    return LookaheadResult{ LookaheadType::none, 0 };
+                }
             }
             if (tad.isChangingLane() || tad.isOvertaking())
             {


### PR DESCRIPTION
This is a vanilla mistake although in vanilla whether it would crash or not is up for debate. I suspect it would crash on some saves. Either way I have marked it as an "original bug" in the change log.