### PR TITLE
Rewrite vehicle lists to use rowInfo and std::sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 ------------------------------------------------------------------------
 - Feature: [#1438] Add basic blueprint feature for copy, paste and rotate railroad track.
 - Feature: [#3639] The Locomotion title screen music can now be listened to during scenario play.
+- Change: [#3702, #3703, #3704, #3705] Improved performance for vehicle, industry, town, station, and company lists.
 - Fix: [#2248, #3681] Newly placed signals can incorrectly update track network.
+- Fix: [#3173] Having multiple (station) vehicle lists open at once may cause duplicates and/or flashing listings.
 - Fix: [#3334] Auto order of cars with centrePosition flag incorrectly calculated.
 - Fix: [#3634] Invalidation issue when show AI planning is turned off.
 - Fix: [#3638] Loan can go negative.

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -873,6 +873,8 @@ namespace OpenLoco::Ui::Windows::Station
                 auto* rhsVehicle = EntityManager::get<VehicleHead>(rhs);
                 return orderByName(*lhsVehicle, *rhsVehicle);
             });
+
+            self.invalidate();
         }
 
         void removeTrainFromList(Window& self, EntityId head)
@@ -1019,8 +1021,6 @@ namespace OpenLoco::Ui::Windows::Station
             self.callPrepareDraw();
 
             sortVehicleList(self);
-
-            self.invalidate();
         }
 
         static void event_08(Window& self)

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -820,25 +820,7 @@ namespace OpenLoco::Ui::Windows::Station
 
         static void refreshVehicleList(Window* self)
         {
-            auto currentVehicleType = getCurrentVehicleType(self);
             self->rowCount = 0;
-
-            for (auto* vehicle : VehicleManager::VehicleList())
-            {
-                if (!vehicleStopsAtActiveStation(vehicle, StationId(self->number)))
-                {
-                    continue;
-                }
-
-                Common::setVehicleTypeAvailable(*self, vehicle->vehicleType);
-
-                if (vehicle->vehicleType != currentVehicleType)
-                {
-                    continue;
-                }
-
-                vehicle->vehicleFlags &= ~Vehicles::VehicleFlags::sorted;
-            }
         }
 
         static bool orderByName(const VehicleHead& lhs, const VehicleHead& rhs)
@@ -865,6 +847,7 @@ namespace OpenLoco::Ui::Windows::Station
             auto currentVehicleType = getCurrentVehicleType(self);
             EntityId insertId = EntityId::null;
 
+            auto vehicleRowId = 0U;
             for (auto* vehicle : VehicleManager::VehicleList())
             {
                 if (vehicle->vehicleType != currentVehicleType)
@@ -872,7 +855,7 @@ namespace OpenLoco::Ui::Windows::Station
                     continue;
                 }
 
-                if (vehicle->hasVehicleFlags(Vehicles::VehicleFlags::sorted))
+                if (self->rowInfo[vehicleRowId])
                 {
                     continue;
                 }
@@ -909,7 +892,7 @@ namespace OpenLoco::Ui::Windows::Station
                     refreshVehicleList(self);
                     return;
                 }
-                vehicle->vehicleFlags |= Vehicles::VehicleFlags::sorted;
+                self->rowInfo[vehicleRowId] = true;
 
                 if (vehicle->id != EntityId(self->rowInfo[self->rowCount]))
                 {

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -290,7 +290,8 @@ namespace OpenLoco::Ui::Windows::Station
 
     namespace VehiclesStopping
     {
-        static void refreshVehicleList(Window* self);
+        static void populateVehicleList(Window& self);
+        static void sortVehicleList(Window& self);
     }
 
     // 0x0048F210
@@ -331,7 +332,7 @@ namespace OpenLoco::Ui::Windows::Station
         window->invalidate();
 
         // We'll need the vehicle list to determine what vehicle tabs to show
-        VehiclesStopping::refreshVehicleList(window);
+        VehiclesStopping::populateVehicleList(*window);
 
         window->setWidgets(Station::widgets);
         window->holdableWidgets = 0;
@@ -813,14 +814,35 @@ namespace OpenLoco::Ui::Windows::Station
             return false;
         }
 
-        static VehicleType getCurrentVehicleType(Window* self)
+        static VehicleType getCurrentVehicleType(Window& self)
         {
-            return static_cast<VehicleType>(self->currentTab - (Common::widx::tab_vehicles_trains - Common::widx::tab_station));
+            return static_cast<VehicleType>(self.currentTab - (Common::widx::tab_vehicles_trains - Common::widx::tab_station));
         }
 
-        static void refreshVehicleList(Window* self)
+        static void populateVehicleList(Window& self)
         {
-            self->rowCount = 0;
+            self.rowCount = 0;
+
+            // Populate vehicle list with relevant entity ids
+            auto currentVehicleType = getCurrentVehicleType(self);
+            for (auto* vehicle : VehicleManager::VehicleList())
+            {
+                if (!vehicleStopsAtActiveStation(vehicle, StationId(self.number)))
+                {
+                    continue;
+                }
+
+                Common::setVehicleTypeAvailable(self, vehicle->vehicleType);
+
+                if (vehicle->vehicleType != currentVehicleType)
+                {
+                    continue;
+                }
+
+                self.rowInfo[self.rowCount++] = enumValue(vehicle->head);
+            }
+
+            sortVehicleList(self);
         }
 
         static bool orderByName(const VehicleHead& lhs, const VehicleHead& rhs)
@@ -842,89 +864,25 @@ namespace OpenLoco::Ui::Windows::Station
             return Utility::strlogicalcmp(lhsString, rhsString) < 0;
         }
 
-        static void updateVehicleList(Window* self)
+        static void sortVehicleList(Window& self)
         {
-            auto currentVehicleType = getCurrentVehicleType(self);
-            EntityId insertId = EntityId::null;
+            auto list = std::span<EntityId>(reinterpret_cast<EntityId*>(self.rowInfo), self.rowCount);
 
-            auto vehicleRowId = 0U;
-            for (auto* vehicle : VehicleManager::VehicleList())
-            {
-                if (vehicle->vehicleType != currentVehicleType)
-                {
-                    continue;
-                }
-
-                if (self->rowInfo[vehicleRowId])
-                {
-                    continue;
-                }
-
-                if (!vehicleStopsAtActiveStation(vehicle, StationId(self->number)))
-                {
-                    continue;
-                }
-
-                if (insertId == EntityId::null)
-                {
-                    insertId = vehicle->id;
-                    continue;
-                }
-
-                auto* insertVehicle = EntityManager::get<VehicleHead>(insertId);
-                if (insertVehicle == nullptr)
-                {
-                    continue;
-                }
-                if (orderByName(*vehicle, *insertVehicle))
-                {
-                    insertId = vehicle->id;
-                    continue;
-                }
-            }
-
-            if (insertId != EntityId::null)
-            {
-                auto vehicle = EntityManager::get<VehicleHead>(insertId);
-                if (vehicle == nullptr)
-                {
-                    self->var_83C = self->rowCount;
-                    refreshVehicleList(self);
-                    return;
-                }
-                self->rowInfo[vehicleRowId] = true;
-
-                if (vehicle->id != EntityId(self->rowInfo[self->rowCount]))
-                {
-                    self->rowInfo[self->rowCount] = enumValue(vehicle->id);
-                }
-
-                self->rowCount++;
-
-                if (self->rowCount > self->var_83C)
-                {
-                    self->var_83C = self->rowCount;
-                }
-            }
-            else
-            {
-                if (self->var_83C != self->rowCount)
-                {
-                    self->var_83C = self->rowCount;
-                }
-
-                refreshVehicleList(self);
-            }
+            std::sort(list.begin(), list.end(), [self](EntityId lhs, EntityId rhs) {
+                auto* lhsVehicle = EntityManager::get<VehicleHead>(lhs);
+                auto* rhsVehicle = EntityManager::get<VehicleHead>(rhs);
+                return orderByName(*lhsVehicle, *rhsVehicle);
+            });
         }
 
         void removeTrainFromList(Window& self, EntityId head)
         {
-            for (auto i = 0; i < self.var_83C; ++i)
+            for (auto i = 0; i < self.rowCount; ++i)
             {
-                auto& entry = self.rowInfo[i];
-                if (entry == enumValue(head))
+                auto entryId = EntityId(self.rowInfo[i]);
+                if (entryId == head)
                 {
-                    entry = enumValue(EntityId::null);
+                    self.rowInfo[i] = enumValue(EntityId::null);
                 }
             }
         }
@@ -942,7 +900,7 @@ namespace OpenLoco::Ui::Windows::Station
                 StringIds::stringid_ships,
             };
 
-            auto currentVehicleType = getCurrentVehicleType(&self);
+            auto currentVehicleType = getCurrentVehicleType(self);
             self.widgets[Common::widx::caption].text = kTypeToCaption[enumValue(currentVehicleType)];
 
             // Basic frame widget dimensions
@@ -967,8 +925,8 @@ namespace OpenLoco::Ui::Windows::Station
                 // Set status bar
                 FormatArguments args{ widget.textArgs };
                 auto& footerStringPair = kTypeToFooterStringIds[enumValue(currentVehicleType)];
-                args.push(self.var_83C == 1 ? footerStringPair.first : footerStringPair.second);
-                args.push(self.var_83C);
+                args.push(self.rowCount == 1 ? footerStringPair.first : footerStringPair.second);
+                args.push(self.rowCount);
             }
         }
 
@@ -988,7 +946,7 @@ namespace OpenLoco::Ui::Windows::Station
             drawingCtx.clearSingle(shade);
 
             auto yPos = 0;
-            for (auto i = 0; i < self.var_83C; i++)
+            for (auto i = 0; i < self.rowCount; i++)
             {
                 const auto vehicleId = EntityId(self.rowInfo[i]);
 
@@ -1060,9 +1018,7 @@ namespace OpenLoco::Ui::Windows::Station
             self.frameNo++;
             self.callPrepareDraw();
 
-            updateVehicleList(&self);
-            updateVehicleList(&self);
-            updateVehicleList(&self);
+            sortVehicleList(self);
 
             self.invalidate();
         }
@@ -1082,7 +1038,7 @@ namespace OpenLoco::Ui::Windows::Station
 
         static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            scrollHeight = self.var_83C * self.rowHeight;
+            scrollHeight = self.rowCount * self.rowHeight;
         }
 
         static CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, CursorId fallback)
@@ -1093,7 +1049,7 @@ namespace OpenLoco::Ui::Windows::Station
             }
 
             uint16_t currentIndex = yPos / self.rowHeight;
-            if (currentIndex < self.var_83C && self.rowInfo[currentIndex] != -1)
+            if (currentIndex < self.rowCount && self.rowInfo[currentIndex] != -1)
             {
                 return CursorId::handPointer;
             }
@@ -1106,7 +1062,7 @@ namespace OpenLoco::Ui::Windows::Station
             self.flags &= ~WindowFlags::notScrollView;
 
             uint16_t currentRow = y / self.rowHeight;
-            if (currentRow < self.var_83C)
+            if (currentRow < self.rowCount)
             {
                 self.rowHover = self.rowInfo[currentRow];
             }
@@ -1119,7 +1075,7 @@ namespace OpenLoco::Ui::Windows::Station
         static void onScrollMouseDown(Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             uint16_t currentRow = y / self.rowHeight;
-            if (currentRow >= self.var_83C)
+            if (currentRow >= self.rowCount)
             {
                 return;
             }
@@ -1406,9 +1362,7 @@ namespace OpenLoco::Ui::Windows::Station
             self.rowHeight = tabInfo.rowHeight;
 
             // We'll need the vehicle list to determine what vehicle tabs to show
-            VehiclesStopping::refreshVehicleList(&self);
-            self.rowCount = 0;
-            self.var_83C = 0;
+            VehiclesStopping::populateVehicleList(self);
             self.rowHover = -1;
 
             self.invalidate();

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -155,10 +155,14 @@ namespace OpenLoco::Ui::Windows::VehicleList
         return false;
     }
 
+    static void sortVehicleList(Window& self);
+
     // 0x004C1D4F
-    static void refreshVehicleList(Window& self)
+    static void populateVehicleList(Window& self)
     {
         self.rowCount = 0;
+
+        // Populate vehicle list with relevant entity ids
         for (auto* vehicle : VehicleManager::VehicleList())
         {
             if (vehicle->vehicleType != static_cast<VehicleType>(self.currentTab))
@@ -176,8 +180,10 @@ namespace OpenLoco::Ui::Windows::VehicleList
                 continue;
             }
 
-            vehicle->vehicleFlags &= ~Vehicles::VehicleFlags::sorted;
+            self.rowInfo[self.rowCount++] = enumValue(vehicle->head);
         }
+
+        sortVehicleList(self);
     }
 
     // 0x004C1E4F
@@ -248,82 +254,15 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C1D92
-    static void updateVehicleList(Window& self)
+    static void sortVehicleList(Window& self)
     {
-        EntityId insertId = EntityId::null;
+        auto list = std::span<EntityId>(reinterpret_cast<EntityId*>(self.rowInfo), self.rowCount);
 
-        for (auto* vehicle : VehicleManager::VehicleList())
-        {
-            if (vehicle->vehicleType != static_cast<VehicleType>(self.currentTab))
-            {
-                continue;
-            }
-
-            if (vehicle->owner != CompanyId(self.number))
-            {
-                continue;
-            }
-
-            if (vehicle->hasVehicleFlags(Vehicles::VehicleFlags::sorted))
-            {
-                continue;
-            }
-
-            if (isCargoFilterActive(self) && !vehicleIsTransportingCargo(vehicle, self.var_852))
-            {
-                continue;
-            }
-
-            if (insertId == EntityId::null)
-            {
-                insertId = vehicle->id;
-                continue;
-            }
-
-            auto* insertVehicle = EntityManager::get<VehicleHead>(insertId);
-            if (insertVehicle == nullptr)
-            {
-                continue;
-            }
-            if (getOrder(SortMode(self.sortMode), *vehicle, *insertVehicle))
-            {
-                insertId = vehicle->id;
-                continue;
-            }
-        }
-
-        if (insertId != EntityId::null)
-        {
-            auto vehicle = EntityManager::get<VehicleHead>(insertId);
-            if (vehicle == nullptr)
-            {
-                self.var_83C = self.rowCount;
-                refreshVehicleList(self);
-                return;
-            }
-            vehicle->vehicleFlags |= Vehicles::VehicleFlags::sorted;
-
-            if (vehicle->id != EntityId(self.rowInfo[self.rowCount]))
-            {
-                self.rowInfo[self.rowCount] = enumValue(vehicle->id);
-            }
-
-            self.rowCount++;
-
-            if (self.rowCount > self.var_83C)
-            {
-                self.var_83C = self.rowCount;
-            }
-        }
-        else
-        {
-            if (self.var_83C != self.rowCount)
-            {
-                self.var_83C = self.rowCount;
-            }
-
-            refreshVehicleList(self);
-        }
+        std::sort(list.begin(), list.end(), [self](EntityId lhs, EntityId rhs) {
+            auto* lhsVehicle = EntityManager::get<VehicleHead>(lhs);
+            auto* rhsVehicle = EntityManager::get<VehicleHead>(rhs);
+            return getOrder(SortMode(self.sortMode), *lhsVehicle, *rhsVehicle);
+        });
     }
 
     // 0x004C2A6E
@@ -463,12 +402,11 @@ namespace OpenLoco::Ui::Windows::VehicleList
         self->width = kWindowSize.width;
         self->height = kWindowSize.height;
         self->sortMode = 0;
-        self->var_83C = 0;
         self->rowHover = -1;
         self->var_850 = static_cast<int16_t>(FilterMode::allVehicles);
         self->var_852 = 0xFFFF;
 
-        refreshVehicleList(*self);
+        populateVehicleList(*self);
 
         self->invalidate();
 
@@ -482,12 +420,12 @@ namespace OpenLoco::Ui::Windows::VehicleList
     // 0x004C1D19
     void removeTrainFromList(Window& self, EntityId head)
     {
-        for (auto i = 0; i < self.var_83C; ++i)
+        for (auto i = 0; i < self.rowCount; ++i)
         {
-            auto& entry = self.rowInfo[i];
-            if (entry == enumValue(head))
+            auto entryId = EntityId(self.rowInfo[i]);
+            if (entryId == head)
             {
-                entry = enumValue(EntityId::null);
+                self.rowInfo[i] = enumValue(EntityId::null);
             }
         }
     }
@@ -579,8 +517,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
             auto& widget = self.widgets[Widx::status_bar];
             FormatArguments args{ widget.textArgs };
             auto& footerStringPair = kTypeToFooterStringIds[self.currentTab];
-            args.push(self.var_83C == 1 ? footerStringPair.first : footerStringPair.second);
-            args.push(self.var_83C);
+            args.push(self.rowCount == 1 ? footerStringPair.first : footerStringPair.second);
+            args.push(self.rowCount);
         }
 
         static constexpr std::array<StringId, 2> kTypeToFilterStringIds{
@@ -645,7 +583,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         drawingCtx.clearSingle(shade);
 
         auto yPos = 0;
-        for (auto i = 0; i < self.var_83C; i++)
+        for (auto i = 0; i < self.rowCount; i++)
         {
             const auto vehicleId = EntityId(self.rowInfo[i]);
 
@@ -775,9 +713,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
         }
 
         self.rowCount = 0;
-        refreshVehicleList(self);
+        populateVehicleList(self);
 
-        self.var_83C = 0;
         self.rowHover = -1;
 
         self.callOnResize();
@@ -822,7 +759,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
                 self.sortMode = sortMode;
                 self.invalidate();
-                refreshVehicleList(self);
+                populateVehicleList(self);
                 break;
             }
         }
@@ -910,9 +847,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
         disableUnavailableVehicleTypes(self);
 
         self.rowCount = 0;
-        refreshVehicleList(self);
+        populateVehicleList(self);
 
-        self.var_83C = 0;
         self.rowHover = -1;
 
         self.callOnResize();
@@ -960,10 +896,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         auto widgetIndex = getTabFromType(static_cast<VehicleType>(self.currentTab));
         WindowManager::invalidateWidget(WindowType::vehicleList, self.number, widgetIndex);
 
-        // It adds 3 vehicles per update, this is not an accident.
-        updateVehicleList(self);
-        updateVehicleList(self);
-        updateVehicleList(self);
+        sortVehicleList(self);
 
         self.invalidate();
     }
@@ -986,7 +919,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     // 0x004C265B
     static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        scrollHeight = self.var_83C * self.rowHeight;
+        scrollHeight = self.rowCount * self.rowHeight;
     }
 
     // 0x004C266D
@@ -998,7 +931,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         }
 
         uint16_t currentIndex = yPos / self.rowHeight;
-        if (currentIndex < self.var_83C && self.rowInfo[currentIndex] != -1)
+        if (currentIndex < self.rowCount && EntityId(self.rowInfo[currentIndex]) != EntityId::null)
         {
             return CursorId::handPointer;
         }
@@ -1014,7 +947,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         self.flags &= ~WindowFlags::notScrollView;
 
         uint16_t currentRow = y / self.rowHeight;
-        if (currentRow < self.var_83C)
+        if (currentRow < self.rowCount)
         {
             self.rowHover = self.rowInfo[currentRow];
         }
@@ -1088,7 +1021,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     static void onScrollMouseDown(Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         uint16_t currentRow = y / self.rowHeight;
-        if (currentRow >= self.var_83C)
+        if (currentRow >= self.rowCount)
         {
             return;
         }

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -258,7 +258,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     {
         auto list = std::span<EntityId>(reinterpret_cast<EntityId*>(self.rowInfo), self.rowCount);
 
-        std::sort(list.begin(), list.end(), [self](EntityId lhs, EntityId rhs) {
+        std::stable_sort(list.begin(), list.end(), [self](EntityId lhs, EntityId rhs) {
             auto* lhsVehicle = EntityManager::get<VehicleHead>(lhs);
             auto* rhsVehicle = EntityManager::get<VehicleHead>(rhs);
             return getOrder(SortMode(self.sortMode), *lhsVehicle, *rhsVehicle);

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -263,6 +263,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
             auto* rhsVehicle = EntityManager::get<VehicleHead>(rhs);
             return getOrder(SortMode(self.sortMode), *lhsVehicle, *rhsVehicle);
         });
+
+        self.invalidate();
     }
 
     // 0x004C2A6E
@@ -897,8 +899,6 @@ namespace OpenLoco::Ui::Windows::VehicleList
         WindowManager::invalidateWidget(WindowType::vehicleList, self.number, widgetIndex);
 
         sortVehicleList(self);
-
-        self.invalidate();
     }
 
     // 0x004C2640

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -79,8 +79,8 @@ namespace OpenLoco::Vehicles
         unk_0 = 1U << 0,
         commandStop = 1U << 1, // commanded to stop??
         unk_2 = 1U << 2,
-        unk_3 = 1U << 3, // unused; previously used by vehicle list
-        unk_4 = 1U << 4,
+        sorted = 1U << 3, // unused; previously used by vehicle list
+        unk_4 = 1U << 4,  // unused
         unk_5 = 1U << 5,
         manualControl = 1U << 6,
         shuntCheat = 1U << 7,

--- a/src/OpenLoco/src/Vehicles/Vehicle.h
+++ b/src/OpenLoco/src/Vehicles/Vehicle.h
@@ -79,7 +79,8 @@ namespace OpenLoco::Vehicles
         unk_0 = 1U << 0,
         commandStop = 1U << 1, // commanded to stop??
         unk_2 = 1U << 2,
-        sorted = 1U << 3, // vehicle list
+        unk_3 = 1U << 3, // unused; previously used by vehicle list
+        unk_4 = 1U << 4,
         unk_5 = 1U << 5,
         manualControl = 1U << 6,
         shuntCheat = 1U << 7,


### PR DESCRIPTION
This rewrites the vehicle lists to make use of window-specific `rowInfo` state to store the relevant entity ids. Previously, the lists were performing a rolling update, making use of a flag on the vehicle entities themselves to determine whether an _insertion sort_ (!) was needed. This is now replaced with a more efficient `std::sort` that runs on every tick. Happily, this gets rid of a good chunk of custom code.

Most importantly, though, the removal of the global state means we can now have several vehicle lists open without side-effects. This fixes #3173.

Other windows with lists could probably do with a similar refactor. I may get around to this as well.

<img width="1024" height="768" alt="Boulder Breakers (1)" src="https://github.com/user-attachments/assets/28510985-b9a5-4a52-9264-7c7a461bc085" />

