### PR TITLE
Load an intrinsic InterfaceSkin to allow for additional interface images

### DIFF
--- a/src/OpenLoco/src/Graphics/Gfx.h
+++ b/src/OpenLoco/src/Graphics/Gfx.h
@@ -30,8 +30,9 @@ namespace OpenLoco::Gfx
     {
         constexpr uint32_t kDisc = 0x101A; // And GOG
         constexpr uint32_t kTemporaryObjects = 0x1000;
+        constexpr uint32_t kIntrinsicInterface = 0x500;
         constexpr uint32_t kSteam = 0x0F38;
-        constexpr uint32_t kObjects = 0x40000 - kTemporaryObjects;
+        constexpr uint32_t kObjects = 0x40000 - kTemporaryObjects - kIntrinsicInterface;
 
         // After loading a save we have the following images expected:
         // 0x00000-0x01019: Disc (or GOG or Steam) images (Note: Steam is missing some images but will be padded up to the disc count during load)

--- a/src/OpenLoco/src/Objects/InterfaceSkinObject.cpp
+++ b/src/OpenLoco/src/Objects/InterfaceSkinObject.cpp
@@ -14,8 +14,18 @@ namespace OpenLoco
         auto stringRes = ObjectManager::loadStringTable(remainingData, handle, 0);
         name = stringRes.str;
         remainingData = remainingData.subspan(stringRes.tableLength);
+        const auto initImageCount = ObjectManager::getTotalNumImages();
         auto imageRes = ObjectManager::loadImageTable(remainingData);
         img = imageRes.imageOffset;
+        const auto numImagesLoaded = ObjectManager::getTotalNumImages() - initImageCount;
+        // Pad out the image table with images from the intrinsic interface
+        // this is because existing interface skins were created before we
+        // added more.
+        for (auto i = numImagesLoaded; i < InterfaceSkin::ImageIds::kNewImageEnd; ++i)
+        {
+            *Gfx::getG1Element(img + i) = *Gfx::getG1Element(Gfx::G1ExpectedCount::kDisc + Gfx::G1ExpectedCount::kTemporaryObjects + i);
+        }
+        ObjectManager::setTotalNumImages(ObjectManager::getTotalNumImages() + InterfaceSkin::ImageIds::kNewImageEnd - numImagesLoaded);
         assert(remainingData.size() == imageRes.tableLength);
     }
 

--- a/src/OpenLoco/src/Objects/InterfaceSkinObject.h
+++ b/src/OpenLoco/src/Objects/InterfaceSkinObject.h
@@ -522,5 +522,9 @@ namespace OpenLoco
         constexpr uint32_t toolbar_menu_map_west = 467;
         constexpr uint32_t toolbar_menu_map_south = 468;
         constexpr uint32_t toolbar_menu_map_east = 469;
+
+        constexpr uint32_t kNewImageStart = 470;
+        constexpr uint32_t kOpenLocoLogo = 470;
+        constexpr uint32_t kNewImageEnd = 471;
     }
 }

--- a/src/OpenLoco/src/Objects/ObjectManager.cpp
+++ b/src/OpenLoco/src/Objects/ObjectManager.cpp
@@ -88,6 +88,13 @@ namespace OpenLoco::ObjectManager
         std::span<ObjectEntry2> objectEntryExtendeds;
     };
 
+    struct PreLoadedObject
+    {
+        std::span<std::byte> objectData;
+        Object* object; // Owning pointer!
+        ObjectHeader header;
+    };
+
     static_assert(Traits::IsPOD<ObjectHeader>::value, "Object Header must be trivial for I/O purposes");
 
     // 0x004FE0B8
@@ -128,6 +135,8 @@ namespace OpenLoco::ObjectManager
     static bool _isTemporaryObject = false;
     // 0x0050D15C
     static Object* _temporaryObject = nullptr;
+
+    static PreLoadedObject _intrinsicInterfaceObject = {};
 
     static ObjectRepositoryItem& getRepositoryItem(ObjectType type)
     {
@@ -361,7 +370,7 @@ namespace OpenLoco::ObjectManager
         Core::Timer reloadTimer;
         size_t loadedObjects{};
 
-        setTotalNumImages(Gfx::G1ExpectedCount::kDisc + Gfx::G1ExpectedCount::kTemporaryObjects);
+        setTotalNumImages(Gfx::G1ExpectedCount::kDisc + Gfx::G1ExpectedCount::kTemporaryObjects + Gfx::G1ExpectedCount::kIntrinsicInterface);
 
         forEachLoadedObject([&loadedObjects](const LoadedObjectHandle& handle) {
             auto* obj = getAny(handle);
@@ -412,13 +421,6 @@ namespace OpenLoco::ObjectManager
             _temporaryObject = nullptr;
         }
     }
-
-    struct PreLoadedObject
-    {
-        std::span<std::byte> objectData;
-        Object* object; // Owning pointer!
-        ObjectHeader header;
-    };
 
     static std::optional<PreLoadedObject> findAndPreLoadObject(const ObjectHeader& header)
     {
@@ -480,6 +482,39 @@ namespace OpenLoco::ObjectManager
         }
 
         return preLoadObj;
+    }
+
+    void loadIntrinsicInterfaceGraphics()
+    {
+        const auto filePath = Environment::getPath(Environment::PathId::objects) / "InterfaceSkin" / "OG_INTERDEF.dat";
+        FileStream fs(filePath, StreamMode::read);
+        SawyerStreamReader stream(fs);
+        stream.read(&_intrinsicInterfaceObject.header, sizeof(_intrinsicInterfaceObject.header));
+        if (_intrinsicInterfaceObject.header.getType() != ObjectType::interfaceSkin && _intrinsicInterfaceObject.header.getName() != "OG_INTERDEF")
+        {
+            // Something wrong has happened and installed object does not match index
+            Logging::error("Mismatch between installed object header and object file header for intrinsic interface graphics!");
+            return;
+        }
+        std::span<const std::byte> data;
+        data = stream.readChunk();
+        _intrinsicInterfaceObject.object = reinterpret_cast<Object*>(malloc(data.size()));
+        std::copy(std::begin(data), std::end(data), reinterpret_cast<std::byte*>(_intrinsicInterfaceObject.object));
+        _intrinsicInterfaceObject.objectData = std::span<std::byte>(reinterpret_cast<std::byte*>(_intrinsicInterfaceObject.object), data.size());
+
+        const auto oldNumImages = getTotalNumImages();
+        setTotalNumImages(Gfx::G1ExpectedCount::kDisc + Gfx::G1ExpectedCount::kTemporaryObjects);
+        callObjectLoad({ ObjectType::interfaceSkin, 0 }, *_intrinsicInterfaceObject.object, _intrinsicInterfaceObject.objectData);
+        setTotalNumImages(oldNumImages);
+    }
+
+    void unloadIntrinsicInterfaceGraphics()
+    {
+        if (_intrinsicInterfaceObject.object != nullptr)
+        {
+            free(_intrinsicInterfaceObject.object);
+            _intrinsicInterfaceObject.object = nullptr;
+        }
     }
 
     // 0x0047176D
@@ -555,7 +590,7 @@ namespace OpenLoco::ObjectManager
             return false;
         }
 
-        if (getTotalNumImages() >= Gfx::G1ExpectedCount::kObjects + Gfx::G1ExpectedCount::kTemporaryObjects + Gfx::G1ExpectedCount::kDisc)
+        if (getTotalNumImages() >= Gfx::G1ExpectedCount::kObjects + Gfx::G1ExpectedCount::kTemporaryObjects + Gfx::G1ExpectedCount::kDisc + Gfx::G1ExpectedCount::kIntrinsicInterface)
         {
             free(preLoadObj->object);
             // Too many objects loaded and no free image space
@@ -782,7 +817,7 @@ namespace OpenLoco::ObjectManager
             return false;
         }
 
-        if (getTotalNumImages() >= Gfx::G1ExpectedCount::kObjects + Gfx::G1ExpectedCount::kTemporaryObjects + Gfx::G1ExpectedCount::kDisc)
+        if (getTotalNumImages() >= Gfx::G1ExpectedCount::kObjects + Gfx::G1ExpectedCount::kTemporaryObjects + Gfx::G1ExpectedCount::kDisc + Gfx::G1ExpectedCount::kIntrinsicInterface)
         {
             // Free objectData?
             return false;

--- a/src/OpenLoco/src/Objects/ObjectManager.h
+++ b/src/OpenLoco/src/Objects/ObjectManager.h
@@ -185,6 +185,8 @@ namespace OpenLoco::ObjectManager
     // Unloads and frees the entry
     void unload(const ObjectHeader& header);
     bool load(const ObjectHeader& header);
+    void loadIntrinsicInterfaceGraphics();
+    void unloadIntrinsicInterfaceGraphics();
 
     bool tryInstallObject(const ObjectHeader& object, std::span<const std::byte> data);
 

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -122,6 +122,7 @@ namespace OpenLoco
         Audio::disposeDSound();
         Ui::disposeCursors();
         Localisation::unloadLanguageFile();
+        ObjectManager::unloadIntrinsicInterfaceGraphics();
 
         auto tempFilePath = Environment::getPathNoWarning(Environment::PathId::_1tmp);
         if (fs::exists(tempFilePath))
@@ -189,6 +190,7 @@ namespace OpenLoco
         startupChecks();
 
         Gfx::loadG1();
+        ObjectManager::loadIntrinsicInterfaceGraphics();
         Gfx::initialise();
 
         Ui::initialise();

--- a/src/OpenLoco/src/Ui/Windows/TitleLogo.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleLogo.cpp
@@ -1,6 +1,8 @@
 #include "Graphics/Colour.h"
 #include "Graphics/DrawingContext.h"
 #include "Graphics/ImageIds.h"
+#include "Objects/InterfaceSkinObject.h"
+#include "Objects/ObjectManager.h"
 #include "OpenLoco.h"
 #include "Ui/Widget.h"
 #include "Ui/Widgets/Wt3Widget.h"
@@ -46,7 +48,9 @@ namespace OpenLoco::Ui::Windows::TitleLogo
     // 0x00439298
     static void draw(Ui::Window& window, Gfx::DrawingContext& drawingCtx)
     {
-        drawingCtx.drawImage(window.x, window.y, ImageIds::locomotion_logo);
+        auto* interface = ObjectManager::get<InterfaceSkinObject>();
+
+        drawingCtx.drawImage(window.x, window.y, interface->img + InterfaceSkin::ImageIds::kOpenLocoLogo);
     }
 
     // 0x004392AD


### PR DESCRIPTION
Somewhat an experiment to see how this would look for adding new interface skin images. Its not the prettiest. In the long run we would remove InterfaceSkin from the normal objects and make it a special intrinsic object that doesn't get unloaded.