### PR TITLE
Replace remaining users of var_83C with rowCount

### DIFF
--- a/src/OpenLoco/src/Ui/Window.h
+++ b/src/OpenLoco/src/Ui/Window.h
@@ -198,7 +198,7 @@ namespace OpenLoco::Ui
         ScrollArea scrollAreas[kMaxScrollAreas];
         int16_t rowInfo[1000];
         uint16_t rowCount;
-        uint16_t var_83C;
+        uint16_t var_83C; // unused
         uint16_t rowHeight;
         int16_t rowHover = -1;
         union

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -390,7 +390,6 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
 
             window->rowHeight = kScrollRowHeight[window->currentTab];
             window->rowCount = 0;
-            window->var_83C = 0;
             window->rowHover = -1;
             window->invalidate();
             window->setWidgets(_widgets);
@@ -745,7 +744,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         if (_buildTargetVehicle != vehicleId)
         {
             _buildTargetVehicle = vehicleId;
-            window->var_83C = 0;
+            window->rowCount = 0;
             window->invalidate();
         }
 
@@ -760,14 +759,12 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
 
         generateBuildableVehiclesArray(vehicleType, trackType, veh);
 
-        window->var_83C = _numAvailableVehicles;
-        window->rowCount = 0;
-
         for (auto i = 0; i < _numAvailableVehicles; i++)
         {
             window->rowInfo[i] = _availableVehicles[i];
         }
 
+        window->rowCount = _numAvailableVehicles;
         window->rowHover = -1;
         window->invalidate();
     }
@@ -821,7 +818,6 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 setTrackTypeTabs(&window);
                 resetTrackTypeTabSelection(&window);
                 window.rowCount = 0;
-                window.var_83C = 0;
                 window.rowHover = -1;
                 sub_4B92A5(&window);
                 window.callOnResize();
@@ -851,7 +847,6 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 setTopToolbarLastTrack(_trackTypesForTab[tab] & ~(1 << 7), _trackTypesForTab[tab] & (1 << 7));
                 _buildTargetVehicle = -1;
                 window.rowCount = 0;
-                window.var_83C = 0;
                 window.rowHover = -1;
                 sub_4B92A5(&window);
                 window.callOnResize();
@@ -1102,7 +1097,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
             return;
         }
 
-        if (window.var_83C == 0)
+        if (window.rowCount == 0)
         {
             return;
         }
@@ -1140,7 +1135,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     // 0x4C37B9
     static void getScrollSize(Ui::Window& window, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
-        scrollHeight = window.var_83C * window.rowHeight;
+        scrollHeight = window.rowCount * window.rowHeight;
     }
 
     // 0x4C384B
@@ -1152,7 +1147,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         }
 
         auto scrollItem = y / window.rowHeight;
-        if (scrollItem >= window.var_83C)
+        if (scrollItem >= window.rowCount)
         {
             return;
         }
@@ -1203,7 +1198,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
 
         auto scrollItem = y / window.rowHeight;
         int16_t item = -1;
-        if (scrollItem < window.var_83C)
+        if (scrollItem < window.rowCount)
         {
             item = window.rowInfo[scrollItem];
         }
@@ -1267,7 +1262,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         }
 
         auto scrollItem = yPos / window.rowHeight;
-        if (scrollItem >= window.var_83C)
+        if (scrollItem >= window.rowCount)
         {
             return fallback;
         }
@@ -1562,7 +1557,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
             {
                 auto colour = Colours::getShade(window.getColour(WindowColour::secondary).c(), 4);
                 drawingCtx.clear(colour * 0x01010101);
-                if (window.var_83C == 0)
+                if (window.rowCount == 0)
                 {
                     auto defaultMessage = StringIds::no_vehicles_available;
                     FormatArguments args{};
@@ -1585,7 +1580,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 else
                 {
                     int16_t y = 0;
-                    for (auto i = 0; i < window.var_83C; ++i, y += window.rowHeight)
+                    for (auto i = 0; i < window.rowCount; ++i, y += window.rowHeight)
                     {
                         if (y + window.rowHeight + 30 <= rt.y)
                         {

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -760,18 +760,14 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
 
         generateBuildableVehiclesArray(vehicleType, trackType, veh);
 
-        int numRows = _numAvailableVehicles;
-        uint16_t* src = _availableVehicles;
-        int16_t* dest = window->rowInfo;
-        window->var_83C = numRows;
+        window->var_83C = _numAvailableVehicles;
         window->rowCount = 0;
-        while (numRows != 0)
+
+        for (auto i = 0; i < _numAvailableVehicles; i++)
         {
-            *dest = *src;
-            dest++;
-            src++;
-            numRows--;
+            window->rowInfo[i] = _availableVehicles[i];
         }
+
         window->rowHover = -1;
         window->invalidate();
     }

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -187,7 +187,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             self.scrollAreas[0].contentHeight = scrollHeight;
 
             auto i = 0;
-            for (; i <= self.var_83C; i++)
+            for (; i <= self.rowCount; i++)
             {
                 if (self.rowInfo[i] == self.rowHover)
                 {
@@ -195,7 +195,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 }
             }
 
-            if (i >= self.var_83C)
+            if (i >= self.rowCount)
             {
                 i = 0;
             }
@@ -221,12 +221,12 @@ namespace OpenLoco::Ui::Windows::Terraform
                 treeCount++;
             }
 
-            self.var_83C = treeCount;
+            self.rowCount = treeCount;
             auto rowHover = -1;
 
             if (getGameState().lastTreeOption != 0xFF)
             {
-                for (auto i = 0; i < self.var_83C; i++)
+                for (auto i = 0; i < self.rowCount; i++)
                 {
                     if (getGameState().lastTreeOption == self.rowInfo[i])
                     {
@@ -236,7 +236,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 }
             }
 
-            if (rowHover == -1 && self.var_83C != 0)
+            if (rowHover == -1 && self.rowCount != 0)
             {
                 rowHover = self.rowInfo[0];
             }
@@ -263,7 +263,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             Input::setFlag(Input::Flags::flag6);
             _terraformGhostPlacedFlags = Common::GhostPlacedFlags::none;
             _lastTreeCost = 0x80000000;
-            self.var_83C = 0;
+            self.rowCount = 0;
             self.rowHover = -1;
             refreshTreeList(self);
             updateTreeColours(self);
@@ -633,7 +633,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BBEC1
         static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            scrollHeight = (self.var_83C + 8) / 9;
+            scrollHeight = (self.rowCount + 8) / 9;
             if (scrollHeight == 0)
             {
                 scrollHeight += 1;
@@ -651,7 +651,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         {
             auto index = getRowIndex(x, y);
 
-            for (auto i = 0; i < self.var_83C; i++)
+            for (auto i = 0; i < self.rowCount; i++)
             {
                 auto rowInfo = self.rowInfo[i];
                 index--;
@@ -678,7 +678,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             auto index = getRowIndex(x, y);
             uint16_t rowInfo = y;
             auto i = 0;
-            for (; i < self.var_83C; i++)
+            for (; i < self.rowCount; i++)
             {
                 rowInfo = self.rowInfo[i];
                 index--;
@@ -837,7 +837,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             uint16_t xPos = 0;
             uint16_t yPos = 0;
-            for (uint16_t i = 0; i < self.var_83C; i++)
+            for (uint16_t i = 0; i < self.rowCount; i++)
             {
                 _lastTreeColourFlag = 0xFFFF;
                 if (self.rowInfo[i] != self.rowHover)
@@ -956,7 +956,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             window->callPrepareDraw();
             window->initScrollWidgets();
 
-            window->var_83C = 0;
+            window->rowCount = 0;
             window->rowHover = -1;
 
             PlantTrees::refreshTreeList(*window);
@@ -2262,7 +2262,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             self.scrollAreas[0].contentHeight = scrollHeight;
 
             auto i = 0;
-            for (; i <= self.var_83C; i++)
+            for (; i <= self.rowCount; i++)
             {
                 if (self.rowInfo[i] == self.rowHover)
                 {
@@ -2270,7 +2270,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 }
             }
 
-            if (i >= self.var_83C)
+            if (i >= self.rowCount)
             {
                 i = 0;
             }
@@ -2296,12 +2296,12 @@ namespace OpenLoco::Ui::Windows::Terraform
                 wallCount++;
             }
 
-            self.var_83C = wallCount;
+            self.rowCount = wallCount;
             auto rowHover = -1;
 
             if (getGameState().lastWallOption != 0xFF)
             {
-                for (auto i = 0; i < self.var_83C; i++)
+                for (auto i = 0; i < self.rowCount; i++)
                 {
                     if (getGameState().lastWallOption == self.rowInfo[i])
                     {
@@ -2311,7 +2311,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 }
             }
 
-            if (rowHover == -1 && self.var_83C != 0)
+            if (rowHover == -1 && self.rowCount != 0)
             {
                 rowHover = self.rowInfo[0];
             }
@@ -2336,7 +2336,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             ToolManager::toolSet(self, Common::widx::panel, CursorId::placeFence);
             Input::setFlag(Input::Flags::flag6);
             _terraformGhostPlacedFlags = Common::GhostPlacedFlags::none;
-            self.var_83C = 0;
+            self.rowCount = 0;
             self.rowHover = -1;
             refreshWallList(self);
         }
@@ -2563,7 +2563,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BC359
         static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            scrollHeight = (self.var_83C + 9) / 10;
+            scrollHeight = (self.rowCount + 9) / 10;
             if (scrollHeight == 0)
             {
                 scrollHeight += 1;
@@ -2581,7 +2581,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         {
             auto index = getRowIndex(x, y);
 
-            for (auto i = 0; i < self.var_83C; i++)
+            for (auto i = 0; i < self.rowCount; i++)
             {
                 auto rowInfo = self.rowInfo[i];
                 index--;
@@ -2606,7 +2606,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             uint16_t rowInfo = 0xFFFF;
             auto i = 0;
 
-            for (; i < self.var_83C; i++)
+            for (; i < self.rowCount; i++)
             {
                 rowInfo = self.rowInfo[i];
                 index--;
@@ -2615,7 +2615,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     break;
                 }
             }
-            if (i >= self.var_83C)
+            if (i >= self.rowCount)
             {
                 rowInfo = 0xFFFF;
             }
@@ -2682,7 +2682,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             uint16_t xPos = 0;
             uint16_t yPos = 0;
-            for (uint16_t i = 0; i < self.var_83C; i++)
+            for (uint16_t i = 0; i < self.rowCount; i++)
             {
                 if (self.rowInfo[i] != self.rowHover)
                 {


### PR DESCRIPTION
With the various 'list' windows recently refactored, the `var_83C` is now hardly used. This PR replaces the two remaining instances (build vehicle, terraform/trees) with `rowCount` as well. Makes things just a little bit more readable.