### PR TITLE
Address regressions from moving jukebox to its own window

### DIFF
--- a/src/OpenLoco/src/Audio/Music.cpp
+++ b/src/OpenLoco/src/Audio/Music.cpp
@@ -68,7 +68,7 @@ namespace OpenLoco::Audio
         {
             const auto& mi = Jukebox::changeTrack();
             playMusic(mi.pathId, cfg.audio.mainVolume, false);
-            Ui::WindowManager::invalidate(Ui::WindowType::options);
+            Ui::WindowManager::invalidate(Ui::WindowType::musicJukebox);
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/MusicJukebox.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MusicJukebox.cpp
@@ -95,6 +95,9 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
             args.push(songName);
         }
 
+        self.activatedWidgets = 0;
+        self.disabledWidgets = 0;
+
         // Jukebox controls (stop/play/skip)
         if (!SceneManager::isPlayMode())
         {


### PR DESCRIPTION
When changing jukebox tracks, the game would still invalidate the Options window rather than the Jukebox. This is an oversight from #3707.

The playback buttons would stay pressed/activated even after toggling had already happened. This was due to `.activatedWidgets` not being reset.

Similarly, the 'edit music playlist' button would not correctly toggle away from its disabled state. This was due to `.disabledWidgets` not being reset.

Regressions from #3707