### PR TITLE
Add option to set a default company name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,13 @@ ClientBin/
 *.pfx
 *.publishsettings
 orleans.codegen.cs
+*.swp
+
+# CScope data
+cscope.files
+cscope.in.out
+cscope.out
+cscope.po.out
 
 # Since there are multiple workflows, uncomment next line to ignore bower_components
 # (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 26.04+ (???)
 ------------------------------------------------------------------------
+- Feature: [#3720] A preferred company name can now be set, separate from the preferred owner name.
 - Change: [#3517] Letters with unsupported diacritics/accents are temporarily replaced with regular letters to keep e.g. Czech, Slovak readable.
 - Change: [#3710] The Build Vehicle window is now wider by default, moving the sorting options to a dedicated dropdown.
 - Change: [#3734] The Station Construction tab now lists accepted and produced cargo in full, with labels along the icons.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2490,3 +2490,10 @@ strings:
   2435: 'Keep vehicle cargo on modify or pickup'
   2436: '{SMALLFONT}{COLOUR BLACK}When enabled, cargo will not be cleared from the entire vehicle when adding cars, moving cars or picking up the vehicle'
   2437: "Sort by"
+  2438: 'Preferred company'
+  2439: Use preferred company name when starting a new game
+  2440: "{SMALLFONT}{COLOUR BLACK}Select this option to use the same company name every time you start a new game"
+  2441: "{COLOUR WINDOW_2}Preferred company name: {COLOUR BLACK}{STRINGID}"
+  2442: Preferred Company Name
+  2443: "Enter the preferred company name:"
+  2444: ""

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2496,5 +2496,4 @@ strings:
   2441: "{COLOUR WINDOW_2}Preferred company name: {COLOUR BLACK}{STRINGID}"
   2442: Preferred Company Name
   2443: "Enter the preferred company name:"
-  2444: ""
-  2445: Can't change company name...
+  2444: Can't change company name...

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2497,3 +2497,4 @@ strings:
   2442: Preferred Company Name
   2443: "Enter the preferred company name:"
   2444: ""
+  2445: Can't change company name...

--- a/src/OpenLoco/include/OpenLoco/Config.h
+++ b/src/OpenLoco/include/OpenLoco/Config.h
@@ -214,6 +214,8 @@ namespace OpenLoco::Config
         std::string preferredOwnerName;
         bool usePreferredOwnerFace;
         ObjectHeader preferredOwnerFace;
+        bool usePreferredCompanyName = false;
+        std::string preferredCompanyName;
 
         int32_t scenarioSelectedTab;
 

--- a/src/OpenLoco/include/OpenLoco/GameStateFlags.h
+++ b/src/OpenLoco/include/OpenLoco/GameStateFlags.h
@@ -9,6 +9,7 @@ namespace OpenLoco
         tileManagerLoaded = (1U << 0),
         unk2 = (1U << 1),
         preferredOwnerName = (1U << 2),
+        preferredCompanyName = (1U << 3)
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(GameStateFlags);
 }

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -2151,6 +2151,13 @@ namespace OpenLoco::StringIds
     constexpr StringId cheat_keep_cargo_modify_pickup = 2435;
     constexpr StringId tooltip_keep_cargo_modify_pickup = 2436;
     constexpr StringId sortComponents = 2437;
+    constexpr StringId preferred_company_name = 2438;
+    constexpr StringId use_preferred_company_name = 2439;
+    constexpr StringId use_preferred_company_name_tip = 2440;
+    constexpr StringId wcolour2_preferred_company_name = 2441;
+    constexpr StringId title_preferred_company_name = 2442;
+    constexpr StringId enter_preferred_company_name = 2443;
+    constexpr StringId buffer_company = 2444;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -2158,6 +2158,7 @@ namespace OpenLoco::StringIds
     constexpr StringId title_preferred_company_name = 2442;
     constexpr StringId enter_preferred_company_name = 2443;
     constexpr StringId buffer_company = 2444;
+    constexpr StringId cannot_change_company_name = 2445;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -2157,8 +2157,7 @@ namespace OpenLoco::StringIds
     constexpr StringId wcolour2_preferred_company_name = 2441;
     constexpr StringId title_preferred_company_name = 2442;
     constexpr StringId enter_preferred_company_name = 2443;
-    constexpr StringId buffer_company = 2444;
-    constexpr StringId cannot_change_company_name = 2445;
+    constexpr StringId cannot_change_company_name = 2444;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/include/OpenLoco/World/CompanyManager.h
+++ b/src/OpenLoco/include/OpenLoco/World/CompanyManager.h
@@ -49,6 +49,7 @@ namespace OpenLoco::CompanyManager
     void updateOwnerStatus();
     void updateColours();
     void setPreferredName();
+    void setPreferredCompany();
 
     void spendMoneyEffect(const World::Pos3& loc, const CompanyId company, const currency32_t amount);
     void applyPaymentToCompany(const CompanyId id, const currency32_t payment, const ExpenditureType type);

--- a/src/OpenLoco/include/OpenLoco/World/CompanyManager.h
+++ b/src/OpenLoco/include/OpenLoco/World/CompanyManager.h
@@ -49,7 +49,7 @@ namespace OpenLoco::CompanyManager
     void updateOwnerStatus();
     void updateColours();
     void setPreferredName();
-    void setPreferredCompany();
+    void setPreferredCompanyName();
 
     void spendMoneyEffect(const World::Pos3& loc, const CompanyId company, const currency32_t amount);
     void applyPaymentToCompany(const CompanyId id, const currency32_t payment, const ExpenditureType type);

--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -328,6 +328,10 @@ namespace OpenLoco::Config
         node["preferredOwnerFace"] = _config.preferredOwnerFace;
         node["usePreferredOwnerFace"] = _config.usePreferredOwnerFace;
 
+        // Preferred company
+        node["preferredCompanyName"] = _config.preferredCompanyName;
+        node["usePreferredCompanyName"] = _config.usePreferredCompanyName;
+
         // Shortcuts
         const auto& shortcuts = _config.shortcuts;
         const auto& shortcutDefs = Input::ShortcutManager::getList();

--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -189,6 +189,10 @@ namespace OpenLoco::Config
         _config.preferredOwnerFace = config["preferredOwnerFace"].as<ObjectHeader>(kEmptyObjectHeader);
         _config.usePreferredOwnerFace = config["usePreferredOwnerFace"].as<bool>(false);
 
+        // Preferred comapny
+        _config.preferredCompanyName = config["preferredCompanyName"].as<std::string>("");
+        _config.usePreferredCompanyName = config["usePreferredCompanyName"].as<bool>(false);
+
         // Misc settings
         _config.scenarioSelectedTab = config["scenarioSelectedTab"].as<int32_t>(2);
 

--- a/src/OpenLoco/src/Ui.cpp
+++ b/src/OpenLoco/src/Ui.cpp
@@ -855,6 +855,18 @@ namespace OpenLoco::Ui
             Game::removeFlags(GameStateFlags::preferredOwnerName);
         }
 
+        if (Game::hasFlags(GameStateFlags::preferredCompanyName))
+        {
+            if (!SceneManager::isTitleMode() && !SceneManager::isEditorMode())
+            {
+                if (Tutorial::state() == Tutorial::State::none)
+                {
+                    CompanyManager::setPreferredCompany();
+                }
+            }
+            Game::removeFlags(GameStateFlags::preferredCompanyName);
+        }
+
         if (MultiPlayer::resetFlag(MultiPlayer::flags::flag_5))
         {
             GameCommands::LoadSaveQuitGameArgs args{};

--- a/src/OpenLoco/src/Ui.cpp
+++ b/src/OpenLoco/src/Ui.cpp
@@ -861,7 +861,7 @@ namespace OpenLoco::Ui
             {
                 if (Tutorial::state() == Tutorial::State::none)
                 {
-                    CompanyManager::setPreferredCompany();
+                    CompanyManager::setPreferredCompanyName();
                 }
             }
             Game::removeFlags(GameStateFlags::preferredCompanyName);

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -1961,12 +1961,12 @@ namespace OpenLoco::Ui::Windows::Options
             // Preferred company group
             Widgets::GroupBox({ 4, 135 }, { 412, 47 }, WindowColour::secondary, StringIds::preferred_company_name),
 
-            //Preferred company name
+            // Preferred company name
             Widgets::Checkbox({ 10, 149 }, { 400, 12 }, WindowColour::secondary, StringIds::use_preferred_company_name, StringIds::use_preferred_company_name_tip),
             Widgets::Button({ 265, 164 }, { 75, 12 }, WindowColour::secondary, StringIds::change),
             Widgets::Label({ 24, 164 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::wcolour2_preferred_company_name)
 
-            //TODO: default colours?
+            // TODO: default colours?
 
         );
 

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -1914,7 +1914,7 @@ namespace OpenLoco::Ui::Windows::Options
 
     namespace Company
     {
-        static constexpr Ui::Size kWindowSize = { 420, 134 };
+        static constexpr Ui::Size kWindowSize = { 420, 187 };
 
         namespace Widx
         {
@@ -1931,6 +1931,11 @@ namespace OpenLoco::Ui::Windows::Options
                 labelPreferredOwnerName,
 
                 ownerFacePreview,
+
+                groupPreferredCompany,
+                usePreferredCompanyName,
+                changeCompanyNameBtn,
+                labelPreferredCompanyName,
             };
         }
 
@@ -1951,7 +1956,17 @@ namespace OpenLoco::Ui::Windows::Options
             Widgets::Label({ 24, 112 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::wcolour2_preferred_owner_name),
 
             // Preferred owner preview
-            Widgets::ImageButton({ 345, 59 }, { 66, 66 }, WindowColour::secondary, Widget::kContentNull)
+            Widgets::ImageButton({ 345, 59 }, { 66, 66 }, WindowColour::secondary, Widget::kContentNull),
+
+            // Preferred company group
+            Widgets::GroupBox({ 4, 135 }, { 412, 47 }, WindowColour::secondary, StringIds::preferred_company_name),
+
+            //Preferred company name
+            Widgets::Checkbox({ 10, 149 }, { 400, 12 }, WindowColour::secondary, StringIds::use_preferred_company_name, StringIds::use_preferred_company_name_tip),
+            Widgets::Button({ 265, 164 }, { 75, 12 }, WindowColour::secondary, StringIds::change),
+            Widgets::Label({ 24, 164 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::wcolour2_preferred_company_name)
+
+            //TODO: default colours?
 
         );
 
@@ -2021,6 +2036,15 @@ namespace OpenLoco::Ui::Windows::Options
                 self.object = nullptr;
             }
 
+            if (Config::get().usePreferredCompanyName)
+            {
+                self.activatedWidgets |= (1ULL << Widx::usePreferredCompanyName);
+            }
+            else
+            {
+                self.disabledWidgets |= (1ULL << Widx::changeCompanyNameBtn);
+            }
+
             // Set preferred owner name.
             {
                 // TODO: Do not share this buffer, also unsafe, we should change the localisation to use a string pointer.
@@ -2047,6 +2071,18 @@ namespace OpenLoco::Ui::Windows::Options
             }
 
             loadPreferredFace(self);
+
+            // Set preferred company nam
+            {
+                // TODO: Do not share this buffer, also unsafe, we should change the localisation to use a string pointer.
+                auto buffer = (char*)StringManager::getString(StringIds::buffer_company);
+                const char* companyName = Config::get().preferredCompanyName.c_str();
+                strcpy(buffer, companyName);
+                buffer[strlen(companyName)] = '\0';
+
+                FormatArguments args{ self.widgets[Widx::labelPreferredCompanyName].textArgs };
+                args.push(StringIds::buffer_company);
+            }
         }
 
         static void draw(Window& self, Gfx::DrawingContext& drawingCtx)
@@ -2099,6 +2135,30 @@ namespace OpenLoco::Ui::Windows::Options
             }
         }
 
+        static void changePreferredCompany(Window& self)
+        {
+            auto buffer = (char*)StringManager::getString(StringIds::buffer_company);
+            const char* companyName = Config::get().preferredCompanyName.c_str();
+            strcpy(buffer, companyName);
+            buffer[strlen(companyName)] = '\0';
+
+            TextInput::openTextInput(&self, StringIds::preferred_company_name, StringIds::enter_preferred_company_name, StringIds::buffer_company, Widx::usePreferredCompanyName, {});
+        }
+
+        static void usePreferredCompanyNameMouseUp(Window& self)
+        {
+            auto& cfg = Config::get();
+            cfg.usePreferredCompanyName ^= true;
+            Config::write();
+
+            self.invalidate();
+
+            if (cfg.usePreferredCompanyName && cfg.preferredCompanyName.empty())
+            {
+                changePreferredCompany(self);
+            }
+        }
+
         static void onMouseUp(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
             if (Common::onMouseUp(self, wi, id))
@@ -2124,6 +2184,14 @@ namespace OpenLoco::Ui::Windows::Options
                 case Widx::ownerFacePreview:
                     changePreferredFace(self);
                     break;
+
+                case Widx::usePreferredCompanyName:
+                    usePreferredCompanyNameMouseUp(self);
+                    break;
+
+                case Widx::changeCompanyNameBtn:
+                    changePreferredCompany(self);
+                    break;
             }
         }
 
@@ -2141,6 +2209,19 @@ namespace OpenLoco::Ui::Windows::Options
             self.invalidate();
         }
 
+        static void setPreferredCompany(Window& self, const char* str)
+        {
+            auto& cfg = Config::get();
+            cfg.preferredCompanyName = str;
+            if (cfg.preferredCompanyName.empty())
+            {
+                cfg.usePreferredCompanyName = false;
+            }
+
+            Config::write();
+            self.invalidate();
+        }
+
         // 0x004C1304
         static void textInput(Window& self, WidgetIndex_t i, [[maybe_unused]] const WidgetId id, const char* str)
         {
@@ -2148,6 +2229,10 @@ namespace OpenLoco::Ui::Windows::Options
             {
                 case Widx::usePreferredOwnerName:
                     setPreferredName(self, str);
+                    break;
+
+                case Widx::usePreferredCompanyName:
+                    setPreferredCompany(self, str);
                     break;
             }
         }

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -2209,7 +2209,7 @@ namespace OpenLoco::Ui::Windows::Options
             self.invalidate();
         }
 
-        static void setPreferredCompany(Window& self, const char* str)
+        static void setPreferredCompanyName(Window& self, const char* str)
         {
             auto& cfg = Config::get();
             cfg.preferredCompanyName = str;
@@ -2232,7 +2232,7 @@ namespace OpenLoco::Ui::Windows::Options
                     break;
 
                 case Widx::usePreferredCompanyName:
-                    setPreferredCompany(self, str);
+                    setPreferredCompanyName(self, str);
                     break;
             }
         }

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -2075,13 +2075,13 @@ namespace OpenLoco::Ui::Windows::Options
             // Set preferred company nam
             {
                 // TODO: Do not share this buffer, also unsafe, we should change the localisation to use a string pointer.
-                auto buffer = (char*)StringManager::getString(StringIds::buffer_company);
+                auto buffer = (char*)StringManager::getString(StringIds::buffer_2040);
                 const char* companyName = Config::get().preferredCompanyName.c_str();
                 strcpy(buffer, companyName);
                 buffer[strlen(companyName)] = '\0';
 
                 FormatArguments args{ self.widgets[Widx::labelPreferredCompanyName].textArgs };
-                args.push(StringIds::buffer_company);
+                args.push(StringIds::buffer_2040);
             }
         }
 
@@ -2137,12 +2137,12 @@ namespace OpenLoco::Ui::Windows::Options
 
         static void changePreferredCompany(Window& self)
         {
-            auto buffer = (char*)StringManager::getString(StringIds::buffer_company);
+            auto buffer = (char*)StringManager::getString(StringIds::buffer_2040);
             const char* companyName = Config::get().preferredCompanyName.c_str();
             strcpy(buffer, companyName);
             buffer[strlen(companyName)] = '\0';
 
-            TextInput::openTextInput(&self, StringIds::preferred_company_name, StringIds::enter_preferred_company_name, StringIds::buffer_company, Widx::usePreferredCompanyName, {});
+            TextInput::openTextInput(&self, StringIds::preferred_company_name, StringIds::enter_preferred_company_name, StringIds::buffer_2040, Widx::usePreferredCompanyName, {});
         }
 
         static void usePreferredCompanyNameMouseUp(Window& self)

--- a/src/OpenLoco/src/World/CompanyManager.cpp
+++ b/src/OpenLoco/src/World/CompanyManager.cpp
@@ -812,6 +812,7 @@ namespace OpenLoco::CompanyManager
         // Original network logic removed
         auto& gameState = getGameState();
         gameState.flags |= GameStateFlags::preferredOwnerName;
+        gameState.flags |= GameStateFlags::preferredCompanyName;
 
         // Any preference with respect to owner face?
         auto competitorId = Config::get().usePreferredOwnerFace ? selectNewCompetitorFromHeader(Config::get().preferredOwnerFace)
@@ -1241,6 +1242,57 @@ namespace OpenLoco::CompanyManager
             }
         }
 
+        // Don't clobber if there's a preferred name
+        if (!Config::get().usePreferredCompanyName)
+        {
+            // Only continue if we've not set a custom company name yet.
+            auto* company = get(GameCommands::getUpdatingCompanyId());
+            if (company == nullptr || company->name != StringIds::new_company)
+            {
+                return;
+            }
+    
+            // Temporarily store the preferred name in buffer string 2039.
+            char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+            strncpy(buffer_2039, Config::get().preferredOwnerName.c_str(), 256);
+    
+            // Prepare '{NAME} Transport' in a buffer.
+            {
+                char companyName[256] = { 0 };
+                FormatArguments args{};
+                args.push(StringIds::buffer_2039);
+                StringManager::formatString(companyName, StringIds::company_owner_name_transport, args);
+    
+                // Now, set the company name.
+    
+                GameCommands::setErrorTitle(StringIds::cannot_rename_this_company);
+    
+                GameCommands::ChangeCompanyNameArgs changeCompanyNameArgs{};
+    
+                changeCompanyNameArgs.companyId = GameCommands::getUpdatingCompanyId();
+                changeCompanyNameArgs.bufferIndex = 1;
+                std::memcpy(changeCompanyNameArgs.buffer, companyName, 36);
+    
+                GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
+    
+                changeCompanyNameArgs.bufferIndex = 2;
+    
+                GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
+    
+                changeCompanyNameArgs.bufferIndex = 0;
+    
+                GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
+            }
+        }
+    }
+
+    void setPreferredCompany()
+    {
+        if (!Config::get().usePreferredCompanyName)
+        {
+            return;
+        }
+
         // Only continue if we've not set a custom company name yet.
         auto* company = get(GameCommands::getUpdatingCompanyId());
         if (company == nullptr || company->name != StringIds::new_company)
@@ -1248,36 +1300,26 @@ namespace OpenLoco::CompanyManager
             return;
         }
 
-        // Temporarily store the preferred name in buffer string 2039.
-        char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
-        strncpy(buffer_2039, Config::get().preferredOwnerName.c_str(), 256);
-
-        // Prepare '{NAME} Transport' in a buffer.
+        GameCommands::setErrorTitle(StringIds::cannot_change_company_name);
         {
-            char companyName[256] = { 0 };
-            FormatArguments args{};
-            args.push(StringIds::buffer_2039);
-            StringManager::formatString(companyName, StringIds::company_owner_name_transport, args);
+            GameCommands::ChangeCompanyNameArgs args{};
 
-            // Now, set the company name.
+            args.companyId = GameCommands::getUpdatingCompanyId();
+            args.bufferIndex = 1;
+            std::memcpy(args.buffer, Config::get().preferredCompanyName.c_str(), 36);
 
-            GameCommands::setErrorTitle(StringIds::cannot_rename_this_company);
+            GameCommands::doCommand(args, GameCommands::Flags::apply);
 
-            GameCommands::ChangeCompanyNameArgs changeCompanyNameArgs{};
+            args.bufferIndex = 2;
 
-            changeCompanyNameArgs.companyId = GameCommands::getUpdatingCompanyId();
-            changeCompanyNameArgs.bufferIndex = 1;
-            std::memcpy(changeCompanyNameArgs.buffer, companyName, 36);
+            GameCommands::doCommand(args, GameCommands::Flags::apply);
 
-            GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
+            args.bufferIndex = 0;
 
-            changeCompanyNameArgs.bufferIndex = 2;
-
-            GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
-
-            changeCompanyNameArgs.bufferIndex = 0;
-
-            GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
+            if (GameCommands::doCommand(args, GameCommands::Flags::apply))
+            {
+                Ui::Windows::TextInput::cancel();
+            }
         }
     }
 

--- a/src/OpenLoco/src/World/CompanyManager.cpp
+++ b/src/OpenLoco/src/World/CompanyManager.cpp
@@ -1251,36 +1251,36 @@ namespace OpenLoco::CompanyManager
             {
                 return;
             }
-    
+
             // Temporarily store the preferred name in buffer string 2039.
             char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
             strncpy(buffer_2039, Config::get().preferredOwnerName.c_str(), 256);
-    
+
             // Prepare '{NAME} Transport' in a buffer.
             {
                 char companyName[256] = { 0 };
                 FormatArguments args{};
                 args.push(StringIds::buffer_2039);
                 StringManager::formatString(companyName, StringIds::company_owner_name_transport, args);
-    
+
                 // Now, set the company name.
-    
+
                 GameCommands::setErrorTitle(StringIds::cannot_rename_this_company);
-    
+
                 GameCommands::ChangeCompanyNameArgs changeCompanyNameArgs{};
-    
+
                 changeCompanyNameArgs.companyId = GameCommands::getUpdatingCompanyId();
                 changeCompanyNameArgs.bufferIndex = 1;
                 std::memcpy(changeCompanyNameArgs.buffer, companyName, 36);
-    
+
                 GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
-    
+
                 changeCompanyNameArgs.bufferIndex = 2;
-    
+
                 GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
-    
+
                 changeCompanyNameArgs.bufferIndex = 0;
-    
+
                 GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
             }
         }

--- a/src/OpenLoco/src/World/CompanyManager.cpp
+++ b/src/OpenLoco/src/World/CompanyManager.cpp
@@ -1243,46 +1243,48 @@ namespace OpenLoco::CompanyManager
         }
 
         // Don't clobber if there's a preferred name
-        if (!Config::get().usePreferredCompanyName)
+        if (Config::get().usePreferredCompanyName)
         {
-            // Only continue if we've not set a custom company name yet.
-            auto* company = get(GameCommands::getUpdatingCompanyId());
-            if (company == nullptr || company->name != StringIds::new_company)
-            {
-                return;
-            }
+            return;
+        }
 
-            // Temporarily store the preferred name in buffer string 2039.
-            char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
-            strncpy(buffer_2039, Config::get().preferredOwnerName.c_str(), 256);
+        // Only continue if we've not set a custom company name yet.
+        auto* company = get(GameCommands::getUpdatingCompanyId());
+        if (company == nullptr || company->name != StringIds::new_company)
+        {
+            return;
+        }
 
-            // Prepare '{NAME} Transport' in a buffer.
-            {
-                char companyName[256] = { 0 };
-                FormatArguments args{};
-                args.push(StringIds::buffer_2039);
-                StringManager::formatString(companyName, StringIds::company_owner_name_transport, args);
+        // Temporarily store the preferred name in buffer string 2039.
+        char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+        strncpy(buffer_2039, Config::get().preferredOwnerName.c_str(), 256);
 
-                // Now, set the company name.
+        // Prepare '{NAME} Transport' in a buffer.
+        {
+            char companyName[256] = { 0 };
+            FormatArguments args{};
+            args.push(StringIds::buffer_2039);
+            StringManager::formatString(companyName, StringIds::company_owner_name_transport, args);
 
-                GameCommands::setErrorTitle(StringIds::cannot_rename_this_company);
+            // Now, set the company name.
 
-                GameCommands::ChangeCompanyNameArgs changeCompanyNameArgs{};
+            GameCommands::setErrorTitle(StringIds::cannot_rename_this_company);
 
-                changeCompanyNameArgs.companyId = GameCommands::getUpdatingCompanyId();
-                changeCompanyNameArgs.bufferIndex = 1;
-                std::memcpy(changeCompanyNameArgs.buffer, companyName, 36);
+            GameCommands::ChangeCompanyNameArgs changeCompanyNameArgs{};
 
-                GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
+            changeCompanyNameArgs.companyId = GameCommands::getUpdatingCompanyId();
+            changeCompanyNameArgs.bufferIndex = 1;
+            std::memcpy(changeCompanyNameArgs.buffer, companyName, 36);
 
-                changeCompanyNameArgs.bufferIndex = 2;
+            GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
 
-                GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
+            changeCompanyNameArgs.bufferIndex = 2;
 
-                changeCompanyNameArgs.bufferIndex = 0;
+            GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
 
-                GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
-            }
+            changeCompanyNameArgs.bufferIndex = 0;
+
+            GameCommands::doCommand(changeCompanyNameArgs, GameCommands::Flags::apply);
         }
     }
 

--- a/src/OpenLoco/src/World/CompanyManager.cpp
+++ b/src/OpenLoco/src/World/CompanyManager.cpp
@@ -1288,7 +1288,7 @@ namespace OpenLoco::CompanyManager
         }
     }
 
-    void setPreferredCompany()
+    void setPreferredCompanyName()
     {
         if (!Config::get().usePreferredCompanyName)
         {


### PR DESCRIPTION
Something I noticed was the game allowed you to set a preferred owner name, but not a preferred company name.  This PR addresses that.

<img width="678" height="309" alt="UI elements added to the options menu just below the name and face selection" src="https://github.com/user-attachments/assets/60feffa5-f86c-4253-83cb-0f65a93b35ad" />
<img width="873" height="538" alt="The preferred name appears in-game even when a default owner isn't set." src="https://github.com/user-attachments/assets/f633c4ba-ae74-4252-8cf5-5a027aeb29f3" />

I've probably missed something or made some sort of mistake, so please let me know; tonight's the first I've looked at this code at all.

One possibility for future addition is adding default colour scheme as well.