### PR TITLE
Fix invalid memory access when dragging vehicle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix: [#3638] Loan can go negative.
 - Fix: [#3655] Incorrect scaffolding preview image in object selection window.
 - Fix: [#3694] Crash when starting bus/truck immediately behind another bus/truck (original bug).
+- Fix: [#3721] Potential crash when dragging a vehicle component in a vehicle window.
 
 26.03.1 (2026-04-01)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -2018,7 +2018,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
         static Vehicles::VehicleBase* getCarFromScrollViewPos(Ui::Window& self, const Ui::Point& pos)
         {
-            Input::setPressedWidgetIndex(widx::carList);
             auto res = Ui::ScrollView::getPart(self, &self.widgets[widx::carList], pos.x, pos.y);
             if (res.area != ScrollPart::view)
             {


### PR DESCRIPTION
I've looked at this for a while and I'm not convinced that any function should really be messing with the pressed widget index outside of the mouse interaction code. This is an alternative fix for #3622. I can't tell any difference with this change. I'm pretty sure its a correct change from vanilla.

Despite its name pressed widget index is used with dragged window some of the time but not all of the time. I tried to look into whether we could just not do that but its all quite complex.