### PR TITLE
Fix item removal for list windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Change: [#3710] The Build Vehicle window is now wider by default, moving the sorting options to a dedicated dropdown.
 - Change: [#3734] The Station Construction tab now lists accepted and produced cargo in full, with labels along the icons.
+- Fix: [#3727] Removing a vehicle/station/industry/town while the respective list window is open can crash the game.
 
 26.04 (2026-04-29)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -591,17 +591,22 @@ namespace OpenLoco::Ui::Windows::CompanyList
 
     void removeCompany(CompanyId id)
     {
-        auto* w = WindowManager::find(WindowType::companyList);
-        if (w != nullptr)
+        auto* window = WindowManager::find(WindowType::companyList);
+        if (window == nullptr)
         {
-            for (auto i = 0; i < w->rowCount; i++)
-            {
-                if (static_cast<CompanyId>(w->rowInfo[i]) == id)
-                {
-                    w->rowInfo[i] = -1;
-                }
-            }
+            return;
         }
+
+        auto list = std::span<CompanyId>(reinterpret_cast<CompanyId*>(window->rowInfo), window->rowCount);
+
+        auto newEnd = std::remove_if(list.begin(), list.end(), [id](CompanyId el) { return el == id; });
+        auto numRemoved = std::distance(newEnd, list.end());
+
+        if (numRemoved > 0)
+        {
+            window->rowCount -= numRemoved;
+        }
+
         WindowManager::invalidate(WindowType::companyList);
     }
 

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -441,7 +441,13 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     stringId = StringIds::wcolour2_stringid;
                 }
 
-                auto company = CompanyManager::get(CompanyId(rowItem));
+                auto* company = CompanyManager::get(CompanyId(rowItem));
+                if (company == nullptr || company->empty())
+                {
+                    removeCompany(CompanyId(rowItem));
+                    continue;
+                }
+
                 auto competitorObj = ObjectManager::get<CompetitorObject>(company->competitorId);
                 auto imageId = Gfx::recolour(competitorObj->images[enumValue(company->ownerEmotion)], company->mainColours.primary);
 

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -634,12 +634,14 @@ namespace OpenLoco::Ui::Windows::IndustryList
             return;
         }
 
-        for (auto i = 0; i < wnd->rowCount; ++i)
+        auto list = std::span<IndustryId>(reinterpret_cast<IndustryId*>(wnd->rowInfo), wnd->rowCount);
+
+        auto newEnd = std::remove_if(list.begin(), list.end(), [id](IndustryId el) { return el == id; });
+        auto numRemoved = std::distance(newEnd, list.end());
+
+        if (numRemoved > 0)
         {
-            if (static_cast<IndustryId>(wnd->rowInfo[i]) == id)
-            {
-                wnd->rowInfo[i] = enumValue(IndustryId::null);
-            }
+            wnd->rowCount -= numRemoved;
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -234,15 +234,19 @@ namespace OpenLoco::Ui::Windows::StationList
     {
         auto* station = StationManager::get(stationId);
         auto* window = WindowManager::find(WindowType::stationList, enumValue(station->owner));
-        if (window != nullptr)
+        if (window == nullptr)
         {
-            for (uint16_t i = 0; i < window->rowCount; i++)
-            {
-                if (stationId == StationId(window->rowInfo[i]))
-                {
-                    window->rowInfo[i] = enumValue(StationId::null);
-                }
-            }
+            return;
+        }
+
+        auto list = std::span<StationId>(reinterpret_cast<StationId*>(window->rowInfo), window->rowCount);
+
+        auto newEnd = std::remove_if(list.begin(), list.end(), [stationId](StationId el) { return el == stationId; });
+        auto numRemoved = std::distance(newEnd, list.end());
+
+        if (numRemoved > 0)
+        {
+            window->rowCount -= numRemoved;
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -467,7 +467,12 @@ namespace OpenLoco::Ui::Windows::StationList
                 text_colour_id = StringIds::wcolour2_stringid;
             }
 
-            auto station = StationManager::get(stationId);
+            auto* station = StationManager::get(stationId);
+            if (station == nullptr || station->empty())
+            {
+                removeStationFromList(stationId);
+                continue;
+            }
 
             // First, draw the town name.
             {

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -879,13 +879,14 @@ namespace OpenLoco::Ui::Windows::Station
 
         void removeTrainFromList(Window& self, EntityId head)
         {
-            for (auto i = 0; i < self.rowCount; ++i)
+            auto list = std::span<EntityId>(reinterpret_cast<EntityId*>(self.rowInfo), self.rowCount);
+
+            auto newEnd = std::remove_if(list.begin(), list.end(), [head](EntityId el) { return el == head; });
+            auto numRemoved = std::distance(newEnd, list.end());
+
+            if (numRemoved > 0)
             {
-                auto entryId = EntityId(self.rowInfo[i]);
-                if (entryId == head)
-                {
-                    self.rowInfo[i] = enumValue(EntityId::null);
-                }
+                self.rowCount -= numRemoved;
             }
         }
 
@@ -966,6 +967,7 @@ namespace OpenLoco::Ui::Windows::Station
                 auto head = EntityManager::get<VehicleHead>(vehicleId);
                 if (head == nullptr)
                 {
+                    removeTrainFromList(self, vehicleId);
                     continue;
                 }
 

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -593,12 +593,14 @@ namespace OpenLoco::Ui::Windows::TownList
             return;
         }
 
-        for (auto i = 0; i < window->rowCount; i++)
+        auto list = std::span<TownId>(reinterpret_cast<TownId*>(window->rowInfo), window->rowCount);
+
+        auto newEnd = std::remove_if(list.begin(), list.end(), [townId](TownId el) { return el == townId; });
+        auto numRemoved = std::distance(newEnd, list.end());
+
+        if (numRemoved > 0)
         {
-            if (window->rowInfo[i] == enumValue(townId))
-            {
-                window->rowInfo[i] = -1;
-            }
+            window->rowCount -= numRemoved;
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -193,11 +193,12 @@ namespace OpenLoco::Ui::Windows::TownList
                     text_colour_id = StringIds::wcolour2_stringid;
                 }
 
-                if (townId == TownId::null)
+                auto* town = TownManager::get(townId);
+                if (town == nullptr || town->empty())
                 {
+                    removeTown(townId);
                     continue;
                 }
-                auto town = TownManager::get(townId);
 
                 // Town Name
                 {

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -422,13 +422,14 @@ namespace OpenLoco::Ui::Windows::VehicleList
     // 0x004C1D19
     void removeTrainFromList(Window& self, EntityId head)
     {
-        for (auto i = 0; i < self.rowCount; ++i)
+        auto list = std::span<EntityId>(reinterpret_cast<EntityId*>(self.rowInfo), self.rowCount);
+
+        auto newEnd = std::remove_if(list.begin(), list.end(), [head](EntityId el) { return el == head; });
+        auto numRemoved = std::distance(newEnd, list.end());
+
+        if (numRemoved > 0)
         {
-            auto entryId = EntityId(self.rowInfo[i]);
-            if (entryId == head)
-            {
-                self.rowInfo[i] = enumValue(EntityId::null);
-            }
+            self.rowCount -= numRemoved;
         }
     }
 
@@ -603,8 +604,10 @@ namespace OpenLoco::Ui::Windows::VehicleList
             auto head = EntityManager::get<VehicleHead>(vehicleId);
             if (head == nullptr)
             {
+                removeTrainFromList(self, vehicleId);
                 continue;
             }
+
             // Highlight selection.
             if (head->id == EntityId(self.rowHover))
             {


### PR DESCRIPTION
In the previous release, we reworked the list windows (e.g. #3701). The new implementation had an unexpected bug: entry removals led to an immediate crash! What happened?

As it turns out, the functions dedicated to removing a particular entry from the list would overwrite that entry with a null value, rather than actually removing it by shifting the remaining data. The old implementation was fine with this; it would iteratively rewrite the list, anyway. The new implementation, however, tried to actually read these null entries! Unsurprisingly, this then led to a nullptr dereference, leading to a crash.

This PR rewrites the removal functions to actually remove the outdated entries using `std::` library functions, shifting the remaining entries over.