### PR TITLE
List cargo produced/accepted in full in station construction tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.04+ (???)
 ------------------------------------------------------------------------
 - Change: [#3710] The Build Vehicle window is now wider by default, moving the sorting options to a dedicated dropdown.
+- Change: [#3734] The Station Construction tab now lists accepted and produced cargo in full, with labels along the icons.
 
 26.04 (2026-04-29)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -1295,19 +1295,15 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         // Catchment area cargo acceptance list
         origin = Point(xPos, yPos);
         origin = tr.drawStringLeft(origin, Colour::black, StringIds::catchment_area_accepts);
-        origin.x = 14;
+
+        // Indent cargo list compared to the header
+        origin.x = self.x + 14;
         origin.y += 11;
 
-        if (cState.constructingStationAcceptedCargoTypes == 0)
-        {
-            tr.drawStringLeft(origin, Colour::black, StringIds::catchment_area_nothing);
-            origin.y += 11;
-        }
-        else
-        {
+        auto drawCargoList = [&origin, &drawingCtx, &tr, &self](uint32_t cargoTypes) {
             for (uint8_t i = 0; i < ObjectManager::getMaxObjects(ObjectType::cargo); i++)
             {
-                if (!(cState.constructingStationAcceptedCargoTypes & (1 << i)))
+                if (!(cargoTypes & (1 << i)))
                 {
                     continue;
                 }
@@ -1322,12 +1318,24 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                 tr.drawStringLeftClipped(origin + Point{ 12, 1 }, width, Colour::black, StringIds::wcolour2_stringid, args);
                 origin.y += 11;
             }
+        };
+
+        if (cState.constructingStationAcceptedCargoTypes == 0)
+        {
+            tr.drawStringLeft(origin, Colour::black, StringIds::catchment_area_nothing);
+            origin.y += 11;
+        }
+        else
+        {
+            drawCargoList(cState.constructingStationAcceptedCargoTypes);
         }
 
         // Catchment area cargo production list
         origin.x = self.x + 2;
         origin = tr.drawStringLeft(origin, Colour::black, StringIds::catchment_area_produces);
-        origin.x = 14;
+
+        // Indent cargo list compared to the header
+        origin.x = self.x + 14;
         origin.y += 11;
 
         if (cState.constructingStationProducedCargoTypes == 0)
@@ -1337,23 +1345,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         }
         else
         {
-            for (uint8_t i = 0; i < ObjectManager::getMaxObjects(ObjectType::cargo); i++)
-            {
-                if (!(cState.constructingStationProducedCargoTypes & (1 << i)))
-                {
-                    continue;
-                }
-
-                auto* cargoObj = ObjectManager::get<CargoObject>(i);
-                drawingCtx.drawImage(origin.x, origin.y, cargoObj->unitInlineSprite);
-
-                FormatArguments args{};
-                args.push(cargoObj->name);
-
-                auto width = self.width - 12 - 10;
-                tr.drawStringLeftClipped(origin + Point{ 12, 1 }, width, Colour::black, StringIds::wcolour2_stringid, args);
-                origin.y += 11;
-            }
+            drawCargoList(cState.constructingStationProducedCargoTypes);
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -52,7 +52,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     static World::TilePos2 _toolPosDrag;
     static World::TilePos2 _toolPosInitial;
 
-    static constexpr auto widgets = makeWidgets(
+    static constexpr auto kWidgets = makeWidgets(
         Common::makeCommonWidgets(138, 190, StringIds::stringid_2),
         Widgets::dropdownWidgets({ 3, 45 }, { 132, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_station_type),
         Widgets::Wt3Widget({ 35, 60 }, { 68, 68 }, WindowColour::secondary),
@@ -60,7 +60,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
     std::span<const Widget> getWidgets()
     {
-        return widgets;
+        return kWidgets;
     }
 
     WindowEventList events;
@@ -1165,6 +1165,24 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         }
 
         Common::repositionTabs(&self);
+
+        // Following information is only calculated when a ghost has been placed
+        if (!Common::hasGhostVisibilityFlag(GhostVisibilityFlags::station))
+        {
+            return;
+        }
+
+        // Scan number of cargo types accepted and produced
+        auto numAcceptedCargoTypes = std::max(1, std::popcount(cState.constructingStationAcceptedCargoTypes));
+        auto numProducedCargoTypes = std::max(1, std::popcount(cState.constructingStationProducedCargoTypes));
+
+        auto& baseFrame = kWidgets[Common::widx::frame];
+        auto newHeight = baseFrame.height() + 1 + (numAcceptedCargoTypes + numProducedCargoTypes) * 11;
+        auto newSize = Size{ baseFrame.width(), newHeight };
+        self.setSize(newSize, newSize);
+
+        self.widgets[Common::widx::frame].bottom = self.height - 1;
+        self.widgets[Common::widx::panel].bottom = self.height - 2;
     }
 
     // 0x0049DE40
@@ -1251,6 +1269,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
         FormatArguments args{};
 
+        // Prepare (new) station name
         if (cState.constructingStationId == StationId::null)
         {
             args.push(StringIds::new_station);
@@ -1265,6 +1284,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         xPos = self.x + 69;
         yPos = self.widgets[widx::image].bottom + self.y + 18;
 
+        // Draw new station name
         auto origin = Point(xPos, yPos);
         width = self.width - 4;
         tr.drawStringCentredClipped(origin, width, Colour::black, StringIds::new_station_buffer, args);
@@ -1272,58 +1292,67 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         xPos = self.x + 2;
         yPos = self.widgets[widx::image].bottom + self.y + 29;
 
+        // Catchment area cargo acceptance list
         origin = Point(xPos, yPos);
         origin = tr.drawStringLeft(origin, Colour::black, StringIds::catchment_area_accepts);
+        origin.x = 14;
+        origin.y += 11;
 
         if (cState.constructingStationAcceptedCargoTypes == 0)
         {
-            origin = tr.drawStringLeft(origin, Colour::black, StringIds::catchment_area_nothing);
+            tr.drawStringLeft(origin, Colour::black, StringIds::catchment_area_nothing);
+            origin.y += 11;
         }
         else
         {
-            yPos--;
             for (uint8_t i = 0; i < ObjectManager::getMaxObjects(ObjectType::cargo); i++)
             {
-                if (cState.constructingStationAcceptedCargoTypes & (1 << i))
+                if (!(cState.constructingStationAcceptedCargoTypes & (1 << i)))
                 {
-                    auto xPosMax = self.x + self.width - 12;
-                    if (origin.x <= xPosMax)
-                    {
-                        auto cargoObj = ObjectManager::get<CargoObject>(i);
-
-                        drawingCtx.drawImage(origin.x, origin.y, cargoObj->unitInlineSprite);
-                        origin.x += 10;
-                    }
+                    continue;
                 }
+
+                auto* cargoObj = ObjectManager::get<CargoObject>(i);
+                drawingCtx.drawImage(origin.x, origin.y, cargoObj->unitInlineSprite);
+
+                FormatArguments args{};
+                args.push(cargoObj->name);
+
+                auto width = self.width - 12 - 10;
+                tr.drawStringLeftClipped(origin + Point{ 12, 1 }, width, Colour::black, StringIds::wcolour2_stringid, args);
+                origin.y += 11;
             }
         }
 
-        xPos = self.x + 2;
-        yPos = self.widgets[widx::image].bottom + self.y + 49;
-        origin = Point(xPos, yPos);
-
+        // Catchment area cargo production list
+        origin.x = self.x + 2;
         origin = tr.drawStringLeft(origin, Colour::black, StringIds::catchment_area_produces);
+        origin.x = 14;
+        origin.y += 11;
 
         if (cState.constructingStationProducedCargoTypes == 0)
         {
-            origin = tr.drawStringLeft(origin, Colour::black, StringIds::catchment_area_nothing);
+            tr.drawStringLeft(origin, Colour::black, StringIds::catchment_area_nothing);
+            origin.y = 11;
         }
         else
         {
-            yPos--;
             for (uint8_t i = 0; i < ObjectManager::getMaxObjects(ObjectType::cargo); i++)
             {
-                if (cState.constructingStationProducedCargoTypes & (1 << i))
+                if (!(cState.constructingStationProducedCargoTypes & (1 << i)))
                 {
-                    auto xPosMax = self.x + self.width - 12;
-                    if (origin.x <= xPosMax)
-                    {
-                        auto cargoObj = ObjectManager::get<CargoObject>(i);
-
-                        drawingCtx.drawImage(origin.x, origin.y, cargoObj->unitInlineSprite);
-                        origin.x += 10;
-                    }
+                    continue;
                 }
+
+                auto* cargoObj = ObjectManager::get<CargoObject>(i);
+                drawingCtx.drawImage(origin.x, origin.y, cargoObj->unitInlineSprite);
+
+                FormatArguments args{};
+                args.push(cargoObj->name);
+
+                auto width = self.width - 12 - 10;
+                tr.drawStringLeftClipped(origin + Point{ 12, 1 }, width, Colour::black, StringIds::wcolour2_stringid, args);
+                origin.y += 11;
             }
         }
     }

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -1182,7 +1182,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         self.setSize(newSize, newSize);
 
         self.widgets[Common::widx::frame].bottom = self.height - 1;
-        self.widgets[Common::widx::panel].bottom = self.height - 2;
+        self.widgets[Common::widx::panel].bottom = self.height - 1;
     }
 
     // 0x0049DE40

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -1315,7 +1315,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                 args.push(cargoObj->name);
 
                 auto width = self.width - 12 - 10;
-                tr.drawStringLeftClipped(origin + Point{ 12, 1 }, width, Colour::black, StringIds::wcolour2_stringid, args);
+                tr.drawStringLeftClipped(origin + Point{ 12, 1 }, width, Colour::black, StringIds::black_stringid, args);
                 origin.y += 11;
             }
         };


### PR DESCRIPTION
The station construction tab lists the cargo types accepted or produced by a (new) station by means of icons. This PR proposes changing this into a full list of icons as well as labels, resizing the window as needed. This should go a long way in making the game more accessible to new players.

Probably could do with a bit more spacing? Happy to tweak it a bit more.

Before:
<img width="138" height="190" alt="Boulder Breakers (2)" src="https://github.com/user-attachments/assets/5853d14b-a08a-421f-8419-7b5b590cbce4" />

After:
<img width="138" height="235" alt="Boulder Breakers (2)" src="https://github.com/user-attachments/assets/d5c0eb0e-b1f5-4cee-8e70-3c8884069abd" />

Before:
<img width="138" height="190" alt="Boulder Breakers (3)" src="https://github.com/user-attachments/assets/97803b5f-9c06-4d9f-8478-81fdf64c1b31" />

After:
<img width="138" height="257" alt="Boulder Breakers (1)" src="https://github.com/user-attachments/assets/8b39d16a-8603-4c73-9dc1-356979e7ac55" />
