### PR TITLE
Add tooltips to cargo icons in station window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Change: [#3710] The Build Vehicle window is now wider by default, moving the sorting options to a dedicated dropdown.
 - Change: [#3734] The Station Construction tab now lists accepted and produced cargo in full, with labels along the icons.
+- Change: [#3735] The Station window now shows a tooltip for accepted cargo types when pointing at their icons.
 - Fix: [#3651] Industry and town lists are not cleared immediately when generating a new landscape in the editor.
 - Fix: [#3727] Removing a vehicle/station/industry/town while the respective list window is open can crash the game.
 - Fix: [#3730] Checkbox widget labels are not limited to their designated width.

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -401,7 +401,7 @@ namespace OpenLoco::Ui::Windows::Station
 
             const char* acceptedLabel = StringManager::getString(StringIds::accepted_cargo_separator);
             auto labelWidth = tr.getStringWidth(acceptedLabel);
-            auto origin = self.position() + self.widgets[widx::status_bar].position() + Point{ labelWidth, -1 };
+            auto origin = self.position() + self.widgets[widx::status_bar].position() + Point{ labelWidth + 2, -1 };
 
             auto station = StationManager::get(StationId(self.number));
             uint8_t cargoTypeCount = 0;
@@ -492,7 +492,7 @@ namespace OpenLoco::Ui::Windows::Station
 
                 // Now find out where we're pointing relative to the label
                 const auto mousePos = Input::getMouseLocation();
-                const auto startPos = self.position() + self.widgets[widx::status_bar].position();
+                const auto startPos = self.position() + self.widgets[widx::status_bar].position() + Point{ 2, -1 };
                 const auto relPos = mousePos - startPos;
 
                 // Find out which cargo icon we must be pointing at, if any

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -423,7 +423,9 @@ namespace OpenLoco::Ui::Windows::Station
 
             if (cargoTypeCount == 0)
             {
-                tr.drawStringLeft(origin, Colour::black, StringIds::cargo_nothing_accepted);
+                FormatArguments args{};
+                args.push(StringIds::cargo_nothing_accepted);
+                tr.drawStringLeft(origin + Point{ 0, 1 }, Colour::black, StringIds::black_stringid, args);
             }
         }
 

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -362,7 +362,7 @@ namespace OpenLoco::Ui::Windows::Station
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(223, 136),
             Widgets::ScrollView({ 3, 44 }, { 217, 80 }, WindowColour::secondary, 2),
-            Widgets::Label({ 3, 125 }, { 195, 10 }, WindowColour::secondary, ContentAlign::center, StringIds::empty, StringIds::unused_small_black_string),
+            Widgets::Label({ 3, 125 }, { 195, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::accepted_cargo_separator, StringIds::small_black_string),
             Widgets::ImageButton({ 198, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::show_station_catchment, StringIds::station_catchment)
 
         );
@@ -399,8 +399,9 @@ namespace OpenLoco::Ui::Windows::Station
             self.draw(drawingCtx);
             Common::drawTabs(self, drawingCtx);
 
-            auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
-            buffer = StringManager::formatString(buffer, StringIds::accepted_cargo_separator);
+            const char* acceptedLabel = StringManager::getString(StringIds::accepted_cargo_separator);
+            auto labelWidth = tr.getStringWidth(acceptedLabel);
+            auto origin = self.position() + self.widgets[widx::status_bar].position() + Point{ labelWidth, -1 };
 
             auto station = StationManager::get(StationId(self.number));
             uint8_t cargoTypeCount = 0;
@@ -408,32 +409,22 @@ namespace OpenLoco::Ui::Windows::Station
             for (uint32_t cargoId = 0; cargoId < kMaxCargoStats; cargoId++)
             {
                 auto& stats = station->cargoStats[cargoId];
-
                 if (!stats.isAccepted())
                 {
                     continue;
                 }
 
-                *buffer++ = ' ';
-                *buffer++ = ControlCodes::inlineSpriteStr;
-                *(reinterpret_cast<uint32_t*>(buffer)) = ObjectManager::get<CargoObject>(cargoId)->unitInlineSprite;
-                buffer += 4;
+                auto* cargoObj = ObjectManager::get<CargoObject>(cargoId);
+                drawingCtx.drawImage(origin, cargoObj->unitInlineSprite);
+                origin.x += 12;
 
                 cargoTypeCount++;
             }
 
             if (cargoTypeCount == 0)
             {
-                buffer = StringManager::formatString(buffer, StringIds::cargo_nothing_accepted);
+                tr.drawStringLeft(origin, Colour::black, StringIds::cargo_nothing_accepted);
             }
-
-            *buffer++ = '\0';
-
-            const auto& widget = self.widgets[widx::status_bar];
-            const auto width = widget.width();
-            auto point = Point(self.x + widget.left - 1, self.y + widget.top - 1);
-
-            tr.drawStringLeftClipped(point, width, Colour::black, StringIds::buffer_1250);
         }
 
         // 0x0048EB0B

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -499,14 +499,11 @@ namespace OpenLoco::Ui::Windows::Station
 
                 // Find out which cargo icon we must be pointing at, if any
                 const auto cargoPointedAt = (relPos.x - labelWidth) / 12;
-
-                // Find cargo at this position
                 auto* station = StationManager::get(StationId(self.number));
                 auto cargoIndex = 0;
                 for (uint32_t cargoId = 0; cargoId < kMaxCargoStats; cargoId++)
                 {
                     auto& stats = station->cargoStats[cargoId];
-
                     if (!stats.isAccepted())
                     {
                         continue;

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -362,7 +362,7 @@ namespace OpenLoco::Ui::Windows::Station
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(223, 136),
             Widgets::ScrollView({ 3, 44 }, { 217, 80 }, WindowColour::secondary, 2),
-            Widgets::Label({ 3, 125 }, { 195, 10 }, WindowColour::secondary, ContentAlign::center),
+            Widgets::Label({ 3, 125 }, { 195, 10 }, WindowColour::secondary, ContentAlign::center, StringIds::empty, StringIds::unused_small_black_string),
             Widgets::ImageButton({ 198, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::show_station_catchment, StringIds::station_catchment)
 
         );
@@ -484,10 +484,55 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EB4F
-        static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static std::optional<FormatArguments> tooltip(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
             FormatArguments args{};
-            args.push(StringIds::tooltip_scroll_cargo_list);
+
+            if (widgetIndex == widx::scrollview)
+            {
+                args.push(StringIds::tooltip_scroll_cargo_list);
+            }
+            else if (widgetIndex == widx::status_bar)
+            {
+                // First, find out how wide the 'Accepted:' label is
+                const char* acceptedLabel = StringManager::getString(StringIds::accepted_cargo_separator);
+                const auto font = Gfx::Font::medium_bold;
+                const int16_t labelWidth = Gfx::TextRenderer::getStringWidthNewLined(font, acceptedLabel);
+
+                // Now find out where we're pointing relative to the label
+                const auto mousePos = Input::getMouseLocation();
+                const auto startPos = self.position() + self.widgets[widx::status_bar].position();
+                const auto relPos = mousePos - startPos;
+
+                // Find out which cargo icon we must be pointing at, if any
+                const auto cargoPointedAt = (relPos.x - labelWidth) / 12;
+
+                // Find cargo at this position
+                auto* station = StationManager::get(StationId(self.number));
+                auto cargoIndex = 0;
+                for (uint32_t cargoId = 0; cargoId < kMaxCargoStats; cargoId++)
+                {
+                    auto& stats = station->cargoStats[cargoId];
+
+                    if (!stats.isAccepted())
+                    {
+                        continue;
+                    }
+
+                    if (cargoIndex != cargoPointedAt)
+                    {
+                        cargoIndex++;
+                        continue;
+                    }
+
+                    auto* cargoObj = ObjectManager::get<CargoObject>(cargoId);
+                    args.push(cargoObj->name);
+                    return args;
+                }
+
+                return std::nullopt;
+            }
+
             return args;
         }
 


### PR DESCRIPTION
<img width="264" height="200" alt="Screenshot 2026-05-15 at 18 49 22" src="https://github.com/user-attachments/assets/7b749223-2295-43e7-95f7-88bdc8eead01" />

<img width="270" height="204" alt="Screenshot 2026-05-15 at 18 59 04" src="https://github.com/user-attachments/assets/ed977eca-1ef6-404d-9057-07738fabfbf5" />

<img width="270" height="204" alt="Screenshot 2026-05-15 at 18 59 25" src="https://github.com/user-attachments/assets/e890d189-a16d-4fd0-bbd2-fc37e24c6960" />
