### PR TITLE
Fix save state not being deterministic due to auto save

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: OpenLoco/TestData
-          ref: b21e716f7158f5f6a3dad6df6905ad5a376501b9
+          ref: a4328bfa3c7f1df7a2e690baade0af181929b0b4
           path: TestData
       - name: Run Simulate Test
         if: ${{ github.repository == 'OpenLoco/OpenLoco' && env.ASSETS_SSH_KEY != null }}

--- a/src/OpenLoco/src/GameSaveCompare.cpp
+++ b/src/OpenLoco/src/GameSaveCompare.cpp
@@ -12,6 +12,7 @@
 #include "S5/S5Options.h"
 #include "Vehicles/Vehicle.h"
 #include <OpenLoco/Core/FileStream.h>
+#include <OpenLoco/Core/MemoryStream.h>
 
 using namespace OpenLoco::Diagnostics;
 
@@ -670,12 +671,26 @@ namespace OpenLoco::GameSaveCompare
 
     bool compareGameStates(const fs::path& path)
     {
-        char* gameStateChar = (char*)(&getGameState());
-        S5::GameState* currentS5GameState = reinterpret_cast<S5::GameState*>(gameStateChar);
         Logging::info("Comparing reference file {} to current GameState frame", path);
+
+        MemoryStream ms;
+        if (!S5::exportGameStateToFile(ms, S5::SaveFlags::noWindowClose))
+        {
+            Logging::error("Failed to export current game state for comparison");
+            return false;
+        }
+
+        ms.setPosition(0);
+        auto currentGameState = S5::loadSave(ms);
+        if (currentGameState == nullptr)
+        {
+            Logging::error("Failed to reload exported current game state for comparison");
+            return false;
+        }
+
         FileStream referenceFile(path, StreamMode::read);
         auto referenceGameState = S5::loadSave(referenceFile);
-        return compareGameStates(*currentS5GameState, referenceGameState->gameState, false);
+        return compareGameStates(currentGameState->gameState, referenceGameState->gameState, false);
     }
 
     bool compareGameStates(const fs::path& path1, const fs::path& path2, bool displayAllDivergences)

--- a/src/OpenLoco/src/GameSaveCompare.cpp
+++ b/src/OpenLoco/src/GameSaveCompare.cpp
@@ -674,7 +674,7 @@ namespace OpenLoco::GameSaveCompare
         S5::GameState* currentS5GameState = reinterpret_cast<S5::GameState*>(gameStateChar);
         Logging::info("Comparing reference file {} to current GameState frame", path);
         FileStream referenceFile(path, StreamMode::read);
-        auto referenceGameState = S5::importSave(referenceFile);
+        auto referenceGameState = S5::loadSave(referenceFile);
         return compareGameStates(*currentS5GameState, referenceGameState->gameState, false);
     }
 
@@ -685,9 +685,9 @@ namespace OpenLoco::GameSaveCompare
         Logging::info("   file2: {}", path2);
 
         FileStream file1(path1, StreamMode::read);
-        auto state1 = S5::importSave(file1);
+        auto state1 = S5::loadSave(file1);
         FileStream file2(path2, StreamMode::read);
-        auto state2 = S5::importSave(file2);
+        auto state2 = S5::loadSave(file2);
         auto match = compareGameStates(state1->gameState, state2->gameState, displayAllDivergences);
         match &= compareElements(state1->tileElements, state2->tileElements, displayAllDivergences);
         return match;

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -330,7 +330,7 @@ namespace OpenLoco::S5
     }
 
     // 0x00441FC9
-    std::unique_ptr<S5File> importSave(Stream& stream)
+    std::unique_ptr<S5File> loadSave(Stream& stream)
     {
         SawyerStreamReader fs(stream);
         if (!fs.validateChecksum())
@@ -483,7 +483,7 @@ namespace OpenLoco::S5
             Ui::ProgressBar::begin(StringIds::loading);
             Ui::ProgressBar::setProgress(10);
 
-            auto file = importSave(stream);
+            auto file = loadSave(stream);
 
             Ui::ProgressBar::setProgress(90);
 

--- a/src/OpenLoco/src/S5/S5.h
+++ b/src/OpenLoco/src/S5/S5.h
@@ -130,7 +130,7 @@ namespace OpenLoco::S5
     const LoadError& getLastLoadError();
     void resetLastLoadError();
 
-    std::unique_ptr<S5File> importSave(Stream& stream);
+    std::unique_ptr<S5File> loadSave(Stream& stream);
     bool importSaveToGameState(const fs::path& path, LoadFlags flags);
     bool importSaveToGameState(Stream& stream, LoadFlags flags);
     std::unique_ptr<SaveDetails> readSaveDetails(const fs::path& path);

--- a/src/OpenLoco/src/World/Station.cpp
+++ b/src/OpenLoco/src/World/Station.cpp
@@ -1264,9 +1264,9 @@ namespace OpenLoco
         }
 
         // Remove tile by moving the remaining tiles over the one to remove
-        // NB: erasing is handled by StationManager::zeroUnused; not calling std::erase due to type mismatches
         std::rotate(foundTilePos, foundTilePos + 1, std::end(station->stationTiles));
         station->stationTileSize--;
+        station->stationTiles[std::size(station->stationTiles) - 1] = World::Pos3{};
     }
 
     // 0x0048F482

--- a/src/OpenLoco/src/World/StationManager.cpp
+++ b/src/OpenLoco/src/World/StationManager.cpp
@@ -630,18 +630,28 @@ namespace OpenLoco::StationManager
                 stats.quantity = 0;
                 stats.origin = StationId::null;
                 stats.flags = StationCargoStatsFlags::none;
+                stats.age = 0;
                 stats.rating = 150;
+                stats.enrouteAge = 0;
+                stats.vehicleSpeed = {};
+                stats.vehicleAge = 0;
+                stats.industryId = IndustryId::null;
                 stats.densityPerTile = 0;
             }
 
             station.x = pos.x;
             station.y = pos.y;
             station.z = pos.z;
+            station.labelFrame = {};
             station.flags = StationFlags::flag_5;
             station.stationTileSize = 0;
             station.noTilesTimeout = 0;
             station.var_3B0 = 0;
             station.var_3B1 = 0;
+            station.var_3B2 = 0;
+            station.airportRotation = 0;
+            station.airportStartPos = {};
+            station.airportMovementOccupiedEdges = 0;
 
             return station.id();
         }


### PR DESCRIPTION
The whole reason it was not deterministic is that there was lingering state for stations, when auto save was enabled it would zero some fields out, this also impacted how cargo stats were calculated since it used the old data which also influenced the prng. Now exporting a save with auto save on or off always outputs binary identical files and the determinism bug is gone. 

Since some fields are now zero I have to also update the test file.

Edit: Pushed the branch also onto the main repo to get a run https://github.com/OpenLoco/OpenLoco/actions/runs/26335339920, just to see if we are all green given the PR doesn't run this.