### PR TITLE
Temporarily disable options that interfere with tutorial operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.05+ (???)
 ------------------------------------------------------------------------
 - Feature: [#3768] Add tab to town window to show delivered cargo last month.
+- Change: [#3740] Options that interfere with tutorial operation are temporarily disabled options during playback.
 
 26.05 (2026-05-30)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/include/OpenLoco/Tutorial.h
+++ b/src/OpenLoco/include/OpenLoco/Tutorial.h
@@ -7,6 +7,7 @@ namespace OpenLoco::Tutorial
     enum class State : uint8_t
     {
         none,
+        initialising,
         playing,
         recording,
     };

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -129,6 +129,7 @@ namespace OpenLoco::Input
         switch (Tutorial::state())
         {
             case Tutorial::State::none:
+            case Tutorial::State::initialising:
                 break;
 
             case Tutorial::State::playing:

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -287,6 +287,7 @@ namespace OpenLoco::Input
         switch (Tutorial::state())
         {
             case Tutorial::State::none:
+            case Tutorial::State::initialising:
             {
                 _cursor2 = _cursor;
                 break;

--- a/src/OpenLoco/src/Tutorial.cpp
+++ b/src/OpenLoco/src/Tutorial.cpp
@@ -68,6 +68,8 @@ namespace OpenLoco::Tutorial
             return;
         }
 
+        _state = State::initialising;
+
         // NB: only used by tutorial widget drawing after.
         _tutorialNumber = tutorialNumber;
 
@@ -93,6 +95,7 @@ namespace OpenLoco::Tutorial
         {
             if (!Ui::setDisplayMode(Config::ScreenMode::window, newResolution))
             {
+                _state = State::none;
                 return;
             }
         }
@@ -136,8 +139,9 @@ namespace OpenLoco::Tutorial
     void stop()
     {
         _state = State::none;
+        Config::read();
+        Ui::triggerResize();
         Gfx::invalidateScreen();
-        Gui::resize();
     }
 
     // 0x0043C7A2

--- a/src/OpenLoco/src/Tutorial.cpp
+++ b/src/OpenLoco/src/Tutorial.cpp
@@ -74,7 +74,7 @@ namespace OpenLoco::Tutorial
         _tutorialNumber = tutorialNumber;
 
         // Figure out what dimensions to use for the tutorial, and whether we can continue using scaling.
-        const auto& config = Config::get();
+        auto& config = Config::get();
         Config::Resolution newResolution = tutorialResolution;
         if (config.scaleFactor > 1.0)
         {
@@ -99,6 +99,10 @@ namespace OpenLoco::Tutorial
                 return;
             }
         }
+
+        // Disable options that interfere with tutorial operations.
+        config.cheatsMenuEnabled = false;
+        config.invertRightMouseViewPan = false;
 
         // Get the environment file for this tutorial.
         static constexpr Environment::PathId tutorialFileIds[] = {

--- a/src/OpenLoco/src/Tutorial.cpp
+++ b/src/OpenLoco/src/Tutorial.cpp
@@ -144,8 +144,7 @@ namespace OpenLoco::Tutorial
     {
         _state = State::none;
         Config::read();
-        Ui::triggerResize();
-        Gfx::invalidateScreen();
+        Ui::setDisplayMode(Config::get().display.mode);
     }
 
     // 0x0043C7A2

--- a/src/OpenLoco/src/Ui.cpp
+++ b/src/OpenLoco/src/Ui.cpp
@@ -471,6 +471,11 @@ namespace OpenLoco::Ui
         Gui::resize();
         Gfx::invalidateScreen();
 
+        if (Tutorial::state() == Tutorial::State::initialising)
+        {
+            return;
+        }
+
         // Save window size to config if NOT maximized
         auto wf = SDL_GetWindowFlags(_window);
         if (!_isChangingDisplayMode && !(wf & SDL_WINDOW_MAXIMIZED) && !(wf & SDL_WINDOW_FULLSCREEN))
@@ -1002,7 +1007,6 @@ namespace OpenLoco::Ui
 
         config.scaleFactor = newScaleFactor;
 
-        OpenLoco::Config::write();
         Ui::triggerResize();
         Gfx::invalidateScreen();
     }
@@ -1017,6 +1021,7 @@ namespace OpenLoco::Ui
         }
 
         setWindowScaling(newScaleFactor);
+        Config::write();
     }
 
     bool hasInputFocus()

--- a/src/OpenLoco/src/Ui.cpp
+++ b/src/OpenLoco/src/Ui.cpp
@@ -471,7 +471,7 @@ namespace OpenLoco::Ui
         Gui::resize();
         Gfx::invalidateScreen();
 
-        if (Tutorial::state() == Tutorial::State::initialising)
+        if (Tutorial::state() != Tutorial::State::none)
         {
             return;
         }
@@ -615,6 +615,7 @@ namespace OpenLoco::Ui
         }
 
         auto& config = Config::get();
+        /*
         if (config.display.mode == Config::ScreenMode::window)
         {
             int32_t currentWidth = 0;
@@ -625,14 +626,17 @@ namespace OpenLoco::Ui
                 _lastWindowedResolution = { currentWidth, currentHeight };
             }
         }
+        */
 
         // Set the new dimensions of the screen.
         if (mode == Config::ScreenMode::window)
         {
+            /*
             if (_lastWindowedResolution.isPositive())
             {
                 newResolution = _lastWindowedResolution;
             }
+            */
 
             if (!SDL_SetWindowSize(_window, newResolution.width, newResolution.height))
             {
@@ -689,6 +693,14 @@ namespace OpenLoco::Ui
         }
 
         SDL_SyncWindow(_window);
+
+        if (Tutorial::state() == Tutorial::State::initialising)
+        {
+            Ui::triggerResize();
+            Gfx::invalidateScreen();
+            _isChangingDisplayMode = false;
+            return true;
+        }
 
         // It appears we were successful in setting the screen mode, so let's up date the config.
         config.display.mode = mode;


### PR DESCRIPTION
The in-game tutorials consist of mouse pointer recordings, making them inflexible in terms of how the game window is set up. To this end, we modify the screen resolution and scaling factor as needed. Until now, these changes were not reverted when the tutorial ended. Through minimal modifications, this PR changes this such that the config is now no longer written, meaning it can simply be reloaded when the tutorial is aborted or ended.

In the same way, the tutorial code now temporarily disables two config settings that interfere with tutorial operations: the cheat menu, and inversion mouse drag.