### PR TITLE
Recognize RISC-V in version metadata

### DIFF
--- a/src/Version/include/OpenLoco/Version.hpp
+++ b/src/Version/include/OpenLoco/Version.hpp
@@ -10,6 +10,14 @@
     #define OPENLOCO_ARCHITECTURE "x86-64"
 #elif defined(__i386__) || defined(_M_IX86)
     #define OPENLOCO_ARCHITECTURE "x86"
+#elif defined(__riscv)
+    #if __riscv_xlen == 64
+        #define OPENLOCO_ARCHITECTURE "RISC-V64"
+    #elif __riscv_xlen == 32
+        #define OPENLOCO_ARCHITECTURE "RISC-V32"
+    #else
+        #define OPENLOCO_ARCHITECTURE "RISC-V"
+    #endif
 #elif defined(__aarch64__) || defined(_M_ARM64)
     #define OPENLOCO_ARCHITECTURE "AArch64"
 #elif defined(__arm__) || defined(_M_ARM)


### PR DESCRIPTION
## Why

`OpenLoco` already has portable code paths for the small version metadata consumer used by `Version.hpp`, but the header currently treats unknown architectures as a hard error.

For `riscv64`, that means a minimal consumer fails immediately at the version header boundary:

- `OPENLOCO_ARCHITECTURE` only recognizes x86, x86-64, AArch64, and ARM today;
- a real `riscv64` C++ compile stops with `#error "OPENLOCO_ARCHITECTURE is undefined. Please add identification."`;
- this prevents even simple RISC-V-targeted builds from producing correct platform/version strings.

This patch keeps the rest of the engine unchanged and adds the missing `RISC-V` architecture identification that the existing interface already expects.

## What changed

- Updated `src/Version/include/OpenLoco/Version.hpp`:
  - recognize `__riscv`;
  - map `__riscv_xlen == 64` to `RISC-V64`;
  - map `__riscv_xlen == 32` to `RISC-V32`;
  - keep a generic `RISC-V` fallback for other RISC-V XLEN values.

## Verification

- Verified the pre-patch failure mode with a real `riscv64` cross-compiler:
  - compiling a minimal consumer that includes `OpenLoco/Version.hpp` failed with `OPENLOCO_ARCHITECTURE is undefined`.
- Verified native behavior after the patch in Docker (`ubuntu:24.04`):
  - compiled a minimal C++20 consumer with host `g++`;
  - ran it successfully;
  - output: `Linux (x86-64)`.
- Verified real `riscv64` cross-compilation in Docker:
  - compiled the same minimal consumer with `riscv64-linux-gnu-g++`;
  - confirmed the result with `riscv64-linux-gnu-readelf -h`;
  - reported machine type: `RISC-V`.
- Verified real `riscv64` execution under QEMU:
  - ran the produced binary with `qemu-riscv64-static -L /usr/riscv64-linux-gnu`;
  - output: `Linux (RISC-V64)`;
  - `QEMU_EXIT=0`.

## Notes

- This patch does not add a RISC-V-specific optimized backend.
- The goal is to remove an unnecessary architecture-identification blocker for `riscv64`, not to change gameplay, rendering, or platform runtime behavior.