### PR TITLE
Cargo on premises stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.05+ (???)
 ------------------------------------------------------------------------
 - Feature: [#3569] Add a "home" button to the browse prompt window.
+- Feature: [#3760] Add amount of cargo awaiting processing and transport to the industry window.
 - Feature: [#3768] Add tab to town window to show delivered cargo last month.
 - Feature: [#3805] Keyboard shortcuts can now combine multiple modifiers, including left and right Ctrl and Alt.
 - Change: [#3740] Options that interfere with tutorial operation are temporarily disabled options during playback.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2508,3 +2508,5 @@ strings:
   2453: "Music"
   2454: "{COLOUR WINDOW_2}Play music during gameplay"
   2455: "Open jukebox..."
+  2456: "{COLOUR WINDOW_2}Cargo awaiting processing:"
+  2457: "{COLOUR WINDOW_2}Cargo awaiting transport:"

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -2169,6 +2169,8 @@ namespace OpenLoco::StringIds
     constexpr StringId frame_music = 2453;
     constexpr StringId play_game_music = 2454;
     constexpr StringId options_open_jukebox = 2455;
+    constexpr StringId cargo_awaiting_processing = 2456;
+    constexpr StringId cargo_awaiting_transport = 2457;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -441,7 +441,7 @@ namespace OpenLoco::Ui::Windows::Industry
 
     namespace Transported
     {
-        static constexpr Ui::Size kWindowSize = { 300, 127 };
+        static constexpr Ui::Size kWindowSize = { 300, 196 };
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(300, 126, StringIds::title_statistics)
@@ -499,6 +499,35 @@ namespace OpenLoco::Ui::Windows::Industry
                 }
                 origin.y += 4;
                 origin.x -= 4;
+
+                // Draw input buffer stats
+                tr.drawStringLeft(origin, Colour::black, StringIds::cargo_awaiting_processing);
+                origin.y += 10;
+                origin.x += 4;
+                cargoNumber = 0;
+                for (const auto& requiredCargoType : industryObj->requiredCargoType)
+                {
+                    if (requiredCargoType != kCargoTypeNull)
+                    {
+                        auto cargoObj = ObjectManager::get<CargoObject>(requiredCargoType);
+                        FormatArguments args{};
+
+                        if (industry->receivedCargoQuantityPreviousMonth[cargoNumber] == 1)
+                        {
+                            args.push(cargoObj->unitNameSingular);
+                        }
+                        else
+                        {
+                            args.push(cargoObj->unitNamePlural);
+                        }
+                        args.push<uint32_t>(industry->receivedCargoQuantityDailyTotal[cargoNumber]);
+
+                        origin = tr.drawStringLeftWrapped(origin, 290, Colour::black, StringIds::black_stringid, args);
+                    }
+                    cargoNumber++;
+                }
+                origin.y += 4;
+                origin.x -= 4;
             }
 
             // Draw Last Months produced cargo stats
@@ -531,6 +560,38 @@ namespace OpenLoco::Ui::Windows::Industry
                     }
                     cargoNumber++;
                 }
+                origin.y += 4;
+                origin.x -= 4;
+
+                // Draw output buffer stats
+                tr.drawStringLeft(origin, Colour::black, StringIds::cargo_awaiting_transport);
+                origin.y += 10;
+                origin.x += 4;
+
+                cargoNumber = 0;
+                for (const auto& producedCargoType : industryObj->producedCargoType)
+                {
+                    if (producedCargoType != kCargoTypeNull)
+                    {
+                        auto cargoObj = ObjectManager::get<CargoObject>(producedCargoType);
+                        FormatArguments args{};
+
+                        if (industry->receivedCargoQuantityPreviousMonth[cargoNumber] == 1)
+                        {
+                            args.push(cargoObj->unitNameSingular);
+                        }
+                        else
+                        {
+                            args.push(cargoObj->unitNamePlural);
+                        }
+                        args.push<uint32_t>(industry->outputBuffer[cargoNumber]);
+
+                        origin = tr.drawStringLeftWrapped(origin, 290, Colour::black, StringIds::black_stringid, args);
+                    }
+                    cargoNumber++;
+                }
+                origin.y += 4;
+                origin.x -= 4;
             }
         }
 


### PR DESCRIPTION
This PR adds two new sections to the statistics page to track the industry's performance for the input buffer and output buffer. With this, users can identify delivery imbalances or overproduction.

<img width="307" height="198" alt="image" src="https://github.com/user-attachments/assets/c64c48a9-51a7-4592-bb95-6a86c98f0f60" />

The way that Locomotion handles the input and output buffers means that these stats are not very useful at the moment, but may be more useful in the future if industry behavior regarding the buffers changes.

I'm open to suggestions on the strings.