### PR TITLE
Rename IndustryElement fields

### DIFF
--- a/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
+++ b/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "OpenLoco/Core/EnumFlags.hpp"
 #include "TileElement.h"
 
 namespace OpenLoco
@@ -9,6 +10,12 @@ namespace OpenLoco
 
 namespace OpenLoco::World
 {
+    enum class IndustryElementFlags : uint16_t
+    {
+        none = 0U,
+        randomAnimationPlaying = 1U << 5,
+    };
+    OPENLOCO_ENABLE_ENUM_OPERATORS(IndustryElementFlags);
 #pragma pack(push, 1)
 
     struct IndustryElement : public TileElement
@@ -18,7 +25,11 @@ namespace OpenLoco::World
     private:
         IndustryId _industryId;
         uint8_t _5;
-        uint16_t _6;
+        union
+        {
+            uint16_t _6;
+            IndustryElementFlags industryFlags;
+        };
 
     public:
         // _4
@@ -64,6 +75,10 @@ namespace OpenLoco::World
         void setIsConstructed(bool val);
 
         bool update(const World::Pos2& loc);
+        constexpr bool hasFlags(IndustryElementFlags flagsToTest) const
+        {
+            return (industryFlags & flagsToTest) != IndustryElementFlags::none;
+        }
     };
 #pragma pack(pop)
     static_assert(sizeof(IndustryElement) == kTileElementSize);

--- a/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
+++ b/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
@@ -24,8 +24,6 @@ namespace OpenLoco::World
     // ? : Unused
     constexpr uint8_t kIndustryElement5TileSequenceMask = 0b0000'0011;
     constexpr uint8_t kIndustryElement5SectionConstructionProgressMask = 0b1110'0000;
-    constexpr uint16_t kIndustryElement6SectionsCompletedMask = 0b0000'0000'0011'1111;
-    constexpr uint16_t kIndustryElement6RandomAnimationTypeMask = 0b0000'0000'0000'0011;
 
     // Field 6: CCCC'CBBB'BBPA'??TT or CCCC'CBBB'BBSS'SSSS
     // C : Colour
@@ -35,6 +33,8 @@ namespace OpenLoco::World
     // T : Random animation type
     // S : Section construct completed
     // ? : Unused
+    constexpr uint16_t kIndustryElement6SectionsCompletedMask = 0b0000'0000'0011'1111;
+    constexpr uint16_t kIndustryElement6RandomAnimationTypeMask = 0b0000'0000'0000'0011;
     constexpr uint16_t kIndustryElement6RandomAnimationAvailable = (1 << 4);
     constexpr uint16_t kIndustryElement6RandomAnimationPlaying = (1 << 5);
     constexpr uint16_t kIndustryElement6BuildingTypeMask = 0b0000'0111'1100'0000;

--- a/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
+++ b/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
@@ -17,7 +17,7 @@ namespace OpenLoco::World
     constexpr uint16_t kIndustryElement6RandomAnimationPlaying = (1 << 5);
     constexpr uint16_t kIndustryElement6BuildingTypeMask = 0b0000'0111'1100'0000;
     constexpr uint16_t kIndustryElement6ColourMask = 0b1111'1000'0000'0000;
-    constexpr uint16_t kIndustryElement5TileSequenceMask = 0b0000'0011;
+    constexpr uint8_t kIndustryElement5TileSequenceMask = 0b0000'0011;
     constexpr uint8_t kIndustryElement5SectionConstructionProgressMask = 0b1110'0000;
 
 #pragma pack(push, 1)

--- a/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
+++ b/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
@@ -10,6 +10,8 @@ namespace OpenLoco
 
 namespace OpenLoco::World
 {
+    constexpr uint8_t kIndustryElement0RotationMask = 0b0000'0011;
+    constexpr uint8_t kIndustryElement0Constructed = 0b1000'0000;
     constexpr uint8_t kIndustryElement5TileSequenceMask = 0b0000'0011;
     constexpr uint8_t kIndustryElement5SectionConstructionProgressMask = 0b1110'0000;
     // The sections complete mask and random animation masks are used at mutually exclusive times
@@ -43,11 +45,11 @@ namespace OpenLoco::World
             _6 &= ~kIndustryElement6BuildingTypeMask;
             _6 |= type << 6;
         }
-        uint8_t rotation() const { return _0 & 0x3; }
+        uint8_t rotation() const { return _0 & kIndustryElement0RotationMask; }
         void setRotation(const uint8_t rotation)
         {
-            _0 &= ~0x3;
-            _0 |= rotation & 0x3;
+            _0 &= ~kIndustryElement0RotationMask;
+            _0 |= rotation & kIndustryElement0RotationMask;
         }
         // var_5_03
         uint8_t sequenceIndex() const;
@@ -70,7 +72,7 @@ namespace OpenLoco::World
         uint8_t sectionsCompleted() const;
         void setSectionsCompleted(uint8_t val);
 
-        bool isConstructed() const { return _0 & 0x80; }
+        bool isConstructed() const { return _0 & kIndustryElement0Constructed; }
         void setIsConstructed(bool val);
 
         bool update(const World::Pos2& loc);

--- a/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
+++ b/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
@@ -10,13 +10,31 @@ namespace OpenLoco
 
 namespace OpenLoco::World
 {
+    // Field 0:  C?TT'TTRR
+    // C : Is Constructed
+    // T : Element type
+    // R : Rotation
+    // ? : Unused
     constexpr uint8_t kIndustryElement0RotationMask = 0b0000'0011;
-    constexpr uint8_t kIndustryElement0Constructed = 0b1000'0000;
+    constexpr uint8_t kIndustryElement0Constructed = (1 << 7);
+
+    // Field 5: PPP?'??SS
+    // P : Section construction progress
+    // S : Sequence index
+    // ? : Unused
     constexpr uint8_t kIndustryElement5TileSequenceMask = 0b0000'0011;
     constexpr uint8_t kIndustryElement5SectionConstructionProgressMask = 0b1110'0000;
-    // The sections complete mask and random animation masks are used at mutually exclusive times
     constexpr uint16_t kIndustryElement6SectionsCompletedMask = 0b0000'0000'0011'1111;
     constexpr uint16_t kIndustryElement6RandomAnimationTypeMask = 0b0000'0000'0000'0011;
+
+    // Field 6: CCCC'CBBB'BBPA'??TT or CCCC'CBBB'BBSS'SSSS
+    // C : Colour
+    // B : Building type
+    // P : Random animation playing
+    // A : Random animation available
+    // T : Random animation type
+    // S : Section construct completed
+    // ? : Unused
     constexpr uint16_t kIndustryElement6RandomAnimationAvailable = (1 << 4);
     constexpr uint16_t kIndustryElement6RandomAnimationPlaying = (1 << 5);
     constexpr uint16_t kIndustryElement6BuildingTypeMask = 0b0000'0111'1100'0000;

--- a/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
+++ b/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
@@ -10,19 +10,14 @@ namespace OpenLoco
 
 namespace OpenLoco::World
 {
-    enum class IndustryElementFlags : uint16_t
-    {
-        none = 0U,
-        playingRandomAnimation = 1U << 4,
-        randomAnimationQueued = 1U << 5,
-    };
-    OPENLOCO_ENABLE_ENUM_OPERATORS(IndustryElementFlags);
 
     constexpr uint16_t kIndustryElement6ColourMask = 0xF800;
     constexpr uint16_t kIndustryElement6BuildingTypeMask = 0x07C0;
     constexpr uint16_t kIndustryElement6RandomAnimationTypeMask = 0x0003;
     constexpr uint16_t kIndustryElement6SectionsCompletedMask = 0x001F;
     constexpr uint16_t kIndustryElement5TileSequenceMask = 0x03;
+    constexpr uint16_t kIndustryElement6RandomAnimationQueued = (1 << 5);
+    constexpr uint16_t kIndustryElement6RandomAnimationPlaying = (1 << 4);
     constexpr uint8_t kIndustryElement5SectionConstructionProgressMask = 0xE0;
 
 #pragma pack(push, 1)
@@ -95,18 +90,12 @@ namespace OpenLoco::World
         void setIsConstructed(bool val);
 
         bool update(const World::Pos2& loc);
-        constexpr bool hasFlags(IndustryElementFlags flagsToTest) const
-        {
-            return (static_cast<IndustryElementFlags>(_6) & flagsToTest) == flagsToTest;
-        }
-        void setFlags(IndustryElementFlags flagsToSet)
-        {
-            _6 |= enumValue(flagsToSet);
-        }
-        void unsetFlags(IndustryElementFlags flagsToUnset)
-        {
-            _6 &= ~enumValue(flagsToUnset);
-        };
+
+        bool randomAnimationQueued() const { return _6 & kIndustryElement6RandomAnimationQueued; }
+        void setRandomAnimationQueued(bool val);
+
+        bool randomAnimationPlaying() const { return _6 & kIndustryElement6RandomAnimationPlaying; }
+        void setRandomAnimationPlaying(bool val);
 
         constexpr uint8_t randomAnimationType() const
         {

--- a/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
+++ b/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
@@ -10,6 +10,8 @@ namespace OpenLoco
 
 namespace OpenLoco::World
 {
+    constexpr uint8_t kIndustryElement5TileSequenceMask = 0b0000'0011;
+    constexpr uint8_t kIndustryElement5SectionConstructionProgressMask = 0b1110'0000;
     // The sections complete mask and random animation masks are used at mutually exclusive times
     constexpr uint16_t kIndustryElement6SectionsCompletedMask = 0b0000'0000'0011'1111;
     constexpr uint16_t kIndustryElement6RandomAnimationTypeMask = 0b0000'0000'0000'0011;
@@ -17,8 +19,6 @@ namespace OpenLoco::World
     constexpr uint16_t kIndustryElement6RandomAnimationPlaying = (1 << 5);
     constexpr uint16_t kIndustryElement6BuildingTypeMask = 0b0000'0111'1100'0000;
     constexpr uint16_t kIndustryElement6ColourMask = 0b1111'1000'0000'0000;
-    constexpr uint8_t kIndustryElement5TileSequenceMask = 0b0000'0011;
-    constexpr uint8_t kIndustryElement5SectionConstructionProgressMask = 0b1110'0000;
 
 #pragma pack(push, 1)
 

--- a/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
+++ b/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
@@ -10,15 +10,15 @@ namespace OpenLoco
 
 namespace OpenLoco::World
 {
-
-    constexpr uint16_t kIndustryElement6ColourMask = 0xF800;
-    constexpr uint16_t kIndustryElement6BuildingTypeMask = 0x07C0;
-    constexpr uint16_t kIndustryElement6RandomAnimationTypeMask = 0x0003;
-    constexpr uint16_t kIndustryElement6SectionsCompletedMask = 0x001F;
-    constexpr uint16_t kIndustryElement5TileSequenceMask = 0x03;
-    constexpr uint16_t kIndustryElement6RandomAnimationPlaying = (1 << 5);
+    // The sections complete mask and random animation masks are used at mutually exclusive times
+    constexpr uint16_t kIndustryElement6SectionsCompletedMask = 0b0000'0000'0011'1111;
+    constexpr uint16_t kIndustryElement6RandomAnimationTypeMask = 0b0000'0000'0000'0011;
     constexpr uint16_t kIndustryElement6RandomAnimationAvailable = (1 << 4);
-    constexpr uint8_t kIndustryElement5SectionConstructionProgressMask = 0xE0;
+    constexpr uint16_t kIndustryElement6RandomAnimationPlaying = (1 << 5);
+    constexpr uint16_t kIndustryElement6BuildingTypeMask = 0b0000'0111'1100'0000;
+    constexpr uint16_t kIndustryElement6ColourMask = 0b1111'1000'0000'0000;
+    constexpr uint16_t kIndustryElement5TileSequenceMask = 0b0000'0011;
+    constexpr uint8_t kIndustryElement5SectionConstructionProgressMask = 0b1110'0000;
 
 #pragma pack(push, 1)
 
@@ -28,23 +28,7 @@ namespace OpenLoco::World
 
     private:
         IndustryId _industryId;
-
-        /* Field _5 data structures
-         * 0b111xxxxx = construction progress of uppermost section
-         * 0bxxxxxx11 = sequence number of multi-tile building
-         * 0bxxx111xx = unused bits
-         */
         uint8_t _5;
-
-        /* Field _6 data structures
-         * 0b11111xxxxxxxxxxx = colour
-         * 0bxxxxx11111xxxxxx = building type
-         * 0bxxxxxxxxxx1xxxxx = random animation is playing
-         * 0bxxxxxxxxxxx1xxxx = random animations can play
-         * 0bxxxxxxxxxxxxxx11 = random animation type
-         * 0bxxxxxxxxxxxx11xx = unused bits (of above)
-         * 0bxxxxxxxxxx111111 = number of building sections completed
-         */
         uint16_t _6;
 
     public:

--- a/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
+++ b/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
@@ -13,7 +13,11 @@ namespace OpenLoco::World
     enum class IndustryElementFlags : uint16_t
     {
         none = 0U,
-        randomAnimationPlaying = 1U << 5,
+        randomAnimationTypeMask = 0x3U << 0,
+        playingRandomAnimation = 1U << 4,
+        randomAnimationQueued = 1U << 5,
+        buildingTypeMask = 0x1FU << 6,
+        colourMask = 0x1FU << 11,
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(IndustryElementFlags);
 #pragma pack(push, 1)
@@ -25,11 +29,17 @@ namespace OpenLoco::World
     private:
         IndustryId _industryId;
         uint8_t _5;
-        union
-        {
-            uint16_t _6;
-            IndustryElementFlags industryFlags;
-        };
+
+        /* Field _6 data structures
+         * 0b11111xxxxxxxxxxx = colour
+         * 0bxxxxxx11111xxxxx = building type
+         * 0bxxxxxxxxxxx1xxxx = random animation is queued and will play at the next opportunity
+         * 0bxxxxxxxxxxxx1xxx = random animation is currently playing
+         * 0bxxxxxxxxxxxxxx11 = random animation type
+         * 0bxxxxx1xxxxxxx1xx = unused bits
+         * 0bxxxxxxxxxx111111 = number of building sections
+         */
+        uint16_t _6;
 
     public:
         // _4
@@ -67,9 +77,8 @@ namespace OpenLoco::World
             _6 |= enumValue(c) << 11;
         }
 
-        // This has two uses. When under construction it is the number of completed sections. Otherwise its animation sequence related
-        uint8_t var_6_003F() const;
-        void setVar_6_003F(uint8_t val);
+        uint8_t sectionsCompleted() const;
+        void setSectionsCompleted(uint8_t val);
 
         bool isConstructed() const { return _0 & 0x80; }
         void setIsConstructed(bool val);
@@ -77,8 +86,22 @@ namespace OpenLoco::World
         bool update(const World::Pos2& loc);
         constexpr bool hasFlags(IndustryElementFlags flagsToTest) const
         {
-            return (industryFlags & flagsToTest) != IndustryElementFlags::none;
+            return (static_cast<IndustryElementFlags>(_6) & flagsToTest) == flagsToTest;
         }
+        void setFlags(IndustryElementFlags flagsToSet)
+        {
+            _6 |= enumValue(flagsToSet);
+        }
+        void unsetFlags(IndustryElementFlags flagsToUnset)
+        {
+            _6 &= ~enumValue(flagsToUnset);
+        };
+
+        constexpr uint8_t randomAnimationType() const
+        {
+            return _6 & enumValue(IndustryElementFlags::randomAnimationTypeMask);
+        }
+        void setRandomAnimationType(uint8_t type);
     };
 #pragma pack(pop)
     static_assert(sizeof(IndustryElement) == kTileElementSize);

--- a/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
+++ b/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
@@ -69,6 +69,6 @@ namespace OpenLoco::World
     static_assert(sizeof(IndustryElement) == kTileElementSize);
 
     struct Animation;
-    bool updateIndustryAnimation1(const Animation& anim);
-    bool updateIndustryAnimation2(const Animation& anim);
+    bool updateIndustryContinuousAnimation(const Animation& anim);
+    bool updateIndustryRandomAnimation(const Animation& anim);
 }

--- a/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
+++ b/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
@@ -13,13 +13,18 @@ namespace OpenLoco::World
     enum class IndustryElementFlags : uint16_t
     {
         none = 0U,
-        randomAnimationTypeMask = 0x3U << 0,
         playingRandomAnimation = 1U << 4,
         randomAnimationQueued = 1U << 5,
-        buildingTypeMask = 0x1FU << 6,
-        colourMask = 0x1FU << 11,
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(IndustryElementFlags);
+
+    constexpr uint16_t kIndustryElement6ColourMask = 0xF800;
+    constexpr uint16_t kIndustryElement6BuildingTypeMask = 0x07C0;
+    constexpr uint16_t kIndustryElement6RandomAnimationTypeMask = 0x0003;
+    constexpr uint16_t kIndustryElement6SectionsCompletedMask = 0x001F;
+    constexpr uint16_t kIndustryElement5TileSequenceMask = 0x03;
+    constexpr uint8_t kIndustryElement5SectionConstructionProgressMask = 0xE0;
+
 #pragma pack(push, 1)
 
     struct IndustryElement : public TileElement
@@ -28,16 +33,22 @@ namespace OpenLoco::World
 
     private:
         IndustryId _industryId;
+
+        /* Field _5 data structures
+         * 0b111xxxxx = construction progress of uppermost section
+         * 0bxxxxxx11 = sequence number of multi-tile building
+         * 0bxxx111xx = unused bits
+         */
         uint8_t _5;
 
         /* Field _6 data structures
          * 0b11111xxxxxxxxxxx = colour
-         * 0bxxxxxx11111xxxxx = building type
-         * 0bxxxxxxxxxxx1xxxx = random animation is queued and will play at the next opportunity
-         * 0bxxxxxxxxxxxx1xxx = random animation is currently playing
+         * 0bxxxxx11111xxxxxx = building type
+         * 0bxxxxxxxxxx1xxxxx = random animation is queued and will play at the next opportunity
+         * 0bxxxxxxxxxxx1xxxx = random animation is currently playing
          * 0bxxxxxxxxxxxxxx11 = random animation type
-         * 0bxxxxx1xxxxxxx1xx = unused bits
-         * 0bxxxxxxxxxx111111 = number of building sections
+         * 0bxxxxxxxxxxxx11xx = unused bits (of above)
+         * 0bxxxxxxxxxx111111 = number of building sections completed
          */
         uint16_t _6;
 
@@ -50,7 +61,7 @@ namespace OpenLoco::World
         uint8_t buildingType() const;
         void setBuildingType(uint8_t type)
         {
-            _6 &= ~0x7C0;
+            _6 &= ~kIndustryElement6BuildingTypeMask;
             _6 |= type << 6;
         }
         uint8_t rotation() const { return _0 & 0x3; }
@@ -63,17 +74,17 @@ namespace OpenLoco::World
         uint8_t sequenceIndex() const;
         void setSequenceIndex(const uint8_t index)
         {
-            _5 &= ~0x3;
-            _5 |= index & 0x3;
+            _5 &= ~kIndustryElement5TileSequenceMask;
+            _5 |= index & kIndustryElement5TileSequenceMask;
         }
         // var_5_E0
         uint8_t sectionProgress() const;
         void setSectionProgress(uint8_t val);
 
-        Colour var_6_F800() const;
+        Colour colour() const;
         void setColour(Colour c)
         {
-            _6 &= ~0xF800;
+            _6 &= ~kIndustryElement6ColourMask;
             _6 |= enumValue(c) << 11;
         }
 
@@ -99,7 +110,7 @@ namespace OpenLoco::World
 
         constexpr uint8_t randomAnimationType() const
         {
-            return _6 & enumValue(IndustryElementFlags::randomAnimationTypeMask);
+            return _6 & kIndustryElement6RandomAnimationTypeMask;
         }
         void setRandomAnimationType(uint8_t type);
     };

--- a/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
+++ b/src/OpenLoco/include/OpenLoco/Map/IndustryElement.h
@@ -16,8 +16,8 @@ namespace OpenLoco::World
     constexpr uint16_t kIndustryElement6RandomAnimationTypeMask = 0x0003;
     constexpr uint16_t kIndustryElement6SectionsCompletedMask = 0x001F;
     constexpr uint16_t kIndustryElement5TileSequenceMask = 0x03;
-    constexpr uint16_t kIndustryElement6RandomAnimationQueued = (1 << 5);
-    constexpr uint16_t kIndustryElement6RandomAnimationPlaying = (1 << 4);
+    constexpr uint16_t kIndustryElement6RandomAnimationPlaying = (1 << 5);
+    constexpr uint16_t kIndustryElement6RandomAnimationAvailable = (1 << 4);
     constexpr uint8_t kIndustryElement5SectionConstructionProgressMask = 0xE0;
 
 #pragma pack(push, 1)
@@ -39,8 +39,8 @@ namespace OpenLoco::World
         /* Field _6 data structures
          * 0b11111xxxxxxxxxxx = colour
          * 0bxxxxx11111xxxxxx = building type
-         * 0bxxxxxxxxxx1xxxxx = random animation is queued and will play at the next opportunity
-         * 0bxxxxxxxxxxx1xxxx = random animation is currently playing
+         * 0bxxxxxxxxxx1xxxxx = random animation is playing
+         * 0bxxxxxxxxxxx1xxxx = random animations can play
          * 0bxxxxxxxxxxxxxx11 = random animation type
          * 0bxxxxxxxxxxxx11xx = unused bits (of above)
          * 0bxxxxxxxxxx111111 = number of building sections completed
@@ -91,11 +91,11 @@ namespace OpenLoco::World
 
         bool update(const World::Pos2& loc);
 
-        bool randomAnimationQueued() const { return _6 & kIndustryElement6RandomAnimationQueued; }
-        void setRandomAnimationQueued(bool val);
-
         bool randomAnimationPlaying() const { return _6 & kIndustryElement6RandomAnimationPlaying; }
         void setRandomAnimationPlaying(bool val);
+
+        bool randomAnimationAvailable() const { return _6 & kIndustryElement6RandomAnimationAvailable; }
+        void setRandomAnimationAvailable(bool val);
 
         constexpr uint8_t randomAnimationType() const
         {

--- a/src/OpenLoco/src/GameCommands/Industries/CreateIndustry.cpp
+++ b/src/OpenLoco/src/GameCommands/Industries/CreateIndustry.cpp
@@ -343,7 +343,7 @@ namespace OpenLoco::GameCommands
                 elIndustry.setSectionProgress(0);
                 elIndustry.setColour(colour);
                 elIndustry.setBuildingType(buildingType);
-                elIndustry.setVar_6_003F(0);
+                elIndustry.setSectionsCompleted(0);
                 World::AnimationManager::createAnimation(3, World::toWorldSpace(tilePos), elIndustry.baseZ());
                 elIndustry.setGhost(flags & Flags::ghost);
                 Ui::ViewportManager::invalidate(World::toWorldSpace(tilePos), elIndustry.baseHeight(), elIndustry.clearHeight());

--- a/src/OpenLoco/src/Map/AnimationManager.cpp
+++ b/src/OpenLoco/src/Map/AnimationManager.cpp
@@ -63,9 +63,9 @@ namespace OpenLoco::World::AnimationManager
             case 2:
                 return false;
             case 3:
-                return updateIndustryAnimation1(anim);
+                return updateIndustryContinuousAnimation(anim);
             case 4:
-                return updateIndustryAnimation2(anim);
+                return updateIndustryRandomAnimation(anim);
             case 5:
                 return updateBuildingAnimation1(anim);
             case 6:

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -185,7 +185,7 @@ namespace OpenLoco::World
                     break;
                 }
             }
-            if (hasAZeroFrame && !(var_6_003F() & (1 << 5)))
+            if (hasAZeroFrame && !hasFlags(IndustryElementFlags::randomAnimationPlaying))
             {
                 std::array<uint8_t, 8> _E0C3D4{};
                 auto ptr = _E0C3D4.begin();
@@ -302,7 +302,7 @@ namespace OpenLoco::World
             {
                 continue;
             }
-            if (!(elIndustry->var_6_003F() & (1 << 5)))
+            if (!elIndustry->hasFlags(IndustryElementFlags::randomAnimationPlaying))
             {
                 continue;
             }

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -22,39 +22,39 @@ namespace OpenLoco::World
 
     uint8_t IndustryElement::buildingType() const
     {
-        return (_6 >> 6) & 0x1F;
+        return (_6 & kIndustryElement6BuildingTypeMask) >> 6;
     }
 
-    Colour IndustryElement::var_6_F800() const
+    Colour IndustryElement::colour() const
     {
-        return static_cast<Colour>((_6 >> 11) & 0x1F);
+        return static_cast<Colour>((_6 & kIndustryElement6ColourMask) >> 11);
     }
 
     uint8_t IndustryElement::sectionsCompleted() const
     {
-        return _6 & 0x3F;
+        return _6 & kIndustryElement6SectionsCompletedMask;
     }
 
     void IndustryElement::setSectionsCompleted(uint8_t val)
     {
-        _6 &= ~(0x3F);
-        _6 |= val & 0x3F;
+        _6 &= ~kIndustryElement6SectionsCompletedMask;
+        _6 |= val & kIndustryElement6SectionsCompletedMask;
     }
 
     uint8_t IndustryElement::sectionProgress() const
     {
-        return (_5 >> 5) & 0x7;
+        return (_5 & kIndustryElement5SectionConstructionProgressMask) >> 5;
     }
 
     void IndustryElement::setSectionProgress(uint8_t val)
     {
-        _5 &= ~(0xE0);
-        _5 |= (val & 0x7) << 5;
+        _5 &= ~kIndustryElement5SectionConstructionProgressMask;
+        _5 |= (val << 5 ) & kIndustryElement5SectionConstructionProgressMask;
     }
 
     uint8_t IndustryElement::sequenceIndex() const
     {
-        return _5 & 0x3;
+        return _5 & kIndustryElement5TileSequenceMask;
     }
 
     void IndustryElement::setIsConstructed(bool val)
@@ -65,7 +65,7 @@ namespace OpenLoco::World
 
     void IndustryElement::setRandomAnimationType(uint8_t type)
     {
-        _6 &= ~enumValue(IndustryElementFlags::randomAnimationTypeMask);
+        _6 &= ~kIndustryElement6RandomAnimationTypeMask;
         _6 |= type;
     }
 

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -30,12 +30,12 @@ namespace OpenLoco::World
         return static_cast<Colour>((_6 >> 11) & 0x1F);
     }
 
-    uint8_t IndustryElement::var_6_003F() const
+    uint8_t IndustryElement::sectionsCompleted() const
     {
         return _6 & 0x3F;
     }
 
-    void IndustryElement::setVar_6_003F(uint8_t val)
+    void IndustryElement::setSectionsCompleted(uint8_t val)
     {
         _6 &= ~(0x3F);
         _6 |= val & 0x3F;
@@ -61,6 +61,12 @@ namespace OpenLoco::World
     {
         _0 &= ~(1 << 7);
         _0 |= val ? (1 << 7) : 0;
+    }
+
+    void IndustryElement::setRandomAnimationType(uint8_t type)
+    {
+        _6 &= ~enumValue(IndustryElementFlags::randomAnimationTypeMask);
+        _6 |= type;
     }
 
     // 0x0045769A
@@ -119,12 +125,12 @@ namespace OpenLoco::World
         {
             bool newConstructed = isConstructed();
             uint8_t newSectionProgress = sectionProgress();
-            uint8_t newNumSections = var_6_003F();
+            uint8_t newNumSections = sectionsCompleted();
 
             const auto progress = sectionProgress();
             if (progress == 0x7)
             {
-                const size_t numSections = var_6_003F();
+                const size_t numSections = sectionsCompleted();
                 const auto parts = indObj->getBuildingParts(type);
                 const auto heights = indObj->getBuildingPartHeights();
                 if (parts.size() <= numSections + 1)
@@ -166,7 +172,7 @@ namespace OpenLoco::World
             applyToMultiTile(*this, loc, isMultiTile, [newConstructed, newSectionProgress, newNumSections](World::IndustryElement& elIndustry, const World::Pos2& pos) {
                 elIndustry.setIsConstructed(newConstructed);
                 elIndustry.setSectionProgress(newSectionProgress);
-                elIndustry.setVar_6_003F(newNumSections);
+                elIndustry.setSectionsCompleted(newNumSections);
                 Ui::ViewportManager::invalidate(pos, elIndustry.baseHeight(), elIndustry.clearHeight(), ZoomLevel::quarter);
             });
         }
@@ -185,7 +191,7 @@ namespace OpenLoco::World
                     break;
                 }
             }
-            if (hasAZeroFrame && !hasFlags(IndustryElementFlags::randomAnimationPlaying))
+            if (hasAZeroFrame && !hasFlags(IndustryElementFlags::randomAnimationQueued))
             {
                 std::array<uint8_t, 8> _E0C3D4{};
                 auto ptr = _E0C3D4.begin();
@@ -203,9 +209,10 @@ namespace OpenLoco::World
                     if ((rand & 0x700) == 0)
                     {
                         const auto randAnim = _E0C3D4[(numAnimations * (rand & 0xFF)) / 256];
-                        const auto newVar6_3F = randAnim | (1 << 5) | (var_6_003F() & 0xC);
-                        applyToMultiTile(*this, loc, isMultiTile, [newVar6_3F](IndustryElement& elIndustry, [[maybe_unused]] const World::Pos2& pos) {
-                            elIndustry.setVar_6_003F(newVar6_3F);
+                        applyToMultiTile(*this, loc, isMultiTile, [randAnim](IndustryElement& elIndustry, [[maybe_unused]] const World::Pos2& pos)
+                        {
+                            elIndustry.setFlags(IndustryElementFlags::randomAnimationQueued);
+                            elIndustry.setRandomAnimationType(randAnim);
                         });
                         AnimationManager::createAnimation(4, loc, baseZ());
                     }
@@ -302,7 +309,7 @@ namespace OpenLoco::World
             {
                 continue;
             }
-            if (!elIndustry->hasFlags(IndustryElementFlags::randomAnimationPlaying))
+            if (!elIndustry->hasFlags(IndustryElementFlags::randomAnimationQueued))
             {
                 continue;
             }
@@ -313,7 +320,7 @@ namespace OpenLoco::World
             const auto buildingParts = indObj->getBuildingParts(type);
             const auto buildingPartAnims = indObj->getBuildingPartAnimations();
             // Guaranteed power of 2
-            auto animLength = indObj->getAnimationSequence(elIndustry->var_6_003F() & 0x3).size();
+            auto animLength = indObj->getAnimationSequence(elIndustry->randomAnimationType()).size();
             const auto isMultiTile = indObj->buildingSizeFlags & (1 << type);
 
             for (auto& part : buildingParts)
@@ -323,13 +330,13 @@ namespace OpenLoco::World
                 {
                     const auto animSpeed = partAnim.animationSpeed & ~(1 << 7);
                     const auto speedMask = animLength - 1;
-                    if (elIndustry->var_6_003F() & (1 << 4))
+                    if (elIndustry->hasFlags(IndustryElementFlags::playingRandomAnimation))
                     {
                         if ((speedMask & (ScenarioManager::getScenarioTicks() >> animSpeed)) == 0)
                         {
                             applyToMultiTile(*elIndustry, anim.pos, isMultiTile, [](World::IndustryElement& elIndustry, const World::Pos2& pos) {
                                 Ui::ViewportManager::invalidate(pos, elIndustry.baseHeight(), elIndustry.clearHeight(), ZoomLevel::quarter);
-                                elIndustry.setVar_6_003F(elIndustry.var_6_003F() & ~(1 << 5));
+                                elIndustry.unsetFlags(IndustryElementFlags::randomAnimationQueued);
                             });
                             return true;
                         }
@@ -351,7 +358,7 @@ namespace OpenLoco::World
                         {
                             applyToMultiTile(*elIndustry, anim.pos, isMultiTile, [](World::IndustryElement& elIndustry, const World::Pos2& pos) {
                                 Ui::ViewportManager::invalidate(pos, elIndustry.baseHeight(), elIndustry.clearHeight(), ZoomLevel::quarter);
-                                elIndustry.setVar_6_003F(elIndustry.var_6_003F() | (1 << 4));
+                                elIndustry.setFlags(IndustryElementFlags::playingRandomAnimation);
                             });
                         }
                         return false;

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -15,6 +15,9 @@
 
 namespace OpenLoco::World
 {
+    constexpr auto kSectionComplete = 0x7;
+    constexpr auto kConstructionComplete = std::numeric_limits<uint8_t>::max();
+
     Industry* IndustryElement::industry() const
     {
         return IndustryManager::get(_industryId);
@@ -140,7 +143,7 @@ namespace OpenLoco::World
             uint8_t newNumSections = sectionsCompleted();
 
             const auto progress = sectionProgress();
-            if (progress == 0x7)
+            if (progress == kSectionComplete)
             {
                 const size_t numSections = sectionsCompleted();
                 const auto parts = indObj->getBuildingParts(type);
@@ -150,7 +153,7 @@ namespace OpenLoco::World
                     ind->under_construction++;
                     if (ind->under_construction >= ind->numTiles)
                     {
-                        ind->under_construction = 0xFF;
+                        ind->under_construction = kConstructionComplete;
                         Ui::WindowManager::invalidate(Ui::WindowType::industry, enumValue(ind->id()));
                         Ui::WindowManager::invalidate(Ui::WindowType::industryList);
                     }
@@ -231,7 +234,7 @@ namespace OpenLoco::World
             }
         }
 
-        if (ind->under_construction == 0xFF)
+        if (ind->under_construction == kConstructionComplete)
         {
             const coord_t upperRange = isMultiTile ? 5 : 4;
             constexpr coord_t kLowerRange = 4;

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -59,8 +59,8 @@ namespace OpenLoco::World
 
     void IndustryElement::setIsConstructed(bool val)
     {
-        _0 &= ~(1 << 7);
-        _0 |= val ? (1 << 7) : 0;
+        _0 &= ~kIndustryElement0Constructed;
+        _0 |= val ? kIndustryElement0Constructed : 0;
     }
 
     void IndustryElement::setRandomAnimationType(uint8_t type)

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -49,7 +49,7 @@ namespace OpenLoco::World
     void IndustryElement::setSectionProgress(uint8_t val)
     {
         _5 &= ~kIndustryElement5SectionConstructionProgressMask;
-        _5 |= (val << 5 ) & kIndustryElement5SectionConstructionProgressMask;
+        _5 |= (val << 5) & kIndustryElement5SectionConstructionProgressMask;
     }
 
     uint8_t IndustryElement::sequenceIndex() const
@@ -209,8 +209,7 @@ namespace OpenLoco::World
                     if ((rand & 0x700) == 0)
                     {
                         const auto randAnim = _E0C3D4[(numAnimations * (rand & 0xFF)) / 256];
-                        applyToMultiTile(*this, loc, isMultiTile, [randAnim](IndustryElement& elIndustry, [[maybe_unused]] const World::Pos2& pos)
-                        {
+                        applyToMultiTile(*this, loc, isMultiTile, [randAnim](IndustryElement& elIndustry, [[maybe_unused]] const World::Pos2& pos) {
                             elIndustry.setFlags(IndustryElementFlags::randomAnimationQueued);
                             elIndustry.setRandomAnimationType(randAnim);
                         });

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -69,16 +69,16 @@ namespace OpenLoco::World
         _6 |= type;
     }
 
+    void IndustryElement::setRandomAnimationAvailable(bool val)
+    {
+        _6 &= ~kIndustryElement6RandomAnimationAvailable;
+        _6 |= kIndustryElement6RandomAnimationAvailable * val;
+    }
+
     void IndustryElement::setRandomAnimationPlaying(bool val)
     {
         _6 &= ~kIndustryElement6RandomAnimationPlaying;
         _6 |= kIndustryElement6RandomAnimationPlaying * val;
-    }
-
-    void IndustryElement::setRandomAnimationQueued(bool val)
-    {
-        _6 &= ~kIndustryElement6RandomAnimationQueued;
-        _6 |= kIndustryElement6RandomAnimationQueued * val;
     }
 
     // 0x0045769A
@@ -203,7 +203,7 @@ namespace OpenLoco::World
                     break;
                 }
             }
-            if (hasAZeroFrame && !randomAnimationQueued())
+            if (hasAZeroFrame && !randomAnimationPlaying())
             {
                 std::array<uint8_t, 8> _E0C3D4{};
                 auto ptr = _E0C3D4.begin();
@@ -222,7 +222,7 @@ namespace OpenLoco::World
                     {
                         const auto randAnim = _E0C3D4[(numAnimations * (rand & 0xFF)) / 256];
                         applyToMultiTile(*this, loc, isMultiTile, [randAnim](IndustryElement& elIndustry, [[maybe_unused]] const World::Pos2& pos) {
-                            elIndustry.setRandomAnimationQueued(true);
+                            elIndustry.setRandomAnimationPlaying(true);
                             elIndustry.setRandomAnimationType(randAnim);
                         });
                         AnimationManager::createAnimation(4, loc, baseZ());
@@ -320,7 +320,7 @@ namespace OpenLoco::World
             {
                 continue;
             }
-            if (!elIndustry->randomAnimationQueued())
+            if (!elIndustry->randomAnimationPlaying())
             {
                 continue;
             }
@@ -341,13 +341,13 @@ namespace OpenLoco::World
                 {
                     const auto animSpeed = partAnim.animationSpeed & ~(1 << 7);
                     const auto speedMask = animLength - 1;
-                    if (elIndustry->randomAnimationPlaying())
+                    if (elIndustry->randomAnimationAvailable())
                     {
                         if ((speedMask & (ScenarioManager::getScenarioTicks() >> animSpeed)) == 0)
                         {
                             applyToMultiTile(*elIndustry, anim.pos, isMultiTile, [](World::IndustryElement& elIndustry, const World::Pos2& pos) {
                                 Ui::ViewportManager::invalidate(pos, elIndustry.baseHeight(), elIndustry.clearHeight(), ZoomLevel::quarter);
-                                elIndustry.setRandomAnimationQueued(false);
+                                elIndustry.setRandomAnimationPlaying(false);
                             });
                             return true;
                         }
@@ -369,7 +369,7 @@ namespace OpenLoco::World
                         {
                             applyToMultiTile(*elIndustry, anim.pos, isMultiTile, [](World::IndustryElement& elIndustry, const World::Pos2& pos) {
                                 Ui::ViewportManager::invalidate(pos, elIndustry.baseHeight(), elIndustry.clearHeight(), ZoomLevel::quarter);
-                                elIndustry.setRandomAnimationQueued(true);
+                                elIndustry.setRandomAnimationPlaying(true);
                             });
                         }
                         return false;

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -243,7 +243,7 @@ namespace OpenLoco::World
     }
 
     // 0x00456E32
-    bool updateIndustryAnimation1(const Animation& anim)
+    bool updateIndustryContinuousAnimation(const Animation& anim)
     {
         auto tile = TileManager::get(anim.pos);
         for (auto& el : tile)
@@ -288,7 +288,7 @@ namespace OpenLoco::World
     }
 
     // 0x00456EEB
-    bool updateIndustryAnimation2(const Animation& anim)
+    bool updateIndustryRandomAnimation(const Animation& anim)
     {
         auto tile = TileManager::get(anim.pos);
         for (auto& el : tile)

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -69,6 +69,18 @@ namespace OpenLoco::World
         _6 |= type;
     }
 
+    void IndustryElement::setRandomAnimationPlaying(bool val)
+    {
+        _6 &= ~kIndustryElement6RandomAnimationPlaying;
+        _6 |= kIndustryElement6RandomAnimationPlaying * val;
+    }
+
+    void IndustryElement::setRandomAnimationQueued(bool val)
+    {
+        _6 &= ~kIndustryElement6RandomAnimationQueued;
+        _6 |= kIndustryElement6RandomAnimationQueued * val;
+    }
+
     // 0x0045769A
     // A more generic version of the vanilla function
     template<typename TFunction>
@@ -191,7 +203,7 @@ namespace OpenLoco::World
                     break;
                 }
             }
-            if (hasAZeroFrame && !hasFlags(IndustryElementFlags::randomAnimationQueued))
+            if (hasAZeroFrame && !randomAnimationQueued())
             {
                 std::array<uint8_t, 8> _E0C3D4{};
                 auto ptr = _E0C3D4.begin();
@@ -210,7 +222,7 @@ namespace OpenLoco::World
                     {
                         const auto randAnim = _E0C3D4[(numAnimations * (rand & 0xFF)) / 256];
                         applyToMultiTile(*this, loc, isMultiTile, [randAnim](IndustryElement& elIndustry, [[maybe_unused]] const World::Pos2& pos) {
-                            elIndustry.setFlags(IndustryElementFlags::randomAnimationQueued);
+                            elIndustry.setRandomAnimationQueued(true);
                             elIndustry.setRandomAnimationType(randAnim);
                         });
                         AnimationManager::createAnimation(4, loc, baseZ());
@@ -308,7 +320,7 @@ namespace OpenLoco::World
             {
                 continue;
             }
-            if (!elIndustry->hasFlags(IndustryElementFlags::randomAnimationQueued))
+            if (!elIndustry->randomAnimationQueued())
             {
                 continue;
             }
@@ -329,13 +341,13 @@ namespace OpenLoco::World
                 {
                     const auto animSpeed = partAnim.animationSpeed & ~(1 << 7);
                     const auto speedMask = animLength - 1;
-                    if (elIndustry->hasFlags(IndustryElementFlags::playingRandomAnimation))
+                    if (elIndustry->randomAnimationPlaying())
                     {
                         if ((speedMask & (ScenarioManager::getScenarioTicks() >> animSpeed)) == 0)
                         {
                             applyToMultiTile(*elIndustry, anim.pos, isMultiTile, [](World::IndustryElement& elIndustry, const World::Pos2& pos) {
                                 Ui::ViewportManager::invalidate(pos, elIndustry.baseHeight(), elIndustry.clearHeight(), ZoomLevel::quarter);
-                                elIndustry.unsetFlags(IndustryElementFlags::randomAnimationQueued);
+                                elIndustry.setRandomAnimationQueued(false);
                             });
                             return true;
                         }
@@ -357,7 +369,7 @@ namespace OpenLoco::World
                         {
                             applyToMultiTile(*elIndustry, anim.pos, isMultiTile, [](World::IndustryElement& elIndustry, const World::Pos2& pos) {
                                 Ui::ViewportManager::invalidate(pos, elIndustry.baseHeight(), elIndustry.clearHeight(), ZoomLevel::quarter);
-                                elIndustry.setFlags(IndustryElementFlags::playingRandomAnimation);
+                                elIndustry.setRandomAnimationQueued(true);
                             });
                         }
                         return false;

--- a/src/OpenLoco/src/Map/IndustryElement.cpp
+++ b/src/OpenLoco/src/Map/IndustryElement.cpp
@@ -75,13 +75,13 @@ namespace OpenLoco::World
     void IndustryElement::setRandomAnimationAvailable(bool val)
     {
         _6 &= ~kIndustryElement6RandomAnimationAvailable;
-        _6 |= kIndustryElement6RandomAnimationAvailable * val;
+        _6 |= val ? kIndustryElement6RandomAnimationAvailable : 0;
     }
 
     void IndustryElement::setRandomAnimationPlaying(bool val)
     {
         _6 &= ~kIndustryElement6RandomAnimationPlaying;
-        _6 |= kIndustryElement6RandomAnimationPlaying * val;
+        _6 |= val ? kIndustryElement6RandomAnimationPlaying : 0;
     }
 
     // 0x0045769A

--- a/src/OpenLoco/src/Paint/PaintIndustry.cpp
+++ b/src/OpenLoco/src/Paint/PaintIndustry.cpp
@@ -31,14 +31,14 @@ namespace OpenLoco::Paint
         if (!elIndustry.isConstructed())
         {
             ticks = 0;
-            numSections = elIndustry.var_6_003F();
+            numSections = elIndustry.sectionsCompleted();
             sectionProgress = elIndustry.sectionProgress();
         }
 
         std::span<const std::uint8_t> animationSequence{};
-        if ((elIndustry.var_6_003F() & (1 << 5)) && (elIndustry.var_6_003F() & (1 << 4)))
+        if (elIndustry.hasFlags(IndustryElementFlags::randomAnimationQueued | IndustryElementFlags::playingRandomAnimation))
         {
-            animationSequence = indObj.getAnimationSequence(elIndustry.var_6_003F() & 0x3);
+            animationSequence = indObj.getAnimationSequence(elIndustry.randomAnimationType());
         }
 
         uint32_t buildingType = elIndustry.buildingType();

--- a/src/OpenLoco/src/Paint/PaintIndustry.cpp
+++ b/src/OpenLoco/src/Paint/PaintIndustry.cpp
@@ -36,7 +36,7 @@ namespace OpenLoco::Paint
         }
 
         std::span<const std::uint8_t> animationSequence{};
-        if (elIndustry.hasFlags(IndustryElementFlags::randomAnimationQueued | IndustryElementFlags::playingRandomAnimation))
+        if (elIndustry.randomAnimationQueued() && elIndustry.randomAnimationPlaying())
         {
             animationSequence = indObj.getAnimationSequence(elIndustry.randomAnimationType());
         }

--- a/src/OpenLoco/src/Paint/PaintIndustry.cpp
+++ b/src/OpenLoco/src/Paint/PaintIndustry.cpp
@@ -36,7 +36,7 @@ namespace OpenLoco::Paint
         }
 
         std::span<const std::uint8_t> animationSequence{};
-        if (elIndustry.randomAnimationQueued() && elIndustry.randomAnimationPlaying())
+        if (elIndustry.randomAnimationPlaying() && elIndustry.randomAnimationAvailable())
         {
             animationSequence = indObj.getAnimationSequence(elIndustry.randomAnimationType());
         }

--- a/src/OpenLoco/src/Paint/PaintIndustry.cpp
+++ b/src/OpenLoco/src/Paint/PaintIndustry.cpp
@@ -165,7 +165,7 @@ namespace OpenLoco::Paint
         auto* industry = elIndustry.industry();
         auto* indObj = industry->getObject();
 
-        ImageId baseColour(0, elIndustry.var_6_F800());
+        ImageId baseColour(0, elIndustry.colour());
         if (elIndustry.isGhost())
         {
             session.setItemType(Ui::ViewportInteraction::InteractionItem::noInteraction);
@@ -194,7 +194,7 @@ namespace OpenLoco::Paint
             if (session.getRenderTarget()->zoomLevel <= 1)
             {
                 const auto shadowImageOffset = buildingType * 4 + indObj->shadowImageIds + rotation;
-                const ImageId shadowImage = baseColour.withIndex(shadowImageOffset).withTranslucency(Colours::getShadow(elIndustry.var_6_F800()));
+                const ImageId shadowImage = baseColour.withIndex(shadowImageOffset).withTranslucency(Colours::getShadow(elIndustry.colour()));
                 if (isMultiTile)
                 {
                     session.addToPlotListAsChild(shadowImage, imageOffset, bbOffset, bbSize);

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -344,7 +344,7 @@ namespace OpenLoco::S5
                     dstElem.setIndustryId(static_cast<IndustryId>(d.industryId()));
                     dstElem.setSequenceIndex(d.sequenceIndex());
                     dstElem.setSectionProgress(d.sectionProgress());
-                    dstElem.setVar_6_003F(d.var6_003F());
+                    dstElem.setSectionsCompleted(d.var6_003F());
                     dstElem.setBuildingType(d.buildingType());
                     dstElem.setColour(static_cast<Colour>(d.colour()));
                     break;

--- a/src/OpenLoco/src/S5/S5TileElement.cpp
+++ b/src/OpenLoco/src/S5/S5TileElement.cpp
@@ -208,7 +208,7 @@ namespace OpenLoco::S5
                 dstElem.setIndustryId(enumValue(srcElem.industryId()));
                 dstElem.setSequenceIndex(srcElem.sequenceIndex());
                 dstElem.setSectionProgress(srcElem.sectionProgress());
-                dstElem.setVar6_003F(srcElem.var_6_003F());
+                dstElem.setVar6_003F(srcElem.sectionsCompleted());
                 dstElem.setBuildingType(srcElem.buildingType());
                 dstElem.setColour(enumValue(srcElem.var_6_F800()));
                 break;

--- a/src/OpenLoco/src/S5/S5TileElement.cpp
+++ b/src/OpenLoco/src/S5/S5TileElement.cpp
@@ -210,7 +210,7 @@ namespace OpenLoco::S5
                 dstElem.setSectionProgress(srcElem.sectionProgress());
                 dstElem.setVar6_003F(srcElem.sectionsCompleted());
                 dstElem.setBuildingType(srcElem.buildingType());
-                dstElem.setColour(enumValue(srcElem.var_6_F800()));
+                dstElem.setColour(enumValue(srcElem.colour()));
                 break;
             }
         }


### PR DESCRIPTION
Remove some magic numbers, name some unnamed fields

There is a logic change to queuing a new random animation (IndustryElement.cpp#213) which static analysis suggests will have no effect.