### PR TITLE
Window events 8 and 9 refactor

### DIFF
--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -74,8 +74,8 @@ namespace OpenLoco::Ui
         void (*onDropdown)(Window&, WidgetIndex_t, WidgetId, int16_t) = nullptr;
         void (*onPeriodicUpdate)(Window&) = nullptr;
         void (*onUpdate)(Window&) = nullptr;
-        void (*event_08)(Window&) = nullptr;
-        void (*event_09)(Window&) = nullptr;
+        void (*onHandleInputBegin)(Window&) = nullptr;
+        void (*onHandleInputEnd)(Window&) = nullptr;
         void (*onToolUpdate)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
         void (*onToolDown)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
         void (*toolDrag)(Window&, const WidgetIndex_t, WidgetId, const int16_t, const int16_t) = nullptr;
@@ -356,8 +356,8 @@ namespace OpenLoco::Ui
         void callOnDropdown(WidgetIndex_t widgetIndex, WidgetId id, int16_t itemIndex);                                   // 5
         void callOnPeriodicUpdate();                                                                                      // 6
         void callUpdate();                                                                                                // 7
-        void call_8();                                                                                                    // 8
-        void call_9();                                                                                                    // 9
+        void callHandleInputBegin();                                                                                      // 8
+        void callHandleInputEnd();                                                                                        // 9
         void callToolUpdate(WidgetIndex_t widgetIndex, WidgetId id, int16_t xPos, int16_t yPos);                          // 10
         void callToolDown(WidgetIndex_t widgetIndex, WidgetId id, int16_t xPos, int16_t yPos);                            // 11
         void callToolDrag(WidgetIndex_t widgetIndex, WidgetId id, const int16_t xPos, const int16_t yPos);                // 12

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -385,5 +385,6 @@ namespace OpenLoco::Ui
 
     World::Pos2 viewportCoordToMapCoord(int16_t x, int16_t y, int16_t z, int32_t rotation);
     std::optional<World::Pos2> screenGetMapXyWithZ(const Point& mouse, const int16_t z);
-
+    void listWindowOnHandleInputBegin(Window& window);
+    void listWindowOnHandleInputEnd(Window& window);
 }

--- a/src/OpenLoco/include/OpenLoco/Ui/WindowManager.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/WindowManager.h
@@ -79,8 +79,8 @@ namespace OpenLoco::Ui::WindowManager
     Window* createWindowCentred(WindowType type, Ui::Size size, WindowFlags flags, const WindowEventList& events);
     Window* createWindow(WindowType type, Ui::Size size, WindowFlags flags, const WindowEventList& events);
     void dispatchUpdateAll();
-    void callEvent8OnAllWindows();
-    void callEvent9OnAllWindows();
+    void callHandleInputBeginEventOnAllWindows();
+    void callHandleInputEndEventOnAllWindows();
     void callViewportRotateEventOnAllWindows();
     bool callKeyUpEventBackToFront(uint32_t charCode, uint32_t keyCode);
     void relocateWindows();

--- a/src/OpenLoco/src/Ui.cpp
+++ b/src/OpenLoco/src/Ui.cpp
@@ -913,7 +913,7 @@ namespace OpenLoco::Ui
 
         if (Ui::isInitialized())
         {
-            WindowManager::callEvent8OnAllWindows();
+            WindowManager::callHandleInputBeginEventOnAllWindows();
 
             WindowManager::invalidateAllWindowsAfterInput();
             Input::updateCursorPosition();
@@ -955,13 +955,13 @@ namespace OpenLoco::Ui
             Input::processMouseWheel();
         }
 
-        WindowManager::callEvent9OnAllWindows();
+        WindowManager::callHandleInputEndEventOnAllWindows();
     }
 
     // 0x004C98CF
     void minimalHandleInput()
     {
-        WindowManager::callEvent8OnAllWindows();
+        WindowManager::callHandleInputBeginEventOnAllWindows();
 
         WindowManager::invalidateAllWindowsAfterInput();
         Input::updateCursorPosition();
@@ -988,7 +988,7 @@ namespace OpenLoco::Ui
             processMouseTool(x, y);
         }
 
-        WindowManager::callEvent9OnAllWindows();
+        WindowManager::callHandleInputEndEventOnAllWindows();
     }
 
     void setWindowScaling(float newScaleFactor)

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -153,6 +153,27 @@ namespace OpenLoco::Ui
         return std::nullopt;
     }
 
+    void listWindowOnHandleInputBegin(Window& window)
+    {
+        window.flags |= WindowFlags::notScrollView;
+    }
+
+    void listWindowOnHandleInputEnd(Window& window)
+    {
+        if (!window.hasFlags(WindowFlags::notScrollView))
+        {
+            return;
+        }
+
+        if (window.rowHover == -1)
+        {
+            return;
+        }
+
+        window.rowHover = -1;
+        window.invalidate();
+    }
+
     // 0x0045FD41
     // Input:
     // regs.ax:  x

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -989,24 +989,24 @@ namespace OpenLoco::Ui
         eventHandlers->onUpdate(*this);
     }
 
-    void Window::call_8()
+    void Window::callHandleInputBegin()
     {
-        if (eventHandlers->event_08 == nullptr)
+        if (eventHandlers->onHandleInputBegin == nullptr)
         {
             return;
         }
 
-        eventHandlers->event_08(*this);
+        eventHandlers->onHandleInputBegin(*this);
     }
 
-    void Window::call_9()
+    void Window::callHandleInputEnd()
     {
-        if (eventHandlers->event_09 == nullptr)
+        if (eventHandlers->onHandleInputEnd == nullptr)
         {
             return;
         }
 
-        eventHandlers->event_09(*this);
+        eventHandlers->onHandleInputEnd(*this);
     }
 
     void Window::callToolUpdate(WidgetIndex_t widgetIndex, const WidgetId id, int16_t xPos, int16_t yPos)

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -937,17 +937,17 @@ namespace OpenLoco::Ui::WindowManager
         _windows.erase(_windows.begin() + index);
     }
 
-    void callEvent8OnAllWindows()
+    void callHandleInputBeginEventOnAllWindows()
     {
         std::for_each(_windows.rbegin(), _windows.rend(), [](auto& w) {
-            w.call_8();
+            w.callHandleInputBegin();
         });
     }
 
-    void callEvent9OnAllWindows()
+    void callHandleInputEndEventOnAllWindows()
     {
         std::for_each(_windows.rbegin(), _windows.rend(), [](auto& w) {
-            w.call_9();
+            w.callHandleInputEnd();
         });
     }
 

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -264,13 +264,13 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x004362F7
-        static void event_08(Window& self)
+        static void onHandleInputBegin(Window& self)
         {
             self.flags |= WindowFlags::notScrollView;
         }
 
         // 0x004362FF
-        static void event_09(Window& self)
+        static void onHandleInputEnd(Window& self)
         {
             if (!self.hasFlags(WindowFlags::notScrollView))
             {
@@ -524,8 +524,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             .onMouseUp = onMouseUp,
             .onResize = onResize,
             .onUpdate = onUpdate,
-            .event_08 = event_08,
-            .event_09 = event_09,
+            .onHandleInputBegin = onHandleInputBegin,
+            .onHandleInputEnd = onHandleInputEnd,
             .getScrollSize = getScrollSize,
             .scrollMouseDown = onScrollMouseDown,
             .scrollMouseOver = onScrollMouseOver,

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -263,29 +263,6 @@ namespace OpenLoco::Ui::Windows::CompanyList
             sortCompanyList(self);
         }
 
-        // 0x004362F7
-        static void onHandleInputBegin(Window& self)
-        {
-            self.flags |= WindowFlags::notScrollView;
-        }
-
-        // 0x004362FF
-        static void onHandleInputEnd(Window& self)
-        {
-            if (!self.hasFlags(WindowFlags::notScrollView))
-            {
-                return;
-            }
-
-            if (self.rowHover == -1)
-            {
-                return;
-            }
-
-            self.rowHover = -1;
-            self.invalidate();
-        }
-
         // 0x00436321
         static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
@@ -524,8 +501,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
             .onMouseUp = onMouseUp,
             .onResize = onResize,
             .onUpdate = onUpdate,
-            .onHandleInputBegin = onHandleInputBegin,
-            .onHandleInputEnd = onHandleInputEnd,
+            .onHandleInputBegin = listWindowOnHandleInputBegin,
+            .onHandleInputEnd = listWindowOnHandleInputEnd,
             .getScrollSize = getScrollSize,
             .scrollMouseDown = onScrollMouseDown,
             .scrollMouseOver = onScrollMouseOver,

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -498,29 +498,6 @@ namespace OpenLoco::Ui::Windows::IndustryList
             return fallback;
         }
 
-        // 0x004580DE
-        static void onHandleInputBegin(Window& self)
-        {
-            self.flags |= WindowFlags::notScrollView;
-        }
-
-        // 0x004580E6
-        static void onHandleInputEnd(Window& self)
-        {
-            if (!self.hasFlags(WindowFlags::notScrollView))
-            {
-                return;
-            }
-
-            if (self.rowHover == -1)
-            {
-                return;
-            }
-
-            self.rowHover = -1;
-            self.invalidate();
-        }
-
         // 0x00457FCA
         static void tabReset(Window& self)
         {
@@ -539,8 +516,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
         static constexpr WindowEventList kEvents = {
             .onMouseUp = onMouseUp,
             .onUpdate = onUpdate,
-            .onHandleInputBegin = onHandleInputBegin,
-            .onHandleInputEnd = onHandleInputEnd,
+            .onHandleInputBegin = listWindowOnHandleInputBegin,
+            .onHandleInputEnd = listWindowOnHandleInputEnd,
             .getScrollSize = getScrollSize,
             .scrollMouseDown = onScrollMouseDown,
             .scrollMouseOver = onScrollMouseOver,

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -499,13 +499,13 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x004580DE
-        static void event_08(Window& self)
+        static void onHandleInputBegin(Window& self)
         {
             self.flags |= WindowFlags::notScrollView;
         }
 
         // 0x004580E6
-        static void event_09(Window& self)
+        static void onHandleInputEnd(Window& self)
         {
             if (!self.hasFlags(WindowFlags::notScrollView))
             {
@@ -539,8 +539,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
         static constexpr WindowEventList kEvents = {
             .onMouseUp = onMouseUp,
             .onUpdate = onUpdate,
-            .event_08 = event_08,
-            .event_09 = event_09,
+            .onHandleInputBegin = onHandleInputBegin,
+            .onHandleInputEnd = onHandleInputEnd,
             .getScrollSize = getScrollSize,
             .scrollMouseDown = onScrollMouseDown,
             .scrollMouseOver = onScrollMouseOver,
@@ -1028,7 +1028,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458708
-        static void event_08(Window& self)
+        static void onHandleInputBegin(Window& self)
         {
             if (self.var_846 != 0xFFFF)
             {
@@ -1297,7 +1297,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
             .onMouseUp = onMouseUp,
             .onResize = onResize,
             .onUpdate = onUpdate,
-            .event_08 = event_08,
+            .onHandleInputBegin = onHandleInputBegin,
             .onToolUpdate = onToolUpdate,
             .onToolDown = onToolDown,
             .onToolAbort = onToolAbort,

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -114,29 +114,6 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             }
         }
 
-        // 0x0042A847
-        static void onHandleInputBegin(Window& self)
-        {
-            self.flags |= WindowFlags::notScrollView;
-        }
-
-        // 0x0042A84F
-        static void onHandleInputEnd(Window& self)
-        {
-            if (!self.hasFlags(WindowFlags::notScrollView))
-            {
-                return;
-            }
-
-            if (self.rowHover == -1)
-            {
-                return;
-            }
-
-            self.rowHover = -1;
-            self.invalidate();
-        }
-
         // 0x0042A871
         static void getScrollSize([[maybe_unused]] Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
@@ -297,8 +274,8 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             .onMouseUp = onMouseUp,
             .onResize = onResize,
             .onUpdate = Common::onUpdate,
-            .onHandleInputBegin = onHandleInputBegin,
-            .onHandleInputEnd = onHandleInputEnd,
+            .onHandleInputBegin = listWindowOnHandleInputBegin,
+            .onHandleInputEnd = listWindowOnHandleInputEnd,
             .getScrollSize = getScrollSize,
             .scrollMouseDown = scrollMouseDown,
             .scrollMouseOver = scrollMouseOver,

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -115,13 +115,13 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         }
 
         // 0x0042A847
-        static void event_08(Window& self)
+        static void onHandleInputBegin(Window& self)
         {
             self.flags |= WindowFlags::notScrollView;
         }
 
         // 0x0042A84F
-        static void event_09(Window& self)
+        static void onHandleInputEnd(Window& self)
         {
             if (!self.hasFlags(WindowFlags::notScrollView))
             {
@@ -297,8 +297,8 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             .onMouseUp = onMouseUp,
             .onResize = onResize,
             .onUpdate = Common::onUpdate,
-            .event_08 = event_08,
-            .event_09 = event_09,
+            .onHandleInputBegin = onHandleInputBegin,
+            .onHandleInputEnd = onHandleInputEnd,
             .getScrollSize = getScrollSize,
             .scrollMouseDown = scrollMouseDown,
             .scrollMouseOver = scrollMouseOver,

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -342,13 +342,13 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x0049196F
-    static void event_08(Window& window)
+    static void onHandleInputBegin(Window& window)
     {
         window.flags |= WindowFlags::notScrollView;
     }
 
     // 0x00491977
-    static void event_09(Window& window)
+    static void onHandleInputEnd(Window& window)
     {
         if (!window.hasFlags(WindowFlags::notScrollView))
         {
@@ -759,8 +759,8 @@ namespace OpenLoco::Ui::Windows::StationList
         .onMouseDown = onMouseDown,
         .onDropdown = onDropdown,
         .onUpdate = onUpdate,
-        .event_08 = event_08,
-        .event_09 = event_09,
+        .onHandleInputBegin = onHandleInputBegin,
+        .onHandleInputEnd = onHandleInputEnd,
         .getScrollSize = getScrollSize,
         .scrollMouseDown = onScrollMouseDown,
         .scrollMouseOver = onScrollMouseOver,

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -341,29 +341,6 @@ namespace OpenLoco::Ui::Windows::StationList
         return fallback;
     }
 
-    // 0x0049196F
-    static void onHandleInputBegin(Window& window)
-    {
-        window.flags |= WindowFlags::notScrollView;
-    }
-
-    // 0x00491977
-    static void onHandleInputEnd(Window& window)
-    {
-        if (!window.hasFlags(WindowFlags::notScrollView))
-        {
-            return;
-        }
-
-        if (window.rowHover == -1)
-        {
-            return;
-        }
-
-        window.rowHover = -1;
-        window.invalidate();
-    }
-
     // 0x00491344
     static void prepareDraw(Ui::Window& window)
     {
@@ -759,8 +736,8 @@ namespace OpenLoco::Ui::Windows::StationList
         .onMouseDown = onMouseDown,
         .onDropdown = onDropdown,
         .onUpdate = onUpdate,
-        .onHandleInputBegin = onHandleInputBegin,
-        .onHandleInputEnd = onHandleInputEnd,
+        .onHandleInputBegin = listWindowOnHandleInputBegin,
+        .onHandleInputEnd = listWindowOnHandleInputEnd,
         .getScrollSize = getScrollSize,
         .scrollMouseDown = onScrollMouseDown,
         .scrollMouseOver = onScrollMouseOver,

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -1060,12 +1060,12 @@ namespace OpenLoco::Ui::Windows::Station
             sortVehicleList(self);
         }
 
-        static void event_08(Window& self)
+        static void onHandleInputBegin(Window& self)
         {
             self.flags |= WindowFlags::notScrollView;
         }
 
-        static void event_09(Window& self)
+        static void onHandleInputEnd(Window& self)
         {
             if (self.hasFlags(WindowFlags::notScrollView))
             {
@@ -1150,8 +1150,8 @@ namespace OpenLoco::Ui::Windows::Station
             .onMouseUp = Common::onMouseUp,
             .onResize = onResize,
             .onUpdate = onUpdate,
-            .event_08 = event_08,
-            .event_09 = event_09,
+            .onHandleInputBegin = onHandleInputBegin,
+            .onHandleInputEnd = onHandleInputEnd,
             .getScrollSize = getScrollSize,
             .scrollMouseDown = onScrollMouseDown,
             .scrollMouseOver = onScrollMouseOver,

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -1060,19 +1060,6 @@ namespace OpenLoco::Ui::Windows::Station
             sortVehicleList(self);
         }
 
-        static void onHandleInputBegin(Window& self)
-        {
-            self.flags |= WindowFlags::notScrollView;
-        }
-
-        static void onHandleInputEnd(Window& self)
-        {
-            if (self.hasFlags(WindowFlags::notScrollView))
-            {
-                self.rowHover = -1;
-            }
-        }
-
         static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
             scrollHeight = self.rowCount * self.rowHeight;
@@ -1150,8 +1137,8 @@ namespace OpenLoco::Ui::Windows::Station
             .onMouseUp = Common::onMouseUp,
             .onResize = onResize,
             .onUpdate = onUpdate,
-            .onHandleInputBegin = onHandleInputBegin,
-            .onHandleInputEnd = onHandleInputEnd,
+            .onHandleInputBegin = listWindowOnHandleInputBegin,
+            .onHandleInputEnd = listWindowOnHandleInputEnd,
             .getScrollSize = getScrollSize,
             .scrollMouseDown = onScrollMouseDown,
             .scrollMouseOver = onScrollMouseOver,

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -439,7 +439,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBEDF
-        static void event_08(Window& self)
+        static void onHandleInputBegin(Window& self)
         {
             if (self.var_846 != 0xFFFFU)
             {
@@ -884,7 +884,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             .onMouseDown = onMouseDown,
             .onDropdown = onDropdown,
             .onUpdate = onUpdate,
-            .event_08 = event_08,
+            .onHandleInputBegin = onHandleInputBegin,
             .onToolUpdate = onToolUpdate,
             .onToolDown = onToolDown,
             .onToolAbort = onToolAbort,
@@ -2434,7 +2434,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC377
-        static void event_08(Window& self)
+        static void onHandleInputBegin(Window& self)
         {
             if (self.var_846 != 0xFFFFU)
             {
@@ -2724,7 +2724,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             .onMouseUp = Common::onMouseUp,
             .onResize = onResize,
             .onUpdate = onUpdate,
-            .event_08 = event_08,
+            .onHandleInputBegin = onHandleInputBegin,
             .onToolUpdate = onToolUpdate,
             .onToolDown = onToolDown,
             .onToolAbort = onToolAbort,

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -418,29 +418,6 @@ namespace OpenLoco::Ui::Windows::TownList
             sortTownList(self);
         }
 
-        // 0x0049A4D0
-        static void onHandleInputBegin(Window& self)
-        {
-            self.flags |= WindowFlags::notScrollView;
-        }
-
-        // 0x0049A4D8
-        static void onHandleInputEnd(Window& self)
-        {
-            if (!self.hasFlags(WindowFlags::notScrollView))
-            {
-                return;
-            }
-
-            if (self.rowHover == -1)
-            {
-                return;
-            }
-
-            self.rowHover = -1;
-            self.invalidate();
-        }
-
         // 0x0049A4FA
         static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
@@ -490,8 +467,8 @@ namespace OpenLoco::Ui::Windows::TownList
         static constexpr WindowEventList kEvents = {
             .onMouseUp = onMouseUp,
             .onUpdate = onUpdate,
-            .onHandleInputBegin = onHandleInputBegin,
-            .onHandleInputEnd = onHandleInputEnd,
+            .onHandleInputBegin = listWindowOnHandleInputBegin,
+            .onHandleInputEnd = listWindowOnHandleInputEnd,
             .getScrollSize = getScrollSize,
             .scrollMouseDown = onScrollMouseDown,
             .scrollMouseOver = onScrollMouseOver,

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -419,13 +419,13 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A4D0
-        static void event_08(Window& self)
+        static void onHandleInputBegin(Window& self)
         {
             self.flags |= WindowFlags::notScrollView;
         }
 
         // 0x0049A4D8
-        static void event_09(Window& self)
+        static void onHandleInputEnd(Window& self)
         {
             if (!self.hasFlags(WindowFlags::notScrollView))
             {
@@ -490,8 +490,8 @@ namespace OpenLoco::Ui::Windows::TownList
         static constexpr WindowEventList kEvents = {
             .onMouseUp = onMouseUp,
             .onUpdate = onUpdate,
-            .event_08 = event_08,
-            .event_09 = event_09,
+            .onHandleInputBegin = onHandleInputBegin,
+            .onHandleInputEnd = onHandleInputEnd,
             .getScrollSize = getScrollSize,
             .scrollMouseDown = onScrollMouseDown,
             .scrollMouseOver = onScrollMouseOver,
@@ -1395,7 +1395,7 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AEA1
-        static void event_08(Window& self)
+        static void onHandleInputBegin(Window& self)
         {
             if (self.var_846 != 0xFFFF)
             {
@@ -1507,7 +1507,7 @@ namespace OpenLoco::Ui::Windows::TownList
             .onMouseDown = onMouseDown,
             .onDropdown = onDropdown,
             .onUpdate = onUpdate,
-            .event_08 = event_08,
+            .onHandleInputBegin = onHandleInputBegin,
             .onToolUpdate = onToolUpdate,
             .onToolDown = onToolDown,
             .onToolAbort = onToolAbort,

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -198,8 +198,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void switchTab(Window& self, const WidgetIndex_t widgetIndex);
         static void setCaptionEnableState(Window& self);
         static void onPickup(Window& self, const WidgetIndex_t pickupWidx);
-        static void event8(Window& self);
-        static void event9(Window& self);
+        static void onHandleInputBegin(Window& self);
+        static void onHandleInputEnd(Window& self);
         static size_t getNumCars(Ui::Window& self);
         static void drawTabs(Window& window, Gfx::DrawingContext& drawingCtx);
         static void pickupToolUpdate(Window& self, const int16_t x, const int16_t y);
@@ -1985,8 +1985,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             .onMouseDown = onMouseDown,
             .onDropdown = onDropdown,
             .onUpdate = onUpdate,
-            .event_08 = Common::event8,
-            .event_09 = Common::event9,
+            .onHandleInputBegin = Common::onHandleInputBegin,
+            .onHandleInputEnd = Common::onHandleInputEnd,
             .onToolUpdate = onToolUpdate,
             .onToolDown = onToolDown,
             .onToolAbort = onToolAbort,
@@ -2640,8 +2640,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             .onMouseDown = onMouseDown,
             .onDropdown = onDropdown,
             .onUpdate = onUpdate,
-            .event_08 = Common::event8,
-            .event_09 = Common::event9,
+            .onHandleInputBegin = Common::onHandleInputBegin,
+            .onHandleInputEnd = Common::onHandleInputEnd,
             .getScrollSize = getScrollSize,
             .scrollMouseOver = scrollMouseOver,
             .textInput = Common::textInput,
@@ -4083,8 +4083,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             .onMouseDown = onMouseDown,
             .onDropdown = onDropdown,
             .onUpdate = onUpdate,
-            .event_08 = Common::event8,
-            .event_09 = Common::event9,
+            .onHandleInputBegin = Common::onHandleInputBegin,
+            .onHandleInputEnd = Common::onHandleInputEnd,
             .onToolDown = onToolDown,
             .onToolAbort = toolCancel,
             .toolCursor = toolCursor,
@@ -5008,13 +5008,13 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B45DD, 0x004B55A7, 0x004B3C1B
-        static void event8(Window& self)
+        static void onHandleInputBegin(Window& self)
         {
             self.flags |= WindowFlags::notScrollView;
         }
 
         // 0x004B45E5, 0x004B55B6, 0x004B3C23
-        static void event9(Window& self)
+        static void onHandleInputEnd(Window& self)
         {
             if (self.hasFlags(WindowFlags::notScrollView))
             {

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -198,8 +198,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void switchTab(Window& self, const WidgetIndex_t widgetIndex);
         static void setCaptionEnableState(Window& self);
         static void onPickup(Window& self, const WidgetIndex_t pickupWidx);
-        static void onHandleInputBegin(Window& self);
-        static void onHandleInputEnd(Window& self);
         static size_t getNumCars(Ui::Window& self);
         static void drawTabs(Window& window, Gfx::DrawingContext& drawingCtx);
         static void pickupToolUpdate(Window& self, const int16_t x, const int16_t y);
@@ -1985,8 +1983,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             .onMouseDown = onMouseDown,
             .onDropdown = onDropdown,
             .onUpdate = onUpdate,
-            .onHandleInputBegin = Common::onHandleInputBegin,
-            .onHandleInputEnd = Common::onHandleInputEnd,
+            .onHandleInputBegin = listWindowOnHandleInputBegin,
+            .onHandleInputEnd = listWindowOnHandleInputEnd,
             .onToolUpdate = onToolUpdate,
             .onToolDown = onToolDown,
             .onToolAbort = onToolAbort,
@@ -2640,8 +2638,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             .onMouseDown = onMouseDown,
             .onDropdown = onDropdown,
             .onUpdate = onUpdate,
-            .onHandleInputBegin = Common::onHandleInputBegin,
-            .onHandleInputEnd = Common::onHandleInputEnd,
+            .onHandleInputBegin = listWindowOnHandleInputBegin,
+            .onHandleInputEnd = listWindowOnHandleInputEnd,
             .getScrollSize = getScrollSize,
             .scrollMouseOver = scrollMouseOver,
             .textInput = Common::textInput,
@@ -4083,8 +4081,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             .onMouseDown = onMouseDown,
             .onDropdown = onDropdown,
             .onUpdate = onUpdate,
-            .onHandleInputBegin = Common::onHandleInputBegin,
-            .onHandleInputEnd = Common::onHandleInputEnd,
+            .onHandleInputBegin = listWindowOnHandleInputBegin,
+            .onHandleInputEnd = listWindowOnHandleInputEnd,
             .onToolDown = onToolDown,
             .onToolAbort = toolCancel,
             .toolCursor = toolCursor,
@@ -5004,25 +5002,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
             if (head->owner != CompanyManager::getControllingId())
             {
                 self.disabledWidgets |= (1ULL << widx::caption);
-            }
-        }
-
-        // 0x004B45DD, 0x004B55A7, 0x004B3C1B
-        static void onHandleInputBegin(Window& self)
-        {
-            self.flags |= WindowFlags::notScrollView;
-        }
-
-        // 0x004B45E5, 0x004B55B6, 0x004B3C23
-        static void onHandleInputEnd(Window& self)
-        {
-            if (self.hasFlags(WindowFlags::notScrollView))
-            {
-                if (self.rowHover != -1)
-                {
-                    self.rowHover = -1;
-                    self.invalidate();
-                }
             }
         }
 

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -905,13 +905,13 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C2640
-    static void event_08(Window& self)
+    static void onHandleInputBegin(Window& self)
     {
         self.flags |= WindowFlags::notScrollView;
     }
 
     // 0x004C2648
-    static void event_09(Window& self)
+    static void onHandleInputEnd(Window& self)
     {
         if (self.hasFlags(WindowFlags::notScrollView))
         {
@@ -1157,8 +1157,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
         .onMouseDown = onMouseDown,
         .onDropdown = onDropdown,
         .onUpdate = onUpdate,
-        .event_08 = event_08,
-        .event_09 = event_09,
+        .onHandleInputBegin = onHandleInputBegin,
+        .onHandleInputEnd = onHandleInputEnd,
         .getScrollSize = getScrollSize,
         .scrollMouseDown = onScrollMouseDown,
         .scrollMouseOver = onScrollMouseOver,

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -904,21 +904,6 @@ namespace OpenLoco::Ui::Windows::VehicleList
         sortVehicleList(self);
     }
 
-    // 0x004C2640
-    static void onHandleInputBegin(Window& self)
-    {
-        self.flags |= WindowFlags::notScrollView;
-    }
-
-    // 0x004C2648
-    static void onHandleInputEnd(Window& self)
-    {
-        if (self.hasFlags(WindowFlags::notScrollView))
-        {
-            self.rowHover = -1;
-        }
-    }
-
     // 0x004C265B
     static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
     {
@@ -1157,8 +1142,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
         .onMouseDown = onMouseDown,
         .onDropdown = onDropdown,
         .onUpdate = onUpdate,
-        .onHandleInputBegin = onHandleInputBegin,
-        .onHandleInputEnd = onHandleInputEnd,
+        .onHandleInputBegin = listWindowOnHandleInputBegin,
+        .onHandleInputEnd = listWindowOnHandleInputEnd,
         .getScrollSize = getScrollSize,
         .scrollMouseDown = onScrollMouseDown,
         .scrollMouseOver = onScrollMouseOver,


### PR DESCRIPTION
This PR proposes the following refactor changes:
1. Name window events:
    - event 8 → onHandleInputBegin
    - event 9 → onHandleInputEnd
2. De-duplicate code in "list" windows (as their code for these events were essentially identical)
    - VehicleList and StationWindow windows may have slightly different behaviour: they previously did not get invalidated in event 9/onHandleInputEnd. A quick playtest did not reveal any player-visible change however.