### PR TITLE
Include cstring in FormatArguments.hpp

### DIFF
--- a/src/OpenLoco/include/OpenLoco/Localisation/FormatArguments.hpp
+++ b/src/OpenLoco/include/OpenLoco/Localisation/FormatArguments.hpp
@@ -2,6 +2,7 @@
 
 #include <OpenLoco/Core/Exception.hpp>
 #include <array>
+#include <cstring>
 #include <sfl/small_vector.hpp>
 
 namespace OpenLoco


### PR DESCRIPTION
Fixes warning-turned-error on GCC 16.