### PR TITLE
Fix assertion when removing track ahead of a vehicle

### DIFF
--- a/src/OpenLoco/include/OpenLoco/Vehicles/Vehicle.h
+++ b/src/OpenLoco/include/OpenLoco/Vehicles/Vehicle.h
@@ -212,6 +212,7 @@ namespace OpenLoco::Vehicles
     };
 
     void setSignalState(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint8_t trackType, uint32_t flags);
+    void clearSignalStateIfPresent(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint8_t trackType);
     SignalStateFlags getSignalState(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint8_t trackType, uint32_t flags);
     void sub_4A2AD7(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const CompanyId company, const uint8_t trackType);
     void setReverseSignalOccupiedInBlock(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const CompanyId company, const uint8_t trackType);

--- a/src/OpenLoco/src/Vehicles/Routing.cpp
+++ b/src/OpenLoco/src/Vehicles/Routing.cpp
@@ -307,7 +307,7 @@ namespace OpenLoco::Vehicles
     }
 
     // 0x0048963F
-    void setSignalState(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint8_t trackType, uint32_t flags)
+    static void setSignalStateInternal(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint8_t trackType, uint32_t flags, const bool tolerateMissingTrack)
     {
         const auto unk1 = flags & 0xFFFF;
         assert(unk1 != 10); // Only happens if wrong function was called call getSignalState
@@ -332,7 +332,11 @@ namespace OpenLoco::Vehicles
 
             if (!res)
             {
-                // The track may have been removed while a vehicle is still routing over it.
+                if (!tolerateMissingTrack)
+                {
+                    // This shouldn't happen I think. Either way useful in debug to know.
+                    assert(false);
+                }
                 return;
             }
 
@@ -417,6 +421,16 @@ namespace OpenLoco::Vehicles
                 }
             }
         }
+    }
+
+    void setSignalState(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint8_t trackType, uint32_t flags)
+    {
+        setSignalStateInternal(loc, trackAndDirection, trackType, flags, false);
+    }
+
+    void clearSignalStateIfPresent(const World::Pos3& loc, const TrackAndDirection::_TrackAndDirection trackAndDirection, const uint8_t trackType)
+    {
+        setSignalStateInternal(loc, trackAndDirection, trackType, 0, true);
     }
 
     // 0x004A2AF0

--- a/src/OpenLoco/src/Vehicles/Routing.cpp
+++ b/src/OpenLoco/src/Vehicles/Routing.cpp
@@ -332,8 +332,7 @@ namespace OpenLoco::Vehicles
 
             if (!res)
             {
-                // This shouldn't happen I think. Either way useful in debug to know.
-                assert(false);
+                // The track may have been removed while a vehicle is still routing over it.
                 return;
             }
 

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -3990,7 +3990,7 @@ namespace OpenLoco::Vehicles
                 {
                     if (hasSignal)
                     {
-                        setSignalState(pos, tad, trackObjId, 0);
+                        clearSignalStateIfPresent(pos, tad, trackObjId);
                     }
                     leaveLevelCrossing(pos, tad, 9);
                 }
@@ -6207,7 +6207,7 @@ namespace OpenLoco::Vehicles
             {
                 if (hasSignal)
                 {
-                    setSignalState(pos, tad, trackObjId, 0);
+                    clearSignalStateIfPresent(pos, tad, trackObjId);
                 }
                 leaveLevelCrossing(pos, tad, 9);
             }
@@ -6464,7 +6464,7 @@ namespace OpenLoco::Vehicles
                 tad._data = routing & World::Track::AdditionalTaDFlags::basicTaDMask;
                 if (routing & World::Track::AdditionalTaDFlags::hasSignal)
                 {
-                    setSignalState(routingPos, tad, train.tail->trackType, 0);
+                    clearSignalStateIfPresent(routingPos, tad, train.tail->trackType);
                 }
                 routingPos += World::TrackData::getUnkTrack(tad._data).pos;
             }


### PR DESCRIPTION
## Summary

I handle the case where track is removed while a vehicle is still routing over it. When the signal lookup no longer finds that track, I return without triggering the debug assertion.

## Validation

- `cmake --preset posix -DOPENLOCO_BUILD_TESTS=OFF` (with user-local dependencies)
- `ninja -C build/posix src/OpenLoco/CMakeFiles/OpenLoco.dir/Debug/src/Vehicles/Routing.cpp.o`
- `clang-format 18.1.8 --dry-run --Werror src/OpenLoco/src/Vehicles/Routing.cpp`
- `git diff HEAD^ --check`

I deferred the full application build and test suite to CI.

Fixes #3747
