### PR TITLE
Fix unchecking "Play Music" from the top toolbar not invalidating Jukebox window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Feature: [#3569] Add a "home" button to the browse prompt window.
 - Feature: [#3768] Add tab to town window to show delivered cargo last month.
 - Change: [#3740] Options that interfere with tutorial operation are temporarily disabled options during playback.
+- Fix: [#3776] Unchecking "Play Music" from the top toolbar does not invalidate Jukebox window.
 - Fix: [#3790] Some windows (e.g. town population) don't have a window resize handle in the bottom-right corner.
 
 26.05 (2026-05-30)

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -322,7 +322,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                     Jukebox::enableMusic();
                 }
 
-                WindowManager::invalidate(WindowType::musicSelection);
+                WindowManager::invalidate(WindowType::musicJukebox);
                 break;
             }
 


### PR DESCRIPTION
Fixes #3776

There is no reason to invalidate the Music Selection window.