### PR TITLE
Fix #3792: Resolve shortcut bindings at input layer not config

### DIFF
--- a/src/OpenLoco/include/OpenLoco/Config.h
+++ b/src/OpenLoco/include/OpenLoco/Config.h
@@ -3,7 +3,6 @@
 #include "Input.h"
 #include "Objects/Object.h"
 #include <OpenLoco/Core/EnumFlags.hpp>
-#include <OpenLoco/Engine/Input/ShortcutManager.h>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -136,12 +135,6 @@ namespace OpenLoco::Config
         Playlist customJukebox;
     };
 
-    struct KeyboardShortcut
-    {
-        uint32_t keyCode;
-        Input::KeyModifier modifiers;
-    };
-
     struct Network
     {
         bool enabled{};
@@ -219,13 +212,11 @@ namespace OpenLoco::Config
 
         int32_t scenarioSelectedTab;
 
-        std::map<Input::Shortcut, KeyboardShortcut> shortcuts;
+        std::map<std::string, std::string> shortcuts;
     };
 
     Config& get();
 
     Config& read();
     void write();
-
-    void resetShortcuts();
 }

--- a/src/OpenLoco/include/OpenLoco/ConfigConvert.hpp
+++ b/src/OpenLoco/include/OpenLoco/ConfigConvert.hpp
@@ -1,10 +1,8 @@
 #pragma once
 
 #include "Config.h"
-#include "Input.h"
 #include "Objects/Object.h"
 #include <OpenLoco/Engine/Types.hpp>
-#include <SDL3/SDL_keyboard.h>
 #include <yaml-cpp/yaml.h>
 
 #define enum_def(x, y) \
@@ -15,7 +13,6 @@
 namespace YAML
 {
     using namespace OpenLoco::Config;
-    using namespace OpenLoco::Input;
 
     template<typename T>
     using convert_pair_vector = std::vector<std::pair<T, const char*>>;
@@ -50,86 +47,6 @@ namespace YAML
                 }
             }
             return false;
-        }
-    };
-
-    // Keyboard shortcuts
-    template<>
-    struct convert<KeyboardShortcut>
-    {
-        static constexpr char kDelimiter = '+';
-
-        static Node encode(const KeyboardShortcut& rhs)
-        {
-            std::string keyName = "";
-            if (rhs.keyCode == 0xFFFFFFFF)
-            {
-                return Node(keyName);
-            }
-
-            if ((rhs.modifiers & KeyModifier::shift) != KeyModifier::none)
-            {
-                keyName += SDL_GetKeyName(SDLK_LSHIFT);
-                keyName += kDelimiter;
-            }
-            if ((rhs.modifiers & KeyModifier::control) != KeyModifier::none)
-            {
-                keyName += SDL_GetKeyName(SDLK_LCTRL);
-                keyName += kDelimiter;
-            }
-            if ((rhs.modifiers & KeyModifier::unknown) != KeyModifier::none)
-            {
-                keyName += SDL_GetKeyName(SDLK_LGUI);
-                keyName += kDelimiter;
-            }
-
-            keyName += SDL_GetKeyName(rhs.keyCode);
-            return Node(keyName);
-        }
-
-        static bool decode(const Node& node, KeyboardShortcut& rhs)
-        {
-            auto s = node.as<std::string>();
-            if (s.empty())
-            {
-                rhs.keyCode = 0xFFFFFFFF;
-                rhs.modifiers = KeyModifier::invalid;
-                return true;
-            }
-
-            rhs.modifiers = KeyModifier::none;
-            std::size_t current = 0;
-            std::size_t pos = s.find_first_of(kDelimiter, 0);
-            std::string token = s;
-
-            while (pos != std::string::npos)
-            {
-                token = s.substr(current, pos);
-                current = pos + 1;
-                pos = s.find_first_of(kDelimiter, current);
-
-                SDL_Keycode keyCode = SDL_GetKeyFromName(token.c_str());
-
-                // Check against known modifiers
-                if (keyCode == SDLK_LSHIFT || keyCode == SDLK_RSHIFT)
-                {
-                    rhs.modifiers |= KeyModifier::shift;
-                }
-                else if (keyCode == SDLK_LCTRL || keyCode == SDLK_RCTRL)
-                {
-                    rhs.modifiers |= KeyModifier::control;
-                }
-                else if (keyCode == SDLK_LGUI || keyCode == SDLK_RGUI)
-                {
-                    rhs.modifiers |= KeyModifier::unknown;
-                }
-            }
-
-            token = s.substr(current);
-            SDL_Keycode keyCode = SDL_GetKeyFromName(token.c_str());
-            rhs.keyCode = keyCode;
-
-            return true;
         }
     };
 

--- a/src/OpenLoco/include/OpenLoco/Input/Shortcuts.h
+++ b/src/OpenLoco/include/OpenLoco/Input/Shortcuts.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Input.h"
 #include <cstdint>
 
 namespace OpenLoco::Input
@@ -62,8 +63,24 @@ namespace OpenLoco::Input
         openDebugWindow,
     };
 
+    constexpr uint32_t kInvalidKeyCode = 0xFFFFFFFF;
+
+    struct KeyboardBinding
+    {
+        uint32_t keyCode = kInvalidKeyCode;
+        KeyModifier modifiers = KeyModifier::invalid;
+    };
+
     namespace Shortcuts
     {
         void initialize();
+
+        void loadBindings();
+
+        void resetBindings();
+
+        const KeyboardBinding& getBinding(Shortcut id);
+
+        void setBinding(Shortcut id, uint32_t keyCode, KeyModifier modifiers);
     }
 }

--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -3,7 +3,6 @@
 #include "Environment.h"
 #include <Message.h>
 #include <OpenLoco/Core/FileSystem.hpp>
-#include <OpenLoco/Engine/Input/ShortcutManager.h>
 #include <fstream>
 #include <locale>
 #include <yaml-cpp/yaml.h>
@@ -22,19 +21,17 @@ namespace OpenLoco::Config
 
     static void readShortcutConfig(const YAML::Node& scNode)
     {
-        const auto& shortcutDefs = Input::ShortcutManager::getList();
         auto& shortcuts = _config.shortcuts;
-        for (const auto& def : shortcutDefs)
+        shortcuts.clear();
+
+        if (!scNode.IsMap())
         {
-            auto node = scNode[def.configName];
-            if (node)
-            {
-                shortcuts[def.id] = node.as<KeyboardShortcut>();
-            }
-            else
-            {
-                shortcuts[def.id] = YAML::Node(def.defaultBinding).as<KeyboardShortcut>();
-            }
+            return;
+        }
+
+        for (const auto& entry : scNode)
+        {
+            shortcuts[entry.first.as<std::string>()] = entry.second.as<std::string>("");
         }
     }
 
@@ -333,20 +330,10 @@ namespace OpenLoco::Config
         node["usePreferredCompanyName"] = _config.usePreferredCompanyName;
 
         // Shortcuts
-        const auto& shortcuts = _config.shortcuts;
-        const auto& shortcutDefs = Input::ShortcutManager::getList();
         auto scNode = node["shortcuts"];
-        for (const auto& def : shortcutDefs)
+        for (const auto& [configName, binding] : _config.shortcuts)
         {
-            auto it = shortcuts.find(def.id);
-            if (it != std::end(shortcuts))
-            {
-                scNode[def.configName] = it->second;
-            }
-            else
-            {
-                scNode[def.configName] = "";
-            }
+            scNode[configName] = binding;
         }
         node["shortcuts"] = scNode;
 
@@ -360,21 +347,5 @@ namespace OpenLoco::Config
         }
 
         std::locale::global(backupLocale);
-    }
-
-    // 0x004BE3F3
-    void resetShortcuts()
-    {
-        const auto& shortcutDefs = Input::ShortcutManager::getList();
-
-        auto& shortcuts = _config.shortcuts;
-        shortcuts.clear();
-
-        for (const auto& def : shortcutDefs)
-        {
-            shortcuts[def.id] = YAML::Node(def.defaultBinding).as<KeyboardShortcut>();
-        }
-
-        write();
     }
 }

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -253,8 +253,8 @@ namespace OpenLoco::Input
 
     static bool tryShortcut(Shortcut sc, uint32_t keyCode, KeyModifier modifiers)
     {
-        auto cfg = OpenLoco::Config::get();
-        if (cfg.shortcuts[sc].keyCode == keyCode && cfg.shortcuts[sc].modifiers == modifiers)
+        const auto& binding = Shortcuts::getBinding(sc);
+        if (binding.keyCode == keyCode && binding.modifiers == modifiers)
         {
             ShortcutManager::execute(sc);
             return true;

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -1,4 +1,5 @@
 #include "Input/Shortcuts.h"
+#include "Config.h"
 #include "GameCommands/GameCommands.h"
 #include "GameCommands/General/SetGameSpeed.h"
 #include "GameCommands/General/TogglePause.h"
@@ -16,8 +17,11 @@
 #include "World/StationManager.h"
 #include "World/TownManager.h"
 #include <OpenLoco/Engine/Input/ShortcutManager.h>
+#include <SDL3/SDL_keyboard.h>
 #include <array>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 using namespace OpenLoco::Ui;
 
@@ -740,5 +744,157 @@ namespace OpenLoco::Input::Shortcuts
         ShortcutManager::add(Shortcut::gameSpeedExtraFastForward,       StringIds::shortcut_game_speed_extra_fast_forward,      gameSpeedExtraFastForward,      "gameSpeedExtraFastForward",        "");
         ShortcutManager::add(Shortcut::openDebugWindow,                 StringIds::empty,                                       openDebugWindow,                "openDebugWindow",                  "F10");
         // clang-format on
+
+        loadBindings();
+    }
+
+    static constexpr char kBindingDelimiter = '+';
+
+    static std::vector<KeyboardBinding> _bindings;
+
+    static KeyboardBinding parseBinding(const std::string& binding)
+    {
+        if (binding.empty())
+        {
+            return KeyboardBinding{ kInvalidKeyCode, KeyModifier::invalid };
+        }
+
+        KeyboardBinding res{ kInvalidKeyCode, KeyModifier::none };
+
+        std::size_t current = 0;
+        std::size_t pos = binding.find_first_of(kBindingDelimiter, 0);
+        while (pos != std::string::npos)
+        {
+            const auto token = binding.substr(current, pos - current);
+            current = pos + 1;
+            pos = binding.find_first_of(kBindingDelimiter, current);
+
+            const auto keyCode = SDL_GetKeyFromName(token.c_str());
+
+            // Check against known modifiers
+            if (keyCode == SDLK_LSHIFT || keyCode == SDLK_RSHIFT)
+            {
+                res.modifiers |= KeyModifier::shift;
+            }
+            else if (keyCode == SDLK_LCTRL || keyCode == SDLK_RCTRL)
+            {
+                res.modifiers |= KeyModifier::control;
+            }
+            else if (keyCode == SDLK_LGUI || keyCode == SDLK_RGUI)
+            {
+                res.modifiers |= KeyModifier::unknown;
+            }
+        }
+
+        res.keyCode = SDL_GetKeyFromName(binding.substr(current).c_str());
+
+        return res;
+    }
+
+    static std::string formatBinding(const KeyboardBinding& binding)
+    {
+        if (binding.keyCode == kInvalidKeyCode || binding.modifiers == KeyModifier::invalid)
+        {
+            return {};
+        }
+
+        std::string keyName;
+        if ((binding.modifiers & KeyModifier::shift) != KeyModifier::none)
+        {
+            keyName += SDL_GetKeyName(SDLK_LSHIFT);
+            keyName += kBindingDelimiter;
+        }
+        if ((binding.modifiers & KeyModifier::control) != KeyModifier::none)
+        {
+            keyName += SDL_GetKeyName(SDLK_LCTRL);
+            keyName += kBindingDelimiter;
+        }
+        if ((binding.modifiers & KeyModifier::unknown) != KeyModifier::none)
+        {
+            keyName += SDL_GetKeyName(SDLK_LGUI);
+            keyName += kBindingDelimiter;
+        }
+
+        keyName += SDL_GetKeyName(binding.keyCode);
+
+        return keyName;
+    }
+
+    void loadBindings()
+    {
+        const auto& shortcutDefs = ShortcutManager::getList();
+        if (shortcutDefs.empty())
+        {
+            _bindings.clear();
+            return;
+        }
+
+        auto& configShortcuts = Config::get().shortcuts;
+
+        _bindings.assign(enumValue(shortcutDefs.back().id) + 1, KeyboardBinding{});
+        for (const auto& def : shortcutDefs)
+        {
+            auto it = configShortcuts.find(def.configName);
+            if (it == std::end(configShortcuts))
+            {
+                it = configShortcuts.emplace(def.configName, def.defaultBinding).first;
+            }
+
+            _bindings[enumValue(def.id)] = parseBinding(it->second);
+        }
+    }
+
+    // 0x004BE3F3
+    void resetBindings()
+    {
+        auto& configShortcuts = Config::get().shortcuts;
+
+        for (const auto& def : ShortcutManager::getList())
+        {
+            configShortcuts[def.configName] = def.defaultBinding;
+            _bindings[enumValue(def.id)] = parseBinding(def.defaultBinding);
+        }
+
+        Config::write();
+    }
+
+    const KeyboardBinding& getBinding(Shortcut id)
+    {
+        static constexpr KeyboardBinding kUnbound{};
+
+        const auto index = enumValue(id);
+        if (index >= _bindings.size())
+        {
+            return kUnbound;
+        }
+
+        return _bindings[index];
+    }
+
+    void setBinding(Shortcut id, uint32_t keyCode, KeyModifier modifiers)
+    {
+        auto& configShortcuts = Config::get().shortcuts;
+
+        for (const auto& def : ShortcutManager::getList())
+        {
+            auto& binding = _bindings[enumValue(def.id)];
+            if (def.id == id)
+            {
+                binding = KeyboardBinding{ keyCode, modifiers };
+            }
+            else if (binding.keyCode == keyCode && binding.modifiers == modifiers)
+            {
+                // Unbind any shortcut that is already using this keycode.
+                binding = KeyboardBinding{};
+            }
+            else
+            {
+                continue;
+            }
+
+            configShortcuts[def.configName] = formatBinding(binding);
+        }
+
+        Config::write();
     }
 }

--- a/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
+++ b/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
@@ -1,4 +1,3 @@
-#include "Config.h"
 #include "Graphics/Colour.h"
 #include "Graphics/ImageIds.h"
 #include "Graphics/TextRenderer.h"
@@ -92,26 +91,10 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
             return;
         }
 
-        auto& cfg = Config::get();
-
-        // Unbind any shortcuts that may be using the current keycode.
-        for (auto& [id, shortcut] : cfg.shortcuts)
-        {
-            if (shortcut.keyCode == keyCode && shortcut.modifiers == Input::getKeyModifier())
-            {
-                shortcut.keyCode = 0xFFFFFFFF;
-                shortcut.modifiers = KeyModifier::invalid;
-            }
-        }
-
-        // Assign this keybinding to the shortcut we're currently rebinding.
-        auto& shortcut = cfg.shortcuts.at(static_cast<Input::Shortcut>(_editingShortcutIndex));
-        shortcut.keyCode = keyCode;
-        shortcut.modifiers = Input::getKeyModifier();
+        Input::Shortcuts::setBinding(static_cast<Input::Shortcut>(_editingShortcutIndex), keyCode, Input::getKeyModifier());
 
         WindowManager::close(WindowType::editKeyboardShortcut);
         WindowManager::invalidate(WindowType::keyboardShortcuts);
-        Config::write();
     }
 
     // 0x004BE8DF

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -1,8 +1,8 @@
-#include "Config.h"
 #include "Graphics/Colour.h"
 #include "Graphics/ImageIds.h"
 #include "Graphics/RenderTarget.h"
 #include "Graphics/TextRenderer.h"
+#include "Input/Shortcuts.h"
 #include "Localisation/FormatArguments.hpp"
 #include "Localisation/Formatting.h"
 #include "Localisation/StringIds.h"
@@ -151,7 +151,6 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
         drawingCtx.clearSingle(shade);
 
         const auto& shortcutDefs = ShortcutManager::getList();
-        const auto& shortcuts = Config::get().shortcuts;
         auto yPos = 0;
         for (auto i = 0; i < self.rowCount; i++)
         {
@@ -177,20 +176,21 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
             char buffer[128]{};
 
             const auto& def = shortcutDefs[i];
-            auto& shortcut = shortcuts.at(def.id);
-            if (shortcut.keyCode != 0xFFFFFFFF && shortcut.modifiers != KeyModifier::invalid)
+            const auto& binding = Input::Shortcuts::getBinding(def.id);
+
+            if (binding.keyCode != kInvalidKeyCode && binding.modifiers != KeyModifier::invalid)
             {
-                if ((shortcut.modifiers & KeyModifier::shift) == KeyModifier::shift)
+                if ((binding.modifiers & KeyModifier::shift) == KeyModifier::shift)
                 {
                     modifierStringId = StringIds::keyboard_shortcut_modifier_shift;
                 }
-                else if ((shortcut.modifiers & KeyModifier::control) == KeyModifier::control)
+                else if ((binding.modifiers & KeyModifier::control) == KeyModifier::control)
                 {
                     modifierStringId = StringIds::keyboard_shortcut_modifier_ctrl;
                 }
 
                 baseStringId = StringIds::stringptr;
-                getBindingString(shortcut.keyCode, buffer, std::size(buffer));
+                getBindingString(binding.keyCode, buffer, std::size(buffer));
             }
 
             FormatArguments formatter{};
@@ -224,7 +224,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     // 0x004BE832
     static void resetShortcuts(Window* self)
     {
-        Config::resetShortcuts();
+        Input::Shortcuts::resetBindings();
         self->invalidate();
     }
 


### PR DESCRIPTION
The config now remains just a config holding the strings and resolving bindings is now done at the input layer, this cuts the dependency of config and registered shortcuts.

Closes #3792