### PR TITLE
Shortcut improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#3569] Add a "home" button to the browse prompt window.
 - Feature: [#3768] Add tab to town window to show delivered cargo last month.
+- Feature: [#3805] Keyboard shortcuts can now combine multiple modifiers, including left and right Ctrl and Alt.
 - Change: [#3740] Options that interfere with tutorial operation are temporarily disabled options during playback.
 - Fix: [#3776] Unchecking "Play Music" from the top toolbar does not invalidate Jukebox window.
 - Fix: [#3790] Some windows (e.g. town population) don't have a window resize handle in the bottom-right corner.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -1023,7 +1023,7 @@ strings:
   997: "SHIFT + "
   998: "CTRL + "
   999: Change Keyboard Shortcut
-  1000: "{COLOUR WINDOW_2}Press new shortcut key for:{NEWLINE}{NEWLINE_SMALLER}{COLOUR BLACK}“{STRINGID}”"
+  1000: "{COLOUR WINDOW_2}Press new shortcut key for:"
   1001: "{SMALLFONT}{COLOUR BLACK}Click on shortcut description to select new key"
   1002: Scroll View when Pointer at Screen Edge
   1003: "{SMALLFONT}{COLOUR BLACK}Select whether to scroll the view when the mouse pointer is at the screen edge"
@@ -2503,4 +2503,5 @@ strings:
   2448: "ALT + "
   2449: "R.CTRL + "
   2450: "R.ALT + "
-  2451: "{STRINGID}{STRINGID}"
+  2451: "{STRINGID}{STRINGID}{STRINGID}{STRINGID}{STRINGID}"
+  2452: "{COLOUR BLACK}“{STRINGID}”"

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2500,3 +2500,7 @@ strings:
   2445: "{STRINGID} has no nearby transit companies"
   2446: "{STRINGID} has not received any deliveries last month"
   2447: "{SMALLFONT}{COLOUR BLACK}Navigate back to the home folder for this item type"
+  2448: "ALT + "
+  2449: "R.CTRL + "
+  2450: "R.ALT + "
+  2451: "{STRINGID}{STRINGID}"

--- a/src/OpenLoco/include/OpenLoco/Input.h
+++ b/src/OpenLoco/include/OpenLoco/Input.h
@@ -49,10 +49,16 @@ namespace OpenLoco::Input
     {
         none = 0U,
         shift = 1U << 0,
-        control = 1U << 1,
+        leftControl = 1U << 1,
         unknown = 1U << 2,
+        leftAlt = 1U << 3,
+        rightControl = 1U << 4,
+        rightAlt = 1U << 5,
         cheat = 1U << 7,
         invalid = 0xFF,
+
+        control = leftControl | rightControl,
+        alt = leftAlt | rightAlt,
     };
     OPENLOCO_ENABLE_ENUM_OPERATORS(KeyModifier);
 

--- a/src/OpenLoco/include/OpenLoco/Input/Shortcuts.h
+++ b/src/OpenLoco/include/OpenLoco/Input/Shortcuts.h
@@ -3,6 +3,11 @@
 #include "Input.h"
 #include <cstdint>
 
+namespace OpenLoco
+{
+    class FormatArguments;
+}
+
 namespace OpenLoco::Input
 {
     enum class Shortcut : uint32_t
@@ -82,5 +87,7 @@ namespace OpenLoco::Input
         const KeyboardBinding& getBinding(Shortcut id);
 
         void setBinding(Shortcut id, uint32_t keyCode, KeyModifier modifiers);
+
+        void pushModifierStrings(FormatArguments& formatter, KeyModifier modifiers);
     }
 }

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -2164,7 +2164,8 @@ namespace OpenLoco::StringIds
     constexpr StringId keyboard_shortcut_modifier_alt = 2448;
     constexpr StringId keyboard_shortcut_modifier_right_ctrl = 2449;
     constexpr StringId keyboard_shortcut_modifier_right_alt = 2450;
-    constexpr StringId keyboard_shortcut_modifier_pair = 2451;
+    constexpr StringId keyboard_shortcut_modifiers = 2451;
+    constexpr StringId black_quoted_stringid = 2452;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -2161,6 +2161,10 @@ namespace OpenLoco::StringIds
     constexpr StringId town_not_served = 2445;
     constexpr StringId town_no_deliveries = 2446;
     constexpr StringId window_browse_home_folder_tooltip = 2447;
+    constexpr StringId keyboard_shortcut_modifier_alt = 2448;
+    constexpr StringId keyboard_shortcut_modifier_right_ctrl = 2449;
+    constexpr StringId keyboard_shortcut_modifier_right_alt = 2450;
+    constexpr StringId keyboard_shortcut_modifier_pair = 2451;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -254,7 +254,7 @@ namespace OpenLoco::Input
     static bool tryShortcut(Shortcut sc, uint32_t keyCode, KeyModifier modifiers)
     {
         const auto& binding = Shortcuts::getBinding(sc);
-        if (binding.keyCode == keyCode && binding.modifiers == modifiers)
+        if (binding.keyCode == keyCode && binding.modifiers == (modifiers & ~KeyModifier::cheat))
         {
             ShortcutManager::execute(sc);
             return true;
@@ -332,6 +332,11 @@ namespace OpenLoco::Input
                 continue;
             }
 
+            if (nextKey->keyCode == SDLK_LALT || nextKey->keyCode == SDLK_RALT)
+            {
+                continue;
+            }
+
             if (hasKeyModifier(KeyModifier::cheat))
             {
                 if (nextKey->charCode >= 'a' && nextKey->charCode <= 'z')
@@ -344,7 +349,10 @@ namespace OpenLoco::Input
                     _cheatBuffer += nextKey->charCode;
                 }
 
-                continue;
+                if ((_keyModifier & KeyModifier::alt) == KeyModifier::none)
+                {
+                    continue;
+                }
             }
 
             if (WindowManager::callKeyUpEventBackToFront(nextKey->charCode, nextKey->keyCode))
@@ -561,7 +569,7 @@ namespace OpenLoco::Input
         handleScreenshotCountdown();
         edgeScroll();
 
-        _keyModifier = _keyModifier & ~(KeyModifier::shift | KeyModifier::control | KeyModifier::unknown);
+        _keyModifier = _keyModifier & ~(KeyModifier::shift | KeyModifier::control | KeyModifier::alt | KeyModifier::unknown);
 
         if (!_hasKeyboardState)
         {
@@ -580,12 +588,22 @@ namespace OpenLoco::Input
 
         if (_keyboardState[SDL_SCANCODE_LCTRL])
         {
-            _keyModifier |= KeyModifier::control;
+            _keyModifier |= KeyModifier::leftControl;
         }
 
         if (_keyboardState[SDL_SCANCODE_RCTRL])
         {
-            _keyModifier |= KeyModifier::control;
+            _keyModifier |= KeyModifier::rightControl;
+        }
+
+        if (_keyboardState[SDL_SCANCODE_LALT])
+        {
+            _keyModifier |= KeyModifier::leftAlt;
+        }
+
+        if (_keyboardState[SDL_SCANCODE_RALT])
+        {
+            _keyModifier |= KeyModifier::rightAlt;
         }
 
         keyScroll();

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -5,6 +5,7 @@
 #include "GameCommands/General/TogglePause.h"
 #include "GameState.h"
 #include "Input.h"
+#include "Localisation/FormatArguments.hpp"
 #include "Localisation/StringIds.h"
 #include "Scenario/ScenarioOptions.h"
 #include "SceneManager.h"
@@ -18,9 +19,9 @@
 #include "World/TownManager.h"
 #include <OpenLoco/Engine/Input/ShortcutManager.h>
 #include <SDL3/SDL_keyboard.h>
-#include <array>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 using namespace OpenLoco::Ui;
@@ -883,6 +884,24 @@ namespace OpenLoco::Input::Shortcuts
         }
 
         Config::write();
+    }
+
+    void pushModifierStrings(FormatArguments& formatter, KeyModifier modifiers)
+    {
+        static constexpr std::pair<KeyModifier, StringId> kModifierStrings[] = {
+            { KeyModifier::leftControl, StringIds::keyboard_shortcut_modifier_ctrl },
+            { KeyModifier::rightControl, StringIds::keyboard_shortcut_modifier_right_ctrl },
+            { KeyModifier::shift, StringIds::keyboard_shortcut_modifier_shift },
+            { KeyModifier::leftAlt, StringIds::keyboard_shortcut_modifier_alt },
+            { KeyModifier::rightAlt, StringIds::keyboard_shortcut_modifier_right_alt },
+        };
+
+        formatter.push(StringIds::keyboard_shortcut_modifiers);
+
+        for (const auto& [modifier, stringId] : kModifierStrings)
+        {
+            formatter.push((modifiers & modifier) != KeyModifier::none ? stringId : StringIds::empty);
+        }
     }
 
     const KeyboardBinding& getBinding(Shortcut id)

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -776,9 +776,21 @@ namespace OpenLoco::Input::Shortcuts
             {
                 res.modifiers |= KeyModifier::shift;
             }
-            else if (keyCode == SDLK_LCTRL || keyCode == SDLK_RCTRL)
+            else if (keyCode == SDLK_LCTRL)
             {
-                res.modifiers |= KeyModifier::control;
+                res.modifiers |= KeyModifier::leftControl;
+            }
+            else if (keyCode == SDLK_RCTRL)
+            {
+                res.modifiers |= KeyModifier::rightControl;
+            }
+            else if (keyCode == SDLK_LALT)
+            {
+                res.modifiers |= KeyModifier::leftAlt;
+            }
+            else if (keyCode == SDLK_RALT)
+            {
+                res.modifiers |= KeyModifier::rightAlt;
             }
             else if (keyCode == SDLK_LGUI || keyCode == SDLK_RGUI)
             {
@@ -804,9 +816,24 @@ namespace OpenLoco::Input::Shortcuts
             keyName += SDL_GetKeyName(SDLK_LSHIFT);
             keyName += kBindingDelimiter;
         }
-        if ((binding.modifiers & KeyModifier::control) != KeyModifier::none)
+        if ((binding.modifiers & KeyModifier::leftControl) != KeyModifier::none)
         {
             keyName += SDL_GetKeyName(SDLK_LCTRL);
+            keyName += kBindingDelimiter;
+        }
+        if ((binding.modifiers & KeyModifier::rightControl) != KeyModifier::none)
+        {
+            keyName += SDL_GetKeyName(SDLK_RCTRL);
+            keyName += kBindingDelimiter;
+        }
+        if ((binding.modifiers & KeyModifier::leftAlt) != KeyModifier::none)
+        {
+            keyName += SDL_GetKeyName(SDLK_LALT);
+            keyName += kBindingDelimiter;
+        }
+        if ((binding.modifiers & KeyModifier::rightAlt) != KeyModifier::none)
+        {
+            keyName += SDL_GetKeyName(SDLK_RALT);
             keyName += kBindingDelimiter;
         }
         if ((binding.modifiers & KeyModifier::unknown) != KeyModifier::none)
@@ -874,6 +901,8 @@ namespace OpenLoco::Input::Shortcuts
     void setBinding(Shortcut id, uint32_t keyCode, KeyModifier modifiers)
     {
         auto& configShortcuts = Config::get().shortcuts;
+
+        modifiers = modifiers & ~KeyModifier::cheat;
 
         for (const auto& def : ShortcutManager::getList())
         {

--- a/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
+++ b/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
@@ -1,6 +1,4 @@
-#include "Graphics/Colour.h"
 #include "Graphics/ImageIds.h"
-#include "Graphics/TextRenderer.h"
 #include "Input/Shortcuts.h"
 #include "Localisation/FormatArguments.hpp"
 #include "Localisation/StringIds.h"
@@ -10,6 +8,7 @@
 #include "Ui/Widgets/CaptionWidget.h"
 #include "Ui/Widgets/FrameWidget.h"
 #include "Ui/Widgets/ImageButtonWidget.h"
+#include "Ui/Widgets/LabelWidget.h"
 #include "Ui/Widgets/PanelWidget.h"
 #include "Ui/WindowManager.h"
 #include <OpenLoco/Engine/Input/ShortcutManager.h>
@@ -19,15 +18,19 @@ using namespace OpenLoco::Input;
 
 namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
 {
-    static constexpr Ui::Size kWindowSize = { 280, 72 };
+    static constexpr Ui::Size kWindowSize = { 280, 78 };
 
     static uint8_t _editingShortcutIndex;
+    static KeyModifier _pressedModifiers;
 
     static constexpr auto _widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, kWindowSize, WindowColour::primary),
         Widgets::Caption({ 1, 1 }, { kWindowSize.width - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::change_keyboard_shortcut),
         Widgets::ImageButton({ 265, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-        Widgets::Panel({ 0, 15 }, { kWindowSize.width, 57 }, WindowColour::secondary));
+        Widgets::Panel({ 0, 15 }, { kWindowSize.width, kWindowSize.height - 15 }, WindowColour::secondary),
+        Widgets::Label({ 4, 20 }, { kWindowSize.width - 8, 12 }, WindowColour::secondary, ContentAlign::center, StringIds::change_keyboard_shortcut_desc),
+        Widgets::Label({ 4, 34 }, { kWindowSize.width - 8, 12 }, WindowColour::secondary, ContentAlign::center, StringIds::black_quoted_stringid),
+        Widgets::Label({ 4, 54 }, { kWindowSize.width - 8, 12 }, WindowColour::secondary, ContentAlign::center, StringIds::black_stringid));
 
     static const WindowEventList& getEvents();
 
@@ -39,6 +42,9 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
             caption,
             close,
             panel,
+            description,
+            shortcutName,
+            pressedKeys,
         };
     }
 
@@ -47,6 +53,7 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
     {
         WindowManager::close(WindowType::editKeyboardShortcut);
         _editingShortcutIndex = shortcutIndex;
+        _pressedModifiers = KeyModifier::none;
 
         auto window = WindowManager::createWindow(WindowType::editKeyboardShortcut, kWindowSize, WindowFlags::none, getEvents());
 
@@ -97,17 +104,40 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
         WindowManager::invalidate(WindowType::keyboardShortcuts);
     }
 
+    static void onUpdate(Window& self)
+    {
+        const auto modifiers = Input::getKeyModifier() & ~KeyModifier::cheat;
+        if (modifiers == _pressedModifiers)
+        {
+            return;
+        }
+
+        _pressedModifiers = modifiers;
+        self.invalidate();
+    }
+
+    static void prepareDraw(Window& self)
+    {
+        {
+            auto args = FormatArguments(self.widgets[Widx::description].textArgs);
+            args.push(StringIds::empty);
+        }
+
+        {
+            auto args = FormatArguments(self.widgets[Widx::shortcutName].textArgs);
+            args.push(ShortcutManager::getName(static_cast<Shortcut>(_editingShortcutIndex)));
+        }
+
+        {
+            auto args = FormatArguments(self.widgets[Widx::pressedKeys].textArgs);
+            Input::Shortcuts::pushModifierStrings(args, _pressedModifiers);
+        }
+    }
+
     // 0x004BE8DF
     static void draw(Ui::Window& self, Gfx::DrawingContext& drawingCtx)
     {
-        auto tr = Gfx::TextRenderer(drawingCtx);
-
         self.draw(drawingCtx);
-
-        FormatArguments args{};
-        args.push(ShortcutManager::getName(static_cast<Shortcut>(_editingShortcutIndex)));
-        auto point = Ui::Point(self.x + 140, self.y + 32);
-        tr.drawStringCentredWrapped(point, 272, Colour::black, StringIds::change_keyboard_shortcut_desc, args);
     }
 
     // 0x004BE821
@@ -130,6 +160,8 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
 
     static constexpr WindowEventList kEvents = {
         .onMouseUp = onMouseUp,
+        .onUpdate = onUpdate,
+        .prepareDraw = prepareDraw,
         .draw = draw,
         .keyUp = onKeyUp,
     };

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -19,9 +19,8 @@
 #include <OpenLoco/Engine/Input/ShortcutManager.h>
 #include <OpenLoco/Utility/LookupTable.hpp>
 #include <SDL3/SDL_keyboard.h>
-#include <array>
+#include <cstddef>
 #include <unordered_map>
-#include <utility>
 
 using namespace OpenLoco::Input;
 
@@ -29,12 +28,14 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
 {
     static constexpr int kRowHeight = 10; // CJK: 13
 
+    static constexpr Ui::Size kWindowSize = { 420, 238 };
+
     static constexpr auto _widgets = makeWidgets(
-        Widgets::Frame({ 0, 0 }, { 360, 238 }, WindowColour::primary),
-        Widgets::Caption({ 1, 1 }, { 358, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::keyboard_shortcuts),
-        Widgets::ImageButton({ 345, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-        Widgets::Panel({ 0, 15 }, { 360, 223 }, WindowColour::secondary),
-        Widgets::ScrollView({ 4, 19 }, { 352, 202 }, WindowColour::secondary, Scrollbars::vertical, StringIds::keyboard_shortcut_list_tip),
+        Widgets::Frame({ 0, 0 }, kWindowSize, WindowColour::primary),
+        Widgets::Caption({ 1, 1 }, { kWindowSize.width - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::keyboard_shortcuts),
+        Widgets::ImageButton({ kWindowSize.width - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::Panel({ 0, 15 }, { kWindowSize.width, kWindowSize.height - 15 }, WindowColour::secondary),
+        Widgets::ScrollView({ 4, 19 }, { kWindowSize.width - 8, 202 }, WindowColour::secondary, Scrollbars::vertical, StringIds::keyboard_shortcut_list_tip),
         Widgets::Button({ 4, 223 }, { 150, 12 }, WindowColour::secondary, StringIds::reset_keys, StringIds::reset_keys_tip)
 
     );
@@ -67,7 +68,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
         }
 
         // 0x004BF833 (create_options_window)
-        window = WindowManager::createWindowCentred(WindowType::keyboardShortcuts, { 360, 238 }, WindowFlags::none, getEvents());
+        window = WindowManager::createWindowCentred(WindowType::keyboardShortcuts, kWindowSize, WindowFlags::none, getEvents());
 
         window->setWidgets(_widgets);
         window->initScrollWidgets();
@@ -142,44 +143,6 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
         }
     }
 
-    static void pushModifierStrings(FormatArguments& formatter, KeyModifier modifiers)
-    {
-        static constexpr std::pair<KeyModifier, StringId> kModifierStrings[] = {
-            { KeyModifier::leftControl, StringIds::keyboard_shortcut_modifier_ctrl },
-            { KeyModifier::rightControl, StringIds::keyboard_shortcut_modifier_right_ctrl },
-            { KeyModifier::shift, StringIds::keyboard_shortcut_modifier_shift },
-            { KeyModifier::leftAlt, StringIds::keyboard_shortcut_modifier_alt },
-            { KeyModifier::rightAlt, StringIds::keyboard_shortcut_modifier_right_alt },
-        };
-
-        std::array<StringId, std::size(kModifierStrings)> stringIds{};
-        auto count = 0U;
-
-        for (const auto& [modifier, stringId] : kModifierStrings)
-        {
-            if ((modifiers & modifier) != KeyModifier::none)
-            {
-                stringIds[count++] = stringId;
-            }
-        }
-
-        if (count == 0)
-        {
-            formatter.push(StringIds::empty);
-            return;
-        }
-
-        for (auto i = 1U; i < count; i++)
-        {
-            formatter.push(StringIds::keyboard_shortcut_modifier_pair);
-        }
-
-        for (auto i = 0U; i < count; i++)
-        {
-            formatter.push(stringIds[i]);
-        }
-    }
-
     // 0x004BE72C
     static void drawScroll(Ui::Window& self, Gfx::DrawingContext& drawingCtx, [[maybe_unused]] const uint32_t scrollIndex)
     {
@@ -224,10 +187,11 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
                 getBindingString(binding.keyCode, buffer, std::size(buffer));
             }
 
-            FormatArguments formatter{};
+            std::byte argsBuffer[32]{};
+            FormatArguments formatter{ argsBuffer, std::size(argsBuffer) };
             formatter.push(StringIds::keyboard_shortcut_list_format);
             formatter.push(ShortcutManager::getName(static_cast<Shortcut>(i)));
-            pushModifierStrings(formatter, isBound ? binding.modifiers : KeyModifier::none);
+            Input::Shortcuts::pushModifierStrings(formatter, isBound ? binding.modifiers : KeyModifier::none);
             formatter.push(baseStringId);
             formatter.push(buffer);
 

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -19,7 +19,9 @@
 #include <OpenLoco/Engine/Input/ShortcutManager.h>
 #include <OpenLoco/Utility/LookupTable.hpp>
 #include <SDL3/SDL_keyboard.h>
+#include <array>
 #include <unordered_map>
+#include <utility>
 
 using namespace OpenLoco::Input;
 
@@ -140,6 +142,44 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
         }
     }
 
+    static void pushModifierStrings(FormatArguments& formatter, KeyModifier modifiers)
+    {
+        static constexpr std::pair<KeyModifier, StringId> kModifierStrings[] = {
+            { KeyModifier::leftControl, StringIds::keyboard_shortcut_modifier_ctrl },
+            { KeyModifier::rightControl, StringIds::keyboard_shortcut_modifier_right_ctrl },
+            { KeyModifier::shift, StringIds::keyboard_shortcut_modifier_shift },
+            { KeyModifier::leftAlt, StringIds::keyboard_shortcut_modifier_alt },
+            { KeyModifier::rightAlt, StringIds::keyboard_shortcut_modifier_right_alt },
+        };
+
+        std::array<StringId, std::size(kModifierStrings)> stringIds{};
+        auto count = 0U;
+
+        for (const auto& [modifier, stringId] : kModifierStrings)
+        {
+            if ((modifiers & modifier) != KeyModifier::none)
+            {
+                stringIds[count++] = stringId;
+            }
+        }
+
+        if (count == 0)
+        {
+            formatter.push(StringIds::empty);
+            return;
+        }
+
+        for (auto i = 1U; i < count; i++)
+        {
+            formatter.push(StringIds::keyboard_shortcut_modifier_pair);
+        }
+
+        for (auto i = 0U; i < count; i++)
+        {
+            formatter.push(stringIds[i]);
+        }
+    }
+
     // 0x004BE72C
     static void drawScroll(Ui::Window& self, Gfx::DrawingContext& drawingCtx, [[maybe_unused]] const uint32_t scrollIndex)
     {
@@ -176,29 +216,18 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
 
             const auto& def = shortcutDefs[i];
             const auto& binding = Input::Shortcuts::getBinding(def.id);
+            const auto isBound = binding.keyCode != kInvalidKeyCode && binding.modifiers != KeyModifier::invalid;
 
-            if (binding.keyCode != kInvalidKeyCode && binding.modifiers != KeyModifier::invalid)
+            if (isBound)
             {
-                auto* ptr = buffer;
-                auto* const bufferEnd = std::end(buffer);
-
-                if ((binding.modifiers & KeyModifier::control) == KeyModifier::control)
-                {
-                    ptr = StringManager::formatString(ptr, static_cast<size_t>(bufferEnd - ptr), StringIds::keyboard_shortcut_modifier_ctrl);
-                }
-                if ((binding.modifiers & KeyModifier::shift) == KeyModifier::shift)
-                {
-                    ptr = StringManager::formatString(ptr, static_cast<size_t>(bufferEnd - ptr), StringIds::keyboard_shortcut_modifier_shift);
-                }
-
                 baseStringId = StringIds::stringptr;
-                getBindingString(binding.keyCode, ptr, static_cast<size_t>(bufferEnd - ptr));
+                getBindingString(binding.keyCode, buffer, std::size(buffer));
             }
 
             FormatArguments formatter{};
             formatter.push(StringIds::keyboard_shortcut_list_format);
             formatter.push(ShortcutManager::getName(static_cast<Shortcut>(i)));
-            formatter.push(StringIds::empty);
+            pushModifierStrings(formatter, isBound ? binding.modifiers : KeyModifier::none);
             formatter.push(baseStringId);
             formatter.push(buffer);
 

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -171,7 +171,6 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
                 format = StringIds::wcolour2_stringid;
             }
 
-            auto modifierStringId = StringIds::empty;
             auto baseStringId = StringIds::empty;
             char buffer[128]{};
 
@@ -180,23 +179,26 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
 
             if (binding.keyCode != kInvalidKeyCode && binding.modifiers != KeyModifier::invalid)
             {
+                auto* ptr = buffer;
+                auto* const bufferEnd = std::end(buffer);
+
+                if ((binding.modifiers & KeyModifier::control) == KeyModifier::control)
+                {
+                    ptr = StringManager::formatString(ptr, static_cast<size_t>(bufferEnd - ptr), StringIds::keyboard_shortcut_modifier_ctrl);
+                }
                 if ((binding.modifiers & KeyModifier::shift) == KeyModifier::shift)
                 {
-                    modifierStringId = StringIds::keyboard_shortcut_modifier_shift;
-                }
-                else if ((binding.modifiers & KeyModifier::control) == KeyModifier::control)
-                {
-                    modifierStringId = StringIds::keyboard_shortcut_modifier_ctrl;
+                    ptr = StringManager::formatString(ptr, static_cast<size_t>(bufferEnd - ptr), StringIds::keyboard_shortcut_modifier_shift);
                 }
 
                 baseStringId = StringIds::stringptr;
-                getBindingString(binding.keyCode, buffer, std::size(buffer));
+                getBindingString(binding.keyCode, ptr, static_cast<size_t>(bufferEnd - ptr));
             }
 
             FormatArguments formatter{};
             formatter.push(StringIds::keyboard_shortcut_list_format);
             formatter.push(ShortcutManager::getName(static_cast<Shortcut>(i)));
-            formatter.push(modifierStringId);
+            formatter.push(StringIds::empty);
             formatter.push(baseStringId);
             formatter.push(buffer);
 


### PR DESCRIPTION
This allows to use all modifiers and also make a distinction between left and right for like ctrl or alt. Also improved the UI a little bit, shows now which keys are pressed when editing and refactored the windows to use proper constants.

<img width="802" height="632" alt="OpenLoco_2026-07-23_14-28-311784806111" src="https://github.com/user-attachments/assets/6d50c084-c4d2-4935-91d1-bd8f0c762822" />

