### PR TITLE
Fix viewport crash in tutorial 1

### DIFF
--- a/src/OpenLoco/include/OpenLoco/Graphics/DrawingContext.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/DrawingContext.h
@@ -48,28 +48,28 @@ namespace OpenLoco::Gfx
 
         virtual void clearSingle(uint8_t paletteId) = 0;
 
-        virtual void fillRect(int16_t left, int16_t top, int16_t right, int16_t bottom, uint8_t colour, RectFlags flags) = 0;
+        virtual void fillRect(int32_t left, int32_t top, int32_t right, int32_t bottom, uint8_t colour, RectFlags flags) = 0;
 
         void fillRect(const Ui::Point& origin, const Ui::Size& size, uint8_t colour, RectFlags flags)
         {
             fillRect(origin.x, origin.y, origin.x + size.width - 1, origin.y + size.height - 1, colour, flags);
         }
 
-        virtual void drawRect(int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint8_t colour, RectFlags flags) = 0;
+        virtual void drawRect(int32_t x, int32_t y, int32_t dx, int32_t dy, uint8_t colour, RectFlags flags) = 0;
 
         void drawRect(const Ui::Point& origin, const Ui::Size& size, uint8_t colour, RectFlags flags)
         {
             drawRect(origin.x, origin.y, size.width, size.height, colour, flags);
         }
 
-        virtual void fillRectInset(int16_t left, int16_t top, int16_t right, int16_t bottom, AdvancedColour colour, RectInsetFlags flags) = 0;
+        virtual void fillRectInset(int32_t left, int32_t top, int32_t right, int32_t bottom, AdvancedColour colour, RectInsetFlags flags) = 0;
 
         void fillRectInset(const Ui::Point& origin, const Ui::Size& size, AdvancedColour colour, RectInsetFlags flags)
         {
             fillRectInset(origin.x, origin.y, origin.x + size.width - 1, origin.y + size.height - 1, colour, flags);
         }
 
-        virtual void drawRectInset(int16_t x, int16_t y, uint16_t dx, uint16_t dy, AdvancedColour colour, RectInsetFlags flags) = 0;
+        virtual void drawRectInset(int32_t x, int32_t y, int32_t dx, int32_t dy, AdvancedColour colour, RectInsetFlags flags) = 0;
 
         void drawRectInset(const Ui::Point& origin, const Ui::Size& size, AdvancedColour colour, RectInsetFlags flags)
         {
@@ -80,7 +80,7 @@ namespace OpenLoco::Gfx
 
         virtual void drawCircle(const Ui::Point& centre, int32_t radius, int32_t lineWidth, PaletteIndex_t colour) = 0;
 
-        virtual void drawImage(int16_t x, int16_t y, uint32_t image) = 0;
+        virtual void drawImage(int32_t x, int32_t y, uint32_t image) = 0;
 
         void drawImage(const Ui::Point& pos, uint32_t image)
         {

--- a/src/OpenLoco/include/OpenLoco/Graphics/RenderTarget.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/RenderTarget.h
@@ -11,12 +11,12 @@ namespace OpenLoco::Gfx
     struct RenderTarget
     {
         uint8_t* bits;      // 0x00
-        int16_t x;          // 0x04
-        int16_t y;          // 0x06
-        int16_t width;      // 0x08
-        int16_t height;     // 0x0A
-        int16_t pitch;      // 0x0C note: this is actually (pitch - width)
-        uint16_t zoomLevel; // 0x0E
+        int32_t x;          // 0x04
+        int32_t y;          // 0x08
+        int32_t width;      // 0x0C
+        int32_t height;     // 0x10
+        int16_t pitch;      // 0x14 note: this is actually (pitch - width)
+        uint16_t zoomLevel; // 0x16
 
         Ui::Rect getUiRect() const;
         Ui::Rect getDrawableRect() const;

--- a/src/OpenLoco/include/OpenLoco/Graphics/RenderTarget.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/RenderTarget.h
@@ -15,8 +15,8 @@ namespace OpenLoco::Gfx
         int32_t y;          // 0x08
         int32_t width;      // 0x0C
         int32_t height;     // 0x10
-        int16_t pitch;      // 0x14 note: this is actually (pitch - width)
-        uint16_t zoomLevel; // 0x16
+        int32_t pitch;      // 0x14 note: this is actually (pitch - width)
+        uint16_t zoomLevel; // 0x18
 
         Ui::Rect getUiRect() const;
         Ui::Rect getDrawableRect() const;

--- a/src/OpenLoco/include/OpenLoco/Graphics/SoftwareDrawingContext.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/SoftwareDrawingContext.h
@@ -28,13 +28,13 @@ namespace OpenLoco::Gfx
         const RenderTarget& currentRenderTarget() const override;
         void clear(uint32_t fill) override;
         void clearSingle(uint8_t paletteId) override;
-        void fillRect(int16_t left, int16_t top, int16_t right, int16_t bottom, uint8_t colour, RectFlags flags) override;
-        void drawRect(int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint8_t colour, RectFlags flags) override;
-        void fillRectInset(int16_t left, int16_t top, int16_t right, int16_t bottom, AdvancedColour colour, RectInsetFlags flags) override;
-        void drawRectInset(int16_t x, int16_t y, uint16_t dx, uint16_t dy, AdvancedColour colour, RectInsetFlags flags) override;
+        void fillRect(int32_t left, int32_t top, int32_t right, int32_t bottom, uint8_t colour, RectFlags flags) override;
+        void drawRect(int32_t x, int32_t y, int32_t dx, int32_t dy, uint8_t colour, RectFlags flags) override;
+        void fillRectInset(int32_t left, int32_t top, int32_t right, int32_t bottom, AdvancedColour colour, RectInsetFlags flags) override;
+        void drawRectInset(int32_t x, int32_t y, int32_t dx, int32_t dy, AdvancedColour colour, RectInsetFlags flags) override;
         void drawLine(const Ui::Point& a, const Ui::Point& b, PaletteIndex_t colour) override;
         void drawCircle(const Ui::Point& centre, int32_t radius, int32_t lineWidth, PaletteIndex_t colour) override;
-        void drawImage(int16_t x, int16_t y, uint32_t image) override;
+        void drawImage(int32_t x, int32_t y, uint32_t image) override;
         void drawImage(const Ui::Point& pos, const ImageId& image) override;
         void drawImageMasked(const Ui::Point& pos, const ImageId& image, const ImageId& maskImage) override;
         void drawImageSolid(const Ui::Point& pos, const ImageId& image, PaletteIndex_t paletteIndex) override;

--- a/src/OpenLoco/src/Graphics/RenderTarget.cpp
+++ b/src/OpenLoco/src/Graphics/RenderTarget.cpp
@@ -23,7 +23,7 @@ namespace OpenLoco::Gfx
         const Ui::Rect oldRect = src.getUiRect();
         Ui::Rect intersect = oldRect.intersection(newRect);
         const auto stride = oldRect.size.width + src.pitch;
-        const int16_t newPitch = stride - intersect.size.width;
+        const int32_t newPitch = stride - intersect.size.width;
         auto* newBits = src.bits + (stride * (intersect.origin.y - oldRect.origin.y) + (intersect.origin.x - oldRect.origin.x));
         intersect.origin.x = std::max(0, oldRect.origin.x - newRect.origin.x);
         intersect.origin.y = std::max(0, oldRect.origin.y - newRect.origin.y);

--- a/src/OpenLoco/src/Graphics/RenderTarget.cpp
+++ b/src/OpenLoco/src/Graphics/RenderTarget.cpp
@@ -27,7 +27,7 @@ namespace OpenLoco::Gfx
         auto* newBits = src.bits + (stride * (intersect.origin.y - oldRect.origin.y) + (intersect.origin.x - oldRect.origin.x));
         intersect.origin.x = std::max(0, oldRect.origin.x - newRect.origin.x);
         intersect.origin.y = std::max(0, oldRect.origin.y - newRect.origin.y);
-        RenderTarget newRT{ newBits, static_cast<int16_t>(intersect.origin.x), static_cast<int16_t>(intersect.origin.y), static_cast<int16_t>(intersect.size.width), static_cast<int16_t>(intersect.size.height), newPitch, 0 };
+        RenderTarget newRT{ newBits, intersect.origin.x, intersect.origin.y, intersect.size.width, intersect.size.height, newPitch, 0 };
 
         if (newRT.width <= 0 || newRT.height <= 0)
         {

--- a/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
@@ -41,7 +41,7 @@ namespace OpenLoco::Gfx
             ImageIds::noise_mask_7,
         };
 
-        static void drawRect(const RenderTarget& rt, int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint8_t colour, RectFlags flags);
+        static void drawRect(const RenderTarget& rt, int32_t x, int32_t y, int32_t dx, int32_t dy, uint8_t colour, RectFlags flags);
         static void drawImageSolid(const RenderTarget& rt, const Ui::Point& pos, const ImageId& image, PaletteIndex_t paletteIndex);
 
         // 0x00447485
@@ -308,7 +308,7 @@ namespace OpenLoco::Gfx
         }
 
         // 0x00448C79
-        static void drawImage(const RenderTarget* rt, int16_t x, int16_t y, uint32_t image)
+        static void drawImage(const RenderTarget* rt, int32_t x, int32_t y, uint32_t image)
         {
             drawImage(*rt, { x, y }, ImageId::fromUInt32(image));
         }
@@ -316,11 +316,11 @@ namespace OpenLoco::Gfx
         // 0x00450890, 0x00450F87, 0x00450D1E, 0x00450ABA
         template<int32_t TZoomLevel>
         static void drawMaskedZoom(
-            int16_t imageHeight,
-            int16_t imageWidth,
+            int32_t imageHeight,
+            int32_t imageWidth,
             int16_t rowSize,
             const uint8_t* bytesMask,
-            int16_t dstWrap,
+            int32_t dstWrap,
             uint8_t* dstBuf,
             const uint8_t* bytesImage)
         {
@@ -434,7 +434,7 @@ namespace OpenLoco::Gfx
                         newRt.height >>= 1;
                         drawImageMaskedZoom<TZoomLevel - 1>(
                             newRt,
-                            { static_cast<int16_t>(pos.x >> 1), static_cast<int16_t>(pos.y >> 1) },
+                            { pos.x >> 1, pos.y >> 1 },
                             image.withIndexOffset(-g1Image->zoomOffset),
                             maskImage.withIndexOffset(-g1ImageMask->zoomOffset));
                         return;
@@ -442,8 +442,8 @@ namespace OpenLoco::Gfx
                 }
             }
 
-            int16_t imageHeight = g1Image->height;
-            int16_t imageWidth = g1Image->width;
+            int32_t imageHeight = g1Image->height;
+            int32_t imageWidth = g1Image->width;
 
             const auto* imageDataPos = g1Image->offset;
             auto* dstBuf = rt.bits;
@@ -451,7 +451,7 @@ namespace OpenLoco::Gfx
             constexpr uint16_t zoomMask = static_cast<uint16_t>(~0ULL << TZoomLevel);
             constexpr int16_t offsetX = (1 << TZoomLevel) - 1;
 
-            int16_t dstTop = ((g1Image->yOffset + pos.y) & zoomMask) - rt.y;
+            int32_t dstTop = ((g1Image->yOffset + pos.y) & zoomMask) - rt.y;
             if (dstTop >= 0)
             {
                 auto scaledWidth = rt.width >> TZoomLevel;
@@ -478,7 +478,7 @@ namespace OpenLoco::Gfx
                 dstTop = 0;
             }
 
-            int16_t dstBottom = imageHeight + dstTop;
+            int32_t dstBottom = imageHeight + dstTop;
             if (dstBottom > rt.height)
             {
                 imageHeight -= dstBottom - rt.height;
@@ -490,14 +490,14 @@ namespace OpenLoco::Gfx
             }
 
             int16_t rowSize = 0;
-            int16_t dstWrap = rt.pitch + (rt.width >> TZoomLevel);
+            int32_t dstWrap = rt.pitch + (rt.width >> TZoomLevel);
 
             if constexpr (TZoomLevel == 0)
             {
                 dstWrap -= g1Image->width;
             }
 
-            int16_t dstLeft = ((g1Image->xOffset + pos.x + offsetX) & zoomMask) - rt.x;
+            int32_t dstLeft = ((g1Image->xOffset + pos.x + offsetX) & zoomMask) - rt.x;
             if (dstLeft < 0)
             {
                 imageWidth += dstLeft;
@@ -517,7 +517,7 @@ namespace OpenLoco::Gfx
                 dstLeft = 0;
             }
 
-            int16_t dstRight = imageWidth + dstLeft - rt.width;
+            int32_t dstRight = imageWidth + dstLeft - rt.width;
             if (imageWidth + dstLeft > rt.width)
             {
                 imageWidth -= dstRight;
@@ -590,7 +590,7 @@ namespace OpenLoco::Gfx
         // dx: bottom
         // ebp: colour | enumValue(flags)
         // edi: rt
-        static void drawRectImpl(const RenderTarget& rt, int16_t left, int16_t top, int16_t right, int16_t bottom, uint8_t colour, RectFlags flags)
+        static void drawRectImpl(const RenderTarget& rt, int32_t left, int32_t top, int32_t right, int32_t bottom, uint8_t colour, RectFlags flags)
         {
             if (left > right)
             {
@@ -720,18 +720,18 @@ namespace OpenLoco::Gfx
             drawRectImpl(rt, rect.left(), rect.top(), rect.right(), rect.bottom(), colour, flags);
         }
 
-        static void fillRect(const RenderTarget& rt, int16_t left, int16_t top, int16_t right, int16_t bottom, uint8_t colour, RectFlags flags)
+        static void fillRect(const RenderTarget& rt, int32_t left, int32_t top, int32_t right, int32_t bottom, uint8_t colour, RectFlags flags)
         {
             drawRectImpl(rt, left, top, right, bottom, colour, flags);
         }
 
-        static void drawRect(const RenderTarget& rt, int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint8_t colour, RectFlags flags)
+        static void drawRect(const RenderTarget& rt, int32_t x, int32_t y, int32_t dx, int32_t dy, uint8_t colour, RectFlags flags)
         {
             // This makes the function signature more like a drawing application
             drawRectImpl(rt, x, y, x + dx - 1, y + dy - 1, colour, flags);
         }
 
-        static void fillRectInset(const RenderTarget& rt, int16_t left, int16_t top, int16_t right, int16_t bottom, AdvancedColour colour, RectInsetFlags flags)
+        static void fillRectInset(const RenderTarget& rt, int32_t left, int32_t top, int32_t right, int32_t bottom, AdvancedColour colour, RectInsetFlags flags)
         {
             const auto rect = Ui::Rect::fromLTRB(left, top, right, bottom);
             const auto baseColour = static_cast<Colour>(colour);
@@ -836,7 +836,7 @@ namespace OpenLoco::Gfx
             }
         }
 
-        static void drawRectInset(const RenderTarget& rt, int16_t x, int16_t y, uint16_t dx, uint16_t dy, AdvancedColour colour, RectInsetFlags flags)
+        static void drawRectInset(const RenderTarget& rt, int32_t x, int32_t y, int32_t dx, int32_t dy, AdvancedColour colour, RectInsetFlags flags)
         {
             // This makes the function signature more like a drawing application
             fillRectInset(rt, x, y, x + dx - 1, y + dy - 1, colour, flags);
@@ -1041,25 +1041,25 @@ namespace OpenLoco::Gfx
         return Impl::clearSingle(rt, paletteId);
     }
 
-    void SoftwareDrawingContext::fillRect(int16_t left, int16_t top, int16_t right, int16_t bottom, uint8_t colour, RectFlags flags)
+    void SoftwareDrawingContext::fillRect(int32_t left, int32_t top, int32_t right, int32_t bottom, uint8_t colour, RectFlags flags)
     {
         auto& rt = currentRenderTarget();
         return Impl::fillRect(rt, left, top, right, bottom, colour, flags);
     }
 
-    void SoftwareDrawingContext::drawRect(int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint8_t colour, RectFlags flags)
+    void SoftwareDrawingContext::drawRect(int32_t x, int32_t y, int32_t dx, int32_t dy, uint8_t colour, RectFlags flags)
     {
         auto& rt = currentRenderTarget();
         return Impl::drawRect(rt, x, y, dx, dy, colour, flags);
     }
 
-    void SoftwareDrawingContext::fillRectInset(int16_t left, int16_t top, int16_t right, int16_t bottom, AdvancedColour colour, RectInsetFlags flags)
+    void SoftwareDrawingContext::fillRectInset(int32_t left, int32_t top, int32_t right, int32_t bottom, AdvancedColour colour, RectInsetFlags flags)
     {
         auto& rt = currentRenderTarget();
         return Impl::fillRectInset(rt, left, top, right, bottom, colour, flags);
     }
 
-    void SoftwareDrawingContext::drawRectInset(int16_t x, int16_t y, uint16_t dx, uint16_t dy, AdvancedColour colour, RectInsetFlags flags)
+    void SoftwareDrawingContext::drawRectInset(int32_t x, int32_t y, int32_t dx, int32_t dy, AdvancedColour colour, RectInsetFlags flags)
     {
         auto& rt = currentRenderTarget();
         return Impl::drawRectInset(rt, x, y, dx, dy, colour, flags);
@@ -1077,7 +1077,7 @@ namespace OpenLoco::Gfx
         return Impl::drawCircle(rt, centre, radius, lineWidth, colour);
     }
 
-    void SoftwareDrawingContext::drawImage(int16_t x, int16_t y, uint32_t image)
+    void SoftwareDrawingContext::drawImage(int32_t x, int32_t y, uint32_t image)
     {
         auto& rt = currentRenderTarget();
         return Impl::drawImage(&rt, x, y, image);

--- a/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
@@ -448,8 +448,8 @@ namespace OpenLoco::Gfx
             const auto* imageDataPos = g1Image->offset;
             auto* dstBuf = rt.bits;
 
-            constexpr uint16_t zoomMask = static_cast<uint16_t>(~0ULL << TZoomLevel);
-            constexpr int16_t offsetX = (1 << TZoomLevel) - 1;
+            constexpr uint32_t zoomMask = static_cast<uint32_t>(~0ULL << TZoomLevel);
+            constexpr int32_t offsetX = (1 << TZoomLevel) - 1;
 
             int32_t dstTop = ((g1Image->yOffset + pos.y) & zoomMask) - rt.y;
             if (dstTop >= 0)

--- a/src/OpenLoco/src/Viewport.cpp
+++ b/src/OpenLoco/src/Viewport.cpp
@@ -191,9 +191,9 @@ namespace OpenLoco::Ui
         zoomViewRt.x &= bitmask;
         zoomViewRt.y &= bitmask;
 
-        auto unkX = ((zoomViewRt.x - static_cast<int32_t>(viewX & bitmask)) >> zoom) + x;
+        auto unkX = ((static_cast<int32_t>(rect.origin.x & bitmask) - static_cast<int32_t>(viewX & bitmask)) >> zoom) + x;
 
-        auto unkY = ((zoomViewRt.y - static_cast<int32_t>(viewY & bitmask)) >> zoom) + y;
+        auto unkY = ((static_cast<int32_t>(rect.origin.y & bitmask) - static_cast<int32_t>(viewY & bitmask)) >> zoom) + y;
 
         zoomViewRt.pitch = rt.width + rt.pitch - (zoomViewRt.width >> zoom);
         zoomViewRt.bits = rt.bits + (unkX - rt.x) + ((unkY - rt.y) * (rt.width + rt.pitch));

--- a/src/OpenLoco/src/Viewport.cpp
+++ b/src/OpenLoco/src/Viewport.cpp
@@ -191,9 +191,9 @@ namespace OpenLoco::Ui
         zoomViewRt.x &= bitmask;
         zoomViewRt.y &= bitmask;
 
-        auto unkX = ((static_cast<int32_t>(rect.origin.x & bitmask) - static_cast<int32_t>(viewX & bitmask)) >> zoom) + x;
+        auto unkX = ((zoomViewRt.x - static_cast<int32_t>(viewX & bitmask)) >> zoom) + x;
 
-        auto unkY = ((static_cast<int32_t>(rect.origin.y & bitmask) - static_cast<int32_t>(viewY & bitmask)) >> zoom) + y;
+        auto unkY = ((zoomViewRt.y - static_cast<int32_t>(viewY & bitmask)) >> zoom) + y;
 
         zoomViewRt.pitch = rt.width + rt.pitch - (zoomViewRt.width >> zoom);
         zoomViewRt.bits = rt.bits + (unkX - rt.x) + ((unkY - rt.y) * (rt.width + rt.pitch));


### PR DESCRIPTION
Resolves a crash in the tutorial present on macOS and Linux devices. Should resolve #3738, though I'd want some Linux users to confirm, since I've only tested on macOS.

Since `viewX` and `viewY` are `int32_t`, and `zoomViewRt.x` and `zoomViewRt.y` are `int16_t`, this subtraction could encounter a case where the `viewX` exceeded the truncated `zoomViewRt.x`, resulting in a wrap of the value, leading to a garbage offset and going out of bounds. Using the source values, which are actually `int32_t` means that the value isn't truncated, and the subtraction is correct.

There may be better options to solve this, like altering `Gfx::RenderTarget` to use `int32_t` instead of `int16_t`, but I'm not familiar enough with the codebase to make that type of call.

The tutorial still desyncs when attempting to purchase a bus, but that's a different issue.