### PR TITLE
Port all windows to define widgets with WidgetId

### DIFF
--- a/src/OpenLoco/include/OpenLoco/Ui/Widgets/DropdownWidget.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Widgets/DropdownWidget.h
@@ -24,20 +24,21 @@ namespace OpenLoco::Ui::Widgets
         static void draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState);
     };
 
+    // TODO: Make this a single widget.
+    constexpr auto dropdownWidgets(WidgetId comboId, WidgetId buttonId, Ui::Point origin, Ui::Size size, WindowColour colour, uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
+    {
+        const int16_t xPos = origin.x + size.width - 12;
+        const int16_t yPos = origin.y + 1;
+        const uint16_t width = 11;
+        const uint16_t height = 10;
+
+        return makeWidgets(
+            ComboBox(comboId, origin, size, colour, content, tooltip),
+            Button(buttonId, { xPos, yPos }, { width, height }, colour, StringIds::dropdown));
+    }
+
     constexpr auto dropdownWidgets(Ui::Point origin, Ui::Size size, WindowColour colour, uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
     {
-        const auto makeDropdownButtonWidget = [](Ui::Point origin, Ui::Size size, WindowColour colour) {
-            const int16_t xPos = origin.x + size.width - 12;
-            const int16_t yPos = origin.y + 1;
-            const uint16_t width = 11;
-            const uint16_t height = 10;
-
-            return Button({ xPos, yPos }, { width, height }, colour, StringIds::dropdown);
-        };
-
-        // TODO: Make this a single widget.
-        return makeWidgets(
-            ComboBox(origin, size, colour, content, tooltip),
-            makeDropdownButtonWidget(origin, size, colour));
+        return dropdownWidgets(WidgetId::none, WidgetId::none, origin, size, colour, content, tooltip);
     }
 }

--- a/src/OpenLoco/include/OpenLoco/Ui/Widgets/DropdownWidget.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Widgets/DropdownWidget.h
@@ -15,12 +15,6 @@ namespace OpenLoco::Ui::Widgets
             events.draw = &draw;
         }
 
-        constexpr ComboBox(Point origin, Size size, WindowColour colour, StringId content = StringIds::null, StringId tooltip = StringIds::null)
-            : ComboBox(WidgetId::none, origin, size, colour, content, tooltip)
-        {
-            events.draw = &draw;
-        }
-
         static void draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState);
     };
 
@@ -35,10 +29,5 @@ namespace OpenLoco::Ui::Widgets
         return makeWidgets(
             ComboBox(comboId, origin, size, colour, content, tooltip),
             Button(buttonId, { xPos, yPos }, { width, height }, colour, StringIds::dropdown));
-    }
-
-    constexpr auto dropdownWidgets(Ui::Point origin, Ui::Size size, WindowColour colour, uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
-    {
-        return dropdownWidgets(WidgetId::none, WidgetId::none, origin, size, colour, content, tooltip);
     }
 }

--- a/src/OpenLoco/include/OpenLoco/Ui/Widgets/StepperWidget.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Widgets/StepperWidget.h
@@ -6,33 +6,48 @@
 
 namespace OpenLoco::Ui::Widgets
 {
-    constexpr Button makeStepperDecreaseWidget(Ui::Point origin, Ui::Size size, WindowColour colour, [[maybe_unused]] uint32_t content = Widget::kContentNull, [[maybe_unused]] StringId tooltip = StringIds::null)
+    constexpr Button makeStepperDecreaseWidget(WidgetId id, Ui::Point origin, Ui::Size size, WindowColour colour, [[maybe_unused]] uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
     {
         const int16_t xPos = origin.x + size.width - 26;
         const int16_t yPos = origin.y + 1;
         const uint16_t width = 13;
         const uint16_t height = size.height - 2;
 
-        return Button({ xPos, yPos }, { width, height }, colour, StringIds::stepper_minus, tooltip);
+        return Button(id, { xPos, yPos }, { width, height }, colour, StringIds::stepper_minus, tooltip);
     }
 
-    constexpr Button makeStepperIncreaseWidget(Ui::Point origin, Ui::Size size, WindowColour colour, [[maybe_unused]] uint32_t content = Widget::kContentNull, [[maybe_unused]] StringId tooltip = StringIds::null)
+    constexpr Button makeStepperDecreaseWidget(Ui::Point origin, Ui::Size size, WindowColour colour, uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
+    {
+        return makeStepperDecreaseWidget(WidgetId::none, origin, size, colour, content, tooltip);
+    }
+
+    constexpr Button makeStepperIncreaseWidget(WidgetId id, Ui::Point origin, Ui::Size size, WindowColour colour, [[maybe_unused]] uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
     {
         const int16_t xPos = origin.x + size.width - 13;
         const int16_t yPos = origin.y + 1;
         const uint16_t width = 12;
         const uint16_t height = size.height - 2;
 
-        return Button({ xPos, yPos }, { width, height }, colour, StringIds::stepper_plus, tooltip);
+        return Button(id, { xPos, yPos }, { width, height }, colour, StringIds::stepper_plus, tooltip);
+    }
+
+    constexpr Button makeStepperIncreaseWidget(Ui::Point origin, Ui::Size size, WindowColour colour, uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
+    {
+        return makeStepperIncreaseWidget(WidgetId::none, origin, size, colour, content, tooltip);
     }
 
     // TODO: Make this a single widget.
-    constexpr auto stepperWidgets(Ui::Point origin, Ui::Size size, WindowColour colour, uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
+    constexpr auto stepperWidgets(WidgetId valueId, WidgetId decreaseId, WidgetId increaseId, Ui::Point origin, Ui::Size size, WindowColour colour, uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
     {
         return makeWidgets(
-            TextBox(origin, size, colour, content, tooltip),
-            makeStepperDecreaseWidget(origin, size, colour),
-            makeStepperIncreaseWidget(origin, size, colour));
+            TextBox(valueId, origin, size, colour, content, tooltip),
+            makeStepperDecreaseWidget(decreaseId, origin, size, colour),
+            makeStepperIncreaseWidget(increaseId, origin, size, colour));
+    }
+
+    constexpr auto stepperWidgets(Ui::Point origin, Ui::Size size, WindowColour colour, uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
+    {
+        return stepperWidgets(WidgetId::none, WidgetId::none, WidgetId::none, origin, size, colour, content, tooltip);
     }
 
 }

--- a/src/OpenLoco/include/OpenLoco/Ui/Widgets/StepperWidget.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Widgets/StepperWidget.h
@@ -16,11 +16,6 @@ namespace OpenLoco::Ui::Widgets
         return Button(id, { xPos, yPos }, { width, height }, colour, StringIds::stepper_minus, tooltip);
     }
 
-    constexpr Button makeStepperDecreaseWidget(Ui::Point origin, Ui::Size size, WindowColour colour, uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
-    {
-        return makeStepperDecreaseWidget(WidgetId::none, origin, size, colour, content, tooltip);
-    }
-
     constexpr Button makeStepperIncreaseWidget(WidgetId id, Ui::Point origin, Ui::Size size, WindowColour colour, [[maybe_unused]] uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
     {
         const int16_t xPos = origin.x + size.width - 13;
@@ -31,11 +26,6 @@ namespace OpenLoco::Ui::Widgets
         return Button(id, { xPos, yPos }, { width, height }, colour, StringIds::stepper_plus, tooltip);
     }
 
-    constexpr Button makeStepperIncreaseWidget(Ui::Point origin, Ui::Size size, WindowColour colour, uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
-    {
-        return makeStepperIncreaseWidget(WidgetId::none, origin, size, colour, content, tooltip);
-    }
-
     // TODO: Make this a single widget.
     constexpr auto stepperWidgets(WidgetId valueId, WidgetId decreaseId, WidgetId increaseId, Ui::Point origin, Ui::Size size, WindowColour colour, uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
     {
@@ -43,11 +33,6 @@ namespace OpenLoco::Ui::Widgets
             TextBox(valueId, origin, size, colour, content, tooltip),
             makeStepperDecreaseWidget(decreaseId, origin, size, colour),
             makeStepperIncreaseWidget(increaseId, origin, size, colour));
-    }
-
-    constexpr auto stepperWidgets(Ui::Point origin, Ui::Size size, WindowColour colour, uint32_t content = Widget::kContentNull, StringId tooltip = StringIds::null)
-    {
-        return stepperWidgets(WidgetId::none, WidgetId::none, WidgetId::none, origin, size, colour, content, tooltip);
     }
 
 }

--- a/src/OpenLoco/include/OpenLoco/Ui/Windows/Construction/Construction.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Windows/Construction/Construction.h
@@ -123,17 +123,29 @@ namespace OpenLoco::Ui::Windows::Construction
             tab_overhead,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabConstruction{ "tab_construction" };
+            constexpr WidgetId kTabStation{ "tab_station" };
+            constexpr WidgetId kTabSignal{ "tab_signal" };
+            constexpr WidgetId kTabOverhead{ "tab_overhead" };
+        }
+
         constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, windowCaptionId),
-                Widgets::ImageButton({ frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { frameWidth, frameHeight - 41 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_track_road_construction),
-                Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_station_construction),
-                Widgets::Tab({ 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_signal_construction),
-                Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_electrification_construction));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, windowCaptionId),
+                Widgets::ImageButton(Widx::kCloseButton, { frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { frameWidth, frameHeight - 41 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabConstruction, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_track_road_construction),
+                Widgets::Tab(Widx::kTabStation, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_station_construction),
+                Widgets::Tab(Widx::kTabSignal, { 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_signal_construction),
+                Widgets::Tab(Widx::kTabOverhead, { 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_electrification_construction));
         }
 
         void prepareDraw(Window* self);
@@ -208,6 +220,35 @@ namespace OpenLoco::Ui::Windows::Construction
             paste,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kLeftHandCurveVerySmall{ "left_hand_curve_very_small" };
+            constexpr WidgetId kLeftHandCurveSmall{ "left_hand_curve_small" };
+            constexpr WidgetId kLeftHandCurve{ "left_hand_curve" };
+            constexpr WidgetId kLeftHandCurveLarge{ "left_hand_curve_large" };
+            constexpr WidgetId kRightHandCurveLarge{ "right_hand_curve_large" };
+            constexpr WidgetId kRightHandCurve{ "right_hand_curve" };
+            constexpr WidgetId kRightHandCurveSmall{ "right_hand_curve_small" };
+            constexpr WidgetId kRightHandCurveVerySmall{ "right_hand_curve_very_small" };
+            constexpr WidgetId kSBendDualTrackLeft{ "s_bend_dual_track_left" };
+            constexpr WidgetId kSBendLeft{ "s_bend_left" };
+            constexpr WidgetId kStraight{ "straight" };
+            constexpr WidgetId kSBendRight{ "s_bend_right" };
+            constexpr WidgetId kSBendDualTrackRight{ "s_bend_dual_track_right" };
+            constexpr WidgetId kSteepSlopeDown{ "steep_slope_down" };
+            constexpr WidgetId kSlopeDown{ "slope_down" };
+            constexpr WidgetId kLevel{ "level" };
+            constexpr WidgetId kSlopeUp{ "slope_up" };
+            constexpr WidgetId kSteepSlopeUp{ "steep_slope_up" };
+            constexpr WidgetId kBridge{ "bridge" };
+            constexpr WidgetId kBridgeDropdown{ "bridge_dropdown" };
+            constexpr WidgetId kConstruct{ "construct" };
+            constexpr WidgetId kRemove{ "remove" };
+            constexpr WidgetId kRotate90{ "rotate_90" };
+            constexpr WidgetId kCopy{ "copy" };
+            constexpr WidgetId kPaste{ "paste" };
+        }
+
         // clang-format off
         constexpr uint64_t allTrack = {
             (1ULL << widx::left_hand_curve_very_small) |
@@ -269,6 +310,14 @@ namespace OpenLoco::Ui::Windows::Construction
             rotate,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kStation{ "station" };
+            constexpr WidgetId kStationDropdown{ "station_dropdown" };
+            constexpr WidgetId kImage{ "image" };
+            constexpr WidgetId kRotate{ "rotate" };
+        }
+
         std::span<const Widget> getWidgets();
 
         void tabReset(Window& self);
@@ -286,6 +335,14 @@ namespace OpenLoco::Ui::Windows::Construction
             both_directions,
             single_direction,
         };
+
+        namespace Widx
+        {
+            constexpr WidgetId kSignal{ "signal" };
+            constexpr WidgetId kSignalDropdown{ "signal_dropdown" };
+            constexpr WidgetId kBothDirections{ "both_directions" };
+            constexpr WidgetId kSingleDirection{ "single_direction" };
+        }
 
         std::span<const Widget> getWidgets();
 
@@ -306,6 +363,17 @@ namespace OpenLoco::Ui::Windows::Construction
             track,
             track_dropdown,
         };
+
+        namespace Widx
+        {
+            constexpr WidgetId kCheckbox1{ "checkbox_1" };
+            constexpr WidgetId kCheckbox2{ "checkbox_2" };
+            constexpr WidgetId kCheckbox3{ "checkbox_3" };
+            constexpr WidgetId kCheckbox4{ "checkbox_4" };
+            constexpr WidgetId kImage{ "image" };
+            constexpr WidgetId kTrack{ "track" };
+            constexpr WidgetId kTrackDropdown{ "track_dropdown" };
+        }
 
         std::span<const Widget> getWidgets();
 

--- a/src/OpenLoco/include/OpenLoco/Ui/Windows/News/News.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Windows/News/News.h
@@ -36,16 +36,26 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             viewport2Button,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kViewport1{ "viewport1" };
+            constexpr WidgetId kViewport2{ "viewport2" };
+            constexpr WidgetId kViewport1Button{ "viewport1Button" };
+            constexpr WidgetId kViewport2Button{ "viewport2Button" };
+        }
+
         template<typename TFrameWidget>
         constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight)
         {
             return makeWidgets(
-                TFrameWidget({ 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
-                Widgets::ImageButton({ frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Viewport({ 2, frameHeight - 73 }, { 168, 64 }, WindowColour::primary, Widget::kContentUnk),
-                Widgets::Viewport({ 180, frameHeight - 73 }, { 168, 64 }, WindowColour::primary, Widget::kContentUnk),
-                Widgets::ImageButton({ 2, frameHeight - 75 }, { 180, 75 }, WindowColour::primary),
-                Widgets::ImageButton({ 2, frameHeight - 75 }, { 180, 75 }, WindowColour::primary));
+                TFrameWidget(Widx::kFrame, { 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
+                Widgets::ImageButton(Widx::kCloseButton, { frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Viewport(Widx::kViewport1, { 2, frameHeight - 73 }, { 168, 64 }, WindowColour::primary, Widget::kContentUnk),
+                Widgets::Viewport(Widx::kViewport2, { 180, frameHeight - 73 }, { 168, 64 }, WindowColour::primary, Widget::kContentUnk),
+                Widgets::ImageButton(Widx::kViewport1Button, { 2, frameHeight - 75 }, { 180, 75 }, WindowColour::primary),
+                Widgets::ImageButton(Widx::kViewport2Button, { 2, frameHeight - 75 }, { 180, 75 }, WindowColour::primary));
         }
 
         const WindowEventList& getEvents();
@@ -74,6 +84,11 @@ namespace OpenLoco::Ui::Windows::NewsWindow
         {
             frame,
         };
+
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+        }
 
         std::span<const Widget> getWidgets();
 

--- a/src/OpenLoco/include/OpenLoco/Ui/Windows/ToolbarTopCommon.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Windows/ToolbarTopCommon.h
@@ -4,29 +4,26 @@
 
 namespace OpenLoco::Ui::Windows::ToolbarTop::Common
 {
-    namespace Widx
+    enum widx
     {
-        enum
-        {
-            loadsave_menu,
-            audio_menu,
-            w2,
+        loadsave_menu,
+        audio_menu,
+        w2,
 
-            zoom_menu,
-            rotate_menu,
-            view_menu,
+        zoom_menu,
+        rotate_menu,
+        view_menu,
 
-            terraform_menu,
-            railroad_menu,
-            road_menu,
-            port_menu,
-            build_vehicles_menu,
+        terraform_menu,
+        railroad_menu,
+        road_menu,
+        port_menu,
+        build_vehicles_menu,
 
-            vehicles_menu,
-            stations_menu,
-            towns_menu,
-        };
-    }
+        vehicles_menu,
+        stations_menu,
+        towns_menu,
+    };
 
     void prepareTownWidget(Window& self);
 

--- a/src/OpenLoco/include/OpenLoco/Ui/Windows/ToolbarTopCommon.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Windows/ToolbarTopCommon.h
@@ -25,6 +25,23 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
         towns_menu,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kLoadsaveMenu{ "loadsave_menu" };
+        constexpr WidgetId kAudioMenu{ "audio_menu" };
+        constexpr WidgetId kZoomMenu{ "zoom_menu" };
+        constexpr WidgetId kRotateMenu{ "rotate_menu" };
+        constexpr WidgetId kViewMenu{ "view_menu" };
+        constexpr WidgetId kTerraformMenu{ "terraform_menu" };
+        constexpr WidgetId kRailroadMenu{ "railroad_menu" };
+        constexpr WidgetId kRoadMenu{ "road_menu" };
+        constexpr WidgetId kPortMenu{ "port_menu" };
+        constexpr WidgetId kBuildVehiclesMenu{ "build_vehicles_menu" };
+        constexpr WidgetId kVehiclesMenu{ "vehicles_menu" };
+        constexpr WidgetId kStationsMenu{ "stations_menu" };
+        constexpr WidgetId kTownsMenu{ "towns_menu" };
+    }
+
     void prepareTownWidget(Window& self);
 
     void draw(Window& window, Gfx::DrawingContext& drawingCtx);

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -85,6 +85,38 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         scrollview_vehicle_preview,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kFrame{ "frame" };
+        constexpr WidgetId kCaption{ "caption" };
+        constexpr WidgetId kCloseButton{ "close_button" };
+        constexpr WidgetId kPanel{ "panel" };
+        constexpr WidgetId kSearchBox{ "searchBox" };
+        constexpr WidgetId kSearchClearButton{ "searchClearButton" };
+        constexpr WidgetId kFilterLabel{ "filterLabel" };
+        constexpr WidgetId kFilterDropdown{ "filterDropdown" };
+        constexpr WidgetId kCargoLabel{ "cargoLabel" };
+        constexpr WidgetId kCargoDropdown{ "cargoDropdown" };
+        constexpr WidgetId kSortLabel{ "sortLabel" };
+        constexpr WidgetId kSortDropdown{ "sortDropdown" };
+        constexpr WidgetId kTabBuildNewTrains{ "tab_build_new_trains" };
+        constexpr WidgetId kTabBuildNewBuses{ "tab_build_new_buses" };
+        constexpr WidgetId kTabBuildNewTrucks{ "tab_build_new_trucks" };
+        constexpr WidgetId kTabBuildNewTrams{ "tab_build_new_trams" };
+        constexpr WidgetId kTabBuildNewAircraft{ "tab_build_new_aircraft" };
+        constexpr WidgetId kTabBuildNewShips{ "tab_build_new_ships" };
+        constexpr WidgetId kTabTrackType0{ "tab_track_type_0" };
+        constexpr WidgetId kTabTrackType1{ "tab_track_type_1" };
+        constexpr WidgetId kTabTrackType2{ "tab_track_type_2" };
+        constexpr WidgetId kTabTrackType3{ "tab_track_type_3" };
+        constexpr WidgetId kTabTrackType4{ "tab_track_type_4" };
+        constexpr WidgetId kTabTrackType5{ "tab_track_type_5" };
+        constexpr WidgetId kTabTrackType6{ "tab_track_type_6" };
+        constexpr WidgetId kTabTrackType7{ "tab_track_type_7" };
+        constexpr WidgetId kScrollviewVehicleSelection{ "scrollview_vehicle_selection" };
+        constexpr WidgetId kScrollviewVehiclePreview{ "scrollview_vehicle_preview" };
+    }
+
     enum scrollIdx
     {
         vehicle_selection,
@@ -223,39 +255,39 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
 
     // 0x5231D0
     static constexpr auto _widgets = makeWidgets(
-        Widgets::Frame({ 0, 0 }, { 380, 233 }, WindowColour::primary),
-        Widgets::Caption({ 1, 1 }, { 378, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary),
-        Widgets::ImageButton({ 365, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-        Widgets::Panel({ 0, 41 }, { 380, 192 }, WindowColour::secondary),
+        Widgets::Frame(Widx::kFrame, { 0, 0 }, { 380, 233 }, WindowColour::primary),
+        Widgets::Caption(Widx::kCaption, { 1, 1 }, { 378, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary),
+        Widgets::ImageButton(Widx::kCloseButton, { 365, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::Panel(Widx::kPanel, { 0, 41 }, { 380, 192 }, WindowColour::secondary),
 
         // Filter options
-        Widgets::TextBox({ 4, 72 }, { 246, 14 }, WindowColour::secondary),
-        Widgets::Button({ 50, 72 }, { 38, 14 }, WindowColour::secondary, StringIds::clearInput),
-        Widgets::dropdownWidgets({ 3, 87 }, { 90, 12 }, WindowColour::secondary, StringIds::filterComponents),
-        Widgets::dropdownWidgets({ 48, 87 }, { 90, 12 }, WindowColour::secondary, StringIds::filterCargoSupported),
-        Widgets::dropdownWidgets({ 93, 87 }, { 90, 12 }, WindowColour::secondary, StringIds::sortComponents),
+        Widgets::TextBox(Widx::kSearchBox, { 4, 72 }, { 246, 14 }, WindowColour::secondary),
+        Widgets::Button(Widx::kSearchClearButton, { 50, 72 }, { 38, 14 }, WindowColour::secondary, StringIds::clearInput),
+        Widgets::dropdownWidgets(Widx::kFilterLabel, Widx::kFilterDropdown, { 3, 87 }, { 90, 12 }, WindowColour::secondary, StringIds::filterComponents),
+        Widgets::dropdownWidgets(Widx::kCargoLabel, Widx::kCargoDropdown, { 48, 87 }, { 90, 12 }, WindowColour::secondary, StringIds::filterCargoSupported),
+        Widgets::dropdownWidgets(Widx::kSortLabel, Widx::kSortDropdown, { 93, 87 }, { 90, 12 }, WindowColour::secondary, StringIds::sortComponents),
 
         // Primary tabs
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_new_train_vehicles),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_new_buses),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_new_trucks),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_new_trams),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_new_aircraft),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_new_ships),
+        Widgets::Tab(Widx::kTabBuildNewTrains, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_new_train_vehicles),
+        Widgets::Tab(Widx::kTabBuildNewBuses, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_new_buses),
+        Widgets::Tab(Widx::kTabBuildNewTrucks, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_new_trucks),
+        Widgets::Tab(Widx::kTabBuildNewTrams, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_new_trams),
+        Widgets::Tab(Widx::kTabBuildNewAircraft, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_new_aircraft),
+        Widgets::Tab(Widx::kTabBuildNewShips, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_new_ships),
 
         // Secondary tabs
-        Widgets::Tab({ 5, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
-        Widgets::Tab({ 36, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
-        Widgets::Tab({ 67, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
-        Widgets::Tab({ 98, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
-        Widgets::Tab({ 129, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
-        Widgets::Tab({ 160, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
-        Widgets::Tab({ 191, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
-        Widgets::Tab({ 222, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
+        Widgets::Tab(Widx::kTabTrackType0, { 5, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
+        Widgets::Tab(Widx::kTabTrackType1, { 36, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
+        Widgets::Tab(Widx::kTabTrackType2, { 67, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
+        Widgets::Tab(Widx::kTabTrackType3, { 98, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
+        Widgets::Tab(Widx::kTabTrackType4, { 129, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
+        Widgets::Tab(Widx::kTabTrackType5, { 160, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
+        Widgets::Tab(Widx::kTabTrackType6, { 191, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
+        Widgets::Tab(Widx::kTabTrackType7, { 222, 43 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicles_for),
 
         // Scroll and preview areas
-        Widgets::ScrollView({ 3, 102 }, { 374, 146 }, WindowColour::secondary, Scrollbars::vertical),
-        Widgets::ScrollView({ 250, 44 }, { 180, 66 }, WindowColour::secondary, Scrollbars::none)
+        Widgets::ScrollView(Widx::kScrollviewVehicleSelection, { 3, 102 }, { 374, 146 }, WindowColour::secondary, Scrollbars::vertical),
+        Widgets::ScrollView(Widx::kScrollviewVehiclePreview, { 250, 44 }, { 180, 66 }, WindowColour::secondary, Scrollbars::none)
 
     );
 
@@ -772,20 +804,20 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     }
 
     // 0x4C3576
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::close_button:
+            case Widx::kCloseButton:
                 WindowManager::close(&window);
                 break;
 
-            case widx::tab_build_new_trains:
-            case widx::tab_build_new_buses:
-            case widx::tab_build_new_trucks:
-            case widx::tab_build_new_trams:
-            case widx::tab_build_new_aircraft:
-            case widx::tab_build_new_ships:
+            case Widx::kTabBuildNewTrains:
+            case Widx::kTabBuildNewBuses:
+            case Widx::kTabBuildNewTrucks:
+            case Widx::kTabBuildNewTrams:
+            case Widx::kTabBuildNewAircraft:
+            case Widx::kTabBuildNewShips:
             {
 
                 if (Input::hasFlag(Input::Flags::toolActive))
@@ -830,14 +862,14 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 window.moveInsideScreenEdges();
                 break;
             }
-            case widx::tab_track_type_0:
-            case widx::tab_track_type_1:
-            case widx::tab_track_type_2:
-            case widx::tab_track_type_3:
-            case widx::tab_track_type_4:
-            case widx::tab_track_type_5:
-            case widx::tab_track_type_6:
-            case widx::tab_track_type_7:
+            case Widx::kTabTrackType0:
+            case Widx::kTabTrackType1:
+            case Widx::kTabTrackType2:
+            case Widx::kTabTrackType3:
+            case Widx::kTabTrackType4:
+            case Widx::kTabTrackType5:
+            case Widx::kTabTrackType6:
+            case Widx::kTabTrackType7:
             {
                 auto tab = widxToTrackTypeTab(widgetIndex);
                 if (window.currentSecondaryTab == tab)
@@ -859,7 +891,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 break;
             }
 
-            case widx::searchClearButton:
+            case Widx::kSearchClearButton:
             {
                 inputSession.clearInput();
                 sub_4B92A5(&window);
@@ -870,9 +902,9 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         }
     }
 
-    static void onMouseDown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseDown(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        if (widgetIndex == widx::filterDropdown)
+        if (id == Widx::kFilterDropdown)
         {
             auto& dropdown = self.widgets[widx::filterLabel];
             auto numItems = Config::get().displayLockedVehicles ? 5 : 2;
@@ -912,7 +944,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 Dropdown::setItemSelected(3);
             }
         }
-        else if (widgetIndex == widx::sortDropdown)
+        else if (id == Widx::kSortDropdown)
         {
             auto& dropdown = self.widgets[widx::sortLabel];
             auto numItems = 12;
@@ -943,7 +975,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 Dropdown::setItemSelected(11);
             }
         }
-        else if (widgetIndex == widx::cargoDropdown)
+        else if (id == Widx::kCargoDropdown)
         {
             auto& dropdown = self.widgets[widx::cargoLabel];
             auto numItems = 2U;
@@ -1001,14 +1033,14 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         }
     }
 
-    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+    static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
         if (itemIndex < 0)
         {
             return;
         }
 
-        if (widgetIndex == widx::filterDropdown)
+        if (id == Widx::kFilterDropdown)
         {
             if (itemIndex == 0)
             {
@@ -1027,7 +1059,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 _vehicleFilterFlags ^= VehicleFilterFlags::locked;
             }
         }
-        else if (widgetIndex == widx::sortDropdown)
+        else if (id == Widx::kSortDropdown)
         {
             if (itemIndex == 0)
             {
@@ -1074,7 +1106,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 _vehicleSortAscending = false;
             }
         }
-        else if (widgetIndex == widx::cargoDropdown)
+        else if (id == Widx::kCargoDropdown)
         {
             if (itemIndex >= 2)
             {
@@ -1274,9 +1306,9 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
     }
 
     // 0x4C37CB
-    static Ui::CursorId cursor(Window& window, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId cursor(Window& window, [[maybe_unused]] WidgetIndex_t widgetIdx, const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
     {
-        if (widgetIdx != widx::scrollview_vehicle_selection)
+        if (id != Widx::kScrollviewVehicleSelection)
         {
             return fallback;
         }

--- a/src/OpenLoco/src/Ui/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Cheats.cpp
@@ -51,17 +51,26 @@ namespace OpenLoco::Ui::Windows::Cheats
         // this should be 1 more than the number of widgets defined above in commonWidgets
         constexpr uint32_t nextWidx = 8;
 
+        namespace Widx
+        {
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kTabFinances{ "tab_finances" };
+            constexpr WidgetId kTabCompanies{ "tab_companies" };
+            constexpr WidgetId kTabVehicles{ "tab_vehicles" };
+            constexpr WidgetId kTabTowns{ "tab_towns" };
+        }
+
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
                 Widgets::Frame({ 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
                 Widgets::Caption({ 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
-                Widgets::ImageButton({ frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::ImageButton(Widx::kCloseButton, { frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
                 Widgets::Panel({ 0, 41 }, { frameWidth, frameHeight - 41 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-                Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-                Widgets::Tab({ 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-                Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab));
+                Widgets::Tab(Widx::kTabFinances, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+                Widgets::Tab(Widx::kTabCompanies, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+                Widgets::Tab(Widx::kTabVehicles, { 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+                Widgets::Tab(Widx::kTabTowns, { 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab));
         }
 
         static void drawTabs(Ui::Window& self, Gfx::DrawingContext& drawingCtx)
@@ -181,27 +190,47 @@ namespace OpenLoco::Ui::Windows::Cheats
             date_change_apply,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kCashStepValue{ "cash_step_value" };
+            constexpr WidgetId kCashStepDecrease{ "cash_step_decrease" };
+            constexpr WidgetId kCashStepIncrease{ "cash_step_increase" };
+            constexpr WidgetId kCashStepApply{ "cash_step_apply" };
+            constexpr WidgetId kLoanValue{ "loan_value" };
+            constexpr WidgetId kLoanClear{ "loan_clear" };
+            constexpr WidgetId kYearStepValue{ "year_step_value" };
+            constexpr WidgetId kYearStepDecrease{ "year_step_decrease" };
+            constexpr WidgetId kYearStepIncrease{ "year_step_increase" };
+            constexpr WidgetId kMonthStepValue{ "month_step_value" };
+            constexpr WidgetId kMonthStepDecrease{ "month_step_decrease" };
+            constexpr WidgetId kMonthStepIncrease{ "month_step_increase" };
+            constexpr WidgetId kDayStepValue{ "day_step_value" };
+            constexpr WidgetId kDayStepDecrease{ "day_step_decrease" };
+            constexpr WidgetId kDayStepIncrease{ "day_step_increase" };
+            constexpr WidgetId kDateChangeApply{ "date_change_apply" };
+        }
+
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize.width, kWindowSize.height, StringIds::financial_cheats),
             // money
             Widgets::GroupBox({ 4, 48 }, { kWindowSize.width - 8, 33 }, WindowColour::secondary, StringIds::cheat_increase_funds),
             Widgets::Label({ 10, 62 }, { 70, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::cheat_amount),
-            Widgets::stepperWidgets({ 80, 62 }, { 95, 12 }, WindowColour::secondary, StringIds::cheat_loan_value),
-            Widgets::Button({ 180, 62 }, { 60, 12 }, WindowColour::secondary, StringIds::cheat_add),
+            Widgets::stepperWidgets(Widx::kCashStepValue, Widx::kCashStepDecrease, Widx::kCashStepIncrease, { 80, 62 }, { 95, 12 }, WindowColour::secondary, StringIds::cheat_loan_value),
+            Widgets::Button(Widx::kCashStepApply, { 180, 62 }, { 60, 12 }, WindowColour::secondary, StringIds::cheat_add),
             // loan
             Widgets::GroupBox({ 4, 86 }, { kWindowSize.width - 8, 33 }, WindowColour::secondary, StringIds::cheat_clear_loan),
             Widgets::Label({ 10, 100 }, { 70, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::company_current_loan),
-            Widgets::TextBox({ 80, 100 }, { 95, 12 }, WindowColour::secondary, StringIds::cheat_loan_value),
-            Widgets::Button({ 180, 100 }, { 60, 12 }, WindowColour::secondary, StringIds::cheat_clear),
+            Widgets::TextBox(Widx::kLoanValue, { 80, 100 }, { 95, 12 }, WindowColour::secondary, StringIds::cheat_loan_value),
+            Widgets::Button(Widx::kLoanClear, { 180, 100 }, { 60, 12 }, WindowColour::secondary, StringIds::cheat_clear),
             // date/time
             Widgets::GroupBox({ 4, 124 }, { kWindowSize.width - 8, 80 }, WindowColour::secondary, StringIds::cheat_date_change_apply),
             Widgets::Label({ 10, 138 }, { 70, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::cheat_year),
-            Widgets::stepperWidgets({ 80, 138 }, { 95, 12 }, WindowColour::secondary, StringIds::cheat_year_value),
+            Widgets::stepperWidgets(Widx::kYearStepValue, Widx::kYearStepDecrease, Widx::kYearStepIncrease, { 80, 138 }, { 95, 12 }, WindowColour::secondary, StringIds::cheat_year_value),
             Widgets::Label({ 10, 154 }, { 70, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::cheat_month),
-            Widgets::stepperWidgets({ 80, 154 }, { 95, 12 }, WindowColour::secondary, StringIds::black_stringid),
+            Widgets::stepperWidgets(Widx::kMonthStepValue, Widx::kMonthStepDecrease, Widx::kMonthStepIncrease, { 80, 154 }, { 95, 12 }, WindowColour::secondary, StringIds::black_stringid),
             Widgets::Label({ 10, 170 }, { 70, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::cheat_day),
-            Widgets::stepperWidgets({ 80, 170 }, { 95, 12 }, WindowColour::secondary, StringIds::cheat_day_value),
-            Widgets::Button({ 10, 186 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_date_change_apply)
+            Widgets::stepperWidgets(Widx::kDayStepValue, Widx::kDayStepDecrease, Widx::kDayStepIncrease, { 80, 170 }, { 95, 12 }, WindowColour::secondary, StringIds::cheat_day_value),
+            Widgets::Button(Widx::kDateChangeApply, { 10, 186 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_date_change_apply)
 
         );
 
@@ -266,22 +295,22 @@ namespace OpenLoco::Ui::Windows::Cheats
             Common::drawTabs(self, drawingCtx);
         }
 
-        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(self.type);
                     break;
 
-                case Common::widx::tab_finances:
-                case Common::widx::tab_companies:
-                case Common::widx::tab_vehicles:
-                case Common::widx::tab_towns:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabCompanies:
+                case Common::Widx::kTabVehicles:
+                case Common::Widx::kTabTowns:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::cash_step_apply:
+                case Widx::kCashStepApply:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::addCash;
@@ -292,7 +321,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     break;
                 }
 
-                case widx::loan_clear:
+                case Widx::kLoanClear:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::clearLoan;
@@ -302,7 +331,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     break;
                 }
 
-                case widx::date_change_apply:
+                case Widx::kDateChangeApply:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::modifyDate;
@@ -322,45 +351,45 @@ namespace OpenLoco::Ui::Windows::Cheats
             return std::max<int32_t>(0, std::min<int32_t>(getMonthTotalDay(date.year, date.month) - 1, date.day));
         }
 
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
             const auto stepSize = Input::getClickRepeatStepSize();
             const auto cashStepSize = stepSize * 1'000;
             const auto timeStepSize = stepSize;
 
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::cash_step_decrease:
+                case Widx::kCashStepDecrease:
                     _cashIncreaseStep = std::max<currency32_t>(Math::Bound::sub(_cashIncreaseStep, cashStepSize), 0);
                     WindowManager::invalidateWidget(self.type, self.number, widx::cash_step_value);
                     break;
 
-                case widx::cash_step_increase:
+                case Widx::kCashStepIncrease:
                     _cashIncreaseStep = std::max<currency32_t>(Math::Bound::add(_cashIncreaseStep, cashStepSize), 0);
                     WindowManager::invalidateWidget(self.type, self.number, widx::cash_step_value);
                     break;
 
-                case widx::year_step_decrease:
+                case Widx::kYearStepDecrease:
                     _date.year = std::max<int32_t>(OpenLoco::Scenario::kMinYear, Math::Bound::sub(_date.year, timeStepSize));
                     break;
 
-                case widx::year_step_increase:
+                case Widx::kYearStepIncrease:
                     _date.year = Math::Bound::add(_date.year, timeStepSize);
                     break;
 
-                case widx::month_step_decrease:
+                case Widx::kMonthStepDecrease:
                     _date.month = static_cast<MonthId>(std::max<int8_t>(0, Math::Bound::sub(static_cast<int8_t>(_date.month), timeStepSize)));
                     break;
 
-                case widx::month_step_increase:
+                case Widx::kMonthStepIncrease:
                     _date.month = static_cast<MonthId>(std::min<int8_t>(11, Math::Bound::add(static_cast<int8_t>(_date.month), timeStepSize)));
                     break;
 
-                case widx::day_step_decrease:
+                case Widx::kDayStepDecrease:
                     _date.day = std::max<int32_t>(0, Math::Bound::sub(_date.day, timeStepSize));
                     break;
 
-                case widx::day_step_increase:
+                case Widx::kDayStepIncrease:
                     _date.day = std::min<int32_t>(getMonthTotalDay(_date.year, _date.month) - 1, Math::Bound::add(_date.day, timeStepSize));
                     break;
             }
@@ -412,16 +441,27 @@ namespace OpenLoco::Ui::Windows::Cheats
             complete_challenge_button,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kTargetCompanyDropdown{ "target_company_dropdown" };
+            constexpr WidgetId kTargetCompanyDropdownBtn{ "target_company_dropdown_btn" };
+            constexpr WidgetId kSwitchCompanyButton{ "switch_company_button" };
+            constexpr WidgetId kAcquireCompanyAssetsButton{ "acquire_company_assets_button" };
+            constexpr WidgetId kToggleBankruptcyButton{ "toggle_bankruptcy_button" };
+            constexpr WidgetId kToggleJailStatusButton{ "toggle_jail_status_button" };
+            constexpr WidgetId kCompleteChallengeButton{ "complete_challenge_button" };
+        }
+
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize.width, kWindowSize.height, StringIds::company_cheats),
             Widgets::GroupBox({ 4, 48 }, { kWindowSize.width - 8, 33 }, WindowColour::secondary, StringIds::cheat_select_target_company),
-            Widgets::dropdownWidgets({ 10, 62 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::black_stringid),
+            Widgets::dropdownWidgets(Widx::kTargetCompanyDropdown, Widx::kTargetCompanyDropdownBtn, { 10, 62 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::black_stringid),
             Widgets::GroupBox({ 4, 86 }, { kWindowSize.width - 8, 96 }, WindowColour::secondary, StringIds::cheat_select_cheat_to_apply),
-            Widgets::Button({ 10, 100 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_switch_to_company),
-            Widgets::Button({ 10, 116 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_acquire_company_assets),
-            Widgets::Button({ 10, 132 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_toggle_bankruptcy),
-            Widgets::Button({ 10, 148 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_toggle_jail_status),
-            Widgets::Button({ 10, 164 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::completeChallenge)
+            Widgets::Button(Widx::kSwitchCompanyButton, { 10, 100 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_switch_to_company),
+            Widgets::Button(Widx::kAcquireCompanyAssetsButton, { 10, 116 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_acquire_company_assets),
+            Widgets::Button(Widx::kToggleBankruptcyButton, { 10, 132 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_toggle_bankruptcy),
+            Widgets::Button(Widx::kToggleJailStatusButton, { 10, 148 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_toggle_jail_status),
+            Widgets::Button(Widx::kCompleteChallengeButton, { 10, 164 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::completeChallenge)
 
         );
 
@@ -464,22 +504,22 @@ namespace OpenLoco::Ui::Windows::Cheats
             Common::drawTabs(self, drawingCtx);
         }
 
-        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(self.type);
                     break;
 
-                case Common::widx::tab_finances:
-                case Common::widx::tab_companies:
-                case Common::widx::tab_vehicles:
-                case Common::widx::tab_towns:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabCompanies:
+                case Common::Widx::kTabVehicles:
+                case Common::Widx::kTabTowns:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::acquire_company_assets_button:
+                case Widx::kAcquireCompanyAssetsButton:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::acquireAssets;
@@ -490,7 +530,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case widx::switch_company_button:
+                case Widx::kSwitchCompanyButton:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::switchCompany;
@@ -501,7 +541,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case widx::toggle_bankruptcy_button:
+                case Widx::kToggleBankruptcyButton:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::toggleBankruptcy;
@@ -512,7 +552,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case widx::toggle_jail_status_button:
+                case Widx::kToggleJailStatusButton:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::toggleJail;
@@ -523,7 +563,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case widx::complete_challenge_button:
+                case Widx::kCompleteChallengeButton:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::completeChallenge;
@@ -536,22 +576,22 @@ namespace OpenLoco::Ui::Windows::Cheats
             }
         }
 
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            if (widgetIndex == widx::target_company_dropdown_btn)
+            if (id == Widx::kTargetCompanyDropdownBtn)
             {
-                Dropdown::populateCompanySelect(&self, &self.widgets[widgetIndex - 1]);
+                Dropdown::populateCompanySelect(&self, &self.widgets[widx::target_company_dropdown]);
             }
         }
 
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
             if (itemIndex == -1)
             {
                 return;
             }
 
-            if (widgetIndex == widx::target_company_dropdown_btn)
+            if (id == Widx::kTargetCompanyDropdownBtn)
             {
                 _targetCompanyId = Dropdown::getCompanyIdFromSelection(itemIndex);
                 self.invalidate();
@@ -596,16 +636,25 @@ namespace OpenLoco::Ui::Windows::Cheats
             checkbox_keep_cargo_modify_pickup,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kReliablityAllToZero{ "reliablity_all_to_zero" };
+            constexpr WidgetId kReliablityAllToHundred{ "reliablity_all_to_hundred" };
+            constexpr WidgetId kCheckboxDisplayLockedVehicles{ "checkbox_display_locked_vehicles" };
+            constexpr WidgetId kCheckboxBuildLockedVehicles{ "checkbox_build_locked_vehicles" };
+            constexpr WidgetId kCheckboxKeepCargoModifyPickup{ "checkbox_keep_cargo_modify_pickup" };
+        }
+
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize.width, kWindowSize.height, StringIds::vehicle_cheats),
             Widgets::GroupBox({ 4, 48 }, { kWindowSize.width - 8, 49 }, WindowColour::secondary, StringIds::cheat_set_vehicle_reliability),
-            Widgets::Button({ 10, 62 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_reliability_zero),
-            Widgets::Button({ 10, 78 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_reliability_hundred),
+            Widgets::Button(Widx::kReliablityAllToZero, { 10, 62 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_reliability_zero),
+            Widgets::Button(Widx::kReliablityAllToHundred, { 10, 78 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_reliability_hundred),
             Widgets::GroupBox({ 4, 102 }, { kWindowSize.width - 8, 45 }, WindowColour::secondary, StringIds::cheat_build_vehicle_window),
-            Widgets::Checkbox({ 10, 116 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::display_locked_vehicles, StringIds::tooltip_display_locked_vehicles),
-            Widgets::Checkbox({ 25, 130 }, { kWindowSize.width - 35, 12 }, WindowColour::secondary, StringIds::allow_building_locked_vehicles, StringIds::tooltip_build_locked_vehicles),
+            Widgets::Checkbox(Widx::kCheckboxDisplayLockedVehicles, { 10, 116 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::display_locked_vehicles, StringIds::tooltip_display_locked_vehicles),
+            Widgets::Checkbox(Widx::kCheckboxBuildLockedVehicles, { 25, 130 }, { kWindowSize.width - 35, 12 }, WindowColour::secondary, StringIds::allow_building_locked_vehicles, StringIds::tooltip_build_locked_vehicles),
             Widgets::GroupBox({ 4, 152 }, { kWindowSize.width - 8, 30 }, WindowColour::secondary, StringIds::cheat_vehicle_cargo),
-            Widgets::Checkbox({ 10, 166 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_keep_cargo_modify_pickup, StringIds::tooltip_keep_cargo_modify_pickup));
+            Widgets::Checkbox(Widx::kCheckboxKeepCargoModifyPickup, { 10, 166 }, { kWindowSize.width - 20, 12 }, WindowColour::secondary, StringIds::cheat_keep_cargo_modify_pickup, StringIds::tooltip_keep_cargo_modify_pickup));
 
         static void prepareDraw(Window& self)
         {
@@ -648,22 +697,22 @@ namespace OpenLoco::Ui::Windows::Cheats
             Common::drawTabs(self, drawingCtx);
         }
 
-        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(self.type);
                     break;
 
-                case Common::widx::tab_finances:
-                case Common::widx::tab_companies:
-                case Common::widx::tab_vehicles:
-                case Common::widx::tab_towns:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabCompanies:
+                case Common::Widx::kTabVehicles:
+                case Common::Widx::kTabTowns:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::reliablity_all_to_zero:
+                case Widx::kReliablityAllToZero:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::vehicleReliability;
@@ -675,7 +724,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case widx::reliablity_all_to_hundred:
+                case Widx::kReliablityAllToHundred:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::vehicleReliability;
@@ -687,7 +736,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case widx::checkbox_display_locked_vehicles:
+                case Widx::kCheckboxDisplayLockedVehicles:
                 {
                     Config::get().displayLockedVehicles = !Config::get().displayLockedVehicles;
 
@@ -709,7 +758,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     break;
                 }
 
-                case widx::checkbox_build_locked_vehicles:
+                case Widx::kCheckboxBuildLockedVehicles:
                 {
                     if (Config::get().displayLockedVehicles)
                     {
@@ -721,7 +770,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     break;
                 }
 
-                case widx::checkbox_keep_cargo_modify_pickup:
+                case Widx::kCheckboxKeepCargoModifyPickup:
                 {
                     Config::get().keepCargoModifyPickup = !Config::get().keepCargoModifyPickup;
                     Config::write();
@@ -764,13 +813,21 @@ namespace OpenLoco::Ui::Windows::Cheats
             ratings_all_to_max,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kRatingsAllMin10pct{ "ratings_all_min_10pct" };
+            constexpr WidgetId kRatingsAllPlus10pct{ "ratings_all_plus_10pct" };
+            constexpr WidgetId kRatingsAllToMin{ "ratings_all_to_min" };
+            constexpr WidgetId kRatingsAllToMax{ "ratings_all_to_max" };
+        }
+
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize.width, kWindowSize.height, StringIds::town_cheats),
             Widgets::GroupBox({ 4, 48 }, { kWindowSize.width - 8, 49 }, WindowColour::secondary, StringIds::cheat_set_ratings),
-            Widgets::Button({ 10, 62 }, { (kWindowSize.width - 26) / 2, 12 }, WindowColour::secondary, StringIds::cheat_ratings_min_10pct),
-            Widgets::Button({ 3 + (kWindowSize.width / 2), 62 }, { (kWindowSize.width - 26) / 2, 12 }, WindowColour::secondary, StringIds::cheat_ratings_plus_10pct),
-            Widgets::Button({ 10, 78 }, { (kWindowSize.width - 26) / 2, 12 }, WindowColour::secondary, StringIds::cheat_ratings_to_min),
-            Widgets::Button({ 3 + (kWindowSize.width / 2), 78 }, { (kWindowSize.width - 26) / 2, 12 }, WindowColour::secondary, StringIds::cheat_ratings_to_max)
+            Widgets::Button(Widx::kRatingsAllMin10pct, { 10, 62 }, { (kWindowSize.width - 26) / 2, 12 }, WindowColour::secondary, StringIds::cheat_ratings_min_10pct),
+            Widgets::Button(Widx::kRatingsAllPlus10pct, { 3 + (kWindowSize.width / 2), 62 }, { (kWindowSize.width - 26) / 2, 12 }, WindowColour::secondary, StringIds::cheat_ratings_plus_10pct),
+            Widgets::Button(Widx::kRatingsAllToMin, { 10, 78 }, { (kWindowSize.width - 26) / 2, 12 }, WindowColour::secondary, StringIds::cheat_ratings_to_min),
+            Widgets::Button(Widx::kRatingsAllToMax, { 3 + (kWindowSize.width / 2), 78 }, { (kWindowSize.width - 26) / 2, 12 }, WindowColour::secondary, StringIds::cheat_ratings_to_max)
 
         );
 
@@ -786,22 +843,22 @@ namespace OpenLoco::Ui::Windows::Cheats
             Common::drawTabs(self, drawingCtx);
         }
 
-        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(self.type);
                     break;
 
-                case Common::widx::tab_finances:
-                case Common::widx::tab_companies:
-                case Common::widx::tab_vehicles:
-                case Common::widx::tab_towns:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabCompanies:
+                case Common::Widx::kTabVehicles:
+                case Common::Widx::kTabTowns:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::ratings_all_min_10pct:
+                case Widx::kRatingsAllMin10pct:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::companyRatings;
@@ -813,7 +870,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case widx::ratings_all_plus_10pct:
+                case Widx::kRatingsAllPlus10pct:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::companyRatings;
@@ -825,7 +882,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case widx::ratings_all_to_min:
+                case Widx::kRatingsAllToMin:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::companyRatings;
@@ -837,7 +894,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case widx::ratings_all_to_max:
+                case Widx::kRatingsAllToMax:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::companyRatings;

--- a/src/OpenLoco/src/Ui/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Cheats.cpp
@@ -37,22 +37,19 @@ namespace OpenLoco::Ui::Windows::Cheats
 {
     namespace Common
     {
-        namespace Widx
+        enum widx
         {
-            enum
-            {
-                frame,
-                title,
-                close_button,
-                panel,
-                tab_finances,
-                tab_companies,
-                tab_vehicles,
-                tab_towns,
-            };
-            // this should be 1 more than the number of widgets defined above in commonWidgets
-            constexpr uint32_t nextWidx = 8;
-        }
+            frame,
+            title,
+            close_button,
+            panel,
+            tab_finances,
+            tab_companies,
+            tab_vehicles,
+            tab_towns,
+        };
+        // this should be 1 more than the number of widgets defined above in commonWidgets
+        constexpr uint32_t nextWidx = 8;
 
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
@@ -93,7 +90,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                 };
 
                 uint32_t imageId = skin->img;
-                if (self.currentTab == Widx::tab_finances - Widx::tab_finances)
+                if (self.currentTab == widx::tab_finances - widx::tab_finances)
                 {
                     imageId += financesTabImageIds[(self.frameNo / 2) % std::size(financesTabImageIds)];
                 }
@@ -102,13 +99,13 @@ namespace OpenLoco::Ui::Windows::Cheats
                     imageId += financesTabImageIds[0];
                 }
 
-                Widget::drawTab(self, drawingCtx, imageId, Widx::tab_finances);
+                Widget::drawTab(self, drawingCtx, imageId, widx::tab_finances);
             }
 
             // Companies tab
             {
                 const uint32_t imageId = skin->img + InterfaceSkin::ImageIds::tab_company;
-                Widget::drawTab(self, drawingCtx, imageId, Widx::tab_companies);
+                Widget::drawTab(self, drawingCtx, imageId, widx::tab_companies);
             }
 
             // Vehicles tab
@@ -125,7 +122,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                 };
 
                 uint32_t imageId = skin->img;
-                if (self.currentTab == Widx::tab_vehicles - Widx::tab_finances)
+                if (self.currentTab == widx::tab_vehicles - widx::tab_finances)
                 {
                     imageId += vehiclesTabImageIds[(self.frameNo / 2) % std::size(vehiclesTabImageIds)];
                 }
@@ -139,13 +136,13 @@ namespace OpenLoco::Ui::Windows::Cheats
 
                 imageId = Gfx::recolour(imageId, companyColour);
 
-                Widget::drawTab(self, drawingCtx, imageId, Widx::tab_vehicles);
+                Widget::drawTab(self, drawingCtx, imageId, widx::tab_vehicles);
             }
 
             // Towns tab
             {
                 const uint32_t imageId = skin->img + InterfaceSkin::ImageIds::toolbar_menu_towns;
-                Widget::drawTab(self, drawingCtx, imageId, Widx::tab_towns);
+                Widget::drawTab(self, drawingCtx, imageId, widx::tab_towns);
             }
         }
 
@@ -156,36 +153,33 @@ namespace OpenLoco::Ui::Windows::Cheats
     {
         static constexpr Ui::Size kWindowSize = { 250, 210 };
 
-        namespace Widx
+        enum widx
         {
-            enum
-            {
-                cash_step_group = Common::Widx::nextWidx,
-                cash_step_label,
-                cash_step_value,
-                cash_step_decrease,
-                cash_step_increase,
-                cash_step_apply,
-                loan_group,
-                loan_label,
-                loan_value,
-                loan_clear,
-                time_group,
-                year_label,
-                year_step_value,
-                year_step_decrease,
-                year_step_increase,
-                month_label,
-                month_step_value,
-                month_step_decrease,
-                month_step_increase,
-                day_label,
-                day_step_value,
-                day_step_decrease,
-                day_step_increase,
-                date_change_apply,
-            };
-        }
+            cash_step_group = Common::nextWidx,
+            cash_step_label,
+            cash_step_value,
+            cash_step_decrease,
+            cash_step_increase,
+            cash_step_apply,
+            loan_group,
+            loan_label,
+            loan_value,
+            loan_clear,
+            time_group,
+            year_label,
+            year_step_value,
+            year_step_decrease,
+            year_step_increase,
+            month_label,
+            month_step_value,
+            month_step_decrease,
+            month_step_increase,
+            day_label,
+            day_step_value,
+            day_step_decrease,
+            day_step_increase,
+            date_change_apply,
+        };
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize.width, kWindowSize.height, StringIds::financial_cheats),
@@ -212,32 +206,32 @@ namespace OpenLoco::Ui::Windows::Cheats
         );
 
         const uint64_t holdableWidgets
-            = (1 << Widx::cash_step_decrease)
-            | (1 << Widx::cash_step_increase)
-            | (1 << Widx::year_step_decrease)
-            | (1 << Widx::year_step_increase)
-            | (1 << Widx::month_step_decrease)
-            | (1 << Widx::month_step_increase)
-            | (1 << Widx::day_step_decrease)
-            | (1 << Widx::day_step_increase);
+            = (1 << widx::cash_step_decrease)
+            | (1 << widx::cash_step_increase)
+            | (1 << widx::year_step_decrease)
+            | (1 << widx::year_step_increase)
+            | (1 << widx::month_step_decrease)
+            | (1 << widx::month_step_increase)
+            | (1 << widx::day_step_decrease)
+            | (1 << widx::day_step_increase);
 
         static currency32_t _cashIncreaseStep = 10'000;
         static Date _date;
 
         static void prepareDraw(Window& self)
         {
-            self.activatedWidgets = (1 << Common::Widx::tab_finances);
+            self.activatedWidgets = (1 << Common::widx::tab_finances);
 
             // Add cash step label and value
             {
-                auto& widget = self.widgets[Widx::cash_step_value];
+                auto& widget = self.widgets[widx::cash_step_value];
                 FormatArguments args{ widget.textArgs };
                 args.push(_cashIncreaseStep);
             }
 
             // Loan label and value
             {
-                auto& widget = self.widgets[Widx::loan_value];
+                auto& widget = self.widgets[widx::loan_value];
                 FormatArguments args{ widget.textArgs };
                 auto company = CompanyManager::getPlayerCompany();
                 args.push(company->currentLoan);
@@ -245,21 +239,21 @@ namespace OpenLoco::Ui::Windows::Cheats
 
             // Add year label and value
             {
-                auto& widget = self.widgets[Widx::year_step_value];
+                auto& widget = self.widgets[widx::year_step_value];
                 FormatArguments args{ widget.textArgs };
                 args.push(_date.year);
             }
 
             // Add month label and value
             {
-                auto& widget = self.widgets[Widx::month_step_value];
+                auto& widget = self.widgets[widx::month_step_value];
                 FormatArguments args{ widget.textArgs };
                 args.push(StringManager::monthToString(_date.month).second);
             }
 
             // Add day label and value
             {
-                auto& widget = self.widgets[Widx::day_step_value];
+                auto& widget = self.widgets[widx::day_step_value];
                 FormatArguments args{ widget.textArgs };
                 args.push(_date.day + 1); // +1 since days in game are 0-based, but IRL they are 1-based
             }
@@ -276,18 +270,18 @@ namespace OpenLoco::Ui::Windows::Cheats
         {
             switch (widgetIndex)
             {
-                case Common::Widx::close_button:
+                case Common::widx::close_button:
                     WindowManager::close(self.type);
                     break;
 
-                case Common::Widx::tab_finances:
-                case Common::Widx::tab_companies:
-                case Common::Widx::tab_vehicles:
-                case Common::Widx::tab_towns:
+                case Common::widx::tab_finances:
+                case Common::widx::tab_companies:
+                case Common::widx::tab_vehicles:
+                case Common::widx::tab_towns:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case Widx::cash_step_apply:
+                case widx::cash_step_apply:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::addCash;
@@ -298,17 +292,17 @@ namespace OpenLoco::Ui::Windows::Cheats
                     break;
                 }
 
-                case Widx::loan_clear:
+                case widx::loan_clear:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::clearLoan;
 
                     GameCommands::doCommand(args, GameCommands::Flags::apply);
-                    WindowManager::invalidateWidget(self.type, self.number, Widx::loan_value);
+                    WindowManager::invalidateWidget(self.type, self.number, widx::loan_value);
                     break;
                 }
 
-                case Widx::date_change_apply:
+                case widx::date_change_apply:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::modifyDate;
@@ -336,37 +330,37 @@ namespace OpenLoco::Ui::Windows::Cheats
 
             switch (widgetIndex)
             {
-                case Widx::cash_step_decrease:
+                case widx::cash_step_decrease:
                     _cashIncreaseStep = std::max<currency32_t>(Math::Bound::sub(_cashIncreaseStep, cashStepSize), 0);
-                    WindowManager::invalidateWidget(self.type, self.number, Widx::cash_step_value);
+                    WindowManager::invalidateWidget(self.type, self.number, widx::cash_step_value);
                     break;
 
-                case Widx::cash_step_increase:
+                case widx::cash_step_increase:
                     _cashIncreaseStep = std::max<currency32_t>(Math::Bound::add(_cashIncreaseStep, cashStepSize), 0);
-                    WindowManager::invalidateWidget(self.type, self.number, Widx::cash_step_value);
+                    WindowManager::invalidateWidget(self.type, self.number, widx::cash_step_value);
                     break;
 
-                case Widx::year_step_decrease:
+                case widx::year_step_decrease:
                     _date.year = std::max<int32_t>(OpenLoco::Scenario::kMinYear, Math::Bound::sub(_date.year, timeStepSize));
                     break;
 
-                case Widx::year_step_increase:
+                case widx::year_step_increase:
                     _date.year = Math::Bound::add(_date.year, timeStepSize);
                     break;
 
-                case Widx::month_step_decrease:
+                case widx::month_step_decrease:
                     _date.month = static_cast<MonthId>(std::max<int8_t>(0, Math::Bound::sub(static_cast<int8_t>(_date.month), timeStepSize)));
                     break;
 
-                case Widx::month_step_increase:
+                case widx::month_step_increase:
                     _date.month = static_cast<MonthId>(std::min<int8_t>(11, Math::Bound::add(static_cast<int8_t>(_date.month), timeStepSize)));
                     break;
 
-                case Widx::day_step_decrease:
+                case widx::day_step_decrease:
                     _date.day = std::max<int32_t>(0, Math::Bound::sub(_date.day, timeStepSize));
                     break;
 
-                case Widx::day_step_increase:
+                case widx::day_step_increase:
                     _date.day = std::min<int32_t>(getMonthTotalDay(_date.year, _date.month) - 1, Math::Bound::add(_date.day, timeStepSize));
                     break;
             }
@@ -379,7 +373,7 @@ namespace OpenLoco::Ui::Windows::Cheats
         {
             self.frameNo += 1;
             self.callPrepareDraw();
-            WindowManager::invalidateWidget(self.type, self.number, Common::Widx::tab_finances);
+            WindowManager::invalidateWidget(self.type, self.number, Common::widx::tab_finances);
         }
 
         static void initDate()
@@ -405,21 +399,18 @@ namespace OpenLoco::Ui::Windows::Cheats
     {
         static constexpr Ui::Size kWindowSize = { 250, 188 };
 
-        namespace Widx
+        enum widx
         {
-            enum
-            {
-                target_company_group = Common::Widx::nextWidx,
-                target_company_dropdown,
-                target_company_dropdown_btn,
-                select_cheat_group,
-                switch_company_button,
-                acquire_company_assets_button,
-                toggle_bankruptcy_button,
-                toggle_jail_status_button,
-                complete_challenge_button,
-            };
-        }
+            target_company_group = Common::nextWidx,
+            target_company_dropdown,
+            target_company_dropdown_btn,
+            select_cheat_group,
+            switch_company_button,
+            acquire_company_assets_button,
+            toggle_bankruptcy_button,
+            toggle_jail_status_button,
+            complete_challenge_button,
+        };
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize.width, kWindowSize.height, StringIds::company_cheats),
@@ -438,28 +429,28 @@ namespace OpenLoco::Ui::Windows::Cheats
 
         static void prepareDraw(Window& self)
         {
-            self.activatedWidgets = (1 << Common::Widx::tab_companies);
+            self.activatedWidgets = (1 << Common::widx::tab_companies);
 
             if (_targetCompanyId == CompanyManager::getControllingId())
             {
-                self.disabledWidgets |= (1 << Widx::switch_company_button) | (1 << Widx::acquire_company_assets_button);
+                self.disabledWidgets |= (1 << widx::switch_company_button) | (1 << widx::acquire_company_assets_button);
             }
             else
             {
-                self.disabledWidgets &= ~((1 << Widx::switch_company_button) | (1 << Widx::acquire_company_assets_button));
+                self.disabledWidgets &= ~((1 << widx::switch_company_button) | (1 << widx::acquire_company_assets_button));
             }
 
             if (!CompanyManager::isPlayerCompany(_targetCompanyId))
             {
-                self.disabledWidgets |= (1 << Widx::complete_challenge_button);
+                self.disabledWidgets |= (1 << widx::complete_challenge_button);
             }
             else
             {
-                self.disabledWidgets &= ~(1 << Widx::complete_challenge_button);
+                self.disabledWidgets &= ~(1 << widx::complete_challenge_button);
             }
 
             // Current company name
-            auto& widget = self.widgets[Widx::target_company_dropdown];
+            auto& widget = self.widgets[widx::target_company_dropdown];
             auto args = FormatArguments(widget.textArgs);
 
             auto company = CompanyManager::get(_targetCompanyId);
@@ -477,18 +468,18 @@ namespace OpenLoco::Ui::Windows::Cheats
         {
             switch (widgetIndex)
             {
-                case Common::Widx::close_button:
+                case Common::widx::close_button:
                     WindowManager::close(self.type);
                     break;
 
-                case Common::Widx::tab_finances:
-                case Common::Widx::tab_companies:
-                case Common::Widx::tab_vehicles:
-                case Common::Widx::tab_towns:
+                case Common::widx::tab_finances:
+                case Common::widx::tab_companies:
+                case Common::widx::tab_vehicles:
+                case Common::widx::tab_towns:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case Widx::acquire_company_assets_button:
+                case widx::acquire_company_assets_button:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::acquireAssets;
@@ -499,7 +490,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case Widx::switch_company_button:
+                case widx::switch_company_button:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::switchCompany;
@@ -510,7 +501,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case Widx::toggle_bankruptcy_button:
+                case widx::toggle_bankruptcy_button:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::toggleBankruptcy;
@@ -521,7 +512,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case Widx::toggle_jail_status_button:
+                case widx::toggle_jail_status_button:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::toggleJail;
@@ -532,7 +523,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case Widx::complete_challenge_button:
+                case widx::complete_challenge_button:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::completeChallenge;
@@ -547,7 +538,7 @@ namespace OpenLoco::Ui::Windows::Cheats
 
         static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
-            if (widgetIndex == Widx::target_company_dropdown_btn)
+            if (widgetIndex == widx::target_company_dropdown_btn)
             {
                 Dropdown::populateCompanySelect(&self, &self.widgets[widgetIndex - 1]);
             }
@@ -560,7 +551,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                 return;
             }
 
-            if (widgetIndex == Widx::target_company_dropdown_btn)
+            if (widgetIndex == widx::target_company_dropdown_btn)
             {
                 _targetCompanyId = Dropdown::getCompanyIdFromSelection(itemIndex);
                 self.invalidate();
@@ -571,7 +562,7 @@ namespace OpenLoco::Ui::Windows::Cheats
         {
             self.frameNo += 1;
             self.callPrepareDraw();
-            WindowManager::invalidateWidget(self.type, self.number, Common::Widx::tab_finances);
+            WindowManager::invalidateWidget(self.type, self.number, Common::widx::tab_finances);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -593,20 +584,17 @@ namespace OpenLoco::Ui::Windows::Cheats
     {
         static constexpr Ui::Size kWindowSize = { 250, 188 };
 
-        namespace Widx
+        enum widx
         {
-            enum
-            {
-                reliability_group = Common::Widx::nextWidx,
-                reliablity_all_to_zero,
-                reliablity_all_to_hundred,
-                vehicle_locked_group,
-                checkbox_display_locked_vehicles,
-                checkbox_build_locked_vehicles,
-                vehicle_cargo_group,
-                checkbox_keep_cargo_modify_pickup,
-            };
-        }
+            reliability_group = Common::nextWidx,
+            reliablity_all_to_zero,
+            reliablity_all_to_hundred,
+            vehicle_locked_group,
+            checkbox_display_locked_vehicles,
+            checkbox_build_locked_vehicles,
+            vehicle_cargo_group,
+            checkbox_keep_cargo_modify_pickup,
+        };
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize.width, kWindowSize.height, StringIds::vehicle_cheats),
@@ -621,35 +609,35 @@ namespace OpenLoco::Ui::Windows::Cheats
 
         static void prepareDraw(Window& self)
         {
-            self.activatedWidgets = (1 << Common::Widx::tab_vehicles);
+            self.activatedWidgets = (1 << Common::widx::tab_vehicles);
 
             if (Config::get().displayLockedVehicles)
             {
-                self.activatedWidgets |= (1 << Widx::checkbox_display_locked_vehicles);
-                self.disabledWidgets &= ~(1 << Widx::checkbox_build_locked_vehicles);
+                self.activatedWidgets |= (1 << widx::checkbox_display_locked_vehicles);
+                self.disabledWidgets &= ~(1 << widx::checkbox_build_locked_vehicles);
             }
             else
             {
-                self.activatedWidgets &= ~(1 << Widx::checkbox_display_locked_vehicles);
-                self.disabledWidgets |= (1 << Widx::checkbox_build_locked_vehicles);
+                self.activatedWidgets &= ~(1 << widx::checkbox_display_locked_vehicles);
+                self.disabledWidgets |= (1 << widx::checkbox_build_locked_vehicles);
             }
 
             if (Config::get().buildLockedVehicles)
             {
-                self.activatedWidgets |= (1 << Widx::checkbox_build_locked_vehicles);
+                self.activatedWidgets |= (1 << widx::checkbox_build_locked_vehicles);
             }
             else
             {
-                self.activatedWidgets &= ~(1 << Widx::checkbox_build_locked_vehicles);
+                self.activatedWidgets &= ~(1 << widx::checkbox_build_locked_vehicles);
             }
 
             if (Config::get().keepCargoModifyPickup)
             {
-                self.activatedWidgets |= (1 << Widx::checkbox_keep_cargo_modify_pickup);
+                self.activatedWidgets |= (1 << widx::checkbox_keep_cargo_modify_pickup);
             }
             else
             {
-                self.activatedWidgets &= ~(1 << Widx::checkbox_keep_cargo_modify_pickup);
+                self.activatedWidgets &= ~(1 << widx::checkbox_keep_cargo_modify_pickup);
             }
         }
 
@@ -664,18 +652,18 @@ namespace OpenLoco::Ui::Windows::Cheats
         {
             switch (widgetIndex)
             {
-                case Common::Widx::close_button:
+                case Common::widx::close_button:
                     WindowManager::close(self.type);
                     break;
 
-                case Common::Widx::tab_finances:
-                case Common::Widx::tab_companies:
-                case Common::Widx::tab_vehicles:
-                case Common::Widx::tab_towns:
+                case Common::widx::tab_finances:
+                case Common::widx::tab_companies:
+                case Common::widx::tab_vehicles:
+                case Common::widx::tab_towns:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case Widx::reliablity_all_to_zero:
+                case widx::reliablity_all_to_zero:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::vehicleReliability;
@@ -687,7 +675,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case Widx::reliablity_all_to_hundred:
+                case widx::reliablity_all_to_hundred:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::vehicleReliability;
@@ -699,45 +687,45 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case Widx::checkbox_display_locked_vehicles:
+                case widx::checkbox_display_locked_vehicles:
                 {
                     Config::get().displayLockedVehicles = !Config::get().displayLockedVehicles;
 
                     // if we don't want to display locked vehicles, there is no reason to allow building them
                     if (Config::get().displayLockedVehicles)
                     {
-                        self.disabledWidgets &= ~(1 << Widx::checkbox_build_locked_vehicles);
+                        self.disabledWidgets &= ~(1 << widx::checkbox_build_locked_vehicles);
                     }
                     else
                     {
                         Config::get().buildLockedVehicles = false;
-                        self.disabledWidgets |= (1 << Widx::checkbox_build_locked_vehicles);
+                        self.disabledWidgets |= (1 << widx::checkbox_build_locked_vehicles);
                     }
 
                     Config::write();
-                    WindowManager::invalidateWidget(self.type, self.number, Widx::checkbox_build_locked_vehicles);
-                    WindowManager::invalidateWidget(self.type, self.number, Widx::checkbox_display_locked_vehicles);
+                    WindowManager::invalidateWidget(self.type, self.number, widx::checkbox_build_locked_vehicles);
+                    WindowManager::invalidateWidget(self.type, self.number, widx::checkbox_display_locked_vehicles);
                     WindowManager::invalidate(WindowType::buildVehicle);
                     break;
                 }
 
-                case Widx::checkbox_build_locked_vehicles:
+                case widx::checkbox_build_locked_vehicles:
                 {
                     if (Config::get().displayLockedVehicles)
                     {
                         Config::get().buildLockedVehicles = !Config::get().buildLockedVehicles;
                         Config::write();
-                        WindowManager::invalidateWidget(self.type, self.number, Widx::checkbox_build_locked_vehicles);
+                        WindowManager::invalidateWidget(self.type, self.number, widx::checkbox_build_locked_vehicles);
                         WindowManager::invalidate(WindowType::buildVehicle);
                     }
                     break;
                 }
 
-                case Widx::checkbox_keep_cargo_modify_pickup:
+                case widx::checkbox_keep_cargo_modify_pickup:
                 {
                     Config::get().keepCargoModifyPickup = !Config::get().keepCargoModifyPickup;
                     Config::write();
-                    WindowManager::invalidateWidget(self.type, self.number, Widx::checkbox_keep_cargo_modify_pickup);
+                    WindowManager::invalidateWidget(self.type, self.number, widx::checkbox_keep_cargo_modify_pickup);
                     break;
                 }
             }
@@ -747,7 +735,7 @@ namespace OpenLoco::Ui::Windows::Cheats
         {
             self.frameNo += 1;
             self.callPrepareDraw();
-            WindowManager::invalidateWidget(self.type, self.number, Common::Widx::tab_vehicles);
+            WindowManager::invalidateWidget(self.type, self.number, Common::widx::tab_vehicles);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -767,17 +755,14 @@ namespace OpenLoco::Ui::Windows::Cheats
     {
         static constexpr Ui::Size kWindowSize = { 250, 103 };
 
-        namespace Widx
+        enum widx
         {
-            enum
-            {
-                ratings_group = Common::Widx::nextWidx,
-                ratings_all_min_10pct,
-                ratings_all_plus_10pct,
-                ratings_all_to_min,
-                ratings_all_to_max,
-            };
-        }
+            ratings_group = Common::nextWidx,
+            ratings_all_min_10pct,
+            ratings_all_plus_10pct,
+            ratings_all_to_min,
+            ratings_all_to_max,
+        };
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize.width, kWindowSize.height, StringIds::town_cheats),
@@ -791,7 +776,7 @@ namespace OpenLoco::Ui::Windows::Cheats
 
         static void prepareDraw(Window& self)
         {
-            self.activatedWidgets = (1 << Common::Widx::tab_towns);
+            self.activatedWidgets = (1 << Common::widx::tab_towns);
         }
 
         static void draw(Ui::Window& self, Gfx::DrawingContext& drawingCtx)
@@ -805,18 +790,18 @@ namespace OpenLoco::Ui::Windows::Cheats
         {
             switch (widgetIndex)
             {
-                case Common::Widx::close_button:
+                case Common::widx::close_button:
                     WindowManager::close(self.type);
                     break;
 
-                case Common::Widx::tab_finances:
-                case Common::Widx::tab_companies:
-                case Common::Widx::tab_vehicles:
-                case Common::Widx::tab_towns:
+                case Common::widx::tab_finances:
+                case Common::widx::tab_companies:
+                case Common::widx::tab_vehicles:
+                case Common::widx::tab_towns:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case Widx::ratings_all_min_10pct:
+                case widx::ratings_all_min_10pct:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::companyRatings;
@@ -828,7 +813,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case Widx::ratings_all_plus_10pct:
+                case widx::ratings_all_plus_10pct:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::companyRatings;
@@ -840,7 +825,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case Widx::ratings_all_to_min:
+                case widx::ratings_all_to_min:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::companyRatings;
@@ -852,7 +837,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     return;
                 }
 
-                case Widx::ratings_all_to_max:
+                case widx::ratings_all_to_max:
                 {
                     GameCommands::GenericCheatArgs args{};
                     args.subcommand = CheatCommand::companyRatings;
@@ -870,7 +855,7 @@ namespace OpenLoco::Ui::Windows::Cheats
         {
             self.frameNo += 1;
             self.callPrepareDraw();
-            WindowManager::invalidateWidget(self.type, self.number, Common::Widx::tab_towns);
+            WindowManager::invalidateWidget(self.type, self.number, Common::widx::tab_towns);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -903,7 +888,7 @@ namespace OpenLoco::Ui::Windows::Cheats
         Finances::initDate();
 
         window->setWidgets(Finances::_widgets);
-        window->currentTab = Common::Widx::tab_finances - Common::Widx::tab_finances;
+        window->currentTab = Common::widx::tab_finances - Common::widx::tab_finances;
         window->holdableWidgets = Finances::holdableWidgets;
         window->initScrollWidgets();
 
@@ -927,16 +912,16 @@ namespace OpenLoco::Ui::Windows::Cheats
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { Finances::_widgets,  Widx::tab_finances,  Finances::getEvents(),  &Finances::holdableWidgets, Finances::kWindowSize  },
-            { Companies::_widgets, Widx::tab_companies, Companies::getEvents(), nullptr,                    Companies::kWindowSize },
-            { Vehicles::_widgets,  Widx::tab_vehicles,  Vehicles::getEvents(),  nullptr,                    Vehicles::kWindowSize  },
-            { Towns::_widgets,     Widx::tab_towns,     Towns::getEvents(),     nullptr,                    Towns::kWindowSize     },
+            { Finances::_widgets,  widx::tab_finances,  Finances::getEvents(),  &Finances::holdableWidgets, Finances::kWindowSize  },
+            { Companies::_widgets, widx::tab_companies, Companies::getEvents(), nullptr,                    Companies::kWindowSize },
+            { Vehicles::_widgets,  widx::tab_vehicles,  Vehicles::getEvents(),  nullptr,                    Vehicles::kWindowSize  },
+            { Towns::_widgets,     widx::tab_towns,     Towns::getEvents(),     nullptr,                    Towns::kWindowSize     },
         };
         // clang-format on
 
         static void switchTab(Window& self, WidgetIndex_t widgetIndex)
         {
-            self.currentTab = widgetIndex - Widx::tab_finances;
+            self.currentTab = widgetIndex - widx::tab_finances;
             self.frameNo = 0;
 
             auto tabInfo = tabInformationByTabOffset[self.currentTab];

--- a/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
@@ -47,14 +47,22 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
         face_frame
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kCaption{ "caption" };
+        constexpr WidgetId kCloseButton{ "close_button" };
+        constexpr WidgetId kScrollview{ "scrollview" };
+        constexpr WidgetId kFaceFrame{ "face_frame" };
+    }
+
     // 0x509680
     static constexpr auto widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, kWindowSize, WindowColour::primary),
-        Widgets::Caption({ 1, 1 }, { 398, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, StringIds::company_face_selection_title),
-        Widgets::ImageButton({ 385, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::Caption(Widx::kCaption, { 1, 1 }, { 398, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, StringIds::company_face_selection_title),
+        Widgets::ImageButton(Widx::kCloseButton, { 385, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
         Widgets::Panel({ 0, 15 }, { 400, 257 }, WindowColour::secondary),
-        Widgets::ScrollView({ 4, 19 }, { 188, 248 }, WindowColour::secondary, Scrollbars::vertical, StringIds::tooltip_company_face_selection),
-        Widgets::Tab({ 265, 23 }, { 66, 66 }, WindowColour::secondary)
+        Widgets::ScrollView(Widx::kScrollview, { 4, 19 }, { 188, 248 }, WindowColour::secondary, Scrollbars::vertical, StringIds::tooltip_company_face_selection),
+        Widgets::Tab(Widx::kFaceFrame, { 265, 23 }, { 66, 66 }, WindowColour::secondary)
 
     );
 
@@ -130,11 +138,11 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
     }
 
     // 0x435299
-    static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::close_button:
+            case Widx::kCloseButton:
                 WindowManager::close(&self);
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -61,20 +61,35 @@ namespace OpenLoco::Ui::Windows::CompanyList
             tab_speed_records,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabCompanyList{ "tab_company_list" };
+            constexpr WidgetId kTabPerformance{ "tab_performance" };
+            constexpr WidgetId kTabCargoUnits{ "tab_cargo_units" };
+            constexpr WidgetId kTabCargoDistance{ "tab_cargo_distance" };
+            constexpr WidgetId kTabValues{ "tab_values" };
+            constexpr WidgetId kTabPaymentRates{ "tab_payment_rates" };
+            constexpr WidgetId kTabSpeedRecords{ "tab_speed_records" };
+        }
+
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
-                Widgets::ImageButton({ frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { frameWidth, 231 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_compare_companies),
-                Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_company_performance),
-                Widgets::Tab({ 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_cargo_graphs),
-                Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_cargo_distance_graphs),
-                Widgets::Tab({ 127, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_company_values),
-                Widgets::Tab({ 158, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_cargo_payment_rates),
-                Widgets::Tab({ 189, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_speed_records));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
+                Widgets::ImageButton(Widx::kCloseButton, { frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { frameWidth, 231 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabCompanyList, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_compare_companies),
+                Widgets::Tab(Widx::kTabPerformance, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_company_performance),
+                Widgets::Tab(Widx::kTabCargoUnits, { 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_cargo_graphs),
+                Widgets::Tab(Widx::kTabCargoDistance, { 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_cargo_distance_graphs),
+                Widgets::Tab(Widx::kTabValues, { 127, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_company_values),
+                Widgets::Tab(Widx::kTabPaymentRates, { 158, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_cargo_payment_rates),
+                Widgets::Tab(Widx::kTabSpeedRecords, { 189, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_speed_records));
         }
 
         static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id);
@@ -102,14 +117,24 @@ namespace OpenLoco::Ui::Windows::CompanyList
             status_bar,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kSortName{ "sort_name" };
+            constexpr WidgetId kSortStatus{ "sort_status" };
+            constexpr WidgetId kSortPerformance{ "sort_performance" };
+            constexpr WidgetId kSortValue{ "sort_value" };
+            constexpr WidgetId kScrollview{ "scrollview" };
+            constexpr WidgetId kStatusBar{ "status_bar" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(640, 272, StringIds::title_company_list),
-            Widgets::TableHeader({ 4, 43 }, { 175, 12 }, WindowColour::secondary, ImageIds::null, StringIds::tooltip_sort_company_name),
-            Widgets::TableHeader({ 179, 43 }, { 210, 12 }, WindowColour::secondary, ImageIds::null, StringIds::tooltip_sort_company_status),
-            Widgets::TableHeader({ 389, 43 }, { 145, 12 }, WindowColour::secondary, ImageIds::null, StringIds::tooltip_sort_company_performance),
-            Widgets::TableHeader({ 534, 43 }, { 100, 12 }, WindowColour::secondary, ImageIds::null, StringIds::tooltip_sort_company_value),
-            Widgets::ScrollView({ 3, 56 }, { 634, 201 }, WindowColour::secondary, Scrollbars::vertical),
-            Widgets::Label({ 3, kWindowSize.height - 17 }, { kWindowSize.width - kResizeHandleSize, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid)
+            Widgets::TableHeader(Widx::kSortName, { 4, 43 }, { 175, 12 }, WindowColour::secondary, ImageIds::null, StringIds::tooltip_sort_company_name),
+            Widgets::TableHeader(Widx::kSortStatus, { 179, 43 }, { 210, 12 }, WindowColour::secondary, ImageIds::null, StringIds::tooltip_sort_company_status),
+            Widgets::TableHeader(Widx::kSortPerformance, { 389, 43 }, { 145, 12 }, WindowColour::secondary, ImageIds::null, StringIds::tooltip_sort_company_performance),
+            Widgets::TableHeader(Widx::kSortValue, { 534, 43 }, { 100, 12 }, WindowColour::secondary, ImageIds::null, StringIds::tooltip_sort_company_value),
+            Widgets::ScrollView(Widx::kScrollview, { 3, 56 }, { 634, 201 }, WindowColour::secondary, Scrollbars::vertical),
+            Widgets::Label(Widx::kStatusBar, { 3, kWindowSize.height - 17 }, { kWindowSize.width - kResizeHandleSize, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid)
 
         );
 
@@ -122,28 +147,28 @@ namespace OpenLoco::Ui::Windows::CompanyList
         };
 
         // 0x004360A2
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_company_list:
-                case Common::widx::tab_performance:
-                case Common::widx::tab_cargo_units:
-                case Common::widx::tab_cargo_distance:
-                case Common::widx::tab_values:
-                case Common::widx::tab_payment_rates:
-                case Common::widx::tab_speed_records:
+                case Common::Widx::kTabCompanyList:
+                case Common::Widx::kTabPerformance:
+                case Common::Widx::kTabCargoUnits:
+                case Common::Widx::kTabCargoDistance:
+                case Common::Widx::kTabValues:
+                case Common::Widx::kTabPaymentRates:
+                case Common::Widx::kTabSpeedRecords:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case sort_name:
-                case sort_status:
-                case sort_performance:
-                case sort_value:
+                case Widx::kSortName:
+                case Widx::kSortStatus:
+                case Widx::kSortPerformance:
+                case Widx::kSortValue:
                 {
                     auto sortMode = widgetIndex - widx::sort_name;
                     if (self.sortMode == sortMode)
@@ -318,9 +343,9 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         // 0x0043632C
-        static Ui::CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, [[maybe_unused]] WidgetIndex_t widgetIdx, const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
         {
-            if (widgetIdx != widx::scrollview)
+            if (id != Widx::kScrollview)
             {
                 return fallback;
             }
@@ -1344,21 +1369,21 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // clang-format on
 
         // 0x0043667B
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_company_list:
-                case Common::widx::tab_performance:
-                case Common::widx::tab_cargo_units:
-                case Common::widx::tab_cargo_distance:
-                case Common::widx::tab_values:
-                case Common::widx::tab_payment_rates:
-                case Common::widx::tab_speed_records:
+                case Common::Widx::kTabCompanyList:
+                case Common::Widx::kTabPerformance:
+                case Common::Widx::kTabCargoUnits:
+                case Common::Widx::kTabCargoDistance:
+                case Common::Widx::kTabValues:
+                case Common::Widx::kTabPaymentRates:
+                case Common::Widx::kTabSpeedRecords:
                     Common::switchTab(self, widgetIndex);
                     break;
             }

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -72,20 +72,35 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             company_select,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabStatus{ "tab_status" };
+            constexpr WidgetId kTabDetails{ "tab_details" };
+            constexpr WidgetId kTabColourScheme{ "tab_colour_scheme" };
+            constexpr WidgetId kTabFinances{ "tab_finances" };
+            constexpr WidgetId kTabCargoDelivered{ "tab_cargo_delivered" };
+            constexpr WidgetId kTabChallenge{ "tab_challenge" };
+            constexpr WidgetId kCompanySelect{ "company_select" };
+        }
+
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, windowCaptionId),
-                Widgets::ImageButton({ frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { frameWidth, 120 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_owner_and_status),
-                Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_headquarters_and_details),
-                Widgets::Tab({ 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_colour_scheme),
-                Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_finances),
-                Widgets::Tab({ 127, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_cargo_delivered),
-                Widgets::Tab({ 158, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_challenge_for_this_game),
-                Widgets::ImageButton({ 0, 14 }, { 26, 26 }, WindowColour::primary, ImageIds::null, StringIds::tooltip_select_company));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, windowCaptionId),
+                Widgets::ImageButton(Widx::kCloseButton, { frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { frameWidth, 120 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabStatus, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_owner_and_status),
+                Widgets::Tab(Widx::kTabDetails, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_headquarters_and_details),
+                Widgets::Tab(Widx::kTabColourScheme, { 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_colour_scheme),
+                Widgets::Tab(Widx::kTabFinances, { 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_finances),
+                Widgets::Tab(Widx::kTabCargoDelivered, { 127, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_cargo_delivered),
+                Widgets::Tab(Widx::kTabChallenge, { 158, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_challenge_for_this_game),
+                Widgets::ImageButton(Widx::kCompanySelect, { 0, 14 }, { 26, 26 }, WindowColour::primary, ImageIds::null, StringIds::tooltip_select_company));
         }
 
         // 0x004343FC
@@ -134,13 +149,22 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             change_owner_name,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kUnk11{ "unk_11" };
+            constexpr WidgetId kViewport{ "viewport" };
+            constexpr WidgetId kCentreOnViewport{ "centre_on_viewport" };
+            constexpr WidgetId kFace{ "face" };
+            constexpr WidgetId kChangeOwnerName{ "change_owner_name" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(270, 182, StringIds::title_company),
-            Widgets::Label({ 3, 160 }, { 242, 21 }, WindowColour::secondary, ContentAlign::center),
-            Widgets::Viewport({ 3, 44 }, { 96, 120 }, WindowColour::secondary, Widget::kContentUnk),
-            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this),
-            Widgets::ImageButton({ 178, 57 }, { 66, 66 }, WindowColour::secondary, Widget::kContentNull),
-            Widgets::ImageButton({ 154, 124 }, { 112, 22 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_change_owner_name)
+            Widgets::Label(Widx::kUnk11, { 3, 160 }, { 242, 21 }, WindowColour::secondary, ContentAlign::center),
+            Widgets::Viewport(Widx::kViewport, { 3, 44 }, { 96, 120 }, WindowColour::secondary, Widget::kContentUnk),
+            Widgets::ImageButton(Widx::kCentreOnViewport, { 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this),
+            Widgets::ImageButton(Widx::kFace, { 178, 57 }, { 66, 66 }, WindowColour::secondary, Widget::kContentNull),
+            Widgets::ImageButton(Widx::kChangeOwnerName, { 154, 124 }, { 112, 22 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_change_owner_name)
 
         );
 
@@ -281,36 +305,36 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432244
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameCompanyPrompt(&self, widgetIndex);
                     break;
 
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_status:
-                case Common::widx::tab_details:
-                case Common::widx::tab_colour_scheme:
-                case Common::widx::tab_finances:
-                case Common::widx::tab_cargo_delivered:
-                case Common::widx::tab_challenge:
+                case Common::Widx::kTabStatus:
+                case Common::Widx::kTabDetails:
+                case Common::Widx::kTabColourScheme:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabCargoDelivered:
+                case Common::Widx::kTabChallenge:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::centre_on_viewport:
+                case Widx::kCentreOnViewport:
                     self.viewportCentreMain();
                     break;
 
-                case widx::face:
+                case Widx::kFace:
                     CompanyFaceSelection::open(CompanyId(self.number), self.type);
                     break;
 
-                case widx::change_owner_name:
+                case Widx::kChangeOwnerName:
                 {
                     auto company = CompanyManager::get(CompanyId(self.number));
                     TextInput::openTextInput(&self, StringIds::title_name_owner, StringIds::prompt_enter_new_name_for_owner, company->ownerName, widgetIndex, {});
@@ -320,18 +344,18 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432283
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            if (widgetIndex == Common::widx::company_select)
+            if (id == Common::Widx::kCompanySelect)
             {
-                Dropdown::populateCompanySelect(&self, &self.widgets[widgetIndex]);
+                Dropdown::populateCompanySelect(&self, &self.widgets[Common::widx::company_select]);
             }
         }
 
         // 0x0043228E
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            if (widgetIndex == Common::widx::company_select)
+            if (id == Common::Widx::kCompanySelect)
             {
                 Common::switchCompany(&self, itemIndex);
             }
@@ -392,13 +416,13 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x004322F6
-        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
+        static void textInput(Window& self, [[maybe_unused]] WidgetIndex_t callingWidget, const WidgetId id, const char* input)
         {
-            if (callingWidget == Common::widx::caption)
+            if (id == Common::Widx::kCaption)
             {
                 Common::renameCompany(&self, input);
             }
-            else if (callingWidget == widx::change_owner_name)
+            else if (id == Widx::kChangeOwnerName)
             {
                 renameCompanyOwnerName(&self, input);
             }
@@ -692,12 +716,20 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             centre_on_viewport,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kViewport{ "viewport" };
+            constexpr WidgetId kBuildHq{ "build_hq" };
+            constexpr WidgetId kRotateHq{ "rotate_hq" };
+            constexpr WidgetId kCentreOnViewport{ "centre_on_viewport" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(340, 194, StringIds::title_company_details),
-            Widgets::Viewport({ 219, 54 }, { 96, 120 }, WindowColour::secondary, Widget::kContentUnk),
-            Widgets::ImageButton({ 315, 92 }, { 24, 24 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_build_or_move_headquarters),
-            Widgets::ImageButton({ 315, 92 + 26 }, { 24, 24 }, WindowColour::secondary, ImageIds::rotate_object, StringIds::rotate_object_90),
-            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this)
+            Widgets::Viewport(Widx::kViewport, { 219, 54 }, { 96, 120 }, WindowColour::secondary, Widget::kContentUnk),
+            Widgets::ImageButton(Widx::kBuildHq, { 315, 92 }, { 24, 24 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_build_or_move_headquarters),
+            Widgets::ImageButton(Widx::kRotateHq, { 315, 92 + 26 }, { 24, 24 }, WindowColour::secondary, ImageIds::rotate_object, StringIds::rotate_object_90),
+            Widgets::ImageButton(Widx::kCentreOnViewport, { 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this)
 
         );
 
@@ -882,28 +914,28 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432BDD
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameCompanyPrompt(&self, widgetIndex);
                     break;
 
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_status:
-                case Common::widx::tab_details:
-                case Common::widx::tab_colour_scheme:
-                case Common::widx::tab_finances:
-                case Common::widx::tab_cargo_delivered:
-                case Common::widx::tab_challenge:
+                case Common::Widx::kTabStatus:
+                case Common::Widx::kTabDetails:
+                case Common::Widx::kTabColourScheme:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabCargoDelivered:
+                case Common::Widx::kTabChallenge:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::centre_on_viewport:
+                case Widx::kCentreOnViewport:
                     self.viewportCentreMain();
                     break;
             }
@@ -915,29 +947,29 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432C08
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::company_select:
-                    Dropdown::populateCompanySelect(&self, &self.widgets[widgetIndex]);
+                case Common::Widx::kCompanySelect:
+                    Dropdown::populateCompanySelect(&self, &self.widgets[Common::widx::company_select]);
                     break;
 
-                case widx::build_hq:
+                case Widx::kBuildHq:
                     ToolManager::toolSet(self, widgetIndex, CursorId::placeHQ);
                     Input::setFlag(Input::Flags::flag6);
                     break;
 
-                case widx::rotate_hq:
+                case Widx::kRotateHq:
                     rotateHQGhost90Deg();
                     break;
             }
         }
 
         // 0x00432C19
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            if (widgetIndex == Common::widx::company_select)
+            if (id == Common::Widx::kCompanySelect)
             {
                 Common::switchCompany(&self, itemIndex);
             }
@@ -949,9 +981,9 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00432C24
-        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
+        static void textInput(Window& self, [[maybe_unused]] WidgetIndex_t callingWidget, const WidgetId id, const char* input)
         {
-            if (callingWidget == Common::widx::caption)
+            if (id == Common::Widx::kCaption)
             {
                 Common::renameCompany(&self, input);
             }
@@ -1263,6 +1295,42 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             secondary_colour_ships,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kCheckSteamLocomotives{ "check_steam_locomotives" };
+            constexpr WidgetId kCheckDieselLocomotives{ "check_diesel_locomotives" };
+            constexpr WidgetId kCheckElectricLocomotives{ "check_electric_locomotives" };
+            constexpr WidgetId kCheckMultipleUnits{ "check_multiple_units" };
+            constexpr WidgetId kCheckPassengerVehicles{ "check_passenger_vehicles" };
+            constexpr WidgetId kCheckFreightVehicles{ "check_freight_vehicles" };
+            constexpr WidgetId kCheckBuses{ "check_buses" };
+            constexpr WidgetId kCheckTrucks{ "check_trucks" };
+            constexpr WidgetId kCheckAircraft{ "check_aircraft" };
+            constexpr WidgetId kCheckShips{ "check_ships" };
+            constexpr WidgetId kMainColourScheme{ "main_colour_scheme" };
+            constexpr WidgetId kMainColourSteamLocomotives{ "main_colour_steam_locomotives" };
+            constexpr WidgetId kMainColourDieselLocomotives{ "main_colour_diesel_locomotives" };
+            constexpr WidgetId kMainColourElectricLocomotives{ "main_colour_electric_locomotives" };
+            constexpr WidgetId kMainColourMultipleUnits{ "main_colour_multiple_units" };
+            constexpr WidgetId kMainColourPassengerVehicles{ "main_colour_passenger_vehicles" };
+            constexpr WidgetId kMainColourFreightVehicles{ "main_colour_freight_vehicles" };
+            constexpr WidgetId kMainColourBuses{ "main_colour_buses" };
+            constexpr WidgetId kMainColourTrucks{ "main_colour_trucks" };
+            constexpr WidgetId kMainColourAircraft{ "main_colour_aircraft" };
+            constexpr WidgetId kMainColourShips{ "main_colour_ships" };
+            constexpr WidgetId kSecondaryColourScheme{ "secondary_colour_scheme" };
+            constexpr WidgetId kSecondaryColourSteamLocomotives{ "secondary_colour_steam_locomotives" };
+            constexpr WidgetId kSecondaryColourDieselLocomotives{ "secondary_colour_diesel_locomotives" };
+            constexpr WidgetId kSecondaryColourElectricLocomotives{ "secondary_colour_electric_locomotives" };
+            constexpr WidgetId kSecondaryColourMultipleUnits{ "secondary_colour_multiple_units" };
+            constexpr WidgetId kSecondaryColourPassengerVehicles{ "secondary_colour_passenger_vehicles" };
+            constexpr WidgetId kSecondaryColourFreightVehicles{ "secondary_colour_freight_vehicles" };
+            constexpr WidgetId kSecondaryColourBuses{ "secondary_colour_buses" };
+            constexpr WidgetId kSecondaryColourTrucks{ "secondary_colour_trucks" };
+            constexpr WidgetId kSecondaryColourAircraft{ "secondary_colour_aircraft" };
+            constexpr WidgetId kSecondaryColourShips{ "secondary_colour_ships" };
+        }
+
         // clang-format off
         constexpr uint64_t allMainColours = {
             (1ULL << widx::main_colour_scheme) |
@@ -1308,38 +1376,38 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(265, 252, StringIds::title_company_colour_scheme),
-            Widgets::Checkbox({ 15, 81 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_steam_locomotives, StringIds::tooltip_toggle_vehicle_colour_scheme),
-            Widgets::Checkbox({ 15, 98 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_diesel_locomotives, StringIds::tooltip_toggle_vehicle_colour_scheme),
-            Widgets::Checkbox({ 15, 115 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_electric_locomotives, StringIds::tooltip_toggle_vehicle_colour_scheme),
-            Widgets::Checkbox({ 15, 132 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_multiple_units, StringIds::tooltip_toggle_vehicle_colour_scheme),
-            Widgets::Checkbox({ 15, 149 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_passenger_vehicles, StringIds::tooltip_toggle_vehicle_colour_scheme),
-            Widgets::Checkbox({ 15, 166 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_freight_vehicles, StringIds::tooltip_toggle_vehicle_colour_scheme),
-            Widgets::Checkbox({ 15, 183 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_buses, StringIds::tooltip_toggle_vehicle_colour_scheme),
-            Widgets::Checkbox({ 15, 200 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_trucks, StringIds::tooltip_toggle_vehicle_colour_scheme),
-            Widgets::Checkbox({ 15, 217 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_aircraft, StringIds::tooltip_toggle_vehicle_colour_scheme),
-            Widgets::Checkbox({ 15, 234 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_ships, StringIds::tooltip_toggle_vehicle_colour_scheme),
-            Widgets::ColourButton({ 221, 48 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
-            Widgets::ColourButton({ 221, 78 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
-            Widgets::ColourButton({ 221, 95 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
-            Widgets::ColourButton({ 221, 112 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
-            Widgets::ColourButton({ 221, 129 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
-            Widgets::ColourButton({ 221, 146 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
-            Widgets::ColourButton({ 221, 163 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
-            Widgets::ColourButton({ 221, 180 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
-            Widgets::ColourButton({ 221, 197 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
-            Widgets::ColourButton({ 221, 214 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
-            Widgets::ColourButton({ 221, 231 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
-            Widgets::ColourButton({ 239, 48 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
-            Widgets::ColourButton({ 239, 78 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
-            Widgets::ColourButton({ 239, 95 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
-            Widgets::ColourButton({ 239, 112 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
-            Widgets::ColourButton({ 239, 129 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
-            Widgets::ColourButton({ 239, 146 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
-            Widgets::ColourButton({ 239, 163 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
-            Widgets::ColourButton({ 239, 180 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
-            Widgets::ColourButton({ 239, 197 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
-            Widgets::ColourButton({ 239, 214 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
-            Widgets::ColourButton({ 239, 231 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour)
+            Widgets::Checkbox(Widx::kCheckSteamLocomotives, { 15, 81 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_steam_locomotives, StringIds::tooltip_toggle_vehicle_colour_scheme),
+            Widgets::Checkbox(Widx::kCheckDieselLocomotives, { 15, 98 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_diesel_locomotives, StringIds::tooltip_toggle_vehicle_colour_scheme),
+            Widgets::Checkbox(Widx::kCheckElectricLocomotives, { 15, 115 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_electric_locomotives, StringIds::tooltip_toggle_vehicle_colour_scheme),
+            Widgets::Checkbox(Widx::kCheckMultipleUnits, { 15, 132 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_multiple_units, StringIds::tooltip_toggle_vehicle_colour_scheme),
+            Widgets::Checkbox(Widx::kCheckPassengerVehicles, { 15, 149 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_passenger_vehicles, StringIds::tooltip_toggle_vehicle_colour_scheme),
+            Widgets::Checkbox(Widx::kCheckFreightVehicles, { 15, 166 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_freight_vehicles, StringIds::tooltip_toggle_vehicle_colour_scheme),
+            Widgets::Checkbox(Widx::kCheckBuses, { 15, 183 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_buses, StringIds::tooltip_toggle_vehicle_colour_scheme),
+            Widgets::Checkbox(Widx::kCheckTrucks, { 15, 200 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_trucks, StringIds::tooltip_toggle_vehicle_colour_scheme),
+            Widgets::Checkbox(Widx::kCheckAircraft, { 15, 217 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_aircraft, StringIds::tooltip_toggle_vehicle_colour_scheme),
+            Widgets::Checkbox(Widx::kCheckShips, { 15, 234 }, { 204, 12 }, WindowColour::secondary, StringIds::colour_ships, StringIds::tooltip_toggle_vehicle_colour_scheme),
+            Widgets::ColourButton(Widx::kMainColourScheme, { 221, 48 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
+            Widgets::ColourButton(Widx::kMainColourSteamLocomotives, { 221, 78 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
+            Widgets::ColourButton(Widx::kMainColourDieselLocomotives, { 221, 95 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
+            Widgets::ColourButton(Widx::kMainColourElectricLocomotives, { 221, 112 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
+            Widgets::ColourButton(Widx::kMainColourMultipleUnits, { 221, 129 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
+            Widgets::ColourButton(Widx::kMainColourPassengerVehicles, { 221, 146 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
+            Widgets::ColourButton(Widx::kMainColourFreightVehicles, { 221, 163 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
+            Widgets::ColourButton(Widx::kMainColourBuses, { 221, 180 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
+            Widgets::ColourButton(Widx::kMainColourTrucks, { 221, 197 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
+            Widgets::ColourButton(Widx::kMainColourAircraft, { 221, 214 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
+            Widgets::ColourButton(Widx::kMainColourShips, { 221, 231 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
+            Widgets::ColourButton(Widx::kSecondaryColourScheme, { 239, 48 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
+            Widgets::ColourButton(Widx::kSecondaryColourSteamLocomotives, { 239, 78 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
+            Widgets::ColourButton(Widx::kSecondaryColourDieselLocomotives, { 239, 95 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
+            Widgets::ColourButton(Widx::kSecondaryColourElectricLocomotives, { 239, 112 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
+            Widgets::ColourButton(Widx::kSecondaryColourMultipleUnits, { 239, 129 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
+            Widgets::ColourButton(Widx::kSecondaryColourPassengerVehicles, { 239, 146 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
+            Widgets::ColourButton(Widx::kSecondaryColourFreightVehicles, { 239, 163 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
+            Widgets::ColourButton(Widx::kSecondaryColourBuses, { 239, 180 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
+            Widgets::ColourButton(Widx::kSecondaryColourTrucks, { 239, 197 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
+            Widgets::ColourButton(Widx::kSecondaryColourAircraft, { 239, 214 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
+            Widgets::ColourButton(Widx::kSecondaryColourShips, { 239, 231 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour)
 
         );
 
@@ -1457,37 +1525,37 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433032
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameCompanyPrompt(&self, widgetIndex);
                     break;
 
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_status:
-                case Common::widx::tab_details:
-                case Common::widx::tab_colour_scheme:
-                case Common::widx::tab_finances:
-                case Common::widx::tab_cargo_delivered:
-                case Common::widx::tab_challenge:
+                case Common::Widx::kTabStatus:
+                case Common::Widx::kTabDetails:
+                case Common::Widx::kTabColourScheme:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabCargoDelivered:
+                case Common::Widx::kTabChallenge:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::check_steam_locomotives:
-                case widx::check_diesel_locomotives:
-                case widx::check_electric_locomotives:
-                case widx::check_multiple_units:
-                case widx::check_passenger_vehicles:
-                case widx::check_freight_vehicles:
-                case widx::check_buses:
-                case widx::check_trucks:
-                case widx::check_aircraft:
-                case widx::check_ships:
+                case Widx::kCheckSteamLocomotives:
+                case Widx::kCheckDieselLocomotives:
+                case Widx::kCheckElectricLocomotives:
+                case Widx::kCheckMultipleUnits:
+                case Widx::kCheckPassengerVehicles:
+                case Widx::kCheckFreightVehicles:
+                case Widx::kCheckBuses:
+                case Widx::kCheckTrucks:
+                case Widx::kCheckAircraft:
+                case Widx::kCheckShips:
                     // customVehicleColoursSet reserves first bit for main colour scheme even though it can't be changed, so skip it.
                     const auto vehicleType = widgetIndex - widx::check_steam_locomotives + 1;
                     const auto company = CompanyManager::get(CompanyId(self.number));
@@ -1509,25 +1577,25 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433067
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::company_select:
+                case Common::Widx::kCompanySelect:
                     Dropdown::populateCompanySelect(&self, &self.widgets[widgetIndex]);
                     break;
 
-                case main_colour_scheme:
-                case main_colour_steam_locomotives:
-                case main_colour_diesel_locomotives:
-                case main_colour_electric_locomotives:
-                case main_colour_multiple_units:
-                case main_colour_passenger_vehicles:
-                case main_colour_freight_vehicles:
-                case main_colour_buses:
-                case main_colour_trucks:
-                case main_colour_aircraft:
-                case main_colour_ships:
+                case Widx::kMainColourScheme:
+                case Widx::kMainColourSteamLocomotives:
+                case Widx::kMainColourDieselLocomotives:
+                case Widx::kMainColourElectricLocomotives:
+                case Widx::kMainColourMultipleUnits:
+                case Widx::kMainColourPassengerVehicles:
+                case Widx::kMainColourFreightVehicles:
+                case Widx::kMainColourBuses:
+                case Widx::kMainColourTrucks:
+                case Widx::kMainColourAircraft:
+                case Widx::kMainColourShips:
                 {
                     auto* company = CompanyManager::get(CompanyId(self.number));
                     Colour selectedColour;
@@ -1546,17 +1614,17 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     break;
                 }
 
-                case secondary_colour_scheme:
-                case secondary_colour_steam_locomotives:
-                case secondary_colour_diesel_locomotives:
-                case secondary_colour_electric_locomotives:
-                case secondary_colour_multiple_units:
-                case secondary_colour_passenger_vehicles:
-                case secondary_colour_freight_vehicles:
-                case secondary_colour_buses:
-                case secondary_colour_trucks:
-                case secondary_colour_aircraft:
-                case secondary_colour_ships:
+                case Widx::kSecondaryColourScheme:
+                case Widx::kSecondaryColourSteamLocomotives:
+                case Widx::kSecondaryColourDieselLocomotives:
+                case Widx::kSecondaryColourElectricLocomotives:
+                case Widx::kSecondaryColourMultipleUnits:
+                case Widx::kSecondaryColourPassengerVehicles:
+                case Widx::kSecondaryColourFreightVehicles:
+                case Widx::kSecondaryColourBuses:
+                case Widx::kSecondaryColourTrucks:
+                case Widx::kSecondaryColourAircraft:
+                case Widx::kSecondaryColourShips:
                 {
                     auto* company = CompanyManager::get(CompanyId(self.number));
                     Colour selectedColour;
@@ -1578,34 +1646,34 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433092
-        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
+        static void textInput(Window& self, [[maybe_unused]] WidgetIndex_t callingWidget, const WidgetId id, const char* input)
         {
-            if (callingWidget == Common::widx::caption)
+            if (id == Common::Widx::kCaption)
             {
                 Common::renameCompany(&self, input);
             }
         }
 
         // 0x0043309D
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::company_select:
+                case Common::Widx::kCompanySelect:
                     Common::switchCompany(&self, itemIndex);
                     break;
 
-                case widx::main_colour_scheme:
-                case widx::main_colour_steam_locomotives:
-                case widx::main_colour_diesel_locomotives:
-                case widx::main_colour_electric_locomotives:
-                case widx::main_colour_multiple_units:
-                case widx::main_colour_passenger_vehicles:
-                case widx::main_colour_freight_vehicles:
-                case widx::main_colour_buses:
-                case widx::main_colour_trucks:
-                case widx::main_colour_aircraft:
-                case widx::main_colour_ships:
+                case Widx::kMainColourScheme:
+                case Widx::kMainColourSteamLocomotives:
+                case Widx::kMainColourDieselLocomotives:
+                case Widx::kMainColourElectricLocomotives:
+                case Widx::kMainColourMultipleUnits:
+                case Widx::kMainColourPassengerVehicles:
+                case Widx::kMainColourFreightVehicles:
+                case Widx::kMainColourBuses:
+                case Widx::kMainColourTrucks:
+                case Widx::kMainColourAircraft:
+                case Widx::kMainColourShips:
                 {
                     if (itemIndex == -1)
                     {
@@ -1630,17 +1698,17 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     break;
                 }
 
-                case widx::secondary_colour_scheme:
-                case widx::secondary_colour_steam_locomotives:
-                case widx::secondary_colour_diesel_locomotives:
-                case widx::secondary_colour_electric_locomotives:
-                case widx::secondary_colour_multiple_units:
-                case widx::secondary_colour_passenger_vehicles:
-                case widx::secondary_colour_freight_vehicles:
-                case widx::secondary_colour_buses:
-                case widx::secondary_colour_trucks:
-                case widx::secondary_colour_aircraft:
-                case widx::secondary_colour_ships:
+                case Widx::kSecondaryColourScheme:
+                case Widx::kSecondaryColourSteamLocomotives:
+                case Widx::kSecondaryColourDieselLocomotives:
+                case Widx::kSecondaryColourElectricLocomotives:
+                case Widx::kSecondaryColourMultipleUnits:
+                case Widx::kSecondaryColourPassengerVehicles:
+                case Widx::kSecondaryColourFreightVehicles:
+                case Widx::kSecondaryColourBuses:
+                case Widx::kSecondaryColourTrucks:
+                case Widx::kSecondaryColourAircraft:
+                case Widx::kSecondaryColourShips:
                 {
                     if (itemIndex == -1)
                     {
@@ -1711,13 +1779,22 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             loan_autopay,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kScrollview{ "scrollview" };
+            constexpr WidgetId kCurrentLoan{ "currentLoan" };
+            constexpr WidgetId kLoanDecrease{ "loan_decrease" };
+            constexpr WidgetId kLoanIncrease{ "loan_increase" };
+            constexpr WidgetId kLoanAutopay{ "loan_autopay" };
+        }
+
         constexpr uint16_t expenditureColumnWidth = 128;
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(636, 319, StringIds::title_company_finances),
-            Widgets::ScrollView({ 133, 45 }, { 499, 215 }, WindowColour::secondary, Scrollbars::horizontal),
-            Widgets::stepperWidgets({ 87, 264 }, { 100, 12 }, WindowColour::secondary, StringIds::company_current_loan_value),
-            Widgets::Checkbox({ 320, 264 }, { 204, 12 }, WindowColour::secondary, StringIds::loan_autopay, StringIds::tooltip_loan_autopay) // loan_autopay
+            Widgets::ScrollView(Widx::kScrollview, { 133, 45 }, { 499, 215 }, WindowColour::secondary, Scrollbars::horizontal),
+            Widgets::stepperWidgets(Widx::kCurrentLoan, Widx::kLoanDecrease, Widx::kLoanIncrease, { 87, 264 }, { 100, 12 }, WindowColour::secondary, StringIds::company_current_loan_value),
+            Widgets::Checkbox(Widx::kLoanAutopay, { 320, 264 }, { 204, 12 }, WindowColour::secondary, StringIds::loan_autopay, StringIds::tooltip_loan_autopay) // loan_autopay
 
         );
 
@@ -2031,28 +2108,28 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433819
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameCompanyPrompt(&self, widgetIndex);
                     break;
 
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_status:
-                case Common::widx::tab_details:
-                case Common::widx::tab_colour_scheme:
-                case Common::widx::tab_finances:
-                case Common::widx::tab_cargo_delivered:
-                case Common::widx::tab_challenge:
+                case Common::Widx::kTabStatus:
+                case Common::Widx::kTabDetails:
+                case Common::Widx::kTabColourScheme:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabCargoDelivered:
+                case Common::Widx::kTabChallenge:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::loan_autopay:
+                case Widx::kLoanAutopay:
                 {
                     auto company = CompanyManager::get(CompanyId(self.number));
                     company->challengeFlags ^= CompanyFlags::autopayLoan;
@@ -2062,15 +2139,15 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x0043383E
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::company_select:
+                case Common::Widx::kCompanySelect:
                     Dropdown::populateCompanySelect(&self, &self.widgets[widgetIndex]);
                     break;
 
-                case widx::loan_decrease:
+                case Widx::kLoanDecrease:
                 {
                     auto* company = CompanyManager::get(CompanyId(self.number));
                     if (company->currentLoan == 0)
@@ -2086,7 +2163,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                     break;
                 }
 
-                case widx::loan_increase:
+                case Widx::kLoanIncrease:
                 {
                     auto* company = CompanyManager::get(CompanyId(self.number));
 
@@ -2101,9 +2178,9 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x0043385D
-        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
+        static void textInput(Window& self, [[maybe_unused]] WidgetIndex_t callingWidget, const WidgetId id, const char* input)
         {
-            if (callingWidget == Common::widx::caption)
+            if (id == Common::Widx::kCaption)
             {
                 Common::renameCompany(&self, input);
             }
@@ -2135,9 +2212,9 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433868
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            if (widgetIndex == Common::widx::company_select)
+            if (id == Common::Widx::kCompanySelect)
             {
                 Common::switchCompany(&self, itemIndex);
                 scrollToLatestData(self);
@@ -2324,51 +2401,51 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433BE6
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameCompanyPrompt(&self, widgetIndex);
                     break;
 
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_status:
-                case Common::widx::tab_details:
-                case Common::widx::tab_colour_scheme:
-                case Common::widx::tab_finances:
-                case Common::widx::tab_cargo_delivered:
-                case Common::widx::tab_challenge:
+                case Common::Widx::kTabStatus:
+                case Common::Widx::kTabDetails:
+                case Common::Widx::kTabColourScheme:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabCargoDelivered:
+                case Common::Widx::kTabChallenge:
                     Common::switchTab(self, widgetIndex);
                     break;
             }
         }
 
         // 0x00433C0B
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            if (widgetIndex == Common::widx::company_select)
+            if (id == Common::Widx::kCompanySelect)
             {
-                Dropdown::populateCompanySelect(&self, &self.widgets[widgetIndex]);
+                Dropdown::populateCompanySelect(&self, &self.widgets[Common::widx::company_select]);
             }
         }
 
         // 0x00433C16
-        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
+        static void textInput(Window& self, [[maybe_unused]] WidgetIndex_t callingWidget, const WidgetId id, const char* input)
         {
-            if (callingWidget == Common::widx::caption)
+            if (id == Common::Widx::kCaption)
             {
                 Common::renameCompany(&self, input);
             }
         }
 
         // 0x00433C21
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            if (widgetIndex == Common::widx::company_select)
+            if (id == Common::Widx::kCompanySelect)
             {
                 Common::switchCompany(&self, itemIndex);
             }
@@ -2547,33 +2624,33 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         // 0x00433FFE
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameCompanyPrompt(&self, widgetIndex);
                     break;
 
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_status:
-                case Common::widx::tab_details:
-                case Common::widx::tab_colour_scheme:
-                case Common::widx::tab_finances:
-                case Common::widx::tab_cargo_delivered:
-                case Common::widx::tab_challenge:
+                case Common::Widx::kTabStatus:
+                case Common::Widx::kTabDetails:
+                case Common::Widx::kTabColourScheme:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabCargoDelivered:
+                case Common::Widx::kTabChallenge:
                     Common::switchTab(self, widgetIndex);
                     break;
             }
         }
 
         // 0x00434023
-        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
+        static void textInput(Window& self, [[maybe_unused]] WidgetIndex_t callingWidget, const WidgetId id, const char* input)
         {
-            if (callingWidget == Common::widx::caption)
+            if (id == Common::Widx::kCaption)
             {
                 Common::renameCompany(&self, input);
             }

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -97,30 +97,30 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
     static constexpr auto widgets = makeWidgets(
         Common::makeCommonWidgets(138, 276, StringIds::stringid_2),
-        Widgets::ImageButton({ 3, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_left_hand_curve_very_small, StringIds::tooltip_left_hand_curve_very_small),
-        Widgets::ImageButton({ 3, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_left_hand_curve_small, StringIds::tooltip_left_hand_curve_small),
-        Widgets::ImageButton({ 25, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_left_hand_curve, StringIds::tooltip_left_hand_curve),
-        Widgets::ImageButton({ 47, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_left_hand_curve_large, StringIds::tooltip_left_hand_curve_large),
-        Widgets::ImageButton({ 69, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_right_hand_curve_large, StringIds::tooltip_right_hand_curve_large),
-        Widgets::ImageButton({ 91, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_right_hand_curve, StringIds::tooltip_right_hand_curve),
-        Widgets::ImageButton({ 113, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_right_hand_curve_small, StringIds::tooltip_right_hand_curve_small),
-        Widgets::ImageButton({ 113, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_right_hand_curve_very_small, StringIds::tooltip_right_hand_curve_very_small),
-        Widgets::ImageButton({ 9, 69 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_s_bend_dual_track_left, StringIds::tooltip_s_bend_left_dual_track),
-        Widgets::ImageButton({ 33, 69 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_s_bend_left, StringIds::tooltip_s_bend_left),
-        Widgets::ImageButton({ 57, 69 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_straight, StringIds::tooltip_straight),
-        Widgets::ImageButton({ 81, 69 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_s_bend_right, StringIds::tooltip_s_bend_right),
-        Widgets::ImageButton({ 105, 69 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_s_bend_dual_track_right, StringIds::tooltip_s_bend_right_dual_track),
-        Widgets::ImageButton({ 9, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_steep_slope_down, StringIds::tooltip_steep_slope_down),
-        Widgets::ImageButton({ 33, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_slope_down, StringIds::tooltip_slope_down),
-        Widgets::ImageButton({ 57, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_level, StringIds::tooltip_level),
-        Widgets::ImageButton({ 81, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_slope_up, StringIds::tooltip_slope_up),
-        Widgets::ImageButton({ 105, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_steep_slope_up, StringIds::tooltip_steep_slope_up),
-        Widgets::dropdownWidgets({ 40, 123 }, { 58, 20 }, WindowColour::secondary, StringIds::empty, StringIds::tooltip_bridge_stats),
-        Widgets::Wt3Widget({ 3, 145 }, { 132, 100 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_construct),
-        Widgets::ImageButton({ 72, 248 }, { 39, 24 }, WindowColour::secondary, ImageIds::construction_remove, StringIds::tooltip_remove),
-        Widgets::ImageButton({ 111, 248 }, { 24, 24 }, WindowColour::secondary, ImageIds::rotate_object, StringIds::rotate_90),
-        Widgets::Button({ 3, 248 }, { 33, 24 }, WindowColour::secondary, StringIds::construction_copy, StringIds::construction_copy_tooltip),
-        Widgets::Button({ 36, 248 }, { 37, 24 }, WindowColour::secondary, StringIds::construction_paste, StringIds::construction_paste_tooltip)
+        Widgets::ImageButton(Widx::kLeftHandCurveVerySmall, { 3, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_left_hand_curve_very_small, StringIds::tooltip_left_hand_curve_very_small),
+        Widgets::ImageButton(Widx::kLeftHandCurveSmall, { 3, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_left_hand_curve_small, StringIds::tooltip_left_hand_curve_small),
+        Widgets::ImageButton(Widx::kLeftHandCurve, { 25, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_left_hand_curve, StringIds::tooltip_left_hand_curve),
+        Widgets::ImageButton(Widx::kLeftHandCurveLarge, { 47, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_left_hand_curve_large, StringIds::tooltip_left_hand_curve_large),
+        Widgets::ImageButton(Widx::kRightHandCurveLarge, { 69, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_right_hand_curve_large, StringIds::tooltip_right_hand_curve_large),
+        Widgets::ImageButton(Widx::kRightHandCurve, { 91, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_right_hand_curve, StringIds::tooltip_right_hand_curve),
+        Widgets::ImageButton(Widx::kRightHandCurveSmall, { 113, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_right_hand_curve_small, StringIds::tooltip_right_hand_curve_small),
+        Widgets::ImageButton(Widx::kRightHandCurveVerySmall, { 113, 45 }, { 22, 24 }, WindowColour::secondary, ImageIds::construction_right_hand_curve_very_small, StringIds::tooltip_right_hand_curve_very_small),
+        Widgets::ImageButton(Widx::kSBendDualTrackLeft, { 9, 69 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_s_bend_dual_track_left, StringIds::tooltip_s_bend_left_dual_track),
+        Widgets::ImageButton(Widx::kSBendLeft, { 33, 69 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_s_bend_left, StringIds::tooltip_s_bend_left),
+        Widgets::ImageButton(Widx::kStraight, { 57, 69 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_straight, StringIds::tooltip_straight),
+        Widgets::ImageButton(Widx::kSBendRight, { 81, 69 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_s_bend_right, StringIds::tooltip_s_bend_right),
+        Widgets::ImageButton(Widx::kSBendDualTrackRight, { 105, 69 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_s_bend_dual_track_right, StringIds::tooltip_s_bend_right_dual_track),
+        Widgets::ImageButton(Widx::kSteepSlopeDown, { 9, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_steep_slope_down, StringIds::tooltip_steep_slope_down),
+        Widgets::ImageButton(Widx::kSlopeDown, { 33, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_slope_down, StringIds::tooltip_slope_down),
+        Widgets::ImageButton(Widx::kLevel, { 57, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_level, StringIds::tooltip_level),
+        Widgets::ImageButton(Widx::kSlopeUp, { 81, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_slope_up, StringIds::tooltip_slope_up),
+        Widgets::ImageButton(Widx::kSteepSlopeUp, { 105, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_steep_slope_up, StringIds::tooltip_steep_slope_up),
+        Widgets::dropdownWidgets(Widx::kBridge, Widx::kBridgeDropdown, { 40, 123 }, { 58, 20 }, WindowColour::secondary, StringIds::empty, StringIds::tooltip_bridge_stats),
+        Widgets::Wt3Widget(Widx::kConstruct, { 3, 145 }, { 132, 100 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_construct),
+        Widgets::ImageButton(Widx::kRemove, { 72, 248 }, { 39, 24 }, WindowColour::secondary, ImageIds::construction_remove, StringIds::tooltip_remove),
+        Widgets::ImageButton(Widx::kRotate90, { 111, 248 }, { 24, 24 }, WindowColour::secondary, ImageIds::rotate_object, StringIds::rotate_90),
+        Widgets::Button(Widx::kCopy, { 3, 248 }, { 33, 24 }, WindowColour::secondary, StringIds::construction_copy, StringIds::construction_copy_tooltip),
+        Widgets::Button(Widx::kPaste, { 36, 248 }, { 37, 24 }, WindowColour::secondary, StringIds::construction_paste, StringIds::construction_paste_tooltip)
 
     );
 
@@ -517,28 +517,28 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         auto& cState = getConstructionState();
-        switch (widgetIndex)
+        switch (id)
         {
-            case Common::widx::close_button:
+            case Common::Widx::kCloseButton:
                 WindowManager::close(&self);
                 break;
 
-            case Common::widx::tab_construction:
-            case Common::widx::tab_overhead:
-            case Common::widx::tab_signal:
-            case Common::widx::tab_station:
+            case Common::Widx::kTabConstruction:
+            case Common::Widx::kTabOverhead:
+            case Common::Widx::kTabSignal:
+            case Common::Widx::kTabStation:
                 Common::switchTab(self, widgetIndex);
                 break;
 
-            case widx::construct:
+            case Widx::kConstruct:
                 constructTrackOrRoad(&self, widgetIndex);
                 break;
 
-            case widx::remove:
+            case Widx::kRemove:
                 removeTrack(&self, widgetIndex);
                 break;
 
-            case widx::rotate_90:
+            case Widx::kRotate90:
             {
                 if (cState.constructionHover)
                 {
@@ -566,7 +566,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
                 break;
             }
 
-            case widx::copy:
+            case Widx::kCopy:
             {
                 removeConstructionGhosts();
                 _copiedTrack = std::nullopt;
@@ -578,7 +578,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
                 break;
             }
 
-            case widx::paste:
+            case Widx::kPaste:
             {
                 removeConstructionGhosts();
                 if (ToolManager::isToolActive(self.type, 0, widx::paste))
@@ -1783,53 +1783,53 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     {
         auto& cState = getConstructionState();
 
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::left_hand_curve:
+            case Widx::kLeftHandCurve:
                 changeTrackPiece(TrackPiece::left_hand_curve, false);
                 break;
 
-            case widx::right_hand_curve:
+            case Widx::kRightHandCurve:
                 changeTrackPiece(TrackPiece::right_hand_curve, false);
                 break;
 
-            case widx::left_hand_curve_small:
+            case Widx::kLeftHandCurveSmall:
                 changeTrackPiece(TrackPiece::left_hand_curve_small, false);
                 break;
 
-            case widx::right_hand_curve_small:
+            case Widx::kRightHandCurveSmall:
                 changeTrackPiece(TrackPiece::right_hand_curve_small, false);
                 break;
 
-            case widx::left_hand_curve_very_small:
+            case Widx::kLeftHandCurveVerySmall:
                 changeTrackPiece(TrackPiece::left_hand_curve_very_small, false);
                 break;
 
-            case widx::right_hand_curve_very_small:
+            case Widx::kRightHandCurveVerySmall:
                 changeTrackPiece(TrackPiece::right_hand_curve_very_small, false);
                 break;
 
-            case widx::left_hand_curve_large:
+            case Widx::kLeftHandCurveLarge:
                 changeTrackPiece(TrackPiece::left_hand_curve_large, false);
                 break;
 
-            case widx::right_hand_curve_large:
+            case Widx::kRightHandCurveLarge:
                 changeTrackPiece(TrackPiece::right_hand_curve_large, false);
                 break;
 
-            case widx::straight:
+            case Widx::kStraight:
                 changeTrackPiece(TrackPiece::straight, false);
                 break;
 
-            case widx::s_bend_left:
+            case Widx::kSBendLeft:
                 changeTrackPiece(TrackPiece::s_bend_left, false);
                 break;
 
-            case widx::s_bend_right:
+            case Widx::kSBendRight:
                 changeTrackPiece(TrackPiece::s_bend_right, false);
                 break;
 
-            case widx::s_bend_dual_track_left:
+            case Widx::kSBendDualTrackLeft:
             {
                 cState.byte_113603A = 0xFF;
                 removeConstructionGhosts();
@@ -1852,7 +1852,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
                 break;
             }
 
-            case widx::s_bend_dual_track_right:
+            case Widx::kSBendDualTrackRight:
             {
                 cState.byte_113603A = 0xFF;
                 removeConstructionGhosts();
@@ -1875,33 +1875,33 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
                 break;
             }
 
-            case widx::steep_slope_down:
+            case Widx::kSteepSlopeDown:
                 changeTrackPiece(TrackGradient::steep_slope_down, true);
                 break;
 
-            case widx::slope_down:
+            case Widx::kSlopeDown:
                 changeTrackPiece(TrackGradient::slope_down, true);
                 break;
 
-            case widx::level:
+            case Widx::kLevel:
                 changeTrackPiece(TrackGradient::level, true);
                 break;
 
-            case widx::slope_up:
+            case Widx::kSlopeUp:
                 changeTrackPiece(TrackGradient::slope_up, true);
                 break;
 
-            case widx::steep_slope_up:
+            case Widx::kSteepSlopeUp:
                 changeTrackPiece(TrackGradient::steep_slope_up, true);
                 break;
 
-            case widx::bridge_dropdown:
+            case Widx::kBridgeDropdown:
             {
                 bridgeDropdown(&self);
                 break;
             }
 
-            case widx::construct:
+            case Widx::kConstruct:
             {
                 if (Input::getClickRepeatTicks() >= 40)
                 {
@@ -1910,7 +1910,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
                 break;
             }
 
-            case widx::remove:
+            case Widx::kRemove:
             {
                 if (Input::getClickRepeatTicks() >= 40)
                 {
@@ -1922,11 +1922,11 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049D4EA
-    static void onDropdown([[maybe_unused]] Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+    static void onDropdown([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
         auto& cState = getConstructionState();
 
-        if (widgetIndex == widx::bridge_dropdown)
+        if (id == Widx::kBridgeDropdown)
         {
             if (itemIndex != -1)
             {
@@ -2878,9 +2878,9 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
     }
 
     // 0x0049D4F5
-    static Ui::CursorId cursor([[maybe_unused]] Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId cursor([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
     {
-        if (widgetIndex == widx::bridge || widgetIndex == widx::bridge_dropdown)
+        if (id == Widx::kBridge || id == Widx::kBridgeDropdown)
         {
             Ui::ToolTip::setTooltipTimeout(2000);
         }

--- a/src/OpenLoco/src/Ui/Windows/Construction/OverheadTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/OverheadTab.cpp
@@ -39,12 +39,12 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
 {
     static constexpr auto widgets = makeWidgets(
         Common::makeCommonWidgets(138, 192, StringIds::stringid_2),
-        Widgets::Checkbox({ 3, 45 }, { 132, 12 }, WindowColour::secondary, StringIds::empty, StringIds::tooltip_select_track_mod),
-        Widgets::Checkbox({ 3, 57 }, { 132, 12 }, WindowColour::secondary, StringIds::empty, StringIds::tooltip_select_track_mod),
-        Widgets::Checkbox({ 3, 69 }, { 132, 12 }, WindowColour::secondary, StringIds::empty, StringIds::tooltip_select_track_mod),
-        Widgets::Checkbox({ 3, 81 }, { 132, 12 }, WindowColour::secondary, StringIds::empty, StringIds::tooltip_select_track_mod),
-        Widgets::Wt3Widget({ 35, 110 }, { 66, 66 }, WindowColour::secondary),
-        Widgets::dropdownWidgets({ 3, 95 }, { 132, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_track_to_upgrade));
+        Widgets::Checkbox(Widx::kCheckbox1, { 3, 45 }, { 132, 12 }, WindowColour::secondary, StringIds::empty, StringIds::tooltip_select_track_mod),
+        Widgets::Checkbox(Widx::kCheckbox2, { 3, 57 }, { 132, 12 }, WindowColour::secondary, StringIds::empty, StringIds::tooltip_select_track_mod),
+        Widgets::Checkbox(Widx::kCheckbox3, { 3, 69 }, { 132, 12 }, WindowColour::secondary, StringIds::empty, StringIds::tooltip_select_track_mod),
+        Widgets::Checkbox(Widx::kCheckbox4, { 3, 81 }, { 132, 12 }, WindowColour::secondary, StringIds::empty, StringIds::tooltip_select_track_mod),
+        Widgets::Wt3Widget(Widx::kImage, { 35, 110 }, { 66, 66 }, WindowColour::secondary),
+        Widgets::dropdownWidgets(Widx::kTrack, Widx::kTrackDropdown, { 3, 95 }, { 132, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_track_to_upgrade));
 
     std::span<const Widget> getWidgets()
     {
@@ -58,23 +58,23 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
     {
         auto& cState = getConstructionState();
 
-        switch (widgetIndex)
+        switch (id)
         {
-            case Common::widx::close_button:
+            case Common::Widx::kCloseButton:
                 WindowManager::close(&self);
                 break;
 
-            case Common::widx::tab_construction:
-            case Common::widx::tab_overhead:
-            case Common::widx::tab_signal:
-            case Common::widx::tab_station:
+            case Common::Widx::kTabConstruction:
+            case Common::Widx::kTabOverhead:
+            case Common::Widx::kTabSignal:
+            case Common::Widx::kTabStation:
                 Common::switchTab(self, widgetIndex);
                 break;
 
-            case widx::checkbox_1:
-            case widx::checkbox_2:
-            case widx::checkbox_3:
-            case widx::checkbox_4:
+            case Widx::kCheckbox1:
+            case Widx::kCheckbox2:
+            case Widx::kCheckbox3:
+            case Widx::kCheckbox4:
             {
                 auto checkboxIndex = widgetIndex - widx::checkbox_1;
 
@@ -94,9 +94,9 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
     {
         auto& cState = getConstructionState();
 
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::track_dropdown:
+            case Widx::kTrackDropdown:
             {
                 uint8_t modCount = 3;
 
@@ -116,7 +116,7 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
                 break;
             }
 
-            case widx::image:
+            case Widx::kImage:
             {
                 ToolManager::toolCancel();
                 ToolManager::toolSet(self, widgetIndex, CursorId::crosshair);
@@ -126,9 +126,9 @@ namespace OpenLoco::Ui::Windows::Construction::Overhead
     }
 
     // 0x0049EC09
-    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+    static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
-        if (widgetIndex != widx::track_dropdown)
+        if (id != Widx::kTrackDropdown)
         {
             return;
         }

--- a/src/OpenLoco/src/Ui/Windows/Construction/SignalTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/SignalTab.cpp
@@ -31,9 +31,9 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
 {
     static constexpr auto widgets = makeWidgets(
         Common::makeCommonWidgets(138, 167, StringIds::stringid_2),
-        Widgets::dropdownWidgets({ 3, 45 }, { 132, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_signal_type),
-        Widgets::ImageButton({ 27, 110 }, { 40, 40 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_signal_both_directions),
-        Widgets::ImageButton({ 71, 110 }, { 40, 40 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_signal_single_direction));
+        Widgets::dropdownWidgets(Widx::kSignal, Widx::kSignalDropdown, { 3, 45 }, { 132, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_signal_type),
+        Widgets::ImageButton(Widx::kBothDirections, { 27, 110 }, { 40, 40 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_signal_both_directions),
+        Widgets::ImageButton(Widx::kSingleDirection, { 71, 110 }, { 40, 40 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_signal_single_direction));
 
     std::span<const Widget> getWidgets()
     {
@@ -45,16 +45,16 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
     // 0x0049E64E
     static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case Common::widx::close_button:
+            case Common::Widx::kCloseButton:
                 WindowManager::close(&self);
                 break;
 
-            case Common::widx::tab_construction:
-            case Common::widx::tab_overhead:
-            case Common::widx::tab_signal:
-            case Common::widx::tab_station:
+            case Common::Widx::kTabConstruction:
+            case Common::Widx::kTabOverhead:
+            case Common::Widx::kTabSignal:
+            case Common::Widx::kTabStation:
                 Common::switchTab(self, widgetIndex);
                 break;
         }
@@ -64,9 +64,9 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
     static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
         auto& cState = getConstructionState();
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::signal_dropdown:
+            case Widx::kSignalDropdown:
             {
                 uint8_t signalCount = 0;
                 while (cState.signalList[signalCount] != 0xFF)
@@ -97,7 +97,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
                 break;
             }
 
-            case widx::both_directions:
+            case Widx::kBothDirections:
             {
                 cState.isSignalBothDirections = 1;
                 ToolManager::toolCancel();
@@ -105,7 +105,7 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
                 break;
             }
 
-            case widx::single_direction:
+            case Widx::kSingleDirection:
             {
                 cState.isSignalBothDirections = 0;
                 ToolManager::toolCancel();
@@ -116,9 +116,9 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
     }
 
     // 0x0049E67C
-    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+    static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
-        if (widgetIndex != widx::signal_dropdown)
+        if (id != Widx::kSignalDropdown)
         {
             return;
         }

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -55,9 +55,9 @@ namespace OpenLoco::Ui::Windows::Construction::Station
 
     static constexpr auto kWidgets = makeWidgets(
         Common::makeCommonWidgets(138, 190, StringIds::stringid_2),
-        Widgets::dropdownWidgets({ 3, 45 }, { 132, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_station_type),
-        Widgets::Wt3Widget({ 35, 60 }, { 68, 68 }, WindowColour::secondary),
-        Widgets::ImageButton({ 112, 104 }, { 24, 24 }, WindowColour::secondary, ImageIds::rotate_object, StringIds::rotate_90));
+        Widgets::dropdownWidgets(Widx::kStation, Widx::kStationDropdown, { 3, 45 }, { 132, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_station_type),
+        Widgets::Wt3Widget(Widx::kImage, { 35, 60 }, { 68, 68 }, WindowColour::secondary),
+        Widgets::ImageButton(Widx::kRotate, { 112, 104 }, { 24, 24 }, WindowColour::secondary, ImageIds::rotate_object, StringIds::rotate_90));
 
     std::span<const Widget> getWidgets()
     {
@@ -71,20 +71,20 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     {
         auto& cState = getConstructionState();
 
-        switch (widgetIndex)
+        switch (id)
         {
-            case Common::widx::close_button:
+            case Common::Widx::kCloseButton:
                 WindowManager::close(&self);
                 break;
 
-            case Common::widx::tab_construction:
-            case Common::widx::tab_overhead:
-            case Common::widx::tab_signal:
-            case Common::widx::tab_station:
+            case Common::Widx::kTabConstruction:
+            case Common::Widx::kTabOverhead:
+            case Common::Widx::kTabSignal:
+            case Common::Widx::kTabStation:
                 Common::switchTab(self, widgetIndex);
                 break;
 
-            case widx::rotate:
+            case Widx::kRotate:
                 cState.constructionRotation++;
                 cState.constructionRotation = cState.constructionRotation & 3;
                 cState.stationCost = GameCommands::kFailure;
@@ -116,9 +116,9 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     {
         auto& cState = getConstructionState();
 
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::station_dropdown:
+            case Widx::kStationDropdown:
             {
                 uint8_t stationCount = 0;
                 while (cState.stationList[stationCount] != 0xFF)
@@ -151,7 +151,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                 }
                 break;
             }
-            case widx::image:
+            case Widx::kImage:
             {
                 ToolManager::toolCancel();
                 ToolManager::toolSet(self, widgetIndex, CursorId::placeStation);
@@ -161,11 +161,11 @@ namespace OpenLoco::Ui::Windows::Construction::Station
     }
 
     // 0x0049E256
-    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+    static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
         auto& cState = getConstructionState();
 
-        if (widgetIndex == widx::station_dropdown)
+        if (id == Widx::kStationDropdown)
         {
             if (itemIndex == -1)
             {

--- a/src/OpenLoco/src/Ui/Windows/DebugWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/DebugWindow.cpp
@@ -30,7 +30,7 @@ namespace OpenLoco::Ui::Windows::Debug
     static constexpr int32_t kTabWidth = 31;
     static constexpr int32_t kTabHeight = 27;
 
-    namespace widx
+    namespace Widx
     {
         constexpr auto frame = WidgetId("frame");
         constexpr auto title = WidgetId("title");
@@ -60,27 +60,27 @@ namespace OpenLoco::Ui::Windows::Debug
         using namespace Widgets;
 
         static constexpr auto _widgets = makeWidgets(
-            Frame(widx::frame, { 0, 0 }, kWindowSize, WindowColour::primary),
-            Caption(widx::title, { 1, 1 }, { kWindowSize.width - 2, kTitlebarHeight }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::openloco),
-            ImageButton(widx::close, { kWindowSize.width - 15, kMargin }, { 13, kTitlebarHeight }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+            Frame(Widx::frame, { 0, 0 }, kWindowSize, WindowColour::primary),
+            Caption(Widx::title, { 1, 1 }, { kWindowSize.width - 2, kTitlebarHeight }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::openloco),
+            ImageButton(Widx::close, { kWindowSize.width - 15, kMargin }, { 13, kTitlebarHeight }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
 
-            Panel(widx::panel, { 0, kTitlebarHeight + kMargin }, { kWindowSize.width, 245 }, WindowColour::secondary),
+            Panel(Widx::panel, { 0, kTitlebarHeight + kMargin }, { kWindowSize.width, 245 }, WindowColour::secondary),
 
-            Button(widx::button_1, { kMargin, kTitlebarHeight + kMargin + (0 * (kRowSize + kMargin)) }, { kWindowSize.width / 2, kButtonHeight }, WindowColour::secondary, StringIds::openloco),
-            ImageButton(widx::button_2, { kMargin, kTitlebarHeight + kMargin + (1 * (kRowSize + kMargin)) }, { 24, 24 }, WindowColour::secondary, ImageIds::red_flag, StringIds::tooltip_stop_start),
+            Button(Widx::button_1, { kMargin, kTitlebarHeight + kMargin + (0 * (kRowSize + kMargin)) }, { kWindowSize.width / 2, kButtonHeight }, WindowColour::secondary, StringIds::openloco),
+            ImageButton(Widx::button_2, { kMargin, kTitlebarHeight + kMargin + (1 * (kRowSize + kMargin)) }, { 24, 24 }, WindowColour::secondary, ImageIds::red_flag, StringIds::tooltip_stop_start),
 
-            Label(widx::label_1, { kMargin, kTitlebarHeight + kMargin + (2 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, ContentAlign::left, StringIds::openloco),
-            Label(widx::label_2, { kMargin, kTitlebarHeight + kMargin + (3 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, ContentAlign::center, StringIds::openloco),
-            Label(widx::label_3, { kMargin, kTitlebarHeight + kMargin + (4 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, ContentAlign::right, StringIds::openloco),
+            Label(Widx::label_1, { kMargin, kTitlebarHeight + kMargin + (2 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, ContentAlign::left, StringIds::openloco),
+            Label(Widx::label_2, { kMargin, kTitlebarHeight + kMargin + (3 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, ContentAlign::center, StringIds::openloco),
+            Label(Widx::label_3, { kMargin, kTitlebarHeight + kMargin + (4 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, ContentAlign::right, StringIds::openloco),
 
-            Checkbox(widx::checkbox_1, { kMargin, kTitlebarHeight + kMargin + (5 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, StringIds::openloco),
-            Checkbox(widx::checkbox_2, { kMargin, kTitlebarHeight + kMargin + (6 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, StringIds::openloco),
-            Checkbox(widx::checkbox_3, { kMargin, kTitlebarHeight + kMargin + (7 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, StringIds::openloco),
-            Checkbox(widx::checkbox_4, { kMargin, kTitlebarHeight + kMargin + (8 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, StringIds::openloco),
+            Checkbox(Widx::checkbox_1, { kMargin, kTitlebarHeight + kMargin + (5 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, StringIds::openloco),
+            Checkbox(Widx::checkbox_2, { kMargin, kTitlebarHeight + kMargin + (6 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, StringIds::openloco),
+            Checkbox(Widx::checkbox_3, { kMargin, kTitlebarHeight + kMargin + (7 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, StringIds::openloco),
+            Checkbox(Widx::checkbox_4, { kMargin, kTitlebarHeight + kMargin + (8 * (kRowSize + kMargin)) }, { kWindowSize.width - (kMargin * 2), kLabelHeight }, WindowColour::secondary, StringIds::openloco),
 
-            Tab(widx::tab_1, { kMargin + ((kTabWidth + kMargin) * 0), kTitlebarHeight + kMargin + (9 * (kRowSize + kMargin)) }, { kTabWidth, kTabHeight }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town),
-            Tab(widx::tab_2, { kMargin + ((kTabWidth + kMargin) * 1), kTitlebarHeight + kMargin + (9 * (kRowSize + kMargin)) }, { kTabWidth, kTabHeight }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_population_graph),
-            Tab(widx::tab_3, { kMargin + ((kTabWidth + kMargin) * 2), kTitlebarHeight + kMargin + (9 * (kRowSize + kMargin)) }, { kTabWidth, kTabHeight }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town_ratings_each_company)
+            Tab(Widx::tab_1, { kMargin + ((kTabWidth + kMargin) * 0), kTitlebarHeight + kMargin + (9 * (kRowSize + kMargin)) }, { kTabWidth, kTabHeight }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town),
+            Tab(Widx::tab_2, { kMargin + ((kTabWidth + kMargin) * 1), kTitlebarHeight + kMargin + (9 * (kRowSize + kMargin)) }, { kTabWidth, kTabHeight }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_population_graph),
+            Tab(Widx::tab_3, { kMargin + ((kTabWidth + kMargin) * 2), kTitlebarHeight + kMargin + (9 * (kRowSize + kMargin)) }, { kTabWidth, kTabHeight }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town_ratings_each_company)
             //
         );
     }
@@ -100,7 +100,7 @@ namespace OpenLoco::Ui::Windows::Debug
             getEvents());
 
         window->setWidgets(_widgets);
-        // window->disabledWidgets = 1U << widx::tab_3;
+        // window->disabledWidgets = 1U << Widx::tab_3;
         window->initScrollWidgets();
 
         auto getWidgetById = [&](Window& window, const WidgetId id) -> Widget& {
@@ -114,14 +114,14 @@ namespace OpenLoco::Ui::Windows::Debug
             throw std::runtime_error("Widget not found");
         };
 
-        auto& chkbox2 = getWidgetById(*window, widx::checkbox_2);
+        auto& chkbox2 = getWidgetById(*window, Widx::checkbox_2);
         chkbox2.activated = true;
 
-        auto& chkbox3 = getWidgetById(*window, widx::checkbox_3);
+        auto& chkbox3 = getWidgetById(*window, Widx::checkbox_3);
         chkbox3.activated = false;
         chkbox3.disabled = true;
 
-        auto& chkbox4 = getWidgetById(*window, widx::checkbox_4);
+        auto& chkbox4 = getWidgetById(*window, Widx::checkbox_4);
         chkbox4.activated = true;
         chkbox4.disabled = true;
 
@@ -138,7 +138,7 @@ namespace OpenLoco::Ui::Windows::Debug
         const auto& widget = window.widgets[widgetIndex];
         switch (widget.id)
         {
-            case widx::close:
+            case Widx::close:
                 WindowManager::close(window.type);
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/DragVehiclePart.cpp
+++ b/src/OpenLoco/src/Ui/Windows/DragVehiclePart.cpp
@@ -17,9 +17,14 @@ namespace OpenLoco::Ui::Windows::DragVehiclePart
         frame
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kFrame{ "frame" };
+    }
+
     // 0x00522504
     static constexpr auto widgets = makeWidgets(
-        Widgets::Wt3Widget({ 0, 0 }, { 150, 60 }, WindowColour::primary)
+        Widgets::Wt3Widget(Widx::kFrame, { 0, 0 }, { 150, 60 }, WindowColour::primary)
 
     );
 

--- a/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
+++ b/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
@@ -34,19 +34,16 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
 
     static const WindowEventList& getEvents();
 
-    namespace Widx
+    enum widx
     {
-        enum
-        {
-            frame,
-            caption,
-            close,
-            panel,
-            description,
-            shortcutName,
-            pressedKeys,
-        };
-    }
+        frame,
+        caption,
+        close,
+        panel,
+        description,
+        shortcutName,
+        pressedKeys,
+    };
 
     // 0x004BF7B9
     Window* open(const uint8_t shortcutIndex)
@@ -119,17 +116,17 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
     static void prepareDraw(Window& self)
     {
         {
-            auto args = FormatArguments(self.widgets[Widx::description].textArgs);
+            auto args = FormatArguments(self.widgets[widx::description].textArgs);
             args.push(StringIds::empty);
         }
 
         {
-            auto args = FormatArguments(self.widgets[Widx::shortcutName].textArgs);
+            auto args = FormatArguments(self.widgets[widx::shortcutName].textArgs);
             args.push(ShortcutManager::getName(static_cast<Shortcut>(_editingShortcutIndex)));
         }
 
         {
-            auto args = FormatArguments(self.widgets[Widx::pressedKeys].textArgs);
+            auto args = FormatArguments(self.widgets[widx::pressedKeys].textArgs);
             Input::Shortcuts::pushModifierStrings(args, _pressedModifiers);
         }
     }
@@ -145,7 +142,7 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
     {
         switch (widgetIndex)
         {
-            case Widx::close:
+            case widx::close:
                 WindowManager::close(&self);
                 return;
         }

--- a/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
+++ b/src/OpenLoco/src/Ui/Windows/EditKeyboardShortcut.cpp
@@ -23,14 +23,22 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
     static uint8_t _editingShortcutIndex;
     static KeyModifier _pressedModifiers;
 
+    namespace Widx
+    {
+        constexpr WidgetId kClose{ "close" };
+        constexpr WidgetId kDescription{ "description" };
+        constexpr WidgetId kShortcutName{ "shortcutName" };
+        constexpr WidgetId kPressedKeys{ "pressedKeys" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, kWindowSize, WindowColour::primary),
         Widgets::Caption({ 1, 1 }, { kWindowSize.width - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::change_keyboard_shortcut),
-        Widgets::ImageButton({ 265, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::ImageButton(Widx::kClose, { 265, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
         Widgets::Panel({ 0, 15 }, { kWindowSize.width, kWindowSize.height - 15 }, WindowColour::secondary),
-        Widgets::Label({ 4, 20 }, { kWindowSize.width - 8, 12 }, WindowColour::secondary, ContentAlign::center, StringIds::change_keyboard_shortcut_desc),
-        Widgets::Label({ 4, 34 }, { kWindowSize.width - 8, 12 }, WindowColour::secondary, ContentAlign::center, StringIds::black_quoted_stringid),
-        Widgets::Label({ 4, 54 }, { kWindowSize.width - 8, 12 }, WindowColour::secondary, ContentAlign::center, StringIds::black_stringid));
+        Widgets::Label(Widx::kDescription, { 4, 20 }, { kWindowSize.width - 8, 12 }, WindowColour::secondary, ContentAlign::center, StringIds::change_keyboard_shortcut_desc),
+        Widgets::Label(Widx::kShortcutName, { 4, 34 }, { kWindowSize.width - 8, 12 }, WindowColour::secondary, ContentAlign::center, StringIds::black_quoted_stringid),
+        Widgets::Label(Widx::kPressedKeys, { 4, 54 }, { kWindowSize.width - 8, 12 }, WindowColour::secondary, ContentAlign::center, StringIds::black_stringid));
 
     static const WindowEventList& getEvents();
 
@@ -138,11 +146,11 @@ namespace OpenLoco::Ui::Windows::EditKeyboardShortcut
     }
 
     // 0x004BE821
-    static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::close:
+            case Widx::kClose:
                 WindowManager::close(&self);
                 return;
         }

--- a/src/OpenLoco/src/Ui/Windows/Error.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Error.cpp
@@ -39,8 +39,13 @@ namespace OpenLoco::Ui::Windows::Error
             frame,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+        }
+
         static constexpr auto widgets = makeWidgets(
-            Widgets::Panel({ 0, 0 }, { 200, 42 }, WindowColour::primary)
+            Widgets::Panel(Widx::kFrame, { 0, 0 }, { 200, 42 }, WindowColour::primary)
 
         );
     }
@@ -53,9 +58,15 @@ namespace OpenLoco::Ui::Windows::Error
             innerFrame,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kInnerFrame{ "innerFrame" };
+        }
+
         static constexpr auto widgets = makeWidgets(
-            Widgets::Panel({ 0, 0 }, { 250, 70 }, WindowColour::primary),
-            Widgets::Wt3Widget({ 3, 3 }, { 64, 64 }, WindowColour::secondary)
+            Widgets::Panel(Widx::kFrame, { 0, 0 }, { 250, 70 }, WindowColour::primary),
+            Widgets::Wt3Widget(Widx::kInnerFrame, { 3, 3 }, { 64, 64 }, WindowColour::secondary)
 
         );
     }

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -59,15 +59,25 @@ namespace OpenLoco::Ui::Windows::IndustryList
             tab_new_industry,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabIndustryList{ "tab_industry_list" };
+            constexpr WidgetId kTabNewIndustry{ "tab_new_industry" };
+        }
+
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
-                Widgets::ImageButton({ frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { frameWidth, 154 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_industries_list),
-                Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_fund_new_industries));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
+                Widgets::ImageButton(Widx::kCloseButton, { frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { frameWidth, 154 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabIndustryList, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_industries_list),
+                Widgets::Tab(Widx::kTabNewIndustry, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_fund_new_industries));
         }
 
         static void populateIndustryList(Window& self);
@@ -94,14 +104,24 @@ namespace OpenLoco::Ui::Windows::IndustryList
             status_bar,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kSortIndustryName{ "sort_industry_name" };
+            constexpr WidgetId kSortIndustryStatus{ "sort_industry_status" };
+            constexpr WidgetId kSortIndustryProductionTransported{ "sort_industry_production_transported" };
+            constexpr WidgetId kSortIndustryProductionLastMonth{ "sort_industry_production_last_month" };
+            constexpr WidgetId kScrollview{ "scrollview" };
+            constexpr WidgetId kStatusBar{ "status_bar" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(600, 197, StringIds::title_industries),
-            Widgets::TableHeader({ 4, 44 }, { 199, 11 }, WindowColour::secondary, Widget::kContentNull, StringIds::sort_industry_name),
-            Widgets::TableHeader({ 204, 44 }, { 204, 11 }, WindowColour::secondary, Widget::kContentNull, StringIds::sort_industry_status),
-            Widgets::TableHeader({ 444, 44 }, { 159, 11 }, WindowColour::secondary, Widget::kContentNull, StringIds::sort_industry_production_transported),
-            Widgets::TableHeader({ 603, 44 }, { 159, 11 }, WindowColour::secondary, Widget::kContentNull, StringIds::sort_industry_production_last_month),
-            Widgets::ScrollView({ 3, 56 }, { 593, 125 }, WindowColour::secondary, Scrollbars::vertical),
-            Widgets::Label({ 4, kWindowSize.height - 17 }, { kWindowSize.width - kResizeHandleSize, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid)
+            Widgets::TableHeader(Widx::kSortIndustryName, { 4, 44 }, { 199, 11 }, WindowColour::secondary, Widget::kContentNull, StringIds::sort_industry_name),
+            Widgets::TableHeader(Widx::kSortIndustryStatus, { 204, 44 }, { 204, 11 }, WindowColour::secondary, Widget::kContentNull, StringIds::sort_industry_status),
+            Widgets::TableHeader(Widx::kSortIndustryProductionTransported, { 444, 44 }, { 159, 11 }, WindowColour::secondary, Widget::kContentNull, StringIds::sort_industry_production_transported),
+            Widgets::TableHeader(Widx::kSortIndustryProductionLastMonth, { 603, 44 }, { 159, 11 }, WindowColour::secondary, Widget::kContentNull, StringIds::sort_industry_production_last_month),
+            Widgets::ScrollView(Widx::kScrollview, { 3, 56 }, { 593, 125 }, WindowColour::secondary, Scrollbars::vertical),
+            Widgets::Label(Widx::kStatusBar, { 4, kWindowSize.height - 17 }, { kWindowSize.width - kResizeHandleSize, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid)
 
         );
 
@@ -170,21 +190,21 @@ namespace OpenLoco::Ui::Windows::IndustryList
         // 0x00457EC4
         static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_industry_list:
-                case Common::widx::tab_new_industry:
+                case Common::Widx::kTabIndustryList:
+                case Common::Widx::kTabNewIndustry:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::sort_industry_name:
-                case widx::sort_industry_status:
-                case widx::sort_industry_production_transported:
-                case widx::sort_industry_production_last_month:
+                case Widx::kSortIndustryName:
+                case Widx::kSortIndustryStatus:
+                case Widx::kSortIndustryProductionTransported:
+                case Widx::kSortIndustryProductionLastMonth:
                 {
                     auto sortMode = widgetIndex - widx::sort_industry_name;
                     if (self.sortMode == sortMode)
@@ -482,9 +502,9 @@ namespace OpenLoco::Ui::Windows::IndustryList
         }
 
         // 0x00458113
-        static Ui::CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, [[maybe_unused]] WidgetIndex_t widgetIdx, const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
         {
-            if (widgetIdx != widx::scrollview)
+            if (id != Widx::kScrollview)
             {
                 return fallback;
             }
@@ -646,9 +666,14 @@ namespace OpenLoco::Ui::Windows::IndustryList
             scrollview = 6,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kScrollview{ "scrollview" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(577, 171, StringIds::title_fund_new_industries),
-            Widgets::ScrollView({ 3, 45 }, { 549, kRowHeight }, WindowColour::secondary, Scrollbars::vertical)
+            Widgets::ScrollView(Widx::kScrollview, { 3, 45 }, { 549, kRowHeight }, WindowColour::secondary, Scrollbars::vertical)
 
         );
 
@@ -740,14 +765,14 @@ namespace OpenLoco::Ui::Windows::IndustryList
         // 0x0045843A
         static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_industry_list:
-                case Common::widx::tab_new_industry:
+                case Common::Widx::kTabIndustryList:
+                case Common::Widx::kTabNewIndustry:
                     Common::switchTab(self, widgetIndex);
                     break;
             }

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -50,17 +50,29 @@ namespace OpenLoco::Ui::Windows::Industry
             tab_transported,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabIndustry{ "tab_industry" };
+            constexpr WidgetId kTabProduction{ "tab_production" };
+            constexpr WidgetId kTabProduction2{ "tab_production_2" };
+            constexpr WidgetId kTabTransported{ "tab_transported" };
+        }
+
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
-                Widgets::ImageButton({ frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { frameWidth, 95 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_industry),
-                Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_production_graph),
-                Widgets::Tab({ 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_production_graph),
-                Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_statistics));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
+                Widgets::ImageButton(Widx::kCloseButton, { frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { frameWidth, 95 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabIndustry, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_industry),
+                Widgets::Tab(Widx::kTabProduction, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_production_graph),
+                Widgets::Tab(Widx::kTabProduction2, { 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_production_graph),
+                Widgets::Tab(Widx::kTabTransported, { 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_statistics));
         }
 
         // Defined at the bottom of this file.
@@ -91,12 +103,20 @@ namespace OpenLoco::Ui::Windows::Industry
             demolish_industry,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kViewport{ "viewport" };
+            constexpr WidgetId kStatusBar{ "status_bar" };
+            constexpr WidgetId kCentreOnViewport{ "centre_on_viewport" };
+            constexpr WidgetId kDemolishIndustry{ "demolish_industry" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(223, 137, StringIds::title_town),
-            Widgets::Viewport({ 3, 44 }, { 195, 80 }, WindowColour::secondary, Widget::kContentUnk),
-            Widgets::Label({ 3, 115 }, { 195, 21 }, WindowColour::secondary, ContentAlign::center),
-            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this),
-            Widgets::ImageButton({ 198, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::rubbish_bin, StringIds::demolish_this_industry)
+            Widgets::Viewport(Widx::kViewport, { 3, 44 }, { 195, 80 }, WindowColour::secondary, Widget::kContentUnk),
+            Widgets::Label(Widx::kStatusBar, { 3, 115 }, { 195, 21 }, WindowColour::secondary, ContentAlign::center),
+            Widgets::ImageButton(Widx::kCentreOnViewport, { 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this),
+            Widgets::ImageButton(Widx::kDemolishIndustry, { 198, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::rubbish_bin, StringIds::demolish_this_industry)
 
         );
 
@@ -157,30 +177,30 @@ namespace OpenLoco::Ui::Windows::Industry
         // 0x00455C86
         static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameIndustryPrompt(self, widgetIndex);
                     break;
 
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_industry:
-                case Common::widx::tab_production:
-                case Common::widx::tab_production_2:
-                case Common::widx::tab_transported:
+                case Common::Widx::kTabIndustry:
+                case Common::Widx::kTabProduction:
+                case Common::Widx::kTabProduction2:
+                case Common::Widx::kTabTransported:
                     Common::switchTab(self, widgetIndex);
                     break;
 
                 // 0x00455EA2
-                case widx::centre_on_viewport:
+                case Widx::kCentreOnViewport:
                     self.viewportCentreMain();
                     break;
 
                 // 0x00455E59
-                case widx::demolish_industry:
+                case Widx::kDemolishIndustry:
                 {
                     GameCommands::IndustryRemovalArgs args;
                     args.industryId = static_cast<IndustryId>(self.number);
@@ -754,20 +774,20 @@ namespace OpenLoco::Ui::Windows::Industry
         // 0x004565B5, 0x00456505
         static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameIndustryPrompt(self, widgetIndex);
                     break;
 
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_industry:
-                case Common::widx::tab_production:
-                case Common::widx::tab_production_2:
-                case Common::widx::tab_transported:
+                case Common::Widx::kTabIndustry:
+                case Common::Widx::kTabProduction:
+                case Common::Widx::kTabProduction2:
+                case Common::Widx::kTabTransported:
                     Common::switchTab(self, widgetIndex);
                     break;
             }
@@ -800,9 +820,9 @@ namespace OpenLoco::Ui::Windows::Industry
         }
 
         // 0x00455CBC
-        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
+        static void textInput(Window& self, [[maybe_unused]] WidgetIndex_t callingWidget, const WidgetId id, const char* input)
         {
-            if (callingWidget != Common::widx::caption)
+            if (id != Common::Widx::kCaption)
             {
                 return;
             }

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -40,18 +40,15 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
 
     );
 
-    namespace Widx
+    enum widx
     {
-        enum
-        {
-            frame,
-            caption,
-            close_button,
-            panel,
-            list,
-            reset_keys_btn,
-        };
-    }
+        frame,
+        caption,
+        close_button,
+        panel,
+        list,
+        reset_keys_btn,
+    };
 
     static void resetShortcuts(Window* self);
     static const WindowEventList& getEvents();
@@ -206,11 +203,11 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     {
         switch (widgetIndex)
         {
-            case Widx::close_button:
+            case widx::close_button:
                 WindowManager::close(&self);
                 return;
 
-            case Widx::reset_keys_btn:
+            case widx::reset_keys_btn:
                 resetShortcuts(&self);
                 return;
         }

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -30,13 +30,19 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
 
     static constexpr Ui::Size kWindowSize = { 420, 238 };
 
+    namespace Widx
+    {
+        constexpr WidgetId kCloseButton{ "close_button" };
+        constexpr WidgetId kResetKeysBtn{ "reset_keys_btn" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, kWindowSize, WindowColour::primary),
         Widgets::Caption({ 1, 1 }, { kWindowSize.width - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::keyboard_shortcuts),
-        Widgets::ImageButton({ kWindowSize.width - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::ImageButton(Widx::kCloseButton, { kWindowSize.width - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
         Widgets::Panel({ 0, 15 }, { kWindowSize.width, kWindowSize.height - 15 }, WindowColour::secondary),
         Widgets::ScrollView({ 4, 19 }, { kWindowSize.width - 8, 202 }, WindowColour::secondary, Scrollbars::vertical, StringIds::keyboard_shortcut_list_tip),
-        Widgets::Button({ 4, 223 }, { 150, 12 }, WindowColour::secondary, StringIds::reset_keys, StringIds::reset_keys_tip)
+        Widgets::Button(Widx::kResetKeysBtn, { 4, 223 }, { 150, 12 }, WindowColour::secondary, StringIds::reset_keys, StringIds::reset_keys_tip)
 
     );
 
@@ -199,15 +205,15 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
     }
 
     // 0x004BE821
-    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::close_button:
+            case Widx::kCloseButton:
                 WindowManager::close(&self);
                 return;
 
-            case widx::reset_keys_btn:
+            case Widx::kResetKeysBtn:
                 resetShortcuts(&self);
                 return;
         }

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -65,6 +65,21 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             generate_now,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabOptions{ "tab_options" };
+            constexpr WidgetId kTabLand{ "tab_land" };
+            constexpr WidgetId kTabWater{ "tab_water" };
+            constexpr WidgetId kTabForests{ "tab_forests" };
+            constexpr WidgetId kTabTowns{ "tab_towns" };
+            constexpr WidgetId kTabIndustries{ "tab_industries" };
+            constexpr WidgetId kGenerateNow{ "generate_now" };
+        }
+
         enum class ResetLandscapeMode
         {
             generate_now = 0,
@@ -74,17 +89,17 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         static constexpr auto makeCommonWidgets(int32_t frame_height, StringId window_caption_id)
         {
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, { 366, frame_height }, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { 364, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, window_caption_id),
-                Widgets::ImageButton({ 351, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { 366, 175 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_landscape_generation_options),
-                Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_landscape_generation_land),
-                Widgets::Tab({ 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_landscape_generation_water),
-                Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_landscape_generation_forests),
-                Widgets::Tab({ 127, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_landscape_generation_towns),
-                Widgets::Tab({ 158, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_landscape_generation_industries),
-                Widgets::Button({ 196, frame_height - 17 }, { 160, 12 }, WindowColour::secondary, StringIds::button_generate_landscape, StringIds::tooltip_generate_random_landscape));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, { 366, frame_height }, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { 364, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, window_caption_id),
+                Widgets::ImageButton(Widx::kCloseButton, { 351, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { 366, 175 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabOptions, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_landscape_generation_options),
+                Widgets::Tab(Widx::kTabLand, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_landscape_generation_land),
+                Widgets::Tab(Widx::kTabWater, { 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_landscape_generation_water),
+                Widgets::Tab(Widx::kTabForests, { 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_landscape_generation_forests),
+                Widgets::Tab(Widx::kTabTowns, { 127, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_landscape_generation_towns),
+                Widgets::Tab(Widx::kTabIndustries, { 158, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_landscape_generation_industries),
+                Widgets::Button(Widx::kGenerateNow, { 196, frame_height - 17 }, { 160, 12 }, WindowColour::secondary, StringIds::button_generate_landscape, StringIds::tooltip_generate_random_landscape));
         }
 
         // Defined at the bottom of this file.
@@ -127,22 +142,22 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
         static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::close_button:
+                case Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case widx::tab_options:
-                case widx::tab_land:
-                case widx::tab_water:
-                case widx::tab_forests:
-                case widx::tab_towns:
-                case widx::tab_industries:
+                case Widx::kTabOptions:
+                case Widx::kTabLand:
+                case Widx::kTabWater:
+                case Widx::kTabForests:
+                case Widx::kTabTowns:
+                case Widx::kTabIndustries:
                     switchTab(self, widgetIndex);
                     break;
 
-                case widx::generate_now:
+                case Widx::kGenerateNow:
                     confirmResetLandscape(ResetLandscapeMode::generate_now);
                     break;
             }
@@ -288,6 +303,24 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             browseHeightmapFile,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kStartYear{ "start_year" };
+            constexpr WidgetId kStartYearDown{ "start_year_down" };
+            constexpr WidgetId kStartYearUp{ "start_year_up" };
+            constexpr WidgetId kHeightMapBox{ "heightMapBox" };
+            constexpr WidgetId kHeightMapDropdown{ "heightMapDropdown" };
+            constexpr WidgetId kHillObjectLabel{ "hillObjectLabel" };
+            constexpr WidgetId kChangeHeightmapBtn{ "change_heightmap_btn" };
+            constexpr WidgetId kTerrainSmoothingLabel{ "terrainSmoothingLabel" };
+            constexpr WidgetId kTerrainSmoothingNum{ "terrainSmoothingNum" };
+            constexpr WidgetId kTerrainSmoothingNumDown{ "terrainSmoothingNumDown" };
+            constexpr WidgetId kTerrainSmoothingNumUp{ "terrainSmoothingNumUp" };
+            constexpr WidgetId kGenerateWhenGameStarts{ "generate_when_game_starts" };
+            constexpr WidgetId kHeightmapFileLabel{ "heightmapFileLabel" };
+            constexpr WidgetId kBrowseHeightmapFile{ "browseHeightmapFile" };
+        }
+
         // clang-format off
         const uint64_t holdable_widgets =
             (1 << widx::start_year_up) |
@@ -302,21 +335,21 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             // General options
             Widgets::GroupBox({ 4, 50 }, { 358, 50 }, WindowColour::secondary, StringIds::landscapeOptionsGroupGeneral),
             Widgets::Label({ 10, 65 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::start_year),
-            Widgets::stepperWidgets({ 256, 65 }, { 100, 12 }, WindowColour::secondary, StringIds::start_year_value),
+            Widgets::stepperWidgets(Widx::kStartYear, Widx::kStartYearDown, Widx::kStartYearUp, { 256, 65 }, { 100, 12 }, WindowColour::secondary, StringIds::start_year_value),
             Widgets::Label({ 10, 81 }, { 160, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::height_map_source),
-            Widgets::dropdownWidgets({ 176, 81 }, { 180, 12 }, WindowColour::secondary),
+            Widgets::dropdownWidgets(Widx::kHeightMapBox, Widx::kHeightMapDropdown, { 176, 81 }, { 180, 12 }, WindowColour::secondary),
 
             // Generator options
             Widgets::GroupBox({ 4, 105 }, { 358, 50 }, WindowColour::secondary, StringIds::landscapeOptionsGroupGenerator),
-            Widgets::Label({ 10, 120 }, { 260, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::landscapeOptionsCurrentHillObject),
-            Widgets::Button({ 280, 120 }, { 75, 12 }, WindowColour::secondary, StringIds::change),
-            Widgets::Label({ 10, 120 }, { 260, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::landscapeOptionsSmoothingPasses),
-            Widgets::stepperWidgets({ 256, 120 }, { 100, 12 }, WindowColour::secondary, StringIds::uint16_raw),
-            Widgets::Checkbox({ 10, 136 }, { 346, 12 }, WindowColour::secondary, StringIds::label_generate_random_landscape_when_game_starts, StringIds::tooltip_generate_random_landscape_when_game_starts),
+            Widgets::Label(Widx::kHillObjectLabel, { 10, 120 }, { 260, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::landscapeOptionsCurrentHillObject),
+            Widgets::Button(Widx::kChangeHeightmapBtn, { 280, 120 }, { 75, 12 }, WindowColour::secondary, StringIds::change),
+            Widgets::Label(Widx::kTerrainSmoothingLabel, { 10, 120 }, { 260, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::landscapeOptionsSmoothingPasses),
+            Widgets::stepperWidgets(Widx::kTerrainSmoothingNum, Widx::kTerrainSmoothingNumDown, Widx::kTerrainSmoothingNumUp, { 256, 120 }, { 100, 12 }, WindowColour::secondary, StringIds::uint16_raw),
+            Widgets::Checkbox(Widx::kGenerateWhenGameStarts, { 10, 136 }, { 346, 12 }, WindowColour::secondary, StringIds::label_generate_random_landscape_when_game_starts, StringIds::tooltip_generate_random_landscape_when_game_starts),
 
             // PNG browser
-            Widgets::Label({ 10, 120 }, { 260, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::currentHeightmapFile),
-            Widgets::Button({ 280, 120 }, { 75, 12 }, WindowColour::secondary, StringIds::button_browse)
+            Widgets::Label(Widx::kHeightmapFileLabel, { 10, 120 }, { 260, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::currentHeightmapFile),
+            Widgets::Button(Widx::kBrowseHeightmapFile, { 280, 120 }, { 75, 12 }, WindowColour::secondary, StringIds::button_browse)
 
         );
 
@@ -423,11 +456,11 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E1BA
-        static void onDropdown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::heightMapDropdown:
+                case Widx::kHeightMapDropdown:
                     if (itemIndex != -1)
                     {
                         Scenario::getOptions().generator = static_cast<Scenario::LandGeneratorType>(itemIndex);
@@ -438,13 +471,13 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043DC83
-        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
             auto& options = Scenario::getOptions();
 
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::start_year_up:
+                case Widx::kStartYearUp:
                     if (options.scenarioStartYear + 1 <= Scenario::kMaxYear)
                     {
                         options.scenarioStartYear += 1;
@@ -452,7 +485,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     window.invalidate();
                     break;
 
-                case widx::start_year_down:
+                case Widx::kStartYearDown:
                     if (options.scenarioStartYear - 1 >= Scenario::kMinYear)
                     {
                         options.scenarioStartYear -= 1;
@@ -460,17 +493,17 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     window.invalidate();
                     break;
 
-                case widx::terrainSmoothingNumUp:
+                case Widx::kTerrainSmoothingNumUp:
                     options.numTerrainSmoothingPasses = std::clamp(options.numTerrainSmoothingPasses + 1, 1, 5);
                     window.invalidate();
                     break;
 
-                case widx::terrainSmoothingNumDown:
+                case Widx::kTerrainSmoothingNumDown:
                     options.numTerrainSmoothingPasses = std::clamp(options.numTerrainSmoothingPasses - 1, 1, 5);
                     window.invalidate();
                     break;
 
-                case widx::heightMapDropdown:
+                case Widx::kHeightMapDropdown:
                 {
                     Widget& target = window.widgets[widx::heightMapBox];
                     Dropdown::show(window.x + target.left, window.y + target.top, target.width() - 4, target.height(), window.getColour(WindowColour::secondary), std::size(generatorIds), 0x80);
@@ -489,9 +522,9 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         // 0x0043DC58
         static void onMouseUp(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::generate_when_game_starts:
+                case Widx::kGenerateWhenGameStarts:
                     if ((Scenario::getOptions().scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) == Scenario::ScenarioFlags::none)
                     {
                         Scenario::getOptions().scenarioFlags |= Scenario::ScenarioFlags::landscapeGenerationDone;
@@ -504,12 +537,12 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     }
                     break;
 
-                case widx::change_heightmap_btn:
+                case Widx::kChangeHeightmapBtn:
                     EditorController::goToPreviousStep();
                     ObjectSelectionWindow::openInTab(ObjectType::hillShapes);
                     break;
 
-                case widx::browseHeightmapFile:
+                case Widx::kBrowseHeightmapFile:
                 {
                     if (auto res = Game::loadHeightmapOpen())
                     {
@@ -603,18 +636,32 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             scrollview,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kTopographyStyle{ "topography_style" };
+            constexpr WidgetId kTopographyStyleBtn{ "topography_style_btn" };
+            constexpr WidgetId kMinLandHeight{ "min_land_height" };
+            constexpr WidgetId kMinLandHeightDown{ "min_land_height_down" };
+            constexpr WidgetId kMinLandHeightUp{ "min_land_height_up" };
+            constexpr WidgetId kHillDensity{ "hill_density" };
+            constexpr WidgetId kHillDensityDown{ "hill_density_down" };
+            constexpr WidgetId kHillDensityUp{ "hill_density_up" };
+            constexpr WidgetId kHillsEdgeOfMap{ "hillsEdgeOfMap" };
+            constexpr WidgetId kScrollview{ "scrollview" };
+        }
+
         const uint64_t holdable_widgets = (1 << widx::min_land_height_up) | (1 << widx::min_land_height_down) | (1 << widx::hill_density_up) | (1 << widx::hill_density_down);
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(252, StringIds::title_landscape_generation_land),
             Widgets::Label({ 10, 52 }, { 160, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::topography_style),
-            Widgets::dropdownWidgets({ 176, 52 }, { 180, 12 }, WindowColour::secondary),
+            Widgets::dropdownWidgets(Widx::kTopographyStyle, Widx::kTopographyStyleBtn, { 176, 52 }, { 180, 12 }, WindowColour::secondary),
             Widgets::Label({ 10, 68 }, { 250, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::min_land_height),
-            Widgets::stepperWidgets({ 256, 68 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units),
+            Widgets::stepperWidgets(Widx::kMinLandHeight, Widx::kMinLandHeightDown, Widx::kMinLandHeightUp, { 256, 68 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units),
             Widgets::Label({ 10, 84 }, { 250, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::hill_density),
-            Widgets::stepperWidgets({ 256, 84 }, { 100, 12 }, WindowColour::secondary, StringIds::hill_density_percent),
-            Widgets::Checkbox({ 10, 100 }, { 346, 12 }, WindowColour::secondary, StringIds::create_hills_right_up_to_edge_of_map),
-            Widgets::ScrollView({ 4, 116 }, { 358, 112 }, WindowColour::secondary, Scrollbars::vertical)
+            Widgets::stepperWidgets(Widx::kHillDensity, Widx::kHillDensityDown, Widx::kHillDensityUp, { 256, 84 }, { 100, 12 }, WindowColour::secondary, StringIds::hill_density_percent),
+            Widgets::Checkbox(Widx::kHillsEdgeOfMap, { 10, 100 }, { 346, 12 }, WindowColour::secondary, StringIds::create_hills_right_up_to_edge_of_map),
+            Widgets::ScrollView(Widx::kScrollview, { 4, 116 }, { 358, 112 }, WindowColour::secondary, Scrollbars::vertical)
 
         );
 
@@ -723,11 +770,11 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         };
 
         // 0x0043E1BA
-        static void onDropdown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::topography_style_btn:
+                case Widx::kTopographyStyleBtn:
                     if (itemIndex != -1)
                     {
                         Scenario::getOptions().topographyStyle = static_cast<Scenario::TopographyStyle>(itemIndex);
@@ -735,7 +782,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     }
                     break;
 
-                case widx::scrollview:
+                case Widx::kScrollview:
                     if (itemIndex != -1 && window.rowHover != -1)
                     {
                         Scenario::getOptions().landDistributionPatterns[window.rowHover] = static_cast<Scenario::LandDistributionPattern>(itemIndex);
@@ -746,21 +793,21 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E173
-        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
             auto& options = Scenario::getOptions();
 
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::min_land_height_up:
+                case Widx::kMinLandHeightUp:
                     options.minLandHeight = std::min<int8_t>(options.minLandHeight + 1, Scenario::kMaxBaseLandHeight);
                     break;
 
-                case widx::min_land_height_down:
+                case Widx::kMinLandHeightDown:
                     options.minLandHeight = std::max<int8_t>(Scenario::kMinBaseLandHeight, options.minLandHeight - 1);
                     break;
 
-                case widx::topography_style_btn:
+                case Widx::kTopographyStyleBtn:
                 {
                     Widget& target = window.widgets[widx::topography_style];
                     Dropdown::show(window.x + target.left, window.y + target.top, target.width() - 4, target.height(), window.getColour(WindowColour::secondary), std::size(topographyStyleIds), 0x80);
@@ -774,11 +821,11 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     break;
                 }
 
-                case widx::hill_density_up:
+                case Widx::kHillDensityUp:
                     options.hillDensity = std::min<int8_t>(options.hillDensity + 1, Scenario::kMaxHillDensity);
                     break;
 
-                case widx::hill_density_down:
+                case Widx::kHillDensityDown:
                     options.hillDensity = std::max<int8_t>(Scenario::kMinHillDensity, options.hillDensity - 1);
                     break;
 
@@ -792,11 +839,11 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043E14E
-        static void onMouseUp(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& window, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::hillsEdgeOfMap:
+                case Widx::kHillsEdgeOfMap:
                     Scenario::getOptions().scenarioFlags ^= Scenario::ScenarioFlags::hillsEdgeOfMap;
                     window.invalidate();
                     break;
@@ -962,6 +1009,28 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             meander_rate_up,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kSeaLevel{ "sea_level" };
+            constexpr WidgetId kSeaLevelDown{ "sea_level_down" };
+            constexpr WidgetId kSeaLevelUp{ "sea_level_up" };
+            constexpr WidgetId kNumRiverbeds{ "num_riverbeds" };
+            constexpr WidgetId kNumRiverbedsDown{ "num_riverbeds_down" };
+            constexpr WidgetId kNumRiverbedsUp{ "num_riverbeds_up" };
+            constexpr WidgetId kMinRiverWidth{ "min_river_width" };
+            constexpr WidgetId kMinRiverWidthDown{ "min_river_width_down" };
+            constexpr WidgetId kMinRiverWidthUp{ "min_river_width_up" };
+            constexpr WidgetId kMaxRiverWidth{ "max_river_width" };
+            constexpr WidgetId kMaxRiverWidthDown{ "max_river_width_down" };
+            constexpr WidgetId kMaxRiverWidthUp{ "max_river_width_up" };
+            constexpr WidgetId kRiverbankWidth{ "riverbank_width" };
+            constexpr WidgetId kRiverbankWidthDown{ "riverbank_width_down" };
+            constexpr WidgetId kRiverbankWidthUp{ "riverbank_width_up" };
+            constexpr WidgetId kMeanderRate{ "meander_rate" };
+            constexpr WidgetId kMeanderRateDown{ "meander_rate_down" };
+            constexpr WidgetId kMeanderRateUp{ "meander_rate_up" };
+        }
+
         // clang-format off
         const uint64_t holdable_widgets = (1ULL << widx::sea_level_up) | (1ULL << widx::sea_level_down) |
             (1ULL << widx::num_riverbeds_down) | (1ULL << widx::num_riverbeds_up) |
@@ -974,73 +1043,73 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(217, StringIds::title_landscape_generation_water),
             Widgets::Label({ 10, 52 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::sea_level),
-            Widgets::stepperWidgets({ 256, 52 }, { 100, 12 }, WindowColour::secondary, StringIds::sea_level_units),
+            Widgets::stepperWidgets(Widx::kSeaLevel, Widx::kSeaLevelDown, Widx::kSeaLevelUp, { 256, 52 }, { 100, 12 }, WindowColour::secondary, StringIds::sea_level_units),
             Widgets::Label({ 10, 68 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::number_riverbeds),
-            Widgets::stepperWidgets({ 256, 68 }, { 100, 12 }, WindowColour::secondary, StringIds::uint16_raw),
+            Widgets::stepperWidgets(Widx::kNumRiverbeds, Widx::kNumRiverbedsDown, Widx::kNumRiverbedsUp, { 256, 68 }, { 100, 12 }, WindowColour::secondary, StringIds::uint16_raw),
             Widgets::Label({ 10, 84 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::minimum_river_width),
-            Widgets::stepperWidgets({ 256, 84 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units),
+            Widgets::stepperWidgets(Widx::kMinRiverWidth, Widx::kMinRiverWidthDown, Widx::kMinRiverWidthUp, { 256, 84 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units),
             Widgets::Label({ 10, 100 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::maximum_river_width),
-            Widgets::stepperWidgets({ 256, 100 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units),
+            Widgets::stepperWidgets(Widx::kMaxRiverWidth, Widx::kMaxRiverWidthDown, Widx::kMaxRiverWidthUp, { 256, 100 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units),
             Widgets::Label({ 10, 116 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::riverbank_width),
-            Widgets::stepperWidgets({ 256, 116 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units),
+            Widgets::stepperWidgets(Widx::kRiverbankWidth, Widx::kRiverbankWidthDown, Widx::kRiverbankWidthUp, { 256, 116 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units),
             Widgets::Label({ 10, 132 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::meander_rate),
-            Widgets::stepperWidgets({ 256, 132 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units)
+            Widgets::stepperWidgets(Widx::kMeanderRate, Widx::kMeanderRateDown, Widx::kMeanderRateUp, { 256, 132 }, { 100, 12 }, WindowColour::secondary, StringIds::min_land_height_units)
 
         );
 
         // 0x0043E173
-        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
             auto& gameState = getGameState();
             auto& options = Scenario::getOptions();
 
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::sea_level_up:
+                case Widx::kSeaLevelUp:
                     gameState.seaLevel = std::min<int8_t>(gameState.seaLevel + 1, Scenario::kMaxSeaLevel);
                     break;
 
-                case widx::sea_level_down:
+                case Widx::kSeaLevelDown:
                     gameState.seaLevel = std::max<int8_t>(Scenario::kMinSeaLevel, gameState.seaLevel - 1);
                     break;
 
-                case widx::num_riverbeds_up:
+                case Widx::kNumRiverbedsUp:
                     options.numRiverbeds = std::min<int8_t>(options.numRiverbeds + 1, Scenario::kMaxNumRiverbeds);
                     break;
 
-                case widx::num_riverbeds_down:
+                case Widx::kNumRiverbedsDown:
                     options.numRiverbeds = std::max<int8_t>(Scenario::kMinNumRiverbeds, options.numRiverbeds - 1);
                     break;
 
-                case widx::min_river_width_up:
+                case Widx::kMinRiverWidthUp:
                     options.minRiverWidth = std::min<int8_t>(options.minRiverWidth + 1, Scenario::kMaxMinRiverWidth);
                     break;
 
-                case widx::min_river_width_down:
+                case Widx::kMinRiverWidthDown:
                     options.minRiverWidth = std::max<int8_t>(Scenario::kMinMinRiverWidth, options.minRiverWidth - 1);
                     break;
 
-                case widx::max_river_width_up:
+                case Widx::kMaxRiverWidthUp:
                     options.maxRiverWidth = std::min<int8_t>(options.maxRiverWidth + 1, Scenario::kMaxMaxRiverWidth);
                     break;
 
-                case widx::max_river_width_down:
+                case Widx::kMaxRiverWidthDown:
                     options.maxRiverWidth = std::max<int8_t>(Scenario::kMinMaxRiverWidth, options.maxRiverWidth - 1);
                     break;
 
-                case widx::riverbank_width_up:
+                case Widx::kRiverbankWidthUp:
                     options.riverbankWidth = std::min<int8_t>(options.riverbankWidth + 1, Scenario::kMaxRiverbankWidth);
                     break;
 
-                case widx::riverbank_width_down:
+                case Widx::kRiverbankWidthDown:
                     options.riverbankWidth = std::max<int8_t>(Scenario::kMinRiverbankWidth, options.riverbankWidth - 1);
                     break;
 
-                case widx::meander_rate_up:
+                case Widx::kMeanderRateUp:
                     options.riverMeanderRate = std::min<int8_t>(options.riverMeanderRate + 1, Scenario::kMaxRiverMeanderRate);
                     break;
 
-                case widx::meander_rate_down:
+                case Widx::kMeanderRateDown:
                     options.riverMeanderRate = std::max<int8_t>(Scenario::kMinRiverMeanderRate, options.riverMeanderRate - 1);
                     break;
 
@@ -1139,47 +1208,75 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             max_altitude_for_trees_up,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kNumberOfForests{ "number_of_forests" };
+            constexpr WidgetId kNumberOfForestsDown{ "number_of_forests_down" };
+            constexpr WidgetId kNumberOfForestsUp{ "number_of_forests_up" };
+            constexpr WidgetId kMinForestRadius{ "minForestRadius" };
+            constexpr WidgetId kMinForestRadiusDown{ "min_forest_radius_down" };
+            constexpr WidgetId kMinForestRadiusUp{ "min_forest_radius_up" };
+            constexpr WidgetId kMaxForestRadius{ "maxForestRadius" };
+            constexpr WidgetId kMaxForestRadiusDown{ "max_forest_radius_down" };
+            constexpr WidgetId kMaxForestRadiusUp{ "max_forest_radius_up" };
+            constexpr WidgetId kMinForestDensity{ "minForestDensity" };
+            constexpr WidgetId kMinForestDensityDown{ "min_forest_density_down" };
+            constexpr WidgetId kMinForestDensityUp{ "min_forest_density_up" };
+            constexpr WidgetId kMaxForestDensity{ "maxForestDensity" };
+            constexpr WidgetId kMaxForestDensityDown{ "max_forest_density_down" };
+            constexpr WidgetId kMaxForestDensityUp{ "max_forest_density_up" };
+            constexpr WidgetId kNumberRandomTrees{ "number_random_trees" };
+            constexpr WidgetId kNumberRandomTreesDown{ "number_random_trees_down" };
+            constexpr WidgetId kNumberRandomTreesUp{ "number_random_trees_up" };
+            constexpr WidgetId kMinAltitudeForTrees{ "min_altitude_for_trees" };
+            constexpr WidgetId kMinAltitudeForTreesDown{ "min_altitude_for_trees_down" };
+            constexpr WidgetId kMinAltitudeForTreesUp{ "min_altitude_for_trees_up" };
+            constexpr WidgetId kMaxAltitudeForTrees{ "max_altitude_for_trees" };
+            constexpr WidgetId kMaxAltitudeForTreesDown{ "max_altitude_for_trees_down" };
+            constexpr WidgetId kMaxAltitudeForTreesUp{ "max_altitude_for_trees_up" };
+        }
+
         const uint64_t holdable_widgets = (1ULL << widx::number_of_forests_up) | (1ULL << widx::number_of_forests_down) | (1ULL << widx::min_forest_radius_up) | (1ULL << widx::min_forest_radius_down) | (1ULL << widx::max_forest_radius_up) | (1ULL << widx::max_forest_radius_down) | (1ULL << widx::min_forest_density_up) | (1ULL << widx::min_forest_density_down) | (1ULL << widx::max_forest_density_up) | (1 << widx::max_forest_density_down) | (1ULL << widx::number_random_trees_up) | (1ULL << widx::number_random_trees_down) | (1ULL << widx::min_altitude_for_trees_up) | (1ULL << widx::min_altitude_for_trees_down) | (1ULL << widx::max_altitude_for_trees_down) | (1ULL << widx::max_altitude_for_trees_up);
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(217, StringIds::title_landscape_generation_forests),
             Widgets::Label({ 10, 52 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::number_of_forests),
-            Widgets::stepperWidgets({ 256, 52 }, { 100, 12 }, WindowColour::secondary, StringIds::number_of_forests_value),
+            Widgets::stepperWidgets(Widx::kNumberOfForests, Widx::kNumberOfForestsDown, Widx::kNumberOfForestsUp, { 256, 52 }, { 100, 12 }, WindowColour::secondary, StringIds::number_of_forests_value),
             Widgets::Label({ 10, 67 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::min_forest_radius),
-            Widgets::stepperWidgets({ 256, 67 }, { 100, 12 }, WindowColour::secondary, StringIds::min_forest_radius_blocks),
+            Widgets::stepperWidgets(Widx::kMinForestRadius, Widx::kMinForestRadiusDown, Widx::kMinForestRadiusUp, { 256, 67 }, { 100, 12 }, WindowColour::secondary, StringIds::min_forest_radius_blocks),
             Widgets::Label({ 10, 82 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::max_forest_radius),
-            Widgets::stepperWidgets({ 256, 82 }, { 100, 12 }, WindowColour::secondary, StringIds::max_forest_radius_blocks),
+            Widgets::stepperWidgets(Widx::kMaxForestRadius, Widx::kMaxForestRadiusDown, Widx::kMaxForestRadiusUp, { 256, 82 }, { 100, 12 }, WindowColour::secondary, StringIds::max_forest_radius_blocks),
             Widgets::Label({ 10, 97 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::min_forest_density),
-            Widgets::stepperWidgets({ 256, 97 }, { 100, 12 }, WindowColour::secondary, StringIds::min_forest_density_percent),
+            Widgets::stepperWidgets(Widx::kMinForestDensity, Widx::kMinForestDensityDown, Widx::kMinForestDensityUp, { 256, 97 }, { 100, 12 }, WindowColour::secondary, StringIds::min_forest_density_percent),
             Widgets::Label({ 10, 112 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::max_forest_density),
-            Widgets::stepperWidgets({ 256, 112 }, { 100, 12 }, WindowColour::secondary, StringIds::max_forest_density_percent),
+            Widgets::stepperWidgets(Widx::kMaxForestDensity, Widx::kMaxForestDensityDown, Widx::kMaxForestDensityUp, { 256, 112 }, { 100, 12 }, WindowColour::secondary, StringIds::max_forest_density_percent),
             Widgets::Label({ 10, 127 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::number_random_trees),
-            Widgets::stepperWidgets({ 256, 127 }, { 100, 12 }, WindowColour::secondary, StringIds::number_random_trees_value),
+            Widgets::stepperWidgets(Widx::kNumberRandomTrees, Widx::kNumberRandomTreesDown, Widx::kNumberRandomTreesUp, { 256, 127 }, { 100, 12 }, WindowColour::secondary, StringIds::number_random_trees_value),
             Widgets::Label({ 10, 142 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::min_altitude_for_trees),
-            Widgets::stepperWidgets({ 256, 142 }, { 100, 12 }, WindowColour::secondary, StringIds::min_altitude_for_trees_height),
+            Widgets::stepperWidgets(Widx::kMinAltitudeForTrees, Widx::kMinAltitudeForTreesDown, Widx::kMinAltitudeForTreesUp, { 256, 142 }, { 100, 12 }, WindowColour::secondary, StringIds::min_altitude_for_trees_height),
             Widgets::Label({ 10, 157 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::max_altitude_for_trees),
-            Widgets::stepperWidgets({ 256, 157 }, { 100, 12 }, WindowColour::secondary, StringIds::max_altitude_for_trees_height)
+            Widgets::stepperWidgets(Widx::kMaxAltitudeForTrees, Widx::kMaxAltitudeForTreesDown, Widx::kMaxAltitudeForTreesUp, { 256, 157 }, { 100, 12 }, WindowColour::secondary, StringIds::max_altitude_for_trees_height)
 
         );
 
         // 0x0043E670
-        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
             auto& options = Scenario::getOptions();
 
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::number_of_forests_up:
+                case Widx::kNumberOfForestsUp:
                 {
                     options.numberOfForests = std::min<int16_t>(options.numberOfForests + 10, Scenario::kMaxNumForests);
                     break;
                 }
-                case widx::number_of_forests_down:
+                case Widx::kNumberOfForestsDown:
                 {
                     options.numberOfForests = std::max<int16_t>(Scenario::kMinNumForests, options.numberOfForests - 10);
                     break;
                 }
-                case widx::min_forest_radius_up:
+                case Widx::kMinForestRadiusUp:
                 {
                     options.minForestRadius = std::min<int16_t>(options.minForestRadius + 1, Scenario::kMaxForestRadius);
                     if (options.minForestRadius > options.maxForestRadius)
@@ -1188,17 +1285,17 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     }
                     break;
                 }
-                case widx::min_forest_radius_down:
+                case Widx::kMinForestRadiusDown:
                 {
                     options.minForestRadius = std::max<int8_t>(Scenario::kMinForestRadius, options.minForestRadius - 1);
                     break;
                 }
-                case widx::max_forest_radius_up:
+                case Widx::kMaxForestRadiusUp:
                 {
                     options.maxForestRadius = std::clamp<int8_t>(options.maxForestRadius + 1, Scenario::kMinForestRadius, Scenario::kMaxForestRadius);
                     break;
                 }
-                case widx::max_forest_radius_down:
+                case Widx::kMaxForestRadiusDown:
                 {
                     options.maxForestRadius = std::clamp<int8_t>(options.maxForestRadius - 1, Scenario::kMinForestRadius, Scenario::kMaxForestRadius);
                     if (options.maxForestRadius < options.minForestRadius)
@@ -1207,7 +1304,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     }
                     break;
                 }
-                case widx::min_forest_density_up:
+                case Widx::kMinForestDensityUp:
                 {
                     options.minForestDensity = std::min<int8_t>(options.minForestDensity + 1, Scenario::kMaxForestDensity);
                     if (options.minForestDensity > options.maxForestDensity)
@@ -1216,17 +1313,17 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     }
                     break;
                 }
-                case widx::min_forest_density_down:
+                case Widx::kMinForestDensityDown:
                 {
                     options.minForestDensity = std::max<int8_t>(Scenario::kMinForestDensity, options.minForestDensity - 1);
                     break;
                 }
-                case widx::max_forest_density_up:
+                case Widx::kMaxForestDensityUp:
                 {
                     options.maxForestDensity = std::min<int8_t>(options.maxForestDensity + 1, Scenario::kMaxForestDensity);
                     break;
                 }
-                case widx::max_forest_density_down:
+                case Widx::kMaxForestDensityDown:
                 {
                     options.maxForestDensity = std::max<int8_t>(Scenario::kMinForestDensity, options.maxForestDensity - 1);
                     if (options.maxForestDensity < options.minForestDensity)
@@ -1235,17 +1332,17 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     }
                     break;
                 }
-                case widx::number_random_trees_up:
+                case Widx::kNumberRandomTreesUp:
                 {
                     options.numberRandomTrees = std::min<int16_t>(options.numberRandomTrees + 25, Scenario::kMaxNumTrees);
                     break;
                 }
-                case widx::number_random_trees_down:
+                case Widx::kNumberRandomTreesDown:
                 {
                     options.numberRandomTrees = std::max<int16_t>(Scenario::kMinNumTrees, options.numberRandomTrees - 25);
                     break;
                 }
-                case widx::min_altitude_for_trees_up:
+                case Widx::kMinAltitudeForTreesUp:
                 {
                     options.minAltitudeForTrees = std::min<int8_t>(options.minAltitudeForTrees + 1, Scenario::kMaxAltitudeTrees);
                     if (options.minAltitudeForTrees > options.maxAltitudeForTrees)
@@ -1254,17 +1351,17 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     }
                     break;
                 }
-                case widx::min_altitude_for_trees_down:
+                case Widx::kMinAltitudeForTreesDown:
                 {
                     options.minAltitudeForTrees = std::max<int8_t>(Scenario::kMinAltitudeTrees, options.minAltitudeForTrees - 1);
                     break;
                 }
-                case widx::max_altitude_for_trees_up:
+                case Widx::kMaxAltitudeForTreesUp:
                 {
                     options.maxAltitudeForTrees = std::min<int8_t>(options.maxAltitudeForTrees + 1, Scenario::kMaxAltitudeTrees);
                     break;
                 }
-                case widx::max_altitude_for_trees_down:
+                case Widx::kMaxAltitudeForTreesDown:
                 {
                     options.maxAltitudeForTrees = std::max<int8_t>(Scenario::kMinAltitudeTrees, options.maxAltitudeForTrees - 1);
                     if (options.maxAltitudeForTrees < options.minAltitudeForTrees)
@@ -1366,14 +1463,23 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             max_town_size_btn,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kNumberOfTowns{ "number_of_towns" };
+            constexpr WidgetId kNumberOfTownsDown{ "number_of_towns_down" };
+            constexpr WidgetId kNumberOfTownsUp{ "number_of_towns_up" };
+            constexpr WidgetId kMaxTownSize{ "max_town_size" };
+            constexpr WidgetId kMaxTownSizeBtn{ "max_town_size_btn" };
+        }
+
         const uint64_t holdable_widgets = (1 << widx::number_of_towns_up) | (1 << widx::number_of_towns_down);
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(217, StringIds::title_landscape_generation_towns),
             Widgets::Label({ 10, 52 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::number_of_towns),
-            Widgets::stepperWidgets({ 256, 52 }, { 100, 12 }, WindowColour::secondary, StringIds::number_of_towns_value),
+            Widgets::stepperWidgets(Widx::kNumberOfTowns, Widx::kNumberOfTownsDown, Widx::kNumberOfTownsUp, { 256, 52 }, { 100, 12 }, WindowColour::secondary, StringIds::number_of_towns_value),
             Widgets::Label({ 10, 67 }, { 160, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::max_town_size),
-            Widgets::dropdownWidgets({ 176, 67 }, { 180, 12 }, WindowColour::secondary)
+            Widgets::dropdownWidgets(Widx::kMaxTownSize, Widx::kMaxTownSizeBtn, { 176, 67 }, { 180, 12 }, WindowColour::secondary)
 
         );
 
@@ -1389,9 +1495,9 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         };
 
         // 0x0043EA28
-        static void onDropdown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            if (widgetIndex != widx::max_town_size_btn || itemIndex == -1)
+            if (id != Widx::kMaxTownSizeBtn || itemIndex == -1)
             {
                 return;
             }
@@ -1401,13 +1507,13 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043EA0D
-        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
             auto& options = Scenario::getOptions();
 
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::number_of_towns_up:
+                case Widx::kNumberOfTownsUp:
                 {
                     uint16_t newNumTowns = std::min<uint16_t>(options.numberOfTowns + 1, Limits::kMaxTowns);
                     options.numberOfTowns = newNumTowns;
@@ -1415,7 +1521,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     break;
                 }
 
-                case widx::number_of_towns_down:
+                case Widx::kNumberOfTownsDown:
                 {
                     // Vanilla behaviour: Zero-town map generation is allowed in the scenario editor and
                     // is checked on the editor stage progression for non-zero. It is required to be non-zero
@@ -1430,7 +1536,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     break;
                 }
 
-                case widx::max_town_size_btn:
+                case Widx::kMaxTownSizeBtn:
                 {
                     Widget& target = window.widgets[widx::max_town_size];
                     Dropdown::show(window.x + target.left, window.y + target.top, target.width() - 4, target.height(), window.getColour(WindowColour::secondary), std::size(townSizeLabels), 0x80);
@@ -1483,14 +1589,22 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             check_allow_industries_start_up,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kNumIndustries{ "num_industries" };
+            constexpr WidgetId kNumIndustriesBtn{ "num_industries_btn" };
+            constexpr WidgetId kCheckAllowIndustriesCloseDown{ "check_allow_industries_close_down" };
+            constexpr WidgetId kCheckAllowIndustriesStartUp{ "check_allow_industries_start_up" };
+        }
+
         const uint64_t holdable_widgets = 0;
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(217, StringIds::title_landscape_generation_industries),
             Widgets::Label({ 10, 52 }, { 160, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::number_of_industries),
-            Widgets::dropdownWidgets({ 176, 52 }, { 180, 12 }, WindowColour::secondary),
-            Widgets::Checkbox({ 10, 68 }, { 346, 12 }, WindowColour::secondary, StringIds::allow_industries_to_close_down_during_game),
-            Widgets::Checkbox({ 10, 83 }, { 346, 12 }, WindowColour::secondary, StringIds::allow_new_industries_to_start_up_during_game)
+            Widgets::dropdownWidgets(Widx::kNumIndustries, Widx::kNumIndustriesBtn, { 176, 52 }, { 180, 12 }, WindowColour::secondary),
+            Widgets::Checkbox(Widx::kCheckAllowIndustriesCloseDown, { 10, 68 }, { 346, 12 }, WindowColour::secondary, StringIds::allow_industries_to_close_down_during_game),
+            Widgets::Checkbox(Widx::kCheckAllowIndustriesStartUp, { 10, 83 }, { 346, 12 }, WindowColour::secondary, StringIds::allow_new_industries_to_start_up_during_game)
 
         );
 
@@ -1501,9 +1615,9 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         };
 
         // 0x0043EBF8
-        static void onDropdown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            if (widgetIndex != widx::num_industries_btn || itemIndex == -1)
+            if (id != Widx::kNumIndustriesBtn || itemIndex == -1)
             {
                 return;
             }
@@ -1513,11 +1627,11 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
 
         // 0x0043EBF1
-        static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::num_industries_btn:
+                case Widx::kNumIndustriesBtn:
                 {
                     Widget& target = window.widgets[widx::num_industries];
                     Dropdown::show(window.x + target.left, window.y + target.top, target.width() - 4, target.height(), window.getColour(WindowColour::secondary), std::size(numIndustriesLabels), 0x80);
@@ -1531,12 +1645,12 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                     break;
                 }
 
-                case widx::check_allow_industries_close_down:
+                case Widx::kCheckAllowIndustriesCloseDown:
                     IndustryManager::setFlags(IndustryManager::getFlags() ^ IndustryManager::Flags::disallowIndustriesCloseDown);
                     window.invalidate();
                     break;
 
-                case widx::check_allow_industries_start_up:
+                case Widx::kCheckAllowIndustriesStartUp:
                     IndustryManager::setFlags(IndustryManager::getFlags() ^ IndustryManager::Flags::disallowIndustriesStartUp);
                     window.invalidate();
                     break;

--- a/src/OpenLoco/src/Ui/Windows/Main.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Main.cpp
@@ -9,13 +9,10 @@
 
 namespace OpenLoco::Ui::Windows::Main
 {
-    namespace widx
+    enum widx
     {
-        enum
-        {
-            viewport
-        };
-    }
+        viewport
+    };
 
     static constexpr auto _widgets = makeWidgets(
         Widgets::Viewport({ 0, 0 }, { 0, 0 }, WindowColour::primary, Widget::kContentUnk)

--- a/src/OpenLoco/src/Ui/Windows/Main.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Main.cpp
@@ -14,8 +14,13 @@ namespace OpenLoco::Ui::Windows::Main
         viewport
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kViewport{ "viewport" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
-        Widgets::Viewport({ 0, 0 }, { 0, 0 }, WindowColour::primary, Widget::kContentUnk)
+        Widgets::Viewport(Widx::kViewport, { 0, 0 }, { 0, 0 }, WindowColour::primary, Widget::kContentUnk)
 
     );
 

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -111,18 +111,33 @@ namespace OpenLoco::Ui::Windows::MapWindow
         statusBar,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kFrame{ "frame" };
+        constexpr WidgetId kCaption{ "caption" };
+        constexpr WidgetId kCloseButton{ "closeButton" };
+        constexpr WidgetId kPanel{ "panel" };
+        constexpr WidgetId kTabOverall{ "tabOverall" };
+        constexpr WidgetId kTabVehicles{ "tabVehicles" };
+        constexpr WidgetId kTabIndustries{ "tabIndustries" };
+        constexpr WidgetId kTabRoutes{ "tabRoutes" };
+        constexpr WidgetId kTabOwnership{ "tabOwnership" };
+        constexpr WidgetId kScrollview{ "scrollview" };
+        constexpr WidgetId kStatusBar{ "statusBar" };
+    }
+
     static constexpr auto kWidgets = makeWidgets(
-        Widgets::Frame({ 0, 0 }, { 350, 272 }, WindowColour::primary),
-        Widgets::Caption({ 1, 1 }, { 348, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::title_map),
-        Widgets::ImageButton({ 335, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-        Widgets::Panel({ 0, 41 }, { 350, 230 }, WindowColour::secondary),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_map_overall),
-        Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_map_vehicles),
-        Widgets::Tab({ 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_map_industries),
-        Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_map_routes),
-        Widgets::Tab({ 158, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_map_ownership),
-        Widgets::ScrollView({ 3, 44 }, { 240, 215 }, WindowColour::secondary, Scrollbars::horizontal | Scrollbars::vertical),
-        Widgets::Label({ 3, 250 }, { 322, 21 }, WindowColour::secondary, ContentAlign::center)
+        Widgets::Frame(Widx::kFrame, { 0, 0 }, { 350, 272 }, WindowColour::primary),
+        Widgets::Caption(Widx::kCaption, { 1, 1 }, { 348, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::title_map),
+        Widgets::ImageButton(Widx::kCloseButton, { 335, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::Panel(Widx::kPanel, { 0, 41 }, { 350, 230 }, WindowColour::secondary),
+        Widgets::Tab(Widx::kTabOverall, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_map_overall),
+        Widgets::Tab(Widx::kTabVehicles, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_map_vehicles),
+        Widgets::Tab(Widx::kTabIndustries, { 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_map_industries),
+        Widgets::Tab(Widx::kTabRoutes, { 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_map_routes),
+        Widgets::Tab(Widx::kTabOwnership, { 158, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tab_map_ownership),
+        Widgets::ScrollView(Widx::kScrollview, { 3, 44 }, { 240, 215 }, WindowColour::secondary, Scrollbars::horizontal | Scrollbars::vertical),
+        Widgets::Label(Widx::kStatusBar, { 3, 250 }, { 322, 21 }, WindowColour::secondary, ContentAlign::center)
 
     );
 
@@ -192,18 +207,18 @@ namespace OpenLoco::Ui::Windows::MapWindow
     // 0x0046B8CF
     static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::closeButton:
+            case Widx::kCloseButton:
                 WindowManager::close(&self);
                 break;
 
-            case widx::tabOverall:
-            case widx::tabVehicles:
-            case widx::tabIndustries:
-            case widx::tabRoutes:
-            case widx::tabOwnership:
-            case widx::scrollview:
+            case Widx::kTabOverall:
+            case Widx::kTabVehicles:
+            case Widx::kTabIndustries:
+            case Widx::kTabRoutes:
+            case Widx::kTabOwnership:
+            case Widx::kScrollview:
             {
                 auto tabIndex = widgetIndex - widx::tabOverall;
 

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -47,15 +47,25 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             tab_settings,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabMessages{ "tab_messages" };
+            constexpr WidgetId kTabSettings{ "tab_settings" };
+        }
+
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, windowCaptionId),
-                Widgets::ImageButton({ frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { 366, 175 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_recent_messages),
-                Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_message_options));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, windowCaptionId),
+                Widgets::ImageButton(Widx::kCloseButton, { frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { 366, 175 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabMessages, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_recent_messages),
+                Widgets::Tab(Widx::kTabSettings, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_message_options));
         }
 
         static void prepareDraw(Window& self);
@@ -75,23 +85,28 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             scrollview = 6,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kScrollview{ "scrollview" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(366, 217, StringIds::title_messages),
-            Widgets::ScrollView({ 3, 45 }, { 360, 146 }, WindowColour::secondary, Scrollbars::vertical)
+            Widgets::ScrollView(Widx::kScrollview, { 3, 45 }, { 360, 146 }, WindowColour::secondary, Scrollbars::vertical)
 
         );
 
         // 0x0042A6F5
         static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_messages:
-                case Common::widx::tab_settings:
+                case Common::Widx::kTabMessages:
+                case Common::Widx::kTabSettings:
                     Common::switchTab(self, widgetIndex);
                     break;
             }
@@ -401,46 +416,63 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             playSoundEffects,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kCompanyMajorNews{ "company_major_news" };
+            constexpr WidgetId kCompanyMajorNewsDropdown{ "company_major_news_dropdown" };
+            constexpr WidgetId kCompetitorMajorNews{ "competitor_major_news" };
+            constexpr WidgetId kCompetitorMajorNewsDropdown{ "competitor_major_news_dropdown" };
+            constexpr WidgetId kCompanyMinorNews{ "company_minor_news" };
+            constexpr WidgetId kCompanyMinorNewsDropdown{ "company_minor_news_dropdown" };
+            constexpr WidgetId kCompetitorMinorNews{ "competitor_minor_news" };
+            constexpr WidgetId kCompetitorMinorNewsDropdown{ "competitor_minor_news_dropdown" };
+            constexpr WidgetId kGeneralNews{ "general_news" };
+            constexpr WidgetId kGeneralNewsDropdown{ "general_news_dropdown" };
+            constexpr WidgetId kAdvice{ "advice" };
+            constexpr WidgetId kAdviceDropdown{ "advice_dropdown" };
+            constexpr WidgetId kPlaySoundEffects{ "playSoundEffects" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(366, 155, StringIds::title_messages),
 
             Widgets::Label({ 4, 47 }, { 230, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::company_major_news),
-            Widgets::dropdownWidgets({ 236, 47 }, { 124, 12 }, WindowColour::secondary),
+            Widgets::dropdownWidgets(Widx::kCompanyMajorNews, Widx::kCompanyMajorNewsDropdown, { 236, 47 }, { 124, 12 }, WindowColour::secondary),
 
             Widgets::Label({ 4, 62 }, { 230, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::competitor_major_news),
-            Widgets::dropdownWidgets({ 236, 62 }, { 124, 12 }, WindowColour::secondary),
+            Widgets::dropdownWidgets(Widx::kCompetitorMajorNews, Widx::kCompetitorMajorNewsDropdown, { 236, 62 }, { 124, 12 }, WindowColour::secondary),
 
             Widgets::Label({ 4, 77 }, { 230, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::company_minor_news),
-            Widgets::dropdownWidgets({ 236, 77 }, { 124, 12 }, WindowColour::secondary),
+            Widgets::dropdownWidgets(Widx::kCompanyMinorNews, Widx::kCompanyMinorNewsDropdown, { 236, 77 }, { 124, 12 }, WindowColour::secondary),
 
             Widgets::Label({ 4, 92 }, { 230, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::competitor_minor_news),
-            Widgets::dropdownWidgets({ 236, 92 }, { 124, 12 }, WindowColour::secondary),
+            Widgets::dropdownWidgets(Widx::kCompetitorMinorNews, Widx::kCompetitorMinorNewsDropdown, { 236, 92 }, { 124, 12 }, WindowColour::secondary),
 
             Widgets::Label({ 4, 107 }, { 230, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::general_news),
-            Widgets::dropdownWidgets({ 236, 107 }, { 124, 12 }, WindowColour::secondary),
+            Widgets::dropdownWidgets(Widx::kGeneralNews, Widx::kGeneralNewsDropdown, { 236, 107 }, { 124, 12 }, WindowColour::secondary),
 
             Widgets::Label({ 4, 122 }, { 230, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::advice),
-            Widgets::dropdownWidgets({ 236, 122 }, { 124, 12 }, WindowColour::secondary),
+            Widgets::dropdownWidgets(Widx::kAdvice, Widx::kAdviceDropdown, { 236, 122 }, { 124, 12 }, WindowColour::secondary),
 
-            Widgets::Checkbox({ 4, 137 }, { 346, 12 }, WindowColour::secondary, StringIds::playNewsSoundEffects, StringIds::playNewsSoundEffectsTip)
+            Widgets::Checkbox(Widx::kPlaySoundEffects, { 4, 137 }, { 346, 12 }, WindowColour::secondary, StringIds::playNewsSoundEffects, StringIds::playNewsSoundEffectsTip)
 
         );
 
         // 0x0042AA84
         static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_messages:
-                case Common::widx::tab_settings:
+                case Common::Widx::kTabMessages:
+                case Common::Widx::kTabSettings:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::playSoundEffects:
+                case Widx::kPlaySoundEffects:
                 {
                     Config::get().audio.playNewsSounds ^= 1;
                     Config::write();
@@ -459,14 +491,14 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         // 0x0042AA9F
         static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::company_major_news_dropdown:
-                case widx::competitor_major_news_dropdown:
-                case widx::company_minor_news_dropdown:
-                case widx::competitor_minor_news_dropdown:
-                case widx::general_news_dropdown:
-                case widx::advice_dropdown:
+                case Widx::kCompanyMajorNewsDropdown:
+                case Widx::kCompetitorMajorNewsDropdown:
+                case Widx::kCompanyMinorNewsDropdown:
+                case Widx::kCompetitorMinorNewsDropdown:
+                case Widx::kGeneralNewsDropdown:
+                case Widx::kAdviceDropdown:
                 {
                     auto wIndex = widgetIndex - 1;
                     auto widget = self.widgets[wIndex];
@@ -495,14 +527,14 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         // 0x0042AAAC
         static void onDropdown([[maybe_unused]] Window& self, Ui::WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::company_major_news_dropdown:
-                case widx::competitor_major_news_dropdown:
-                case widx::company_minor_news_dropdown:
-                case widx::competitor_minor_news_dropdown:
-                case widx::general_news_dropdown:
-                case widx::advice_dropdown:
+                case Widx::kCompanyMajorNewsDropdown:
+                case Widx::kCompetitorMajorNewsDropdown:
+                case Widx::kCompanyMinorNewsDropdown:
+                case Widx::kCompetitorMinorNewsDropdown:
+                case Widx::kGeneralNewsDropdown:
+                case Widx::kAdviceDropdown:
                 {
                     if (itemIndex == -1)
                     {

--- a/src/OpenLoco/src/Ui/Windows/MusicJukebox.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MusicJukebox.cpp
@@ -22,25 +22,22 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
 {
     static constexpr Ui::Size kWindowSize = { 366, 109 };
 
-    namespace Widx
+    enum widx
     {
-        enum
-        {
-            frame,
-            caption,
-            close_button,
-            panel,
-            currently_playing_label,
-            currently_playing,
-            currently_playing_btn,
-            music_controls_stop,
-            music_controls_play,
-            music_controls_next,
-            music_playlist,
-            music_playlist_btn,
-            edit_selection
-        };
-    }
+        frame,
+        caption,
+        close_button,
+        panel,
+        currently_playing_label,
+        currently_playing,
+        currently_playing_btn,
+        music_controls_stop,
+        music_controls_play,
+        music_controls_next,
+        music_playlist,
+        music_playlist_btn,
+        edit_selection
+    };
 
     static constexpr auto _widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, kWindowSize, WindowColour::primary),
@@ -68,13 +65,13 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
     // 0x004C0217, 0x004C0217
     static void prepareDraw(Window& self)
     {
-        self.widgets[Widx::frame].right = self.width - 1;
-        self.widgets[Widx::frame].bottom = self.height - 1;
-        self.widgets[Widx::panel].right = self.width - 1;
-        self.widgets[Widx::panel].bottom = self.height - 1;
-        self.widgets[Widx::caption].right = self.width - 2;
-        self.widgets[Widx::close_button].left = self.width - 15;
-        self.widgets[Widx::close_button].right = self.width - 15 + 12;
+        self.widgets[widx::frame].right = self.width - 1;
+        self.widgets[widx::frame].bottom = self.height - 1;
+        self.widgets[widx::panel].right = self.width - 1;
+        self.widgets[widx::panel].bottom = self.height - 1;
+        self.widgets[widx::caption].right = self.width - 2;
+        self.widgets[widx::close_button].left = self.width - 15;
+        self.widgets[widx::close_button].right = self.width - 15 + 12;
 
         // Currently playing music track
         {
@@ -91,7 +88,7 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
                     songName = StringIds::music_locomotion_title;
                 }
             }
-            auto args = FormatArguments(self.widgets[Widx::currently_playing].textArgs);
+            auto args = FormatArguments(self.widgets[widx::currently_playing].textArgs);
             args.push(songName);
         }
 
@@ -101,17 +98,17 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
         // Jukebox controls (stop/play/skip)
         if (!SceneManager::isPlayMode())
         {
-            self.disabledWidgets |= (1ULL << Widx::currently_playing) | (1ULL << Widx::currently_playing_btn) | (1ULL << Widx::music_controls_play) | (1ULL << Widx::music_controls_stop) | (1ULL << Widx::music_controls_next);
+            self.disabledWidgets |= (1ULL << widx::currently_playing) | (1ULL << widx::currently_playing_btn) | (1ULL << widx::music_controls_play) | (1ULL << widx::music_controls_stop) | (1ULL << widx::music_controls_next);
         }
         else if (Jukebox::isMusicPlaying())
         {
             // Play button appears pressed
-            self.activatedWidgets |= (1ULL << Widx::music_controls_play);
+            self.activatedWidgets |= (1ULL << widx::music_controls_play);
         }
         else
         {
             // Stop button appears pressed
-            self.activatedWidgets |= (1ULL << Widx::music_controls_stop);
+            self.activatedWidgets |= (1ULL << widx::music_controls_stop);
         }
 
         // Selected playlist
@@ -122,7 +119,7 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
                 StringIds::play_custom_music_selection,
             };
 
-            auto args = FormatArguments(self.widgets[Widx::music_playlist].textArgs);
+            auto args = FormatArguments(self.widgets[widx::music_playlist].textArgs);
 
             StringId selectedPlaylistStringId = playlist_string_ids[enumValue(Config::get().audio.playlist)];
             args.push(selectedPlaylistStringId);
@@ -131,7 +128,7 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
         // Edit custom playlist music selection button
         if (Config::get().audio.playlist != Config::MusicPlaylistType::custom)
         {
-            self.disabledWidgets |= (1ULL << Widx::edit_selection);
+            self.disabledWidgets |= (1ULL << widx::edit_selection);
         }
     }
 
@@ -144,23 +141,23 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
     {
         switch (wi)
         {
-            case Widx::close_button:
+            case widx::close_button:
                 WindowManager::close(&self);
                 return;
 
-            case Widx::music_controls_stop:
+            case widx::music_controls_stop:
                 stopMusic(self);
                 return;
 
-            case Widx::music_controls_play:
+            case widx::music_controls_play:
                 playMusic(self);
                 return;
 
-            case Widx::music_controls_next:
+            case widx::music_controls_next:
                 playNextSong(self);
                 return;
 
-            case Widx::edit_selection:
+            case widx::edit_selection:
                 MusicSelection::open();
                 return;
         }
@@ -170,10 +167,10 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
     {
         switch (wi)
         {
-            case Widx::music_playlist_btn:
+            case widx::music_playlist_btn:
                 musicPlaylistMouseDown(self);
                 break;
-            case Widx::currently_playing_btn:
+            case widx::currently_playing_btn:
                 currentlyPlayingMouseDown(self);
                 break;
         }
@@ -183,10 +180,10 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
     {
         switch (widgetIndex)
         {
-            case Widx::music_playlist_btn:
+            case widx::music_playlist_btn:
                 musicPlaylistDropdown(self, itemIndex);
                 break;
-            case Widx::currently_playing_btn:
+            case widx::currently_playing_btn:
                 currentlyPlayingDropdown(self, itemIndex);
                 break;
         }
@@ -197,7 +194,7 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
     {
         auto tracks = Jukebox::makeSelectedPlaylist();
 
-        auto& dropdown = self.widgets[Widx::currently_playing];
+        auto& dropdown = self.widgets[widx::currently_playing];
         Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), tracks.size(), 0x80);
 
         int index = -1;
@@ -257,7 +254,7 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
     // 0x004C07E4
     static void musicPlaylistMouseDown(const Window& self)
     {
-        auto& dropdown = self.widgets[Widx::music_playlist];
+        auto& dropdown = self.widgets[widx::music_playlist];
         Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 3, 0x80);
 
         Dropdown::add(0, StringIds::dropdown_stringid, StringIds::play_only_music_from_current_era);

--- a/src/OpenLoco/src/Ui/Windows/MusicJukebox.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MusicJukebox.cpp
@@ -39,18 +39,34 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
         edit_selection
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kFrame{ "frame" };
+        constexpr WidgetId kCaption{ "caption" };
+        constexpr WidgetId kCloseButton{ "close_button" };
+        constexpr WidgetId kPanel{ "panel" };
+        constexpr WidgetId kCurrentlyPlaying{ "currently_playing" };
+        constexpr WidgetId kCurrentlyPlayingBtn{ "currently_playing_btn" };
+        constexpr WidgetId kMusicControlsStop{ "music_controls_stop" };
+        constexpr WidgetId kMusicControlsPlay{ "music_controls_play" };
+        constexpr WidgetId kMusicControlsNext{ "music_controls_next" };
+        constexpr WidgetId kMusicPlaylist{ "music_playlist" };
+        constexpr WidgetId kMusicPlaylistBtn{ "music_playlist_btn" };
+        constexpr WidgetId kEditSelection{ "edit_selection" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
-        Widgets::Frame({ 0, 0 }, kWindowSize, WindowColour::primary),
-        Widgets::Caption({ 1, 1 }, { (uint16_t)(kWindowSize.width - 2), 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::jukebox_window_title),
-        Widgets::ImageButton({ (int16_t)(kWindowSize.width - 15), 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-        Widgets::Panel({ 0, 15 }, { kWindowSize.width, 102 }, WindowColour::secondary),
+        Widgets::Frame(Widx::kFrame, { 0, 0 }, kWindowSize, WindowColour::primary),
+        Widgets::Caption(Widx::kCaption, { 1, 1 }, { (uint16_t)(kWindowSize.width - 2), 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::jukebox_window_title),
+        Widgets::ImageButton(Widx::kCloseButton, { (int16_t)(kWindowSize.width - 15), 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::Panel(Widx::kPanel, { 0, 15 }, { kWindowSize.width, 102 }, WindowColour::secondary),
         Widgets::Label({ 10, 27 }, { 145, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::currently_playing),
-        Widgets::dropdownWidgets({ 160, 27 }, { 196, 12 }, WindowColour::secondary, StringIds::stringid),
-        Widgets::ImageButton({ 10, 42 }, { 24, 24 }, WindowColour::secondary, ImageIds::music_controls_stop, StringIds::music_controls_stop_tip),
-        Widgets::ImageButton({ 34, 42 }, { 24, 24 }, WindowColour::secondary, ImageIds::music_controls_play, StringIds::music_controls_play_tip),
-        Widgets::ImageButton({ 58, 42 }, { 24, 24 }, WindowColour::secondary, ImageIds::music_controls_next, StringIds::music_controls_next_tip),
-        Widgets::dropdownWidgets({ 10, 69 }, { 346, 12 }, WindowColour::secondary, StringIds::stringid),
-        Widgets::Button({ 183, 86 }, { 173, 12 }, WindowColour::secondary, StringIds::edit_music_selection, StringIds::edit_music_selection_tip)
+        Widgets::dropdownWidgets(Widx::kCurrentlyPlaying, Widx::kCurrentlyPlayingBtn, { 160, 27 }, { 196, 12 }, WindowColour::secondary, StringIds::stringid),
+        Widgets::ImageButton(Widx::kMusicControlsStop, { 10, 42 }, { 24, 24 }, WindowColour::secondary, ImageIds::music_controls_stop, StringIds::music_controls_stop_tip),
+        Widgets::ImageButton(Widx::kMusicControlsPlay, { 34, 42 }, { 24, 24 }, WindowColour::secondary, ImageIds::music_controls_play, StringIds::music_controls_play_tip),
+        Widgets::ImageButton(Widx::kMusicControlsNext, { 58, 42 }, { 24, 24 }, WindowColour::secondary, ImageIds::music_controls_next, StringIds::music_controls_next_tip),
+        Widgets::dropdownWidgets(Widx::kMusicPlaylist, Widx::kMusicPlaylistBtn, { 10, 69 }, { 346, 12 }, WindowColour::secondary, StringIds::stringid),
+        Widgets::Button(Widx::kEditSelection, { 183, 86 }, { 173, 12 }, WindowColour::secondary, StringIds::edit_music_selection, StringIds::edit_music_selection_tip)
 
     );
 
@@ -137,53 +153,53 @@ namespace OpenLoco::Ui::Windows::MusicJukebox
         self.draw(drawingCtx);
     }
 
-    static void onMouseUp(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Window& self, [[maybe_unused]] WidgetIndex_t wi, const WidgetId id)
     {
-        switch (wi)
+        switch (id)
         {
-            case widx::close_button:
+            case Widx::kCloseButton:
                 WindowManager::close(&self);
                 return;
 
-            case widx::music_controls_stop:
+            case Widx::kMusicControlsStop:
                 stopMusic(self);
                 return;
 
-            case widx::music_controls_play:
+            case Widx::kMusicControlsPlay:
                 playMusic(self);
                 return;
 
-            case widx::music_controls_next:
+            case Widx::kMusicControlsNext:
                 playNextSong(self);
                 return;
 
-            case widx::edit_selection:
+            case Widx::kEditSelection:
                 MusicSelection::open();
                 return;
         }
     }
 
-    static void onMouseDown(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
+    static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t wi, const WidgetId id)
     {
-        switch (wi)
+        switch (id)
         {
-            case widx::music_playlist_btn:
+            case Widx::kMusicPlaylistBtn:
                 musicPlaylistMouseDown(self);
                 break;
-            case widx::currently_playing_btn:
+            case Widx::kCurrentlyPlayingBtn:
                 currentlyPlayingMouseDown(self);
                 break;
         }
     }
 
-    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+    static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::music_playlist_btn:
+            case Widx::kMusicPlaylistBtn:
                 musicPlaylistDropdown(self, itemIndex);
                 break;
-            case widx::currently_playing_btn:
+            case Widx::kCurrentlyPlayingBtn:
                 currentlyPlayingDropdown(self, itemIndex);
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
@@ -47,15 +47,27 @@ namespace OpenLoco::Ui::Windows::MusicSelection
         status_bar,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kFrame{ "frame" };
+        constexpr WidgetId kTitle{ "title" };
+        constexpr WidgetId kClose{ "close" };
+        constexpr WidgetId kPanel{ "panel" };
+        constexpr WidgetId kSortTitle{ "sort_title" };
+        constexpr WidgetId kSortYears{ "sort_years" };
+        constexpr WidgetId kScrollview{ "scrollview" };
+        constexpr WidgetId kStatusBar{ "status_bar" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
-        Widgets::Frame({ 0, 0 }, { kWindowSizeDefault.width, kWindowSizeDefault.height }, WindowColour::primary),
-        Widgets::Caption({ 1, 1 }, { kWindowSizeDefault.width - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::music_selection_title),
-        Widgets::ImageButton({ kWindowSizeDefault.width - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-        Widgets::Panel({ 0, 15 }, { kWindowSizeDefault.width, kWindowSizeDefault.height - 15 }, WindowColour::secondary),
-        Widgets::TableHeader({ kPadding + 1, 17 }, { kWindowSizeDefault.width - 2 * kPadding - kColumnYearsWidth - 1, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_track_title),
-        Widgets::TableHeader({ kWindowSizeDefault.width - kPadding - kColumnYearsWidth, 17 }, { kColumnYearsWidth, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_music_years),
-        Widgets::ScrollView({ kPadding, 30 }, { kWindowSizeDefault.width - 2 * kPadding, kWindowSizeDefault.height - kStatusBarClearance - 30 }, WindowColour::secondary, Scrollbars::vertical, StringIds::music_selection_tooltip),
-        Widgets::Label({ kPadding, kWindowSizeDefault.height - 12 }, { kWindowSizeMin.width - kResizeHandleSize - kPadding, 11 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid)
+        Widgets::Frame(Widx::kFrame, { 0, 0 }, { kWindowSizeDefault.width, kWindowSizeDefault.height }, WindowColour::primary),
+        Widgets::Caption(Widx::kTitle, { 1, 1 }, { kWindowSizeDefault.width - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::music_selection_title),
+        Widgets::ImageButton(Widx::kClose, { kWindowSizeDefault.width - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::Panel(Widx::kPanel, { 0, 15 }, { kWindowSizeDefault.width, kWindowSizeDefault.height - 15 }, WindowColour::secondary),
+        Widgets::TableHeader(Widx::kSortTitle, { kPadding + 1, 17 }, { kWindowSizeDefault.width - 2 * kPadding - kColumnYearsWidth - 1, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_track_title),
+        Widgets::TableHeader(Widx::kSortYears, { kWindowSizeDefault.width - kPadding - kColumnYearsWidth, 17 }, { kColumnYearsWidth, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_music_years),
+        Widgets::ScrollView(Widx::kScrollview, { kPadding, 30 }, { kWindowSizeDefault.width - 2 * kPadding, kWindowSizeDefault.height - kStatusBarClearance - 30 }, WindowColour::secondary, Scrollbars::vertical, StringIds::music_selection_tooltip),
+        Widgets::Label(Widx::kStatusBar, { kPadding, kWindowSizeDefault.height - 12 }, { kWindowSizeMin.width - kResizeHandleSize - kPadding, 11 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid)
 
     );
 
@@ -291,18 +303,18 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     }
 
     // 0x004C1757
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::close:
+            case Widx::kClose:
                 WindowManager::close(window.type);
                 break;
 
-            case sort_title:
+            case Widx::kSortTitle:
                 cycleSortMode(window, Jukebox::MusicSortMode::titleAscending, Jukebox::MusicSortMode::titleDescending);
                 break;
-            case sort_years:
+            case Widx::kSortYears:
                 cycleSortMode(window, Jukebox::MusicSortMode::yearsDescending, Jukebox::MusicSortMode::yearsAscending);
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/NetworkStatus.cpp
+++ b/src/OpenLoco/src/Ui/Windows/NetworkStatus.cpp
@@ -17,7 +17,7 @@
 
 namespace OpenLoco::Ui::Windows::NetworkStatus
 {
-    enum Widx
+    enum widx
     {
         frame,
         caption,
@@ -90,7 +90,7 @@ namespace OpenLoco::Ui::Windows::NetworkStatus
     {
         switch (widgetIndex)
         {
-            case Widx::closeBtn:
+            case widx::closeBtn:
                 WindowManager::close(&window);
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/NetworkStatus.cpp
+++ b/src/OpenLoco/src/Ui/Windows/NetworkStatus.cpp
@@ -25,12 +25,17 @@ namespace OpenLoco::Ui::Windows::NetworkStatus
         panel,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kCloseBtn{ "closeBtn" };
+    }
+
     static constexpr Ui::Size kWindowSize = { 441, 91 };
 
     static constexpr auto widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, { 441, 91 }, WindowColour::primary),
         Widgets::Caption({ 1, 1 }, { 439, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::empty),
-        Widgets::ImageButton({ 426, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::ImageButton(Widx::kCloseBtn, { 426, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
         Widgets::Panel({ 0, 15 }, { 441, 76 }, WindowColour::secondary)
 
     );
@@ -86,11 +91,11 @@ namespace OpenLoco::Ui::Windows::NetworkStatus
         }
     }
 
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::closeBtn:
+            case Widx::kCloseBtn:
                 WindowManager::close(&window);
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -61,24 +61,24 @@ namespace OpenLoco::Ui::Windows::NewsWindow
     namespace Common
     {
         // 0x00429BB7
-        static void onMouseUp([[maybe_unused]] Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                 {
                     MessageManager::clearActiveMessage();
                     break;
                 }
 
-                case Common::widx::viewport1Button:
-                case Common::widx::viewport2Button:
+                case Common::Widx::kViewport1Button:
+                case Common::Widx::kViewport2Button:
                 {
                     if (MessageManager::getActiveIndex() != MessageId::null)
                     {
                         auto news = MessageManager::get(MessageManager::getActiveIndex());
                         const auto& mtd = getMessageTypeDescriptor(news->type);
-                        if (widgetIndex == Common::widx::viewport1Button)
+                        if (id == Common::Widx::kViewport1Button)
                         {
                             if (!mtd.hasFlag(MessageTypeFlags::hasFirstItem))
                             {
@@ -95,7 +95,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
                         MessageItemArgumentType itemType;
                         uint16_t itemId;
-                        if (widgetIndex == Common::widx::viewport1Button)
+                        if (id == Common::Widx::kViewport1Button)
                         {
                             itemType = mtd.argumentTypes[0];
                             itemId = news->itemSubjects[0];

--- a/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
@@ -15,7 +15,7 @@
 namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
 {
     static constexpr auto widgets = makeWidgets(
-        Widgets::Wt3Widget({ 0, 0 }, { 111, 26 }, WindowColour::primary)
+        Widgets::Wt3Widget(Widx::kFrame, { 0, 0 }, { 111, 26 }, WindowColour::primary)
 
     );
 
@@ -25,9 +25,9 @@ namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
     }
 
     // 0x00429EA2
-    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        if (widgetIndex != 0)
+        if (id != Widx::kFrame)
         {
             return;
         }

--- a/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
@@ -38,14 +38,21 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
         scrollview,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kClose{ "close" };
+        constexpr WidgetId kTypeHeader{ "typeHeader" };
+        constexpr WidgetId kChecksumHeader{ "checksumHeader" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, { 360, 238 }, WindowColour::primary),
         Widgets::Caption({ 1, 1 }, { 358, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::objectErrorWindowTitle),
-        Widgets::ImageButton({ 345, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::ImageButton(Widx::kClose, { 345, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
         Widgets::Panel({ 0, 15 }, { 360, 223 }, WindowColour::secondary),
         Widgets::TableHeader({ 4, 43 }, { 100, 12 }, WindowColour::secondary, StringIds::tableHeaderObjectId),
-        Widgets::TableHeader({ 104, 43 }, { 152, 12 }, WindowColour::secondary, StringIds::tableHeaderObjectType),
-        Widgets::TableHeader({ 256, 43 }, { 100, 12 }, WindowColour::secondary, StringIds::tableHeaderObjectChecksum),
+        Widgets::TableHeader(Widx::kTypeHeader, { 104, 43 }, { 152, 12 }, WindowColour::secondary, StringIds::tableHeaderObjectType),
+        Widgets::TableHeader(Widx::kChecksumHeader, { 256, 43 }, { 100, 12 }, WindowColour::secondary, StringIds::tableHeaderObjectChecksum),
         Widgets::ScrollView({ 4, 57 }, { 352, 176 }, WindowColour::secondary, Scrollbars::vertical)
 
     );
@@ -247,11 +254,11 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
         scrollHeight = kRowHeight * window.rowCount;
     }
 
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::close:
+            case Widx::kClose:
                 WindowManager::close(window.type);
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
@@ -26,7 +26,7 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
 
     static std::vector<ObjectHeader> _loadErrorObjectsList;
 
-    enum Widx
+    enum widx
     {
         frame,
         title,
@@ -184,9 +184,9 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
 
         uint16_t y = 0;
         auto namePos = Point(1, y);
-        auto typePos = Point(window.widgets[Widx::typeHeader].left - 4, y);
-        auto typeWidth = window.widgets[Widx::typeHeader].width() - 6;
-        auto checksumPos = Point(window.widgets[Widx::checksumHeader].left - 4, y);
+        auto typePos = Point(window.widgets[widx::typeHeader].left - 4, y);
+        auto typeWidth = window.widgets[widx::typeHeader].width() - 6;
+        auto checksumPos = Point(window.widgets[widx::checksumHeader].left - 4, y);
         for (uint16_t i = 0; i < window.rowCount; i++)
         {
             if (y + kRowHeight < rt.y)
@@ -251,7 +251,7 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
     {
         switch (widgetIndex)
         {
-            case Widx::close:
+            case widx::close:
                 WindowManager::close(window.type);
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -263,48 +263,83 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         objectImage,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kFrame{ "frame" };
+        constexpr WidgetId kCaption{ "caption" };
+        constexpr WidgetId kCloseButton{ "closeButton" };
+        constexpr WidgetId kPanel{ "panel" };
+        constexpr WidgetId kPrimaryTab1{ "primaryTab1" };
+        constexpr WidgetId kPrimaryTab2{ "primaryTab2" };
+        constexpr WidgetId kPrimaryTab3{ "primaryTab3" };
+        constexpr WidgetId kPrimaryTab4{ "primaryTab4" };
+        constexpr WidgetId kPrimaryTab5{ "primaryTab5" };
+        constexpr WidgetId kPrimaryTab6{ "primaryTab6" };
+        constexpr WidgetId kPrimaryTab7{ "primaryTab7" };
+        constexpr WidgetId kPrimaryTab8{ "primaryTab8" };
+        constexpr WidgetId kPrimaryTab9{ "primaryTab9" };
+        constexpr WidgetId kPrimaryTab10{ "primaryTab10" };
+        constexpr WidgetId kPrimaryTab11{ "primaryTab11" };
+        constexpr WidgetId kPrimaryTab12{ "primaryTab12" };
+        constexpr WidgetId kFilterLabel{ "filterLabel" };
+        constexpr WidgetId kFilterDropdown{ "filterDropdown" };
+        constexpr WidgetId kTextInput{ "textInput" };
+        constexpr WidgetId kClearButton{ "clearButton" };
+        constexpr WidgetId kSecondaryTab1{ "secondaryTab1" };
+        constexpr WidgetId kSecondaryTab2{ "secondaryTab2" };
+        constexpr WidgetId kSecondaryTab3{ "secondaryTab3" };
+        constexpr WidgetId kSecondaryTab4{ "secondaryTab4" };
+        constexpr WidgetId kSecondaryTab5{ "secondaryTab5" };
+        constexpr WidgetId kSecondaryTab6{ "secondaryTab6" };
+        constexpr WidgetId kSecondaryTab7{ "secondaryTab7" };
+        constexpr WidgetId kSecondaryTab8{ "secondaryTab8" };
+        constexpr WidgetId kScrollviewFrame{ "scrollviewFrame" };
+        constexpr WidgetId kScrollview{ "scrollview" };
+        constexpr WidgetId kObjectImage{ "objectImage" };
+    }
+
     static constexpr uint8_t kMaxNumPrimaryTabs = 12;
     static constexpr uint8_t kMaxNumSecondaryTabs = 8;
 
     static constexpr auto widgets = makeWidgets(
-        Widgets::Frame({ 0, 0 }, { 600, 398 }, WindowColour::primary),
-        Widgets::Caption({ 1, 1 }, { 598, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::title_object_selection),
-        Widgets::ImageButton({ 585, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-        Widgets::Panel({ 0, 41 }, { 600, 357 }, WindowColour::secondary),
+        Widgets::Frame(Widx::kFrame, { 0, 0 }, { 600, 398 }, WindowColour::primary),
+        Widgets::Caption(Widx::kCaption, { 1, 1 }, { 598, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::title_object_selection),
+        Widgets::ImageButton(Widx::kCloseButton, { 585, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::Panel(Widx::kPanel, { 0, 41 }, { 600, 357 }, WindowColour::secondary),
 
         // Primary tab area
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 127, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 158, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 189, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 220, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 251, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 282, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 313, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 344, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kPrimaryTab1, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kPrimaryTab2, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kPrimaryTab3, { 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kPrimaryTab4, { 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kPrimaryTab5, { 127, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kPrimaryTab6, { 158, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kPrimaryTab7, { 189, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kPrimaryTab8, { 220, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kPrimaryTab9, { 251, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kPrimaryTab10, { 282, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kPrimaryTab11, { 313, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kPrimaryTab12, { 344, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
 
         // Filter options
-        Widgets::dropdownWidgets({ 492, 20 }, { 100, 12 }, WindowColour::primary, StringIds::wcolour2_stringid),
-        Widgets::TextBox({ 4, 45 }, { 246, 14 }, WindowColour::secondary),
-        Widgets::Button({ 254, 45 }, { 38, 14 }, WindowColour::secondary, StringIds::clearInput),
+        Widgets::dropdownWidgets(Widx::kFilterLabel, Widx::kFilterDropdown, { 492, 20 }, { 100, 12 }, WindowColour::primary, StringIds::wcolour2_stringid),
+        Widgets::TextBox(Widx::kTextInput, { 4, 45 }, { 246, 14 }, WindowColour::secondary),
+        Widgets::Button(Widx::kClearButton, { 254, 45 }, { 38, 14 }, WindowColour::secondary, StringIds::clearInput),
 
         // Secondary tabs
-        Widgets::Tab({ 3, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 34, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 65, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 96, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 127, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 158, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 189, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
-        Widgets::Tab({ 220, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kSecondaryTab1, { 3, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kSecondaryTab2, { 34, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kSecondaryTab3, { 65, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kSecondaryTab4, { 96, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kSecondaryTab5, { 127, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kSecondaryTab6, { 158, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kSecondaryTab7, { 189, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
+        Widgets::Tab(Widx::kSecondaryTab8, { 220, 62 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab),
 
         // Scroll and preview areas
-        Widgets::Panel({ 3, 83 }, { 290, 303 }, WindowColour::secondary),
-        Widgets::ScrollView({ 4, 85 }, { 288, 300 }, WindowColour::secondary, Scrollbars::vertical),
-        Widgets::ImageButton({ 391, 45 }, kObjectPreviewSize, WindowColour::secondary)
+        Widgets::Panel(Widx::kScrollviewFrame, { 3, 83 }, { 290, 303 }, WindowColour::secondary),
+        Widgets::ScrollView(Widx::kScrollview, { 4, 85 }, { 288, 300 }, WindowColour::secondary, Scrollbars::vertical),
+        Widgets::ImageButton(Widx::kObjectImage, { 391, 45 }, kObjectPreviewSize, WindowColour::secondary)
 
     );
 
@@ -1366,31 +1401,31 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     // 0x004737BA
     static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::closeButton:
+            case Widx::kCloseButton:
                 tryCloseWindow();
                 break;
 
-            case widx::primaryTab1:
-            case widx::primaryTab2:
-            case widx::primaryTab3:
-            case widx::primaryTab4:
-            case widx::primaryTab5:
-            case widx::primaryTab6:
-            case widx::primaryTab7:
-            case widx::primaryTab8:
-            case widx::primaryTab9:
-            case widx::primaryTab10:
-            case widx::primaryTab11:
-            case widx::primaryTab12:
+            case Widx::kPrimaryTab1:
+            case Widx::kPrimaryTab2:
+            case Widx::kPrimaryTab3:
+            case Widx::kPrimaryTab4:
+            case Widx::kPrimaryTab5:
+            case Widx::kPrimaryTab6:
+            case Widx::kPrimaryTab7:
+            case Widx::kPrimaryTab8:
+            case Widx::kPrimaryTab9:
+            case Widx::kPrimaryTab10:
+            case Widx::kPrimaryTab11:
+            case Widx::kPrimaryTab12:
             {
                 auto clickedTab = widgetIndex - widx::primaryTab1;
                 switchPrimaryTab(self, clickedTab);
                 break;
             }
 
-            case widx::clearButton:
+            case Widx::kClearButton:
             {
                 inputSession.clearInput();
                 applyFilterToObjectList(FilterFlags(self.var_858));
@@ -1399,14 +1434,14 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
                 break;
             }
 
-            case widx::secondaryTab1:
-            case widx::secondaryTab2:
-            case widx::secondaryTab3:
-            case widx::secondaryTab4:
-            case widx::secondaryTab5:
-            case widx::secondaryTab6:
-            case widx::secondaryTab7:
-            case widx::secondaryTab8:
+            case Widx::kSecondaryTab1:
+            case Widx::kSecondaryTab2:
+            case Widx::kSecondaryTab3:
+            case Widx::kSecondaryTab4:
+            case Widx::kSecondaryTab5:
+            case Widx::kSecondaryTab6:
+            case Widx::kSecondaryTab7:
+            case Widx::kSecondaryTab8:
             {
                 auto& subTabs = kMainTabInfo[self.currentTab].subTabs;
                 auto previousSubType = subTabs[self.currentSecondaryTab].objectType;
@@ -1429,9 +1464,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         }
     }
 
-    static void onMouseDown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseDown(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        if (widgetIndex == widx::filterDropdown)
+        if (id == Widx::kFilterDropdown)
         {
             auto& dropdown = self.widgets[widx::filterLabel];
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 7, 0);
@@ -1467,9 +1502,9 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         }
     }
 
-    static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+    static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
-        if (widgetIndex != widx::filterDropdown)
+        if (id != Widx::kFilterDropdown)
         {
             return;
         }

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -76,23 +76,20 @@ namespace OpenLoco::Ui::Windows::Options
 
     namespace Common
     {
-        namespace Widx
+        enum widx
         {
-            enum
-            {
-                frame = 0,
-                caption = 1,
-                close_button = 2,
-                panel = 3,
-                tab_display,
-                tab_rendering,
-                tab_audio,
-                tab_regional,
-                tab_controls,
-                tab_company,
-                tab_miscellaneous,
-            };
-        }
+            frame = 0,
+            caption = 1,
+            close_button = 2,
+            panel = 3,
+            tab_display,
+            tab_rendering,
+            tab_audio,
+            tab_regional,
+            tab_controls,
+            tab_company,
+            tab_miscellaneous,
+        };
 
         enum tab
         {
@@ -110,13 +107,13 @@ namespace OpenLoco::Ui::Windows::Options
             self.activatedWidgets = 1ULL << (self.currentTab + 4);
             self.disabledWidgets = 0;
 
-            self.widgets[Widx::frame].right = self.width - 1;
-            self.widgets[Widx::frame].bottom = self.height - 1;
-            self.widgets[Widx::panel].right = self.width - 1;
-            self.widgets[Widx::panel].bottom = self.height - 1;
-            self.widgets[Widx::caption].right = self.width - 2;
-            self.widgets[Widx::close_button].left = self.width - 15;
-            self.widgets[Widx::close_button].right = self.width - 15 + 12;
+            self.widgets[widx::frame].right = self.width - 1;
+            self.widgets[widx::frame].bottom = self.height - 1;
+            self.widgets[widx::panel].right = self.width - 1;
+            self.widgets[widx::panel].bottom = self.height - 1;
+            self.widgets[widx::caption].right = self.width - 2;
+            self.widgets[widx::close_button].left = self.width - 15;
+            self.widgets[widx::close_button].right = self.width - 15 + 12;
 
             disableTabsByCurrentScene(self);
 
@@ -145,7 +142,7 @@ namespace OpenLoco::Ui::Windows::Options
                     imageId += kRedenderingTabImageIds[0];
                 }
 
-                self.widgets[Widx::tab_rendering].image = imageId;
+                self.widgets[widx::tab_rendering].image = imageId;
             }
 
             static constexpr uint32_t globe_tab_ids[] = {
@@ -190,13 +187,13 @@ namespace OpenLoco::Ui::Windows::Options
                 {
                     imageId = globe_tab_ids[(self.frameNo / 2) % 32];
                 }
-                self.widgets[Widx::tab_regional].image = imageId;
+                self.widgets[widx::tab_regional].image = imageId;
             }
 
             // Company tab
             {
                 const uint32_t imageId = skin->img + InterfaceSkin::ImageIds::tab_company;
-                self.widgets[Widx::tab_company].image = imageId;
+                self.widgets[widx::tab_company].image = imageId;
             }
         }
 
@@ -209,17 +206,17 @@ namespace OpenLoco::Ui::Windows::Options
         {
             switch (wi)
             {
-                case Widx::close_button:
+                case widx::close_button:
                     WindowManager::close(&self);
                     return true;
 
-                case Widx::tab_display:
-                case Widx::tab_rendering:
-                case Widx::tab_audio:
-                case Widx::tab_regional:
-                case Widx::tab_controls:
-                case Widx::tab_company:
-                case Widx::tab_miscellaneous:
+                case widx::tab_display:
+                case widx::tab_rendering:
+                case widx::tab_audio:
+                case widx::tab_regional:
+                case widx::tab_controls:
+                case widx::tab_company:
+                case widx::tab_miscellaneous:
                     Options::tabOnMouseUp(self, wi);
                     return true;
 
@@ -251,27 +248,24 @@ namespace OpenLoco::Ui::Windows::Options
     {
         static constexpr Ui::Size kWindowSize = { 400, 151 };
 
-        namespace Widx
+        enum widx
         {
-            enum
-            {
-                frame_hardware = Common::Widx::tab_miscellaneous + 1,
-                screen_mode_label,
-                screen_mode,
-                screen_mode_btn,
-                display_resolution_label,
-                display_resolution,
-                display_resolution_btn,
-                display_scale_label,
-                display_scale,
-                display_scale_down_btn,
-                display_scale_up_btn,
-                frame_limit_label,
-                frame_limit,
-                frame_limit_btn,
-                show_fps,
-            };
-        }
+            frame_hardware = Common::widx::tab_miscellaneous + 1,
+            screen_mode_label,
+            screen_mode,
+            screen_mode_btn,
+            display_resolution_label,
+            display_resolution,
+            display_resolution_btn,
+            display_scale_label,
+            display_scale,
+            display_scale_down_btn,
+            display_scale_up_btn,
+            frame_limit_label,
+            frame_limit,
+            frame_limit_btn,
+            show_fps,
+        };
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_display),
@@ -303,7 +297,7 @@ namespace OpenLoco::Ui::Windows::Options
 
             switch (wi)
             {
-                case Widx::show_fps:
+                case widx::show_fps:
                 {
                     auto& cfg = OpenLoco::Config::get();
                     cfg.showFPS ^= 1;
@@ -319,20 +313,20 @@ namespace OpenLoco::Ui::Windows::Options
         {
             if (Config::get().display.mode == Config::ScreenMode::fullscreen)
             {
-                self.disabledWidgets &= ~(1ULL << Widx::display_resolution) | (1ULL << Widx::display_resolution_btn);
-                self.disabledWidgets &= ~((1ULL << Widx::display_resolution) | (1ULL << Widx::display_resolution_btn));
+                self.disabledWidgets &= ~(1ULL << widx::display_resolution) | (1ULL << widx::display_resolution_btn);
+                self.disabledWidgets &= ~((1ULL << widx::display_resolution) | (1ULL << widx::display_resolution_btn));
             }
             else
             {
-                self.disabledWidgets |= ((1ULL << Widx::display_resolution) | (1ULL << Widx::display_resolution_btn));
-                self.disabledWidgets |= (1ULL << Widx::display_resolution) | (1ULL << Widx::display_resolution_btn);
+                self.disabledWidgets |= ((1ULL << widx::display_resolution) | (1ULL << widx::display_resolution_btn));
+                self.disabledWidgets |= (1ULL << widx::display_resolution) | (1ULL << widx::display_resolution_btn);
             }
         }
 #endif
 
         static void screenModeMouseDown(const Window& self, [[maybe_unused]] WidgetIndex_t wi)
         {
-            auto& dropdown = self.widgets[Widx::screen_mode];
+            auto& dropdown = self.widgets[widx::screen_mode];
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 3, 0x80);
 
             Dropdown::add(0, StringIds::dropdown_stringid, StringIds::options_mode_windowed);
@@ -368,7 +362,7 @@ namespace OpenLoco::Ui::Windows::Options
         {
             std::vector<Resolution> resolutions = getFullscreenResolutions();
 
-            auto& dropdown = self.widgets[Widx::display_resolution];
+            auto& dropdown = self.widgets[widx::display_resolution];
             Dropdown::showText2(self.x + dropdown.left, self.y + dropdown.top, dropdown.width(), dropdown.height(), self.getColour(WindowColour::secondary), resolutions.size(), 0x80);
 
             auto& cfg = Config::get();
@@ -397,7 +391,7 @@ namespace OpenLoco::Ui::Windows::Options
 
         static void frameLimitMouseDown(const Window& self, [[maybe_unused]] WidgetIndex_t wi)
         {
-            auto& dropdown = self.widgets[Widx::frame_limit];
+            auto& dropdown = self.widgets[widx::frame_limit];
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width(), dropdown.height(), self.getColour(WindowColour::secondary), 3, 0x80);
 
             Dropdown::add(0, StringIds::dropdown_stringid, StringIds::frameRateLimitInternal);
@@ -441,7 +435,7 @@ namespace OpenLoco::Ui::Windows::Options
             if (drawingEngine.setVSync(config.display.vsync))
             {
                 Config::write();
-                WindowManager::invalidateWidget(self.type, self.number, Widx::frame_limit);
+                WindowManager::invalidateWidget(self.type, self.number, widx::frame_limit);
             }
         }
 
@@ -457,19 +451,19 @@ namespace OpenLoco::Ui::Windows::Options
         {
             switch (wi)
             {
-                case Widx::screen_mode_btn:
+                case widx::screen_mode_btn:
                     screenModeMouseDown(self, wi);
                     break;
-                case Widx::display_resolution_btn:
+                case widx::display_resolution_btn:
                     resolutionMouseDown(self, wi);
                     break;
-                case Widx::display_scale_down_btn:
+                case widx::display_scale_down_btn:
                     displayScaleMouseDown(self, wi, -OpenLoco::Ui::ScaleFactor::step);
                     break;
-                case Widx::display_scale_up_btn:
+                case widx::display_scale_up_btn:
                     displayScaleMouseDown(self, wi, OpenLoco::Ui::ScaleFactor::step);
                     break;
-                case Widx::frame_limit_btn:
+                case widx::frame_limit_btn:
                     frameLimitMouseDown(self, wi);
                     break;
             }
@@ -480,13 +474,13 @@ namespace OpenLoco::Ui::Windows::Options
         {
             switch (wi)
             {
-                case Widx::screen_mode_btn:
+                case widx::screen_mode_btn:
                     screenModeDropdown(self, item_index);
                     break;
-                case Widx::display_resolution_btn:
+                case widx::display_resolution_btn:
                     resolutionDropdown(self, item_index);
                     break;
-                case Widx::frame_limit_btn:
+                case widx::frame_limit_btn:
                     frameLimitDropdown(self, item_index);
                     break;
             }
@@ -520,11 +514,11 @@ namespace OpenLoco::Ui::Windows::Options
                     screenModeStringId = StringIds::options_mode_fullscreen_window;
                     break;
             }
-            self.widgets[Widx::screen_mode].text = screenModeStringId;
+            self.widgets[widx::screen_mode].text = screenModeStringId;
 
             // Resolution.
             {
-                auto args = FormatArguments(self.widgets[Widx::display_resolution].textArgs);
+                auto args = FormatArguments(self.widgets[widx::display_resolution].textArgs);
                 auto& resolution = Config::get().display.fullscreenResolution;
                 args.push<uint16_t>(resolution.width);
                 args.push<uint16_t>(resolution.height);
@@ -532,7 +526,7 @@ namespace OpenLoco::Ui::Windows::Options
 
             // Scale.
             {
-                auto args = FormatArguments(self.widgets[Widx::display_scale].textArgs);
+                auto args = FormatArguments(self.widgets[widx::display_scale].textArgs);
                 args.push<int32_t>(Config::get().scaleFactor * 100);
             }
 
@@ -548,21 +542,21 @@ namespace OpenLoco::Ui::Windows::Options
                     frameLimitStringId = StringIds::frameRateLimitUnrestricted;
                 }
             }
-            self.widgets[Widx::frame_limit].text = frameLimitStringId;
+            self.widgets[widx::frame_limit].text = frameLimitStringId;
 
             if (Config::get().showFPS)
             {
-                self.activatedWidgets |= (1ULL << Widx::show_fps);
+                self.activatedWidgets |= (1ULL << widx::show_fps);
             }
 
             if (Config::get().scaleFactor <= OpenLoco::Ui::ScaleFactor::min)
             {
-                self.disabledWidgets |= (1ULL << Widx::display_scale_down_btn);
+                self.disabledWidgets |= (1ULL << widx::display_scale_down_btn);
             }
 
             if (Config::get().scaleFactor >= OpenLoco::Ui::ScaleFactor::max)
             {
-                self.disabledWidgets |= (1ULL << Widx::display_scale_up_btn);
+                self.disabledWidgets |= (1ULL << widx::display_scale_up_btn);
             }
 
 #if !(defined(__APPLE__) && defined(__MACH__))
@@ -581,16 +575,16 @@ namespace OpenLoco::Ui::Windows::Options
         {
             if (Config::get().display.mode != Config::ScreenMode::fullscreen)
             {
-                self.disabledWidgets = (1ULL << Display::Widx::display_resolution) | (1ULL << Display::Widx::display_resolution_btn);
+                self.disabledWidgets = (1ULL << Display::widx::display_resolution) | (1ULL << Display::widx::display_resolution_btn);
             }
 
 #if !(defined(__APPLE__) && defined(__MACH__))
             Display::screenModeToggleEnabled(self);
 #else
-            self.disabledWidgets |= (1ULL << Display::Widx::screen_mode)
-                | (1ULL << Display::Widx::screen_mode_btn)
-                | (1ULL << Display::Widx::display_resolution)
-                | (1ULL << Display::Widx::display_resolution_btn);
+            self.disabledWidgets |= (1ULL << Display::widx::screen_mode)
+                | (1ULL << Display::widx::screen_mode_btn)
+                | (1ULL << Display::widx::display_resolution)
+                | (1ULL << Display::widx::display_resolution_btn);
 #endif
         }
 
@@ -614,31 +608,28 @@ namespace OpenLoco::Ui::Windows::Options
     {
         static constexpr Ui::Size kWindowSize = { 400, 218 };
 
-        namespace Widx
+        enum widx
         {
-            enum
-            {
-                frame_map_rendering = Common::Widx::tab_miscellaneous + 1,
-                vehicles_min_scale_label,
-                vehicles_min_scale,
-                vehicles_min_scale_btn,
-                station_names_min_scale_label,
-                station_names_min_scale,
-                station_names_min_scale_btn,
-                construction_marker_label,
-                construction_marker,
-                construction_marker_btn,
-                landscape_smoothing,
-                gridlines_on_landscape,
-                cash_popup_rendering,
-                show_company_ai_planning,
+            frame_map_rendering = Common::widx::tab_miscellaneous + 1,
+            vehicles_min_scale_label,
+            vehicles_min_scale,
+            vehicles_min_scale_btn,
+            station_names_min_scale_label,
+            station_names_min_scale,
+            station_names_min_scale_btn,
+            construction_marker_label,
+            construction_marker,
+            construction_marker_btn,
+            landscape_smoothing,
+            gridlines_on_landscape,
+            cash_popup_rendering,
+            show_company_ai_planning,
 
-                frame_user_interface,
-                window_frame_style_label,
-                window_frame_style,
-                window_frame_style_btn,
-            };
-        }
+            frame_user_interface,
+            window_frame_style_label,
+            window_frame_style,
+            window_frame_style_btn,
+        };
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::title_options_rendering),
@@ -674,7 +665,7 @@ namespace OpenLoco::Ui::Windows::Options
 
             switch (wi)
             {
-                case Widx::landscape_smoothing:
+                case widx::landscape_smoothing:
                 {
                     auto& cfg = OpenLoco::Config::get();
                     cfg.landscapeSmoothing ^= true;
@@ -683,7 +674,7 @@ namespace OpenLoco::Ui::Windows::Options
                     return;
                 }
 
-                case Widx::gridlines_on_landscape:
+                case widx::gridlines_on_landscape:
                 {
                     auto& cfg = OpenLoco::Config::get();
                     cfg.gridlinesOnLandscape ^= true;
@@ -704,7 +695,7 @@ namespace OpenLoco::Ui::Windows::Options
                     return;
                 }
 
-                case Widx::cash_popup_rendering:
+                case widx::cash_popup_rendering:
                 {
                     auto& cfg = OpenLoco::Config::get();
                     cfg.cashPopupRendering = !cfg.cashPopupRendering;
@@ -713,7 +704,7 @@ namespace OpenLoco::Ui::Windows::Options
                     return;
                 }
 
-                case Widx::show_company_ai_planning:
+                case widx::show_company_ai_planning:
                 {
                     auto& cfg = OpenLoco::Config::get();
                     cfg.showAiPlanningAsGhosts = !cfg.showAiPlanningAsGhosts;
@@ -728,7 +719,7 @@ namespace OpenLoco::Ui::Windows::Options
         // 0x004BFE2E
         static void constructionMarkerMouseDown(const Window& self, [[maybe_unused]] WidgetIndex_t wi)
         {
-            auto& dropdown = self.widgets[Widx::construction_marker];
+            auto& dropdown = self.widgets[widx::construction_marker];
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 2, 0x80);
 
             Dropdown::add(0, StringIds::dropdown_stringid, StringIds::white);
@@ -760,7 +751,7 @@ namespace OpenLoco::Ui::Windows::Options
         // 0x004BFEBE
         static void vehicleZoomMouseDown(const Window& self, [[maybe_unused]] WidgetIndex_t wi)
         {
-            auto& dropdown = self.widgets[Widx::vehicles_min_scale];
+            auto& dropdown = self.widgets[widx::vehicles_min_scale];
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 4, 0x80);
 
             Dropdown::add(0, StringIds::dropdown_stringid, StringIds::full_scale);
@@ -794,7 +785,7 @@ namespace OpenLoco::Ui::Windows::Options
         // 0x004BFF72
         static void stationNamesScaleMouseDown(const Window& self, [[maybe_unused]] WidgetIndex_t wi)
         {
-            auto& dropdown = self.widgets[Widx::station_names_min_scale];
+            auto& dropdown = self.widgets[widx::station_names_min_scale];
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 4, 0x80);
 
             Dropdown::add(0, StringIds::dropdown_stringid, StringIds::full_scale);
@@ -825,7 +816,7 @@ namespace OpenLoco::Ui::Windows::Options
 
         static void windowFrameStyleMouseDown(const Window& self, [[maybe_unused]] WidgetIndex_t wi)
         {
-            auto& dropdown = self.widgets[Widx::window_frame_style];
+            auto& dropdown = self.widgets[widx::window_frame_style];
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 3, 0x80);
 
             Dropdown::add(0, StringIds::dropdown_stringid, StringIds::windowFrameStyleGradient);
@@ -857,16 +848,16 @@ namespace OpenLoco::Ui::Windows::Options
         {
             switch (wi)
             {
-                case Widx::construction_marker_btn:
+                case widx::construction_marker_btn:
                     constructionMarkerMouseDown(self, wi);
                     break;
-                case Widx::vehicles_min_scale_btn:
+                case widx::vehicles_min_scale_btn:
                     vehicleZoomMouseDown(self, wi);
                     break;
-                case Widx::station_names_min_scale_btn:
+                case widx::station_names_min_scale_btn:
                     stationNamesScaleMouseDown(self, wi);
                     break;
-                case Widx::window_frame_style_btn:
+                case widx::window_frame_style_btn:
                     windowFrameStyleMouseDown(self, wi);
                     break;
             }
@@ -877,16 +868,16 @@ namespace OpenLoco::Ui::Windows::Options
         {
             switch (wi)
             {
-                case Widx::construction_marker_btn:
+                case widx::construction_marker_btn:
                     constructionMarkerDropdown(item_index);
                     break;
-                case Widx::vehicles_min_scale_btn:
+                case widx::vehicles_min_scale_btn:
                     vehicleZoomDropdown(item_index);
                     break;
-                case Widx::station_names_min_scale_btn:
+                case widx::station_names_min_scale_btn:
                     stationNamesScaleDropdown(item_index);
                     break;
-                case Widx::window_frame_style_btn:
+                case widx::window_frame_style_btn:
                     windowFrameStyleDropdown(item_index);
                     break;
             }
@@ -909,11 +900,11 @@ namespace OpenLoco::Ui::Windows::Options
 
             if (Config::get().constructionMarker)
             {
-                self.widgets[Widx::construction_marker].text = StringIds::translucent;
+                self.widgets[widx::construction_marker].text = StringIds::translucent;
             }
             else
             {
-                self.widgets[Widx::construction_marker].text = StringIds::white;
+                self.widgets[widx::construction_marker].text = StringIds::white;
             }
 
             static constexpr StringId kScaleStringIds[] = {
@@ -923,8 +914,8 @@ namespace OpenLoco::Ui::Windows::Options
                 StringIds::eighth_scale,
             };
 
-            self.widgets[Widx::vehicles_min_scale].text = kScaleStringIds[Config::get().vehiclesMinScale];
-            self.widgets[Widx::station_names_min_scale].text = kScaleStringIds[Config::get().stationNamesMinScale];
+            self.widgets[widx::vehicles_min_scale].text = kScaleStringIds[Config::get().vehiclesMinScale];
+            self.widgets[widx::station_names_min_scale].text = kScaleStringIds[Config::get().stationNamesMinScale];
 
             static constexpr StringId kWindowStyleStringIds[] = {
                 StringIds::windowFrameStyleGradient,
@@ -932,26 +923,26 @@ namespace OpenLoco::Ui::Windows::Options
                 StringIds::windowFrameStyleTranslucent,
             };
 
-            self.widgets[Widx::window_frame_style].text = kWindowStyleStringIds[enumValue(Config::get().windowFrameStyle)];
+            self.widgets[widx::window_frame_style].text = kWindowStyleStringIds[enumValue(Config::get().windowFrameStyle)];
 
             if (Config::get().landscapeSmoothing)
             {
-                self.activatedWidgets |= (1ULL << Widx::landscape_smoothing);
+                self.activatedWidgets |= (1ULL << widx::landscape_smoothing);
             }
 
             if (Config::get().gridlinesOnLandscape)
             {
-                self.activatedWidgets |= (1ULL << Widx::gridlines_on_landscape);
+                self.activatedWidgets |= (1ULL << widx::gridlines_on_landscape);
             }
 
             if (Config::get().cashPopupRendering)
             {
-                self.activatedWidgets |= (1ULL << Widx::cash_popup_rendering);
+                self.activatedWidgets |= (1ULL << widx::cash_popup_rendering);
             }
 
             if (Config::get().showAiPlanningAsGhosts)
             {
-                self.activatedWidgets |= (1ULL << Widx::show_company_ai_planning);
+                self.activatedWidgets |= (1ULL << widx::show_company_ai_planning);
             }
         }
 
@@ -1006,34 +997,31 @@ namespace OpenLoco::Ui::Windows::Options
 
         static constexpr Ui::Size kWindowSize = { 366, kMusicGroupOffset + kMusicGroupHeight + 4 };
 
-        namespace Widx
+        enum widx
         {
-            enum
-            {
-                frame_sound = Common::Widx::tab_miscellaneous + 1,
-                audio_device,
-                audio_device_btn,
+            frame_sound = Common::widx::tab_miscellaneous + 1,
+            audio_device,
+            audio_device_btn,
 
-                frame_volume,
-                volume_master_label,
-                volume_master,
-                volume_music_label,
-                volume_music,
-                volume_effects_label,
-                volume_effects,
-                volume_vehicles_label,
-                volume_vehicles,
-                volume_ui_label,
-                volume_ui,
-                volume_ambient_label,
-                volume_ambient,
+            frame_volume,
+            volume_master_label,
+            volume_master,
+            volume_music_label,
+            volume_music,
+            volume_effects_label,
+            volume_effects,
+            volume_vehicles_label,
+            volume_vehicles,
+            volume_ui_label,
+            volume_ui,
+            volume_ambient_label,
+            volume_ambient,
 
-                frame_music,
-                play_title_music,
-                play_game_music,
-                open_jukebox,
-            };
-        }
+            frame_music,
+            play_title_music,
+            play_game_music,
+            open_jukebox,
+        };
 
         static constexpr int32_t getSliderRowY(uint8_t num)
         {
@@ -1082,7 +1070,7 @@ namespace OpenLoco::Ui::Windows::Options
 
             // Audio device
             {
-                auto args = FormatArguments(self.widgets[Widx::audio_device].textArgs);
+                auto args = FormatArguments(self.widgets[widx::audio_device].textArgs);
                 auto audioDeviceName = Audio::getCurrentDeviceName();
                 if (audioDeviceName != nullptr)
                 {
@@ -1098,17 +1086,17 @@ namespace OpenLoco::Ui::Windows::Options
             // Play music checkboxes
             if (Config::get().audio.playTitleMusic)
             {
-                self.activatedWidgets |= (1ULL << Widx::play_title_music);
+                self.activatedWidgets |= (1ULL << widx::play_title_music);
             }
             if (Config::get().audio.playJukeboxMusic)
             {
-                self.activatedWidgets |= (1ULL << Widx::play_game_music);
+                self.activatedWidgets |= (1ULL << widx::play_game_music);
             }
 
             // Disable open jukebox button when playing music is disabled
             if (!Config::get().audio.playJukeboxMusic)
             {
-                self.disabledWidgets |= (1ULL << Widx::open_jukebox);
+                self.disabledWidgets |= (1ULL << widx::open_jukebox);
             }
         }
 
@@ -1127,12 +1115,12 @@ namespace OpenLoco::Ui::Windows::Options
         {
             self.draw(drawingCtx);
 
-            drawVolumeSlider(self, drawingCtx, Widx::volume_master, Audio::getChannelVolume(Audio::ChannelId::master));
-            drawVolumeSlider(self, drawingCtx, Widx::volume_music, Audio::getChannelVolume(Audio::ChannelId::music));
-            drawVolumeSlider(self, drawingCtx, Widx::volume_effects, Audio::getChannelVolume(Audio::ChannelId::effects));
-            drawVolumeSlider(self, drawingCtx, Widx::volume_vehicles, Audio::getChannelVolume(Audio::ChannelId::vehicles));
-            drawVolumeSlider(self, drawingCtx, Widx::volume_ui, Audio::getChannelVolume(Audio::ChannelId::ui));
-            drawVolumeSlider(self, drawingCtx, Widx::volume_ambient, Audio::getChannelVolume(Audio::ChannelId::ambient));
+            drawVolumeSlider(self, drawingCtx, widx::volume_master, Audio::getChannelVolume(Audio::ChannelId::master));
+            drawVolumeSlider(self, drawingCtx, widx::volume_music, Audio::getChannelVolume(Audio::ChannelId::music));
+            drawVolumeSlider(self, drawingCtx, widx::volume_effects, Audio::getChannelVolume(Audio::ChannelId::effects));
+            drawVolumeSlider(self, drawingCtx, widx::volume_vehicles, Audio::getChannelVolume(Audio::ChannelId::vehicles));
+            drawVolumeSlider(self, drawingCtx, widx::volume_ui, Audio::getChannelVolume(Audio::ChannelId::ui));
+            drawVolumeSlider(self, drawingCtx, widx::volume_ambient, Audio::getChannelVolume(Audio::ChannelId::ambient));
         }
 
         static void onMouseUp(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
@@ -1144,15 +1132,15 @@ namespace OpenLoco::Ui::Windows::Options
 
             switch (wi)
             {
-                case Widx::play_title_music:
+                case widx::play_title_music:
                     playTitleMusicOnMouseUp(self);
                     return;
 
-                case Widx::play_game_music:
+                case widx::play_game_music:
                     playGameMusicOnMouseUp(self);
                     return;
 
-                case Widx::open_jukebox:
+                case widx::open_jukebox:
                     MusicJukebox::open();
                     return;
             }
@@ -1162,15 +1150,15 @@ namespace OpenLoco::Ui::Windows::Options
         {
             switch (wi)
             {
-                case Widx::audio_device_btn:
+                case widx::audio_device_btn:
                     audioDeviceMouseDown(self);
                     break;
-                case Widx::volume_master:
-                case Widx::volume_music:
-                case Widx::volume_effects:
-                case Widx::volume_vehicles:
-                case Widx::volume_ui:
-                case Widx::volume_ambient:
+                case widx::volume_master:
+                case widx::volume_music:
+                case widx::volume_effects:
+                case widx::volume_vehicles:
+                case widx::volume_ui:
+                case widx::volume_ambient:
                     volumeSliderMouseDown(self, wi);
                     break;
             }
@@ -1180,7 +1168,7 @@ namespace OpenLoco::Ui::Windows::Options
         {
             switch (widgetIndex)
             {
-                case Widx::audio_device_btn:
+                case widx::audio_device_btn:
                     audioDeviceDropdown(self, itemIndex);
                     break;
             }
@@ -1192,7 +1180,7 @@ namespace OpenLoco::Ui::Windows::Options
             const auto& devices = Audio::getDevices();
             if (devices.size() != 0)
             {
-                auto& dropdown = self.widgets[Widx::audio_device];
+                auto& dropdown = self.widgets[widx::audio_device];
                 Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), devices.size(), 0x80);
                 for (size_t i = 0; i < devices.size(); i++)
                 {
@@ -1222,7 +1210,7 @@ namespace OpenLoco::Ui::Windows::Options
                     Audio::playMusic(Environment::PathId::css5, config.audio.mainVolume, true);
                 }
 
-                WindowManager::invalidateWidget(self.type, self.number, Widx::audio_device);
+                WindowManager::invalidateWidget(self.type, self.number, widx::audio_device);
             }
         }
 
@@ -1279,17 +1267,17 @@ namespace OpenLoco::Ui::Windows::Options
         {
             switch (wi)
             {
-                case Widx::volume_master:
+                case widx::volume_master:
                     return Audio::ChannelId::master;
-                case Widx::volume_music:
+                case widx::volume_music:
                     return Audio::ChannelId::music;
-                case Widx::volume_effects:
+                case widx::volume_effects:
                     return Audio::ChannelId::effects;
-                case Widx::volume_vehicles:
+                case widx::volume_vehicles:
                     return Audio::ChannelId::vehicles;
-                case Widx::volume_ui:
+                case widx::volume_ui:
                     return Audio::ChannelId::ui;
-                case Widx::volume_ambient:
+                case widx::volume_ambient:
                     return Audio::ChannelId::ambient;
                 default:
                     return Audio::ChannelId::master;
@@ -1368,29 +1356,26 @@ namespace OpenLoco::Ui::Windows::Options
     {
         static constexpr Ui::Size kWindowSize = { 366, 167 };
 
-        namespace Widx
+        enum widx
         {
-            enum
-            {
-                language_label = Common::Widx::tab_miscellaneous + 1,
-                language,
-                language_btn,
-                distance_label,
-                distance_speed,
-                distance_speed_btn,
-                heights_label,
-                heights,
-                heights_btn,
-                currency_label,
-                currency,
-                currency_btn,
-                preferred_currency_label,
-                preferred_currency,
-                preferred_currency_btn,
-                preferred_currency_for_new_games,
-                preferred_currency_always
-            };
-        }
+            language_label = Common::widx::tab_miscellaneous + 1,
+            language,
+            language_btn,
+            distance_label,
+            distance_speed,
+            distance_speed_btn,
+            heights_label,
+            heights,
+            heights_btn,
+            currency_label,
+            currency,
+            currency_btn,
+            preferred_currency_label,
+            preferred_currency,
+            preferred_currency_btn,
+            preferred_currency_for_new_games,
+            preferred_currency_always
+        };
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_regional),
@@ -1436,7 +1421,7 @@ namespace OpenLoco::Ui::Windows::Options
             Common::prepareDraw(self);
 
             {
-                auto args = FormatArguments(self.widgets[Widx::language].textArgs);
+                auto args = FormatArguments(self.widgets[widx::language].textArgs);
 
                 auto& language = Localisation::getDescriptorForLanguage(Config::get().language);
                 _chosenLanguage = language.nativeName;
@@ -1444,7 +1429,7 @@ namespace OpenLoco::Ui::Windows::Options
             }
 
             {
-                auto args = FormatArguments(self.widgets[Widx::distance_speed].textArgs);
+                auto args = FormatArguments(self.widgets[widx::distance_speed].textArgs);
 
                 StringId current_measurement_format = StringIds::imperial;
                 if (OpenLoco::Config::get().measurementFormat == Config::MeasurementFormat::metric)
@@ -1456,12 +1441,12 @@ namespace OpenLoco::Ui::Windows::Options
             }
 
             {
-                auto args = FormatArguments(self.widgets[Widx::currency].textArgs);
+                auto args = FormatArguments(self.widgets[widx::currency].textArgs);
                 args.push(ObjectManager::get<CurrencyObject>()->name);
             }
 
             {
-                auto args = FormatArguments(self.widgets[Widx::heights].textArgs);
+                auto args = FormatArguments(self.widgets[widx::heights].textArgs);
 
                 StringId current_height_units = StringIds::height_units;
                 if (!OpenLoco::Config::get().showHeightAsUnits)
@@ -1474,18 +1459,18 @@ namespace OpenLoco::Ui::Windows::Options
 
             if (Config::get().usePreferredCurrencyForNewGames)
             {
-                self.activatedWidgets |= (1ULL << Widx::preferred_currency_for_new_games);
+                self.activatedWidgets |= (1ULL << widx::preferred_currency_for_new_games);
             }
 
             if (Config::get().usePreferredCurrencyAlways)
             {
-                self.activatedWidgets |= (1ULL << Widx::preferred_currency_always);
+                self.activatedWidgets |= (1ULL << widx::preferred_currency_always);
             }
 
             if (Config::get().usePreferredCurrencyAlways || SceneManager::isTitleMode())
             {
-                self.disabledWidgets |= (1ULL << Widx::currency);
-                self.disabledWidgets |= (1ULL << Widx::currency_btn);
+                self.disabledWidgets |= (1ULL << widx::currency);
+                self.disabledWidgets |= (1ULL << widx::currency_btn);
             }
         }
 
@@ -1505,11 +1490,11 @@ namespace OpenLoco::Ui::Windows::Options
 
             switch (wi)
             {
-                case Widx::preferred_currency_for_new_games:
+                case widx::preferred_currency_for_new_games:
                     preferredCurrencyNewGameMouseUp(self);
                     return;
 
-                case Widx::preferred_currency_always:
+                case widx::preferred_currency_always:
                     preferredCurrencyAlwaysMouseUp(self);
                     return;
             }
@@ -1520,19 +1505,19 @@ namespace OpenLoco::Ui::Windows::Options
         {
             switch (wi)
             {
-                case Widx::language_btn:
+                case widx::language_btn:
                     languageMouseDown(self);
                     break;
-                case Widx::heights_btn:
+                case widx::heights_btn:
                     heightsLabelsMouseDown(self);
                     break;
-                case Widx::distance_speed_btn:
+                case widx::distance_speed_btn:
                     distanceSpeedMouseDown(self);
                     break;
-                case Widx::currency_btn:
+                case widx::currency_btn:
                     currencyMouseDown(self);
                     break;
-                case Widx::preferred_currency_btn:
+                case widx::preferred_currency_btn:
                     preferredCurrencyMouseDown(self);
                     break;
             }
@@ -1543,23 +1528,23 @@ namespace OpenLoco::Ui::Windows::Options
         {
             switch (widgetIndex)
             {
-                case Widx::language_btn:
+                case widx::language_btn:
                     languageDropdown(self, itemIndex);
                     break;
 
-                case Widx::heights_btn:
+                case widx::heights_btn:
                     heightsLabelsDropdown(self, itemIndex);
                     break;
 
-                case Widx::distance_speed_btn:
+                case widx::distance_speed_btn:
                     distanceSpeedDropdown(self, itemIndex);
                     break;
 
-                case Widx::currency_btn:
+                case widx::currency_btn:
                     currencyDropdown(self, itemIndex);
                     break;
 
-                case Widx::preferred_currency_btn:
+                case widx::preferred_currency_btn:
                     preferredCurrencyDropdown(self, itemIndex);
                     break;
             }
@@ -1570,7 +1555,7 @@ namespace OpenLoco::Ui::Windows::Options
             const auto lds = Localisation::getLanguageDescriptors();
             uint8_t numLanguages = static_cast<uint8_t>(lds.size());
 
-            auto& dropdown = self.widgets[Widx::language];
+            auto& dropdown = self.widgets[widx::language];
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), numLanguages - 1, 0x80);
 
             std::string& current_language = Config::get().language;
@@ -1611,7 +1596,7 @@ namespace OpenLoco::Ui::Windows::Options
         // 0x004C0C73
         static void currencyMouseDown(const Window& self)
         {
-            auto& dropdown = self.widgets[Widx::currency];
+            auto& dropdown = self.widgets[widx::currency];
             auto numItems = ObjectManager::getNumAvailableObjectsByType(ObjectType::currency);
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), numItems, 0x80);
 
@@ -1665,7 +1650,7 @@ namespace OpenLoco::Ui::Windows::Options
         // 0x004C0DCF
         static void preferredCurrencyMouseDown(const Window& self)
         {
-            auto& dropdown = self.widgets[Widx::preferred_currency];
+            auto& dropdown = self.widgets[widx::preferred_currency];
             auto numItems = ObjectManager::getNumAvailableObjectsByType(ObjectType::currency);
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), numItems, 0x80);
 
@@ -1739,7 +1724,7 @@ namespace OpenLoco::Ui::Windows::Options
         // 0x004C0F49
         static void distanceSpeedMouseDown(const Window& self)
         {
-            auto& dropdown = self.widgets[Widx::distance_speed];
+            auto& dropdown = self.widgets[widx::distance_speed];
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 2, 0x80);
 
             Dropdown::add(0, StringIds::dropdown_stringid, StringIds::imperial);
@@ -1772,7 +1757,7 @@ namespace OpenLoco::Ui::Windows::Options
         // 0x004C0FFA
         static void heightsLabelsMouseDown(const Window& self)
         {
-            auto& dropdown = self.widgets[Widx::heights];
+            auto& dropdown = self.widgets[widx::heights];
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 2, 0x80);
 
             Dropdown::add(0, StringIds::dropdown_stringid, StringIds::height_units);
@@ -1834,16 +1819,13 @@ namespace OpenLoco::Ui::Windows::Options
 
     namespace Controls
     {
-        namespace Widx
+        enum widx
         {
-            enum
-            {
-                edge_scrolling = Common::Widx::tab_miscellaneous + 1,
-                zoom_to_cursor,
-                invertRightMouseViewPan,
-                customize_keys
-            };
-        }
+            edge_scrolling = Common::widx::tab_miscellaneous + 1,
+            zoom_to_cursor,
+            invert_right_mouse_view_pan,
+            customize_keys
+        };
 
         static constexpr Ui::Size kWindowSize = { 366, 114 };
 
@@ -1867,18 +1849,18 @@ namespace OpenLoco::Ui::Windows::Options
 
             Common::prepareDraw(self);
 
-            self.activatedWidgets &= ~(1ULL << Widx::edge_scrolling | 1ULL << Widx::zoom_to_cursor | 1ULL << Widx::invertRightMouseViewPan);
+            self.activatedWidgets &= ~(1ULL << widx::edge_scrolling | 1ULL << widx::zoom_to_cursor | 1ULL << widx::invert_right_mouse_view_pan);
             if (Config::get().edgeScrolling)
             {
-                self.activatedWidgets |= (1ULL << Widx::edge_scrolling);
+                self.activatedWidgets |= (1ULL << widx::edge_scrolling);
             }
             if (Config::get().zoomToCursor)
             {
-                self.activatedWidgets |= (1ULL << Widx::zoom_to_cursor);
+                self.activatedWidgets |= (1ULL << widx::zoom_to_cursor);
             }
             if (Config::get().invertRightMouseViewPan)
             {
-                self.activatedWidgets |= (1ULL << Widx::invertRightMouseViewPan);
+                self.activatedWidgets |= (1ULL << widx::invert_right_mouse_view_pan);
             }
         }
 
@@ -1898,19 +1880,19 @@ namespace OpenLoco::Ui::Windows::Options
 
             switch (wi)
             {
-                case Widx::customize_keys:
+                case widx::customize_keys:
                     openKeyboardShortcuts();
                     break;
 
-                case Widx::edge_scrolling:
+                case widx::edge_scrolling:
                     edgeScrollingMouseUp(self);
                     break;
 
-                case Widx::zoom_to_cursor:
+                case widx::zoom_to_cursor:
                     zoomToCursorMouseUp(self);
                     break;
 
-                case Widx::invertRightMouseViewPan:
+                case widx::invert_right_mouse_view_pan:
                     invertRightMouseViewPan(self);
                     break;
             }
@@ -1976,28 +1958,25 @@ namespace OpenLoco::Ui::Windows::Options
     {
         static constexpr Ui::Size kWindowSize = { 420, 187 };
 
-        namespace Widx
+        enum widx
         {
-            enum
-            {
-                groupPreferredOwner = Common::Widx::tab_miscellaneous + 1,
+            groupPreferredOwner = Common::widx::tab_miscellaneous + 1,
 
-                usePreferredOwnerFace,
-                changeOwnerFaceBtn,
-                labelOwnerFace,
+            usePreferredOwnerFace,
+            changeOwnerFaceBtn,
+            labelOwnerFace,
 
-                usePreferredOwnerName,
-                changeOwnerNameBtn,
-                labelPreferredOwnerName,
+            usePreferredOwnerName,
+            changeOwnerNameBtn,
+            labelPreferredOwnerName,
 
-                ownerFacePreview,
+            ownerFacePreview,
 
-                groupPreferredCompany,
-                usePreferredCompanyName,
-                changeCompanyNameBtn,
-                labelPreferredCompanyName,
-            };
-        }
+            groupPreferredCompany,
+            usePreferredCompanyName,
+            changeCompanyNameBtn,
+            labelPreferredCompanyName,
+        };
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_company),
@@ -2075,34 +2054,34 @@ namespace OpenLoco::Ui::Windows::Options
 
             if (Config::get().usePreferredOwnerName)
             {
-                self.activatedWidgets |= (1ULL << Widx::usePreferredOwnerName);
+                self.activatedWidgets |= (1ULL << widx::usePreferredOwnerName);
             }
             else
             {
-                self.disabledWidgets |= (1ULL << Widx::changeOwnerNameBtn);
+                self.disabledWidgets |= (1ULL << widx::changeOwnerNameBtn);
             }
 
             if (Config::get().usePreferredOwnerFace)
             {
-                self.activatedWidgets |= (1ULL << Widx::usePreferredOwnerFace);
+                self.activatedWidgets |= (1ULL << widx::usePreferredOwnerFace);
             }
             else
             {
-                self.disabledWidgets |= ((1ULL << Widx::changeOwnerFaceBtn) | (1ULL << Widx::ownerFacePreview));
+                self.disabledWidgets |= ((1ULL << widx::changeOwnerFaceBtn) | (1ULL << widx::ownerFacePreview));
 
-                self.widgets[Widx::labelOwnerFace].text = StringIds::empty;
-                self.widgets[Widx::ownerFacePreview].content = Widget::kContentNull;
+                self.widgets[widx::labelOwnerFace].text = StringIds::empty;
+                self.widgets[widx::ownerFacePreview].content = Widget::kContentNull;
 
                 self.object = nullptr;
             }
 
             if (Config::get().usePreferredCompanyName)
             {
-                self.activatedWidgets |= (1ULL << Widx::usePreferredCompanyName);
+                self.activatedWidgets |= (1ULL << widx::usePreferredCompanyName);
             }
             else
             {
-                self.disabledWidgets |= (1ULL << Widx::changeCompanyNameBtn);
+                self.disabledWidgets |= (1ULL << widx::changeCompanyNameBtn);
             }
 
             // Set preferred owner name.
@@ -2113,7 +2092,7 @@ namespace OpenLoco::Ui::Windows::Options
                 strcpy(buffer, playerName);
                 buffer[strlen(playerName)] = '\0';
 
-                FormatArguments args{ self.widgets[Widx::labelPreferredOwnerName].textArgs };
+                FormatArguments args{ self.widgets[widx::labelPreferredOwnerName].textArgs };
                 args.push(StringIds::buffer_2039);
             }
 
@@ -2122,12 +2101,12 @@ namespace OpenLoco::Ui::Windows::Options
             {
                 const CompetitorObject* competitor = reinterpret_cast<CompetitorObject*>(self.object);
 
-                self.widgets[Widx::labelOwnerFace].text = StringIds::currentPreferredFace;
+                self.widgets[widx::labelOwnerFace].text = StringIds::currentPreferredFace;
 
-                FormatArguments args{ self.widgets[Widx::labelOwnerFace].textArgs };
+                FormatArguments args{ self.widgets[widx::labelOwnerFace].textArgs };
                 args.push(competitor->firstName);
 
-                self.widgets[Widx::ownerFacePreview].image = ImageId(competitor->images[0]).withIndexOffset(1).withPrimary(Colour::black).toUInt32();
+                self.widgets[widx::ownerFacePreview].image = ImageId(competitor->images[0]).withIndexOffset(1).withPrimary(Colour::black).toUInt32();
             }
 
             loadPreferredFace(self);
@@ -2140,7 +2119,7 @@ namespace OpenLoco::Ui::Windows::Options
                 strcpy(buffer, companyName);
                 buffer[strlen(companyName)] = '\0';
 
-                FormatArguments args{ self.widgets[Widx::labelPreferredCompanyName].textArgs };
+                FormatArguments args{ self.widgets[widx::labelPreferredCompanyName].textArgs };
                 args.push(StringIds::buffer_2040);
             }
         }
@@ -2158,7 +2137,7 @@ namespace OpenLoco::Ui::Windows::Options
             strcpy(buffer, playerName);
             buffer[strlen(playerName)] = '\0';
 
-            TextInput::openTextInput(&self, StringIds::preferred_owner_name, StringIds::enter_preferred_owner_name, StringIds::buffer_2039, Widx::usePreferredOwnerName, {});
+            TextInput::openTextInput(&self, StringIds::preferred_owner_name, StringIds::enter_preferred_owner_name, StringIds::buffer_2039, widx::usePreferredOwnerName, {});
         }
 
         // 0x004C135F
@@ -2202,7 +2181,7 @@ namespace OpenLoco::Ui::Windows::Options
             strcpy(buffer, companyName);
             buffer[strlen(companyName)] = '\0';
 
-            TextInput::openTextInput(&self, StringIds::preferred_company_name, StringIds::enter_preferred_company_name, StringIds::buffer_2040, Widx::usePreferredCompanyName, {});
+            TextInput::openTextInput(&self, StringIds::preferred_company_name, StringIds::enter_preferred_company_name, StringIds::buffer_2040, widx::usePreferredCompanyName, {});
         }
 
         static void usePreferredCompanyNameMouseUp(Window& self)
@@ -2228,28 +2207,28 @@ namespace OpenLoco::Ui::Windows::Options
 
             switch (wi)
             {
-                case Widx::usePreferredOwnerName:
+                case widx::usePreferredOwnerName:
                     usePreferredOwnerNameMouseUp(self);
                     break;
 
-                case Widx::changeOwnerNameBtn:
+                case widx::changeOwnerNameBtn:
                     changePreferredName(self);
                     break;
 
-                case Widx::usePreferredOwnerFace:
+                case widx::usePreferredOwnerFace:
                     usePreferredOwnerFaceMouseUp(self);
                     break;
 
-                case Widx::changeOwnerFaceBtn:
-                case Widx::ownerFacePreview:
+                case widx::changeOwnerFaceBtn:
+                case widx::ownerFacePreview:
                     changePreferredFace(self);
                     break;
 
-                case Widx::usePreferredCompanyName:
+                case widx::usePreferredCompanyName:
                     usePreferredCompanyNameMouseUp(self);
                     break;
 
-                case Widx::changeCompanyNameBtn:
+                case widx::changeCompanyNameBtn:
                     changePreferredCompany(self);
                     break;
             }
@@ -2287,11 +2266,11 @@ namespace OpenLoco::Ui::Windows::Options
         {
             switch (i)
             {
-                case Widx::usePreferredOwnerName:
+                case widx::usePreferredOwnerName:
                     setPreferredName(self, str);
                     break;
 
-                case Widx::usePreferredCompanyName:
+                case widx::usePreferredCompanyName:
                     setPreferredCompanyName(self, str);
                     break;
             }
@@ -2324,32 +2303,29 @@ namespace OpenLoco::Ui::Windows::Options
     {
         static constexpr Ui::Size kWindowSize = { 420, 266 };
 
-        namespace Widx
+        enum widx
         {
-            enum
-            {
-                groupCheats = Common::Widx::tab_miscellaneous + 1,
-                enableCheatsToolbarButton,
-                disableAICompanies,
-                disableTownExpansion,
+            groupCheats = Common::widx::tab_miscellaneous + 1,
+            enableCheatsToolbarButton,
+            disableAICompanies,
+            disableTownExpansion,
 
-                groupVehicleBehaviour,
-                disable_vehicle_breakdowns,
-                disable_vehicle_load_penalty,
-                disableStationSizeLimit,
-                trainsReverseAtSignals,
+            groupVehicleBehaviour,
+            disable_vehicle_breakdowns,
+            disable_vehicle_load_penalty,
+            disableStationSizeLimit,
+            trainsReverseAtSignals,
 
-                groupSaveOptions,
-                autosave_frequency_label,
-                autosave_frequency,
-                autosave_frequency_btn,
-                autosave_amount_label,
-                autosave_amount,
-                autosave_amount_down_btn,
-                autosave_amount_up_btn,
-                export_plugin_objects,
-            };
-        }
+            groupSaveOptions,
+            autosave_frequency_label,
+            autosave_frequency,
+            autosave_frequency_btn,
+            autosave_amount_label,
+            autosave_amount,
+            autosave_amount_down_btn,
+            autosave_amount_up_btn,
+            export_plugin_objects,
+        };
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_miscellaneous),
@@ -2396,45 +2372,45 @@ namespace OpenLoco::Ui::Windows::Options
 
             if (Config::get().cheatsMenuEnabled)
             {
-                self.activatedWidgets |= (1ULL << Widx::enableCheatsToolbarButton);
+                self.activatedWidgets |= (1ULL << widx::enableCheatsToolbarButton);
             }
 
             if (Config::get().breakdownsDisabled)
             {
-                self.activatedWidgets |= (1ULL << Widx::disable_vehicle_breakdowns);
+                self.activatedWidgets |= (1ULL << widx::disable_vehicle_breakdowns);
             }
 
             if (Config::get().trainsReverseAtSignals)
             {
-                self.activatedWidgets |= (1ULL << Widx::trainsReverseAtSignals);
+                self.activatedWidgets |= (1ULL << widx::trainsReverseAtSignals);
             }
 
             if (Config::get().disableVehicleLoadPenaltyCheat)
             {
-                self.activatedWidgets |= (1ULL << Widx::disable_vehicle_load_penalty);
+                self.activatedWidgets |= (1ULL << widx::disable_vehicle_load_penalty);
             }
 
             if (Config::get().disableStationSizeLimit)
             {
-                self.activatedWidgets |= (1ULL << Widx::disableStationSizeLimit);
+                self.activatedWidgets |= (1ULL << widx::disableStationSizeLimit);
             }
 
             if (Config::get().companyAIDisabled)
             {
-                self.activatedWidgets |= (1ULL << Widx::disableAICompanies);
+                self.activatedWidgets |= (1ULL << widx::disableAICompanies);
             }
 
             if (Config::get().townGrowthDisabled)
             {
-                self.activatedWidgets |= (1ULL << Widx::disableTownExpansion);
+                self.activatedWidgets |= (1ULL << widx::disableTownExpansion);
             }
 
             if (Config::get().exportObjectsWithSaves)
             {
-                self.activatedWidgets |= (1ULL << Widx::export_plugin_objects);
+                self.activatedWidgets |= (1ULL << widx::export_plugin_objects);
             }
 
-            self.widgets[Widx::export_plugin_objects].hidden = !ObjectManager::getCustomObjectsInIndexStatus();
+            self.widgets[widx::export_plugin_objects].hidden = !ObjectManager::getCustomObjectsInIndexStatus();
         }
 
         static void drawDropdownContent(const Window& self, Gfx::DrawingContext& drawingCtx, WidgetIndex_t widgetIndex, StringId stringId, int32_t value)
@@ -2470,11 +2446,11 @@ namespace OpenLoco::Ui::Windows::Options
                     stringId = StringIds::autosave_every_x_months;
                     break;
             }
-            drawDropdownContent(self, drawingCtx, Widx::autosave_frequency, stringId, freq);
+            drawDropdownContent(self, drawingCtx, widx::autosave_frequency, stringId, freq);
 
             // Value for autosave amount
             auto scale = Config::get().autosaveAmount;
-            drawDropdownContent(self, drawingCtx, Widx::autosave_amount, StringIds::int_32, scale);
+            drawDropdownContent(self, drawingCtx, widx::autosave_amount, StringIds::int_32, scale);
         }
 
         static void changeAutosaveAmount(Window& self, int32_t delta)
@@ -2571,37 +2547,37 @@ namespace OpenLoco::Ui::Windows::Options
 
             switch (wi)
             {
-                case Widx::enableCheatsToolbarButton:
+                case widx::enableCheatsToolbarButton:
                     enableCheatsToolbarButtonMouseUp(self);
                     break;
 
-                case Widx::disable_vehicle_breakdowns:
+                case widx::disable_vehicle_breakdowns:
                     disableVehicleBreakdownsMouseUp(self);
                     break;
 
-                case Widx::trainsReverseAtSignals:
+                case widx::trainsReverseAtSignals:
                     trainsReverseAtSignalsMouseUp(self);
                     break;
 
-                case Widx::disable_vehicle_load_penalty:
+                case widx::disable_vehicle_load_penalty:
                     Config::get().disableVehicleLoadPenaltyCheat = !Config::get().disableVehicleLoadPenaltyCheat;
-                    WindowManager::invalidateWidget(self.type, self.number, Widx::disable_vehicle_load_penalty);
+                    WindowManager::invalidateWidget(self.type, self.number, widx::disable_vehicle_load_penalty);
                     break;
 
-                case Widx::disableStationSizeLimit:
+                case widx::disableStationSizeLimit:
                     Config::get().disableStationSizeLimit ^= true;
-                    WindowManager::invalidateWidget(self.type, self.number, Widx::disableStationSizeLimit);
+                    WindowManager::invalidateWidget(self.type, self.number, widx::disableStationSizeLimit);
                     break;
 
-                case Widx::disableAICompanies:
+                case widx::disableAICompanies:
                     disableAICompaniesMouseUp(self);
                     break;
 
-                case Widx::disableTownExpansion:
+                case widx::disableTownExpansion:
                     disableTownExpansionMouseUp(self);
                     break;
 
-                case Widx::export_plugin_objects:
+                case widx::export_plugin_objects:
                     exportPluginObjectsMouseUp(self);
                     break;
             }
@@ -2611,13 +2587,13 @@ namespace OpenLoco::Ui::Windows::Options
         {
             switch (wi)
             {
-                case Widx::autosave_frequency_btn:
-                    showAutosaveFrequencyDropdown(self, Widx::autosave_frequency);
+                case widx::autosave_frequency_btn:
+                    showAutosaveFrequencyDropdown(self, widx::autosave_frequency);
                     break;
-                case Widx::autosave_amount_down_btn:
+                case widx::autosave_amount_down_btn:
                     changeAutosaveAmount(self, -1);
                     break;
-                case Widx::autosave_amount_up_btn:
+                case widx::autosave_amount_up_btn:
                     changeAutosaveAmount(self, 1);
                     break;
             }
@@ -2627,7 +2603,7 @@ namespace OpenLoco::Ui::Windows::Options
         {
             switch (wi)
             {
-                case Widx::autosave_frequency_btn:
+                case widx::autosave_frequency_btn:
                     handleAutosaveFrequencyDropdown(self, item_index);
                     break;
             }
@@ -2715,14 +2691,14 @@ namespace OpenLoco::Ui::Windows::Options
 
     static void disableTabsByCurrentScene(Window& self)
     {
-        self.disabledWidgets &= ~(1ULL << Common::Widx::tab_regional);
+        self.disabledWidgets &= ~(1ULL << Common::widx::tab_regional);
 
         if (SceneManager::isEditorMode() && Scenario::getOptions().editorStep == EditorController::Step::objectSelection)
         {
-            self.disabledWidgets |= 1ULL << Common::Widx::tab_regional;
+            self.disabledWidgets |= 1ULL << Common::widx::tab_regional;
         }
 
-        Widget::leftAlignTabs(self, Common::Widx::tab_display, Common::Widx::tab_miscellaneous);
+        Widget::leftAlignTabs(self, Common::widx::tab_display, Common::widx::tab_miscellaneous);
     }
 
     // 0x004C1519 & 0x00474911
@@ -2785,7 +2761,7 @@ namespace OpenLoco::Ui::Windows::Options
     {
         auto* window = open();
 
-        window->callOnMouseUp(Common::Widx::tab_audio, window->widgets[Common::Widx::tab_audio].id);
+        window->callOnMouseUp(Common::widx::tab_audio, window->widgets[Common::widx::tab_audio].id);
 
         return window;
     }
@@ -2815,7 +2791,7 @@ namespace OpenLoco::Ui::Windows::Options
         ToolManager::toolCancel(self.type, self.number);
 
         TextInput::sub_4CE6C9(self.type, self.number);
-        self.currentTab = wi - Common::Widx::tab_display;
+        self.currentTab = wi - Common::widx::tab_display;
         self.frameNo = 0;
         self.flags &= ~(WindowFlags::maximised);
         self.disabledWidgets = 0;
@@ -2837,7 +2813,7 @@ namespace OpenLoco::Ui::Windows::Options
 
         else if ((Common::tab)self.currentTab == Common::tab::audio)
         {
-            self.holdableWidgets = (1ULL << AudioTab::Widx::volume_master) | (1ULL << AudioTab::Widx::volume_music) | (1ULL << AudioTab::Widx::volume_effects) | (1ULL << AudioTab::Widx::volume_vehicles) | (1ULL << AudioTab::Widx::volume_ui) | (1ULL << AudioTab::Widx::volume_ambient);
+            self.holdableWidgets = (1ULL << AudioTab::widx::volume_master) | (1ULL << AudioTab::widx::volume_music) | (1ULL << AudioTab::widx::volume_effects) | (1ULL << AudioTab::widx::volume_vehicles) | (1ULL << AudioTab::widx::volume_ui) | (1ULL << AudioTab::widx::volume_ambient);
         }
 
         self.callOnResize();

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -91,6 +91,21 @@ namespace OpenLoco::Ui::Windows::Options
             tab_miscellaneous,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabDisplay{ "tab_display" };
+            constexpr WidgetId kTabRendering{ "tab_rendering" };
+            constexpr WidgetId kTabAudio{ "tab_audio" };
+            constexpr WidgetId kTabRegional{ "tab_regional" };
+            constexpr WidgetId kTabControls{ "tab_controls" };
+            constexpr WidgetId kTabCompany{ "tab_company" };
+            constexpr WidgetId kTabMiscellaneous{ "tab_miscellaneous" };
+        }
+
         enum tab
         {
             display,
@@ -204,19 +219,19 @@ namespace OpenLoco::Ui::Windows::Options
 
         static bool onMouseUp(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
-            switch (wi)
+            switch (id)
             {
-                case widx::close_button:
+                case Widx::kCloseButton:
                     WindowManager::close(&self);
                     return true;
 
-                case widx::tab_display:
-                case widx::tab_rendering:
-                case widx::tab_audio:
-                case widx::tab_regional:
-                case widx::tab_controls:
-                case widx::tab_company:
-                case widx::tab_miscellaneous:
+                case Widx::kTabDisplay:
+                case Widx::kTabRendering:
+                case Widx::kTabAudio:
+                case Widx::kTabRegional:
+                case Widx::kTabControls:
+                case Widx::kTabCompany:
+                case Widx::kTabMiscellaneous:
                     Options::tabOnMouseUp(self, wi);
                     return true;
 
@@ -230,17 +245,17 @@ namespace OpenLoco::Ui::Windows::Options
             constexpr auto kTabWidth = 31;
 
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, windowSize, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { (uint16_t)(windowSize.width - 2), 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
-                Widgets::ImageButton({ (int16_t)(windowSize.width - 15), 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { windowSize.width, 102 }, WindowColour::secondary),
-                Widgets::Tab({ 3 + kTabWidth * 0, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab_display, StringIds::tooltip_display_options),
-                Widgets::Tab({ 3 + kTabWidth * 1, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_options_rendering),
-                Widgets::Tab({ 3 + kTabWidth * 2, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab_sound, StringIds::tooltip_audio_options),
-                Widgets::Tab({ 3 + kTabWidth * 3, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab_globe_0, StringIds::tooltip_regional_options),
-                Widgets::Tab({ 3 + kTabWidth * 4, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab_control, StringIds::tooltip_control_options),
-                Widgets::Tab({ 3 + kTabWidth * 5, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_options),
-                Widgets::Tab({ 3 + kTabWidth * 6, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab_miscellaneous, StringIds::tooltip_miscellaneous_options));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, windowSize, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { (uint16_t)(windowSize.width - 2), 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
+                Widgets::ImageButton(Widx::kCloseButton, { (int16_t)(windowSize.width - 15), 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { windowSize.width, 102 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabDisplay, { 3 + kTabWidth * 0, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab_display, StringIds::tooltip_display_options),
+                Widgets::Tab(Widx::kTabRendering, { 3 + kTabWidth * 1, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_options_rendering),
+                Widgets::Tab(Widx::kTabAudio, { 3 + kTabWidth * 2, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab_sound, StringIds::tooltip_audio_options),
+                Widgets::Tab(Widx::kTabRegional, { 3 + kTabWidth * 3, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab_globe_0, StringIds::tooltip_regional_options),
+                Widgets::Tab(Widx::kTabControls, { 3 + kTabWidth * 4, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab_control, StringIds::tooltip_control_options),
+                Widgets::Tab(Widx::kTabCompany, { 3 + kTabWidth * 5, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_options),
+                Widgets::Tab(Widx::kTabMiscellaneous, { 3 + kTabWidth * 6, 15 }, { kTabWidth, 27 }, WindowColour::secondary, ImageIds::tab_miscellaneous, StringIds::tooltip_miscellaneous_options));
         }
     }
 
@@ -267,23 +282,37 @@ namespace OpenLoco::Ui::Windows::Options
             show_fps,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kScreenMode{ "screen_mode" };
+            constexpr WidgetId kScreenModeBtn{ "screen_mode_btn" };
+            constexpr WidgetId kDisplayResolution{ "display_resolution" };
+            constexpr WidgetId kDisplayResolutionBtn{ "display_resolution_btn" };
+            constexpr WidgetId kDisplayScale{ "display_scale" };
+            constexpr WidgetId kDisplayScaleDownBtn{ "display_scale_down_btn" };
+            constexpr WidgetId kDisplayScaleUpBtn{ "display_scale_up_btn" };
+            constexpr WidgetId kFrameLimit{ "frame_limit" };
+            constexpr WidgetId kFrameLimitBtn{ "frame_limit_btn" };
+            constexpr WidgetId kShowFps{ "show_fps" };
+        }
+
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_display),
             Widgets::GroupBox({ 4, 49 }, { 392, 97 }, WindowColour::secondary, StringIds::frame_hardware),
 
             Widgets::Label({ 10, 63 }, { 215, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::options_screen_mode),
-            Widgets::dropdownWidgets({ 235, 63 }, { 154, 12 }, WindowColour::secondary, StringIds::empty),
+            Widgets::dropdownWidgets(Widx::kScreenMode, Widx::kScreenModeBtn, { 235, 63 }, { 154, 12 }, WindowColour::secondary, StringIds::empty),
 
             Widgets::Label({ 10, 79 }, { 215, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::display_resolution),
-            Widgets::dropdownWidgets({ 235, 79 }, { 154, 12 }, WindowColour::secondary, StringIds::display_resolution_dropdown_format),
+            Widgets::dropdownWidgets(Widx::kDisplayResolution, Widx::kDisplayResolutionBtn, { 235, 79 }, { 154, 12 }, WindowColour::secondary, StringIds::display_resolution_dropdown_format),
 
             Widgets::Label({ 10, 95 }, { 215, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::window_scale_factor),
-            Widgets::stepperWidgets({ 235, 95 }, { 154, 12 }, WindowColour::secondary, StringIds::scale_formatted),
+            Widgets::stepperWidgets(Widx::kDisplayScale, Widx::kDisplayScaleDownBtn, Widx::kDisplayScaleUpBtn, { 235, 95 }, { 154, 12 }, WindowColour::secondary, StringIds::scale_formatted),
 
             Widgets::Label({ 10, 111 }, { 215, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::frameRateLimitLabel),
-            Widgets::dropdownWidgets({ 235, 111 }, { 154, 12 }, WindowColour::secondary, StringIds::empty),
+            Widgets::dropdownWidgets(Widx::kFrameLimit, Widx::kFrameLimitBtn, { 235, 111 }, { 154, 12 }, WindowColour::secondary, StringIds::empty),
 
-            Widgets::Checkbox({ 10, 127 }, { 380, 12 }, WindowColour::secondary, StringIds::option_show_fps_counter, StringIds::option_show_fps_counter_tooltip)
+            Widgets::Checkbox(Widx::kShowFps, { 10, 127 }, { 380, 12 }, WindowColour::secondary, StringIds::option_show_fps_counter, StringIds::option_show_fps_counter_tooltip)
 
         );
 
@@ -295,9 +324,9 @@ namespace OpenLoco::Ui::Windows::Options
                 return;
             }
 
-            switch (wi)
+            switch (id)
             {
-                case widx::show_fps:
+                case Widx::kShowFps:
                 {
                     auto& cfg = OpenLoco::Config::get();
                     cfg.showFPS ^= 1;
@@ -449,38 +478,38 @@ namespace OpenLoco::Ui::Windows::Options
         // 0x004BFBB7
         static void onMouseDown(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
         {
-            switch (wi)
+            switch (id)
             {
-                case widx::screen_mode_btn:
+                case Widx::kScreenModeBtn:
                     screenModeMouseDown(self, wi);
                     break;
-                case widx::display_resolution_btn:
+                case Widx::kDisplayResolutionBtn:
                     resolutionMouseDown(self, wi);
                     break;
-                case widx::display_scale_down_btn:
+                case Widx::kDisplayScaleDownBtn:
                     displayScaleMouseDown(self, wi, -OpenLoco::Ui::ScaleFactor::step);
                     break;
-                case widx::display_scale_up_btn:
+                case Widx::kDisplayScaleUpBtn:
                     displayScaleMouseDown(self, wi, OpenLoco::Ui::ScaleFactor::step);
                     break;
-                case widx::frame_limit_btn:
+                case Widx::kFrameLimitBtn:
                     frameLimitMouseDown(self, wi);
                     break;
             }
         }
 
         // 0x004BFBE8
-        static void onDropdown(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id, int16_t item_index)
+        static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t wi, const WidgetId id, int16_t item_index)
         {
-            switch (wi)
+            switch (id)
             {
-                case widx::screen_mode_btn:
+                case Widx::kScreenModeBtn:
                     screenModeDropdown(self, item_index);
                     break;
-                case widx::display_resolution_btn:
+                case Widx::kDisplayResolutionBtn:
                     resolutionDropdown(self, item_index);
                     break;
-                case widx::frame_limit_btn:
+                case Widx::kFrameLimitBtn:
                     frameLimitDropdown(self, item_index);
                     break;
             }
@@ -631,27 +660,43 @@ namespace OpenLoco::Ui::Windows::Options
             window_frame_style_btn,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kVehiclesMinScale{ "vehicles_min_scale" };
+            constexpr WidgetId kVehiclesMinScaleBtn{ "vehicles_min_scale_btn" };
+            constexpr WidgetId kStationNamesMinScale{ "station_names_min_scale" };
+            constexpr WidgetId kStationNamesMinScaleBtn{ "station_names_min_scale_btn" };
+            constexpr WidgetId kConstructionMarker{ "construction_marker" };
+            constexpr WidgetId kConstructionMarkerBtn{ "construction_marker_btn" };
+            constexpr WidgetId kLandscapeSmoothing{ "landscape_smoothing" };
+            constexpr WidgetId kGridlinesOnLandscape{ "gridlines_on_landscape" };
+            constexpr WidgetId kCashPopupRendering{ "cash_popup_rendering" };
+            constexpr WidgetId kShowCompanyAiPlanning{ "show_company_ai_planning" };
+            constexpr WidgetId kWindowFrameStyle{ "window_frame_style" };
+            constexpr WidgetId kWindowFrameStyleBtn{ "window_frame_style_btn" };
+        }
+
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::title_options_rendering),
             Widgets::GroupBox({ 4, 49 }, { 392, 128 }, WindowColour::secondary, StringIds::frame_map_rendering),
 
             Widgets::Label({ 10, 63 }, { 215, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::vehicles_min_scale),
-            Widgets::dropdownWidgets({ 235, 63 }, { 154, 12 }, WindowColour::secondary, StringIds::empty, StringIds::vehicles_min_scale_tip),
+            Widgets::dropdownWidgets(Widx::kVehiclesMinScale, Widx::kVehiclesMinScaleBtn, { 235, 63 }, { 154, 12 }, WindowColour::secondary, StringIds::empty, StringIds::vehicles_min_scale_tip),
 
             Widgets::Label({ 10, 79 }, { 215, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::station_names_min_scale),
-            Widgets::dropdownWidgets({ 235, 79 }, { 154, 12 }, WindowColour::secondary, StringIds::empty, StringIds::station_names_min_scale_tip),
+            Widgets::dropdownWidgets(Widx::kStationNamesMinScale, Widx::kStationNamesMinScaleBtn, { 235, 79 }, { 154, 12 }, WindowColour::secondary, StringIds::empty, StringIds::station_names_min_scale_tip),
 
             Widgets::Label({ 10, 95 }, { 215, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::construction_marker),
-            Widgets::dropdownWidgets({ 235, 95 }, { 154, 12 }, WindowColour::secondary, StringIds::empty),
+            Widgets::dropdownWidgets(Widx::kConstructionMarker, Widx::kConstructionMarkerBtn, { 235, 95 }, { 154, 12 }, WindowColour::secondary, StringIds::empty),
 
-            Widgets::Checkbox({ 10, 110 }, { 346, 12 }, WindowColour::secondary, StringIds::landscape_smoothing, StringIds::landscape_smoothing_tip),
-            Widgets::Checkbox({ 10, 126 }, { 346, 12 }, WindowColour::secondary, StringIds::gridlines_on_landscape, StringIds::gridlines_on_landscape_tip),
-            Widgets::Checkbox({ 10, 142 }, { 346, 12 }, WindowColour::secondary, StringIds::cash_popup_rendering, StringIds::tooltip_cash_popup_rendering),
-            Widgets::Checkbox({ 10, 158 }, { 346, 12 }, WindowColour::secondary, StringIds::show_company_ai_planning, StringIds::show_company_ai_planning_tip),
+            Widgets::Checkbox(Widx::kLandscapeSmoothing, { 10, 110 }, { 346, 12 }, WindowColour::secondary, StringIds::landscape_smoothing, StringIds::landscape_smoothing_tip),
+            Widgets::Checkbox(Widx::kGridlinesOnLandscape, { 10, 126 }, { 346, 12 }, WindowColour::secondary, StringIds::gridlines_on_landscape, StringIds::gridlines_on_landscape_tip),
+            Widgets::Checkbox(Widx::kCashPopupRendering, { 10, 142 }, { 346, 12 }, WindowColour::secondary, StringIds::cash_popup_rendering, StringIds::tooltip_cash_popup_rendering),
+            Widgets::Checkbox(Widx::kShowCompanyAiPlanning, { 10, 158 }, { 346, 12 }, WindowColour::secondary, StringIds::show_company_ai_planning, StringIds::show_company_ai_planning_tip),
 
             Widgets::GroupBox({ 4, 180 }, { 392, 32 }, WindowColour::secondary, StringIds::userInterfaceGroup),
             Widgets::Label({ 10, 195 }, { 215, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::windowFrameStyle),
-            Widgets::dropdownWidgets({ 235, 194 }, { 154, 12 }, WindowColour::secondary, StringIds::empty, StringIds::windowFrameStyleTip)
+            Widgets::dropdownWidgets(Widx::kWindowFrameStyle, Widx::kWindowFrameStyleBtn, { 235, 194 }, { 154, 12 }, WindowColour::secondary, StringIds::empty, StringIds::windowFrameStyleTip)
 
         );
 
@@ -663,9 +708,9 @@ namespace OpenLoco::Ui::Windows::Options
                 return;
             }
 
-            switch (wi)
+            switch (id)
             {
-                case widx::landscape_smoothing:
+                case Widx::kLandscapeSmoothing:
                 {
                     auto& cfg = OpenLoco::Config::get();
                     cfg.landscapeSmoothing ^= true;
@@ -674,7 +719,7 @@ namespace OpenLoco::Ui::Windows::Options
                     return;
                 }
 
-                case widx::gridlines_on_landscape:
+                case Widx::kGridlinesOnLandscape:
                 {
                     auto& cfg = OpenLoco::Config::get();
                     cfg.gridlinesOnLandscape ^= true;
@@ -695,7 +740,7 @@ namespace OpenLoco::Ui::Windows::Options
                     return;
                 }
 
-                case widx::cash_popup_rendering:
+                case Widx::kCashPopupRendering:
                 {
                     auto& cfg = OpenLoco::Config::get();
                     cfg.cashPopupRendering = !cfg.cashPopupRendering;
@@ -704,7 +749,7 @@ namespace OpenLoco::Ui::Windows::Options
                     return;
                 }
 
-                case widx::show_company_ai_planning:
+                case Widx::kShowCompanyAiPlanning:
                 {
                     auto& cfg = OpenLoco::Config::get();
                     cfg.showAiPlanningAsGhosts = !cfg.showAiPlanningAsGhosts;
@@ -844,40 +889,40 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004BFBB7
-        static void onMouseDown(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, WidgetIndex_t wi, const WidgetId id)
         {
-            switch (wi)
+            switch (id)
             {
-                case widx::construction_marker_btn:
+                case Widx::kConstructionMarkerBtn:
                     constructionMarkerMouseDown(self, wi);
                     break;
-                case widx::vehicles_min_scale_btn:
+                case Widx::kVehiclesMinScaleBtn:
                     vehicleZoomMouseDown(self, wi);
                     break;
-                case widx::station_names_min_scale_btn:
+                case Widx::kStationNamesMinScaleBtn:
                     stationNamesScaleMouseDown(self, wi);
                     break;
-                case widx::window_frame_style_btn:
+                case Widx::kWindowFrameStyleBtn:
                     windowFrameStyleMouseDown(self, wi);
                     break;
             }
         }
 
         // 0x004BFBE8
-        static void onDropdown([[maybe_unused]] Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id, int16_t item_index)
+        static void onDropdown([[maybe_unused]] Window& self, [[maybe_unused]] WidgetIndex_t wi, const WidgetId id, int16_t item_index)
         {
-            switch (wi)
+            switch (id)
             {
-                case widx::construction_marker_btn:
+                case Widx::kConstructionMarkerBtn:
                     constructionMarkerDropdown(item_index);
                     break;
-                case widx::vehicles_min_scale_btn:
+                case Widx::kVehiclesMinScaleBtn:
                     vehicleZoomDropdown(item_index);
                     break;
-                case widx::station_names_min_scale_btn:
+                case Widx::kStationNamesMinScaleBtn:
                     stationNamesScaleDropdown(item_index);
                     break;
-                case widx::window_frame_style_btn:
+                case Widx::kWindowFrameStyleBtn:
                     windowFrameStyleDropdown(item_index);
                     break;
             }
@@ -1023,6 +1068,21 @@ namespace OpenLoco::Ui::Windows::Options
             open_jukebox,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kAudioDevice{ "audio_device" };
+            constexpr WidgetId kAudioDeviceBtn{ "audio_device_btn" };
+            constexpr WidgetId kPlayTitleMusic{ "play_title_music" };
+            constexpr WidgetId kVolumeMaster{ "volume_master" };
+            constexpr WidgetId kVolumeMusic{ "volume_music" };
+            constexpr WidgetId kVolumeEffects{ "volume_effects" };
+            constexpr WidgetId kVolumeVehicles{ "volume_vehicles" };
+            constexpr WidgetId kVolumeUi{ "volume_ui" };
+            constexpr WidgetId kVolumeAmbient{ "volume_ambient" };
+            constexpr WidgetId kPlayGameMusic{ "play_game_music" };
+            constexpr WidgetId kOpenJukebox{ "open_jukebox" };
+        }
+
         static constexpr int32_t getSliderRowY(uint8_t num)
         {
             return kVolumeGroupOffset + kVolumeFirstSliderYOffset + (kSliderRowHeight * (num / 2));
@@ -1032,26 +1092,26 @@ namespace OpenLoco::Ui::Windows::Options
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_audio),
 
             Widgets::GroupBox({ 4, kSoundGroupOffset }, { kWindowSize.width - 8, kSoundGroupHeight }, WindowColour::secondary, StringIds::frame_sound),
-            Widgets::dropdownWidgets({ 10, kSoundGroupOffset + kDeviceRowOffset }, { 346, 12 }, WindowColour::secondary, StringIds::stringid),
+            Widgets::dropdownWidgets(Widx::kAudioDevice, Widx::kAudioDeviceBtn, { 10, kSoundGroupOffset + kDeviceRowOffset }, { 346, 12 }, WindowColour::secondary, StringIds::stringid),
 
             Widgets::GroupBox({ 4, kVolumeGroupOffset }, { kWindowSize.width - 8, kVolumeGroupHeight }, WindowColour::secondary, StringIds::frame_volume),
             Widgets::Label({ kSliderPrimaryLabelX, getSliderRowY(0) + 3 }, { kSliderLabelWidth, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::master_volume),
-            Widgets::Slider({ kSliderPrimaryX, getSliderRowY(0) - 3 }, { kSliderWidth, 18 }, WindowColour::secondary, Widget::kContentNull, StringIds::set_master_volume_tip),
+            Widgets::Slider(Widx::kVolumeMaster, { kSliderPrimaryX, getSliderRowY(0) - 3 }, { kSliderWidth, 18 }, WindowColour::secondary, Widget::kContentNull, StringIds::set_master_volume_tip),
             Widgets::Label({ kSliderSecondaryLabelX, getSliderRowY(1) + 3 }, { kSliderLabelWidth, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::music_channel_volume),
-            Widgets::Slider({ kSliderSecondaryX, getSliderRowY(1) - 3 }, { kSliderWidth, 18 }, WindowColour::secondary, Widget::kContentNull, StringIds::set_music_channel_volume_tip),
+            Widgets::Slider(Widx::kVolumeMusic, { kSliderSecondaryX, getSliderRowY(1) - 3 }, { kSliderWidth, 18 }, WindowColour::secondary, Widget::kContentNull, StringIds::set_music_channel_volume_tip),
             Widgets::Label({ kSliderPrimaryLabelX, getSliderRowY(2) + 3 }, { kSliderLabelWidth, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::effects_volume),
-            Widgets::Slider({ kSliderPrimaryX, getSliderRowY(2) - 3 }, { kSliderWidth, 18 }, WindowColour::secondary, Widget::kContentNull, StringIds::set_effects_volume_tip),
+            Widgets::Slider(Widx::kVolumeEffects, { kSliderPrimaryX, getSliderRowY(2) - 3 }, { kSliderWidth, 18 }, WindowColour::secondary, Widget::kContentNull, StringIds::set_effects_volume_tip),
             Widgets::Label({ kSliderSecondaryLabelX, getSliderRowY(3) + 3 }, { kSliderLabelWidth, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::vehicles_volume),
-            Widgets::Slider({ kSliderSecondaryX, getSliderRowY(3) - 3 }, { kSliderWidth, 18 }, WindowColour::secondary, Widget::kContentNull, StringIds::set_vehicles_volume_tip),
+            Widgets::Slider(Widx::kVolumeVehicles, { kSliderSecondaryX, getSliderRowY(3) - 3 }, { kSliderWidth, 18 }, WindowColour::secondary, Widget::kContentNull, StringIds::set_vehicles_volume_tip),
             Widgets::Label({ kSliderPrimaryLabelX, getSliderRowY(4) + 3 }, { kSliderLabelWidth, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::ui_volume),
-            Widgets::Slider({ kSliderPrimaryX, getSliderRowY(4) - 3 }, { kSliderWidth, 18 }, WindowColour::secondary, Widget::kContentNull, StringIds::set_ui_volume_tip),
+            Widgets::Slider(Widx::kVolumeUi, { kSliderPrimaryX, getSliderRowY(4) - 3 }, { kSliderWidth, 18 }, WindowColour::secondary, Widget::kContentNull, StringIds::set_ui_volume_tip),
             Widgets::Label({ kSliderSecondaryLabelX, getSliderRowY(5) + 3 }, { kSliderLabelWidth, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::ambient_volume),
-            Widgets::Slider({ kSliderSecondaryX, getSliderRowY(5) - 3 }, { kSliderWidth, 18 }, WindowColour::secondary, Widget::kContentNull, StringIds::set_ambient_volume_tip),
+            Widgets::Slider(Widx::kVolumeAmbient, { kSliderSecondaryX, getSliderRowY(5) - 3 }, { kSliderWidth, 18 }, WindowColour::secondary, Widget::kContentNull, StringIds::set_ambient_volume_tip),
 
             Widgets::GroupBox({ 4, kMusicGroupOffset }, { kWindowSize.width - 8, kMusicGroupHeight }, WindowColour::secondary, StringIds::frame_music),
-            Widgets::Checkbox({ 10, kMusicGroupOffset + kPlayTitleMusicRowOffset }, { 346, 12 }, WindowColour::secondary, StringIds::play_title_music),
-            Widgets::Checkbox({ 10, kMusicGroupOffset + kPlayGameMusicRowOffset }, { 173, 12 }, WindowColour::secondary, StringIds::play_game_music),
-            Widgets::Button({ 236, kMusicGroupOffset + kPlayGameMusicRowOffset }, { 120, 12 }, WindowColour::secondary, StringIds::options_open_jukebox)
+            Widgets::Checkbox(Widx::kPlayTitleMusic, { 10, kMusicGroupOffset + kPlayTitleMusicRowOffset }, { 346, 12 }, WindowColour::secondary, StringIds::play_title_music),
+            Widgets::Checkbox(Widx::kPlayGameMusic, { 10, kMusicGroupOffset + kPlayGameMusicRowOffset }, { 173, 12 }, WindowColour::secondary, StringIds::play_game_music),
+            Widgets::Button(Widx::kOpenJukebox, { 236, kMusicGroupOffset + kPlayGameMusicRowOffset }, { 120, 12 }, WindowColour::secondary, StringIds::options_open_jukebox)
 
         );
 
@@ -1123,52 +1183,52 @@ namespace OpenLoco::Ui::Windows::Options
             drawVolumeSlider(self, drawingCtx, widx::volume_ambient, Audio::getChannelVolume(Audio::ChannelId::ambient));
         }
 
-        static void onMouseUp(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t wi, const WidgetId id)
         {
             if (Common::onMouseUp(self, wi, id))
             {
                 return;
             }
 
-            switch (wi)
+            switch (id)
             {
-                case widx::play_title_music:
+                case Widx::kPlayTitleMusic:
                     playTitleMusicOnMouseUp(self);
                     return;
 
-                case widx::play_game_music:
+                case Widx::kPlayGameMusic:
                     playGameMusicOnMouseUp(self);
                     return;
 
-                case widx::open_jukebox:
+                case Widx::kOpenJukebox:
                     MusicJukebox::open();
                     return;
             }
         }
 
-        static void onMouseDown(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, WidgetIndex_t wi, const WidgetId id)
         {
-            switch (wi)
+            switch (id)
             {
-                case widx::audio_device_btn:
+                case Widx::kAudioDeviceBtn:
                     audioDeviceMouseDown(self);
                     break;
-                case widx::volume_master:
-                case widx::volume_music:
-                case widx::volume_effects:
-                case widx::volume_vehicles:
-                case widx::volume_ui:
-                case widx::volume_ambient:
+                case Widx::kVolumeMaster:
+                case Widx::kVolumeMusic:
+                case Widx::kVolumeEffects:
+                case Widx::kVolumeVehicles:
+                case Widx::kVolumeUi:
+                case Widx::kVolumeAmbient:
                     volumeSliderMouseDown(self, wi);
                     break;
             }
         }
 
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::audio_device_btn:
+                case Widx::kAudioDeviceBtn:
                     audioDeviceDropdown(self, itemIndex);
                     break;
             }
@@ -1377,26 +1437,42 @@ namespace OpenLoco::Ui::Windows::Options
             preferred_currency_always
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kLanguage{ "language" };
+            constexpr WidgetId kLanguageBtn{ "language_btn" };
+            constexpr WidgetId kDistanceSpeed{ "distance_speed" };
+            constexpr WidgetId kDistanceSpeedBtn{ "distance_speed_btn" };
+            constexpr WidgetId kHeights{ "heights" };
+            constexpr WidgetId kHeightsBtn{ "heights_btn" };
+            constexpr WidgetId kCurrency{ "currency" };
+            constexpr WidgetId kCurrencyBtn{ "currency_btn" };
+            constexpr WidgetId kPreferredCurrency{ "preferred_currency" };
+            constexpr WidgetId kPreferredCurrencyBtn{ "preferred_currency_btn" };
+            constexpr WidgetId kPreferredCurrencyForNewGames{ "preferred_currency_for_new_games" };
+            constexpr WidgetId kPreferredCurrencyAlways{ "preferred_currency_always" };
+        }
+
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_regional),
 
             Widgets::Label({ 10, 49 }, { 173, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::options_language),
-            Widgets::dropdownWidgets({ 183, 49 }, { 173, 12 }, WindowColour::secondary, StringIds::stringptr),
+            Widgets::dropdownWidgets(Widx::kLanguage, Widx::kLanguageBtn, { 183, 49 }, { 173, 12 }, WindowColour::secondary, StringIds::stringptr),
 
             Widgets::Label({ 10, 69 }, { 173, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::distance_and_speed),
-            Widgets::dropdownWidgets({ 183, 69 }, { 173, 12 }, WindowColour::secondary, StringIds::stringid),
+            Widgets::dropdownWidgets(Widx::kDistanceSpeed, Widx::kDistanceSpeedBtn, { 183, 69 }, { 173, 12 }, WindowColour::secondary, StringIds::stringid),
 
             Widgets::Label({ 10, 84 }, { 173, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::heights),
-            Widgets::dropdownWidgets({ 183, 84 }, { 173, 12 }, WindowColour::secondary, StringIds::stringid),
+            Widgets::dropdownWidgets(Widx::kHeights, Widx::kHeightsBtn, { 183, 84 }, { 173, 12 }, WindowColour::secondary, StringIds::stringid),
 
             Widgets::Label({ 10, 104 }, { 173, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::current_game_currency),
-            Widgets::dropdownWidgets({ 183, 104 }, { 173, 12 }, WindowColour::secondary, StringIds::stringid, StringIds::current_game_currency_tip),
+            Widgets::dropdownWidgets(Widx::kCurrency, Widx::kCurrencyBtn, { 183, 104 }, { 173, 12 }, WindowColour::secondary, StringIds::stringid, StringIds::current_game_currency_tip),
 
             Widgets::Label({ 10, 119 }, { 173, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::new_game_currency),
-            Widgets::dropdownWidgets({ 183, 119 }, { 173, 12 }, WindowColour::secondary, StringIds::preferred_currency_buffer, StringIds::new_game_currency_tip),
+            Widgets::dropdownWidgets(Widx::kPreferredCurrency, Widx::kPreferredCurrencyBtn, { 183, 119 }, { 173, 12 }, WindowColour::secondary, StringIds::preferred_currency_buffer, StringIds::new_game_currency_tip),
 
-            Widgets::Checkbox({ 10, 134 }, { 346, 12 }, WindowColour::secondary, StringIds::use_preferred_currency_new_game, StringIds::use_preferred_currency_new_game_tip),
-            Widgets::Checkbox({ 10, 148 }, { 346, 12 }, WindowColour::secondary, StringIds::use_preferred_currency_always, StringIds::use_preferred_currency_always_tip)
+            Widgets::Checkbox(Widx::kPreferredCurrencyForNewGames, { 10, 134 }, { 346, 12 }, WindowColour::secondary, StringIds::use_preferred_currency_new_game, StringIds::use_preferred_currency_new_game_tip),
+            Widgets::Checkbox(Widx::kPreferredCurrencyAlways, { 10, 148 }, { 346, 12 }, WindowColour::secondary, StringIds::use_preferred_currency_always, StringIds::use_preferred_currency_always_tip)
 
         );
 
@@ -1481,70 +1557,70 @@ namespace OpenLoco::Ui::Windows::Options
             self.draw(drawingCtx);
         }
 
-        static void onMouseUp(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t wi, const WidgetId id)
         {
             if (Common::onMouseUp(self, wi, id))
             {
                 return;
             }
 
-            switch (wi)
+            switch (id)
             {
-                case widx::preferred_currency_for_new_games:
+                case Widx::kPreferredCurrencyForNewGames:
                     preferredCurrencyNewGameMouseUp(self);
                     return;
 
-                case widx::preferred_currency_always:
+                case Widx::kPreferredCurrencyAlways:
                     preferredCurrencyAlwaysMouseUp(self);
                     return;
             }
         }
 
         // 0x004BFBB7
-        static void onMouseDown(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t wi, const WidgetId id)
         {
-            switch (wi)
+            switch (id)
             {
-                case widx::language_btn:
+                case Widx::kLanguageBtn:
                     languageMouseDown(self);
                     break;
-                case widx::heights_btn:
+                case Widx::kHeightsBtn:
                     heightsLabelsMouseDown(self);
                     break;
-                case widx::distance_speed_btn:
+                case Widx::kDistanceSpeedBtn:
                     distanceSpeedMouseDown(self);
                     break;
-                case widx::currency_btn:
+                case Widx::kCurrencyBtn:
                     currencyMouseDown(self);
                     break;
-                case widx::preferred_currency_btn:
+                case Widx::kPreferredCurrencyBtn:
                     preferredCurrencyMouseDown(self);
                     break;
             }
         }
 
         // 0x004C0C4A
-        static void onDropdown(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Ui::Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::language_btn:
+                case Widx::kLanguageBtn:
                     languageDropdown(self, itemIndex);
                     break;
 
-                case widx::heights_btn:
+                case Widx::kHeightsBtn:
                     heightsLabelsDropdown(self, itemIndex);
                     break;
 
-                case widx::distance_speed_btn:
+                case Widx::kDistanceSpeedBtn:
                     distanceSpeedDropdown(self, itemIndex);
                     break;
 
-                case widx::currency_btn:
+                case Widx::kCurrencyBtn:
                     currencyDropdown(self, itemIndex);
                     break;
 
-                case widx::preferred_currency_btn:
+                case Widx::kPreferredCurrencyBtn:
                     preferredCurrencyDropdown(self, itemIndex);
                     break;
             }
@@ -1827,14 +1903,22 @@ namespace OpenLoco::Ui::Windows::Options
             customize_keys
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kEdgeScrolling{ "edge_scrolling" };
+            constexpr WidgetId kZoomToCursor{ "zoom_to_cursor" };
+            constexpr WidgetId kInvertRightMouseViewPan{ "invert_right_mouse_view_pan" };
+            constexpr WidgetId kCustomizeKeys{ "customize_keys" };
+        }
+
         static constexpr Ui::Size kWindowSize = { 366, 114 };
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_controls),
-            Widgets::Checkbox({ 10, 49 }, { 346, 12 }, WindowColour::secondary, StringIds::scroll_screen_edge, StringIds::scroll_screen_edge_tip),
-            Widgets::Checkbox({ 10, 64 }, { 346, 12 }, WindowColour::secondary, StringIds::zoom_to_cursor, StringIds::zoom_to_cursor_tip),
-            Widgets::Checkbox({ 10, 79 }, { 346, 12 }, WindowColour::secondary, StringIds::invert_right_mouse_dragging, StringIds::tooltip_invert_right_mouse_dragging),
-            Widgets::Button({ 26, 94 }, { 160, 12 }, WindowColour::secondary, StringIds::customise_keys, StringIds::customise_keys_tip)
+            Widgets::Checkbox(Widx::kEdgeScrolling, { 10, 49 }, { 346, 12 }, WindowColour::secondary, StringIds::scroll_screen_edge, StringIds::scroll_screen_edge_tip),
+            Widgets::Checkbox(Widx::kZoomToCursor, { 10, 64 }, { 346, 12 }, WindowColour::secondary, StringIds::zoom_to_cursor, StringIds::zoom_to_cursor_tip),
+            Widgets::Checkbox(Widx::kInvertRightMouseViewPan, { 10, 79 }, { 346, 12 }, WindowColour::secondary, StringIds::invert_right_mouse_dragging, StringIds::tooltip_invert_right_mouse_dragging),
+            Widgets::Button(Widx::kCustomizeKeys, { 26, 94 }, { 160, 12 }, WindowColour::secondary, StringIds::customise_keys, StringIds::customise_keys_tip)
 
         );
 
@@ -1878,21 +1962,21 @@ namespace OpenLoco::Ui::Windows::Options
                 return;
             }
 
-            switch (wi)
+            switch (id)
             {
-                case widx::customize_keys:
+                case Widx::kCustomizeKeys:
                     openKeyboardShortcuts();
                     break;
 
-                case widx::edge_scrolling:
+                case Widx::kEdgeScrolling:
                     edgeScrollingMouseUp(self);
                     break;
 
-                case widx::zoom_to_cursor:
+                case Widx::kZoomToCursor:
                     zoomToCursorMouseUp(self);
                     break;
 
-                case widx::invert_right_mouse_view_pan:
+                case Widx::kInvertRightMouseViewPan:
                     invertRightMouseViewPan(self);
                     break;
             }
@@ -1978,6 +2062,20 @@ namespace OpenLoco::Ui::Windows::Options
             labelPreferredCompanyName,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kUsePreferredOwnerFace{ "usePreferredOwnerFace" };
+            constexpr WidgetId kChangeOwnerFaceBtn{ "changeOwnerFaceBtn" };
+            constexpr WidgetId kLabelOwnerFace{ "labelOwnerFace" };
+            constexpr WidgetId kUsePreferredOwnerName{ "usePreferredOwnerName" };
+            constexpr WidgetId kChangeOwnerNameBtn{ "changeOwnerNameBtn" };
+            constexpr WidgetId kLabelPreferredOwnerName{ "labelPreferredOwnerName" };
+            constexpr WidgetId kOwnerFacePreview{ "ownerFacePreview" };
+            constexpr WidgetId kUsePreferredCompanyName{ "usePreferredCompanyName" };
+            constexpr WidgetId kChangeCompanyNameBtn{ "changeCompanyNameBtn" };
+            constexpr WidgetId kLabelPreferredCompanyName{ "labelPreferredCompanyName" };
+        }
+
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_company),
 
@@ -1985,25 +2083,25 @@ namespace OpenLoco::Ui::Windows::Options
             Widgets::GroupBox({ 4, 50 }, { 412, 80 }, WindowColour::secondary, StringIds::preferred_owner_name),
 
             // Preferred owner face
-            Widgets::Checkbox({ 10, 64 }, { 400, 12 }, WindowColour::secondary, StringIds::usePreferredCompanyFace, StringIds::usePreferredCompanyFaceTip),
-            Widgets::Button({ 265, 79 }, { 75, 12 }, WindowColour::secondary, StringIds::change),
-            Widgets::Label({ 24, 79 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::currentPreferredFace),
+            Widgets::Checkbox(Widx::kUsePreferredOwnerFace, { 10, 64 }, { 400, 12 }, WindowColour::secondary, StringIds::usePreferredCompanyFace, StringIds::usePreferredCompanyFaceTip),
+            Widgets::Button(Widx::kChangeOwnerFaceBtn, { 265, 79 }, { 75, 12 }, WindowColour::secondary, StringIds::change),
+            Widgets::Label(Widx::kLabelOwnerFace, { 24, 79 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::currentPreferredFace),
 
             // Preferred owner name
-            Widgets::Checkbox({ 10, 97 }, { 400, 12 }, WindowColour::secondary, StringIds::use_preferred_owner_name, StringIds::use_preferred_owner_name_tip),
-            Widgets::Button({ 265, 112 }, { 75, 12 }, WindowColour::secondary, StringIds::change),
-            Widgets::Label({ 24, 112 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::wcolour2_preferred_owner_name),
+            Widgets::Checkbox(Widx::kUsePreferredOwnerName, { 10, 97 }, { 400, 12 }, WindowColour::secondary, StringIds::use_preferred_owner_name, StringIds::use_preferred_owner_name_tip),
+            Widgets::Button(Widx::kChangeOwnerNameBtn, { 265, 112 }, { 75, 12 }, WindowColour::secondary, StringIds::change),
+            Widgets::Label(Widx::kLabelPreferredOwnerName, { 24, 112 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::wcolour2_preferred_owner_name),
 
             // Preferred owner preview
-            Widgets::ImageButton({ 345, 59 }, { 66, 66 }, WindowColour::secondary, Widget::kContentNull),
+            Widgets::ImageButton(Widx::kOwnerFacePreview, { 345, 59 }, { 66, 66 }, WindowColour::secondary, Widget::kContentNull),
 
             // Preferred company group
             Widgets::GroupBox({ 4, 135 }, { 412, 47 }, WindowColour::secondary, StringIds::preferred_company_name),
 
             // Preferred company name
-            Widgets::Checkbox({ 10, 149 }, { 400, 12 }, WindowColour::secondary, StringIds::use_preferred_company_name, StringIds::use_preferred_company_name_tip),
-            Widgets::Button({ 265, 164 }, { 75, 12 }, WindowColour::secondary, StringIds::change),
-            Widgets::Label({ 24, 164 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::wcolour2_preferred_company_name)
+            Widgets::Checkbox(Widx::kUsePreferredCompanyName, { 10, 149 }, { 400, 12 }, WindowColour::secondary, StringIds::use_preferred_company_name, StringIds::use_preferred_company_name_tip),
+            Widgets::Button(Widx::kChangeCompanyNameBtn, { 265, 164 }, { 75, 12 }, WindowColour::secondary, StringIds::change),
+            Widgets::Label(Widx::kLabelPreferredCompanyName, { 24, 164 }, { 240, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::wcolour2_preferred_company_name)
 
             // TODO: default colours?
 
@@ -2198,37 +2296,37 @@ namespace OpenLoco::Ui::Windows::Options
             }
         }
 
-        static void onMouseUp(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t wi, const WidgetId id)
         {
             if (Common::onMouseUp(self, wi, id))
             {
                 return;
             }
 
-            switch (wi)
+            switch (id)
             {
-                case widx::usePreferredOwnerName:
+                case Widx::kUsePreferredOwnerName:
                     usePreferredOwnerNameMouseUp(self);
                     break;
 
-                case widx::changeOwnerNameBtn:
+                case Widx::kChangeOwnerNameBtn:
                     changePreferredName(self);
                     break;
 
-                case widx::usePreferredOwnerFace:
+                case Widx::kUsePreferredOwnerFace:
                     usePreferredOwnerFaceMouseUp(self);
                     break;
 
-                case widx::changeOwnerFaceBtn:
-                case widx::ownerFacePreview:
+                case Widx::kChangeOwnerFaceBtn:
+                case Widx::kOwnerFacePreview:
                     changePreferredFace(self);
                     break;
 
-                case widx::usePreferredCompanyName:
+                case Widx::kUsePreferredCompanyName:
                     usePreferredCompanyNameMouseUp(self);
                     break;
 
-                case widx::changeCompanyNameBtn:
+                case Widx::kChangeCompanyNameBtn:
                     changePreferredCompany(self);
                     break;
             }
@@ -2262,15 +2360,15 @@ namespace OpenLoco::Ui::Windows::Options
         }
 
         // 0x004C1304
-        static void textInput(Window& self, WidgetIndex_t i, [[maybe_unused]] const WidgetId id, const char* str)
+        static void textInput(Window& self, [[maybe_unused]] WidgetIndex_t i, const WidgetId id, const char* str)
         {
-            switch (i)
+            switch (id)
             {
-                case widx::usePreferredOwnerName:
+                case Widx::kUsePreferredOwnerName:
                     setPreferredName(self, str);
                     break;
 
-                case widx::usePreferredCompanyName:
+                case Widx::kUsePreferredCompanyName:
                     setPreferredCompanyName(self, str);
                     break;
             }
@@ -2327,32 +2425,49 @@ namespace OpenLoco::Ui::Windows::Options
             export_plugin_objects,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kEnableCheatsToolbarButton{ "enableCheatsToolbarButton" };
+            constexpr WidgetId kDisableAICompanies{ "disableAICompanies" };
+            constexpr WidgetId kDisableTownExpansion{ "disableTownExpansion" };
+            constexpr WidgetId kDisableVehicleBreakdowns{ "disable_vehicle_breakdowns" };
+            constexpr WidgetId kDisableVehicleLoadPenalty{ "disable_vehicle_load_penalty" };
+            constexpr WidgetId kDisableStationSizeLimit{ "disableStationSizeLimit" };
+            constexpr WidgetId kTrainsReverseAtSignals{ "trainsReverseAtSignals" };
+            constexpr WidgetId kAutosaveFrequency{ "autosave_frequency" };
+            constexpr WidgetId kAutosaveFrequencyBtn{ "autosave_frequency_btn" };
+            constexpr WidgetId kAutosaveAmount{ "autosave_amount" };
+            constexpr WidgetId kAutosaveAmountDownBtn{ "autosave_amount_down_btn" };
+            constexpr WidgetId kAutosaveAmountUpBtn{ "autosave_amount_up_btn" };
+            constexpr WidgetId kExportPluginObjects{ "export_plugin_objects" };
+        }
+
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_miscellaneous),
 
             // Gameplay tweaks group
             Widgets::GroupBox({ 4, 49 }, { 412, 62 }, WindowColour::secondary, StringIds::gameplay_tweaks),
-            Widgets::Checkbox({ 10, 64 }, { 400, 12 }, WindowColour::secondary, StringIds::option_cheat_menu_enable, StringIds::tooltip_option_cheat_menu_enable),
-            Widgets::Checkbox({ 10, 79 }, { 400, 12 }, WindowColour::secondary, StringIds::disableAICompanies, StringIds::disableAICompanies_tip),
-            Widgets::Checkbox({ 10, 94 }, { 400, 12 }, WindowColour::secondary, StringIds::disableTownExpansion, StringIds::disableTownExpansion_tip),
+            Widgets::Checkbox(Widx::kEnableCheatsToolbarButton, { 10, 64 }, { 400, 12 }, WindowColour::secondary, StringIds::option_cheat_menu_enable, StringIds::tooltip_option_cheat_menu_enable),
+            Widgets::Checkbox(Widx::kDisableAICompanies, { 10, 79 }, { 400, 12 }, WindowColour::secondary, StringIds::disableAICompanies, StringIds::disableAICompanies_tip),
+            Widgets::Checkbox(Widx::kDisableTownExpansion, { 10, 94 }, { 400, 12 }, WindowColour::secondary, StringIds::disableTownExpansion, StringIds::disableTownExpansion_tip),
 
             // Vehicle behaviour
             Widgets::GroupBox({ 4, 115 }, { 412, 77 }, WindowColour::secondary, StringIds::vehicleTrackBehaviour),
-            Widgets::Checkbox({ 10, 130 }, { 400, 12 }, WindowColour::secondary, StringIds::disable_vehicle_breakdowns),
-            Widgets::Checkbox({ 10, 145 }, { 400, 12 }, WindowColour::secondary, StringIds::disableVehicleLoadingPenalty, StringIds::disableVehicleLoadingPenaltyTip),
-            Widgets::Checkbox({ 10, 160 }, { 400, 12 }, WindowColour::secondary, StringIds::disableStationSizeLimitLabel, StringIds::disableStationSizeLimitTooltip),
-            Widgets::Checkbox({ 10, 175 }, { 400, 12 }, WindowColour::secondary, StringIds::trainsReverseAtSignals),
+            Widgets::Checkbox(Widx::kDisableVehicleBreakdowns, { 10, 130 }, { 400, 12 }, WindowColour::secondary, StringIds::disable_vehicle_breakdowns),
+            Widgets::Checkbox(Widx::kDisableVehicleLoadPenalty, { 10, 145 }, { 400, 12 }, WindowColour::secondary, StringIds::disableVehicleLoadingPenalty, StringIds::disableVehicleLoadingPenaltyTip),
+            Widgets::Checkbox(Widx::kDisableStationSizeLimit, { 10, 160 }, { 400, 12 }, WindowColour::secondary, StringIds::disableStationSizeLimitLabel, StringIds::disableStationSizeLimitTooltip),
+            Widgets::Checkbox(Widx::kTrainsReverseAtSignals, { 10, 175 }, { 400, 12 }, WindowColour::secondary, StringIds::trainsReverseAtSignals),
 
             // Save options group
             Widgets::GroupBox({ 4, 196 }, { 412, 65 }, WindowColour::secondary, StringIds::autosave_preferences),
 
             Widgets::Label({ 10, 211 }, { 200, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::autosave_frequency),
-            Widgets::dropdownWidgets({ 250, 211 }, { 156, 12 }, WindowColour::secondary, StringIds::empty),
+            Widgets::dropdownWidgets(Widx::kAutosaveFrequency, Widx::kAutosaveFrequencyBtn, { 250, 211 }, { 156, 12 }, WindowColour::secondary, StringIds::empty),
 
             Widgets::Label({ 10, 226 }, { 200, 12 }, WindowColour::secondary, ContentAlign::left, StringIds::autosave_amount),
-            Widgets::stepperWidgets({ 250, 226 }, { 156, 12 }, WindowColour::secondary, StringIds::empty),
+            Widgets::stepperWidgets(Widx::kAutosaveAmount, Widx::kAutosaveAmountDownBtn, Widx::kAutosaveAmountUpBtn, { 250, 226 }, { 156, 12 }, WindowColour::secondary, StringIds::empty),
 
-            Widgets::Checkbox({ 10, 241 }, { 400, 12 }, WindowColour::secondary, StringIds::export_plugin_objects, StringIds::export_plugin_objects_tip)
+            Widgets::Checkbox(Widx::kExportPluginObjects, { 10, 241 }, { 400, 12 }, WindowColour::secondary, StringIds::export_plugin_objects, StringIds::export_plugin_objects_tip)
 
         );
 
@@ -2545,65 +2660,65 @@ namespace OpenLoco::Ui::Windows::Options
                 return;
             }
 
-            switch (wi)
+            switch (id)
             {
-                case widx::enableCheatsToolbarButton:
+                case Widx::kEnableCheatsToolbarButton:
                     enableCheatsToolbarButtonMouseUp(self);
                     break;
 
-                case widx::disable_vehicle_breakdowns:
+                case Widx::kDisableVehicleBreakdowns:
                     disableVehicleBreakdownsMouseUp(self);
                     break;
 
-                case widx::trainsReverseAtSignals:
+                case Widx::kTrainsReverseAtSignals:
                     trainsReverseAtSignalsMouseUp(self);
                     break;
 
-                case widx::disable_vehicle_load_penalty:
+                case Widx::kDisableVehicleLoadPenalty:
                     Config::get().disableVehicleLoadPenaltyCheat = !Config::get().disableVehicleLoadPenaltyCheat;
                     WindowManager::invalidateWidget(self.type, self.number, widx::disable_vehicle_load_penalty);
                     break;
 
-                case widx::disableStationSizeLimit:
+                case Widx::kDisableStationSizeLimit:
                     Config::get().disableStationSizeLimit ^= true;
                     WindowManager::invalidateWidget(self.type, self.number, widx::disableStationSizeLimit);
                     break;
 
-                case widx::disableAICompanies:
+                case Widx::kDisableAICompanies:
                     disableAICompaniesMouseUp(self);
                     break;
 
-                case widx::disableTownExpansion:
+                case Widx::kDisableTownExpansion:
                     disableTownExpansionMouseUp(self);
                     break;
 
-                case widx::export_plugin_objects:
+                case Widx::kExportPluginObjects:
                     exportPluginObjectsMouseUp(self);
                     break;
             }
         }
 
-        static void onMouseDown(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t wi, const WidgetId id)
         {
-            switch (wi)
+            switch (id)
             {
-                case widx::autosave_frequency_btn:
+                case Widx::kAutosaveFrequencyBtn:
                     showAutosaveFrequencyDropdown(self, widx::autosave_frequency);
                     break;
-                case widx::autosave_amount_down_btn:
+                case Widx::kAutosaveAmountDownBtn:
                     changeAutosaveAmount(self, -1);
                     break;
-                case widx::autosave_amount_up_btn:
+                case Widx::kAutosaveAmountUpBtn:
                     changeAutosaveAmount(self, 1);
                     break;
             }
         }
 
-        static void onDropdown(Window& self, WidgetIndex_t wi, [[maybe_unused]] const WidgetId id, int16_t item_index)
+        static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t wi, const WidgetId id, int16_t item_index)
         {
-            switch (wi)
+            switch (id)
             {
-                case widx::autosave_frequency_btn:
+                case Widx::kAutosaveFrequencyBtn:
                     handleAutosaveFrequencyDropdown(self, item_index);
                     break;
             }

--- a/src/OpenLoco/src/Ui/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PlayerInfoPanel.cpp
@@ -36,6 +36,15 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
         performanceIndex
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kOuterFrame{ "outer_frame" };
+        constexpr WidgetId kInnerFrame{ "inner_frame" };
+        constexpr WidgetId kPlayer{ "player" };
+        constexpr WidgetId kCompanyValue{ "company_value" };
+        constexpr WidgetId kPerformanceIndex{ "performanceIndex" };
+    }
+
     static void performanceIndexMouseUp();
     static void companyValueTooltip(FormatArguments& args);
     static void performanceIndexTooltip(FormatArguments& args);
@@ -43,11 +52,11 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
 
     // 0x00509d08
     static constexpr auto _widgets = makeWidgets(
-        Widgets::Wt3Widget({ 0, 0 }, { 140, 29 }, WindowColour::primary),
-        Widgets::Wt3Widget({ 2, 2 }, { 136, 25 }, WindowColour::primary),
-        Widgets::ImageButton({ 1, 1 }, { 26, 26 }, WindowColour::primary),
-        Widgets::ImageButton({ 27, 2 }, { 111, 12 }, WindowColour::primary, Widget::kContentNull, StringIds::tooltip_company_value),
-        Widgets::ImageButton({ 27, 14 }, { 111, 12 }, WindowColour::primary, Widget::kContentNull, StringIds::tooltip_performance_index)
+        Widgets::Wt3Widget(Widx::kOuterFrame, { 0, 0 }, { 140, 29 }, WindowColour::primary),
+        Widgets::Wt3Widget(Widx::kInnerFrame, { 2, 2 }, { 136, 25 }, WindowColour::primary),
+        Widgets::ImageButton(Widx::kPlayer, { 1, 1 }, { 26, 26 }, WindowColour::primary),
+        Widgets::ImageButton(Widx::kCompanyValue, { 27, 2 }, { 111, 12 }, WindowColour::primary, Widget::kContentNull, StringIds::tooltip_company_value),
+        Widgets::ImageButton(Widx::kPerformanceIndex, { 27, 14 }, { 111, 12 }, WindowColour::primary, Widget::kContentNull, StringIds::tooltip_performance_index)
 
     );
 
@@ -250,36 +259,36 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     }
 
     // 0x004395A4
-    static void onMouseUp([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::company_value:
+            case Widx::kCompanyValue:
                 companyValueMouseUp();
                 break;
-            case widx::performanceIndex:
+            case Widx::kPerformanceIndex:
                 performanceIndexMouseUp();
                 break;
         }
     }
 
     // 0x004395B1
-    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::player:
+            case Widx::kPlayer:
                 playerMouseDown(&window, widgetIndex);
                 break;
         }
     }
 
     // 0x004395BC
-    static void onDropdown([[maybe_unused]] Window& w, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t item_index)
+    static void onDropdown([[maybe_unused]] Window& w, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t item_index)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::player:
+            case Widx::kPlayer:
                 playerDropdownClick(item_index);
                 break;
         }
@@ -298,12 +307,12 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     }
 
     // 0x004395DE
-    static Ui::CursorId onCursor([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId onCursor([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::company_value:
-            case widx::performanceIndex:
+            case Widx::kCompanyValue:
+            case Widx::kPerformanceIndex:
                 Ui::ToolTip::setTooltipTimeout(2000);
                 break;
         }
@@ -311,16 +320,16 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     }
 
     // 0x004395F5
-    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
         FormatArguments args{};
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::company_value:
+            case Widx::kCompanyValue:
                 companyValueTooltip(args);
                 break;
 
-            case widx::performanceIndex:
+            case Widx::kPerformanceIndex:
                 performanceIndexTooltip(args);
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PlayerInfoPanel.cpp
@@ -27,17 +27,14 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
 {
     static constexpr Ui::Size kWindowSize = { 140, 27 };
 
-    namespace Widx
+    enum widx
     {
-        enum
-        {
-            outer_frame,
-            inner_frame,
-            player,
-            company_value,
-            performanceIndex
-        };
-    }
+        outer_frame,
+        inner_frame,
+        player,
+        company_value,
+        performanceIndex
+    };
 
     static void performanceIndexMouseUp();
     static void companyValueTooltip(FormatArguments& args);
@@ -177,7 +174,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     // 0x004393E7
     static void prepareDraw(Window& window)
     {
-        window.widgets[Widx::inner_frame].hidden = true;
+        window.widgets[widx::inner_frame].hidden = true;
     }
 
     // 0x43944B
@@ -185,7 +182,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     {
         auto tr = Gfx::TextRenderer(drawingCtx);
 
-        Widget& frame = window.widgets[Widx::outer_frame];
+        Widget& frame = window.widgets[widx::outer_frame];
         drawingCtx.drawRect(window.x + frame.left, window.y + frame.top, frame.width(), frame.height(), enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
 
         // Draw widgets.
@@ -214,7 +211,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
             }
 
             auto colour = window.getColour(WindowColour::primary).opaque();
-            if (Input::isHovering(WindowType::playerInfoToolbar, 0, Widx::company_value))
+            if (Input::isHovering(WindowType::playerInfoToolbar, 0, widx::company_value))
             {
                 colour = Colour::white;
             }
@@ -239,7 +236,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
             }
 
             auto colour = window.getColour(WindowColour::primary).opaque();
-            if (Input::isHovering(WindowType::playerInfoToolbar, 0, Widx::performanceIndex))
+            if (Input::isHovering(WindowType::playerInfoToolbar, 0, widx::performanceIndex))
             {
                 colour = Colour::white;
             }
@@ -257,10 +254,10 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     {
         switch (widgetIndex)
         {
-            case Widx::company_value:
+            case widx::company_value:
                 companyValueMouseUp();
                 break;
-            case Widx::performanceIndex:
+            case widx::performanceIndex:
                 performanceIndexMouseUp();
                 break;
         }
@@ -271,7 +268,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     {
         switch (widgetIndex)
         {
-            case Widx::player:
+            case widx::player:
                 playerMouseDown(&window, widgetIndex);
                 break;
         }
@@ -282,7 +279,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     {
         switch (widgetIndex)
         {
-            case Widx::player:
+            case widx::player:
                 playerDropdownClick(item_index);
                 break;
         }
@@ -305,8 +302,8 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
     {
         switch (widgetIndex)
         {
-            case Widx::company_value:
-            case Widx::performanceIndex:
+            case widx::company_value:
+            case widx::performanceIndex:
                 Ui::ToolTip::setTooltipTimeout(2000);
                 break;
         }
@@ -319,11 +316,11 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
         FormatArguments args{};
         switch (widgetIndex)
         {
-            case Widx::company_value:
+            case widx::company_value:
                 companyValueTooltip(args);
                 break;
 
-            case Widx::performanceIndex:
+            case widx::performanceIndex:
                 performanceIndexTooltip(args);
                 break;
         }
@@ -362,7 +359,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
         if (_redrawScheduled)
         {
             _redrawScheduled = false;
-            WindowManager::invalidateWidget(WindowType::playerInfoToolbar, 0, Widx::inner_frame);
+            WindowManager::invalidateWidget(WindowType::playerInfoToolbar, 0, widx::inner_frame);
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/ProgressBar.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ProgressBar.cpp
@@ -19,7 +19,7 @@
 
 namespace OpenLoco::Ui::Windows::ProgressBar
 {
-    enum Widx
+    enum widx
     {
         frame,
         caption,

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -60,17 +60,31 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         scrollview,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kFrame{ "frame" };
+        constexpr WidgetId kCaption{ "caption" };
+        constexpr WidgetId kCloseButton{ "close_button" };
+        constexpr WidgetId kPanel{ "panel" };
+        constexpr WidgetId kFolderPath{ "folder_path" };
+        constexpr WidgetId kParentButton{ "parent_button" };
+        constexpr WidgetId kHomeButton{ "home_button" };
+        constexpr WidgetId kTextFilename{ "text_filename" };
+        constexpr WidgetId kOkButton{ "ok_button" };
+        constexpr WidgetId kScrollview{ "scrollview" };
+    }
+
     static constexpr auto widgets = makeWidgets(
-        Widgets::Frame({ 0, 0 }, { 500, 380 }, WindowColour::primary),
-        Widgets::Caption({ 1, 1 }, { 498, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::empty),
-        Widgets::ImageButton({ 485, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-        Widgets::Panel({ 0, 15 }, { 500, 365 }, WindowColour::secondary),
-        Widgets::Label({ 3, 18 }, { 447, 24 }, WindowColour::secondary, ContentAlign::left, StringIds::window_browse_folder),
-        Widgets::ImageButton({ 449, 18 }, { 24, 24 }, WindowColour::secondary, ImageIds::icon_parent_folder, StringIds::window_browse_parent_folder_tooltip),
-        Widgets::ImageButton({ 473, 18 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_left_turnaround, StringIds::window_browse_home_folder_tooltip),
-        Widgets::TextBox({ 88, 348 }, { 408, 14 }, WindowColour::secondary),
-        Widgets::Button({ 426, 364 }, { 70, 12 }, WindowColour::secondary, StringIds::label_button_ok),
-        Widgets::ScrollView({ 3, 45 }, { 494, 323 }, WindowColour::secondary, Scrollbars::vertical)
+        Widgets::Frame(Widx::kFrame, { 0, 0 }, { 500, 380 }, WindowColour::primary),
+        Widgets::Caption(Widx::kCaption, { 1, 1 }, { 498, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::empty),
+        Widgets::ImageButton(Widx::kCloseButton, { 485, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::Panel(Widx::kPanel, { 0, 15 }, { 500, 365 }, WindowColour::secondary),
+        Widgets::Label(Widx::kFolderPath, { 3, 18 }, { 447, 24 }, WindowColour::secondary, ContentAlign::left, StringIds::window_browse_folder),
+        Widgets::ImageButton(Widx::kParentButton, { 449, 18 }, { 24, 24 }, WindowColour::secondary, ImageIds::icon_parent_folder, StringIds::window_browse_parent_folder_tooltip),
+        Widgets::ImageButton(Widx::kHomeButton, { 473, 18 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_left_turnaround, StringIds::window_browse_home_folder_tooltip),
+        Widgets::TextBox(Widx::kTextFilename, { 88, 348 }, { 408, 14 }, WindowColour::secondary),
+        Widgets::Button(Widx::kOkButton, { 426, 364 }, { 70, 12 }, WindowColour::secondary, StringIds::label_button_ok),
+        Widgets::ScrollView(Widx::kScrollview, { 3, 45 }, { 494, 323 }, WindowColour::secondary, Scrollbars::vertical)
 
     );
 
@@ -210,28 +224,28 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     }
 
     // 0x00446465
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::close_button:
+            case Widx::kCloseButton:
                 _currentDirectory.clear();
                 _targetPath = std::nullopt;
                 WindowManager::close(&window);
                 break;
-            case widx::parent_button:
+            case Widx::kParentButton:
                 upOneLevel();
                 window.var_85A = -1;
                 window.initScrollWidgets();
                 window.invalidate();
                 break;
-            case widx::home_button:
+            case Widx::kHomeButton:
                 defaultDirectory();
                 window.var_85A = -1;
                 window.initScrollWidgets();
                 window.invalidate();
                 break;
-            case widx::ok_button:
+            case Widx::kOkButton:
                 processFileForLoadSave(&window);
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/PromptOkCancelWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptOkCancelWindow.cpp
@@ -30,12 +30,20 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
         cancelButton,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kCaption{ "caption" };
+        constexpr WidgetId kCloseButton{ "closeButton" };
+        constexpr WidgetId kOkButton{ "okButton" };
+        constexpr WidgetId kCancelButton{ "cancelButton" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
         Widgets::Panel({ 0, 0 }, { 280, 92 }, WindowColour::primary),
-        Widgets::Caption({ 1, 1 }, { 278, 13 }, Widgets::Caption::Style::boxed, WindowColour::primary),
-        Widgets::Button({ 267, 2 }, { 11, 11 }, WindowColour::primary, StringIds::close_window_cross, StringIds::tooltip_close_window),
-        Widgets::Button({ 20, 77 }, { 100, 12 }, WindowColour::primary, StringIds::label_ok),
-        Widgets::Button({ 160, 77 }, { 100, 12 }, WindowColour::primary, StringIds::label_button_cancel)
+        Widgets::Caption(Widx::kCaption, { 1, 1 }, { 278, 13 }, Widgets::Caption::Style::boxed, WindowColour::primary),
+        Widgets::Button(Widx::kCloseButton, { 267, 2 }, { 11, 11 }, WindowColour::primary, StringIds::close_window_cross, StringIds::tooltip_close_window),
+        Widgets::Button(Widx::kOkButton, { 20, 77 }, { 100, 12 }, WindowColour::primary, StringIds::label_ok),
+        Widgets::Button(Widx::kCancelButton, { 160, 77 }, { 100, 12 }, WindowColour::primary, StringIds::label_button_cancel)
 
     );
 
@@ -118,16 +126,16 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
     }
 
     // 0x004470FD
-    static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::closeButton:
-            case widx::cancelButton:
+            case Widx::kCloseButton:
+            case Widx::kCancelButton:
                 WindowManager::close(self.type);
                 break;
 
-            case widx::okButton:
+            case Widx::kOkButton:
                 _result = true;
                 WindowManager::close(self.type);
                 break;

--- a/src/OpenLoco/src/Ui/Windows/PromptSaveWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptSaveWindow.cpp
@@ -32,14 +32,24 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
         cancelButton,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kCaption{ "caption" };
+        constexpr WidgetId kCloseButton{ "closeButton" };
+        constexpr WidgetId kPromptLabel{ "promptLabel" };
+        constexpr WidgetId kSaveButton{ "saveButton" };
+        constexpr WidgetId kDontSaveButton{ "dontSaveButton" };
+        constexpr WidgetId kCancelButton{ "cancelButton" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
         Widgets::Panel({ 0, 0 }, { 260, 48 }, WindowColour::primary),
-        Widgets::Caption({ 1, 1 }, { 258, 13 }, Widgets::Caption::Style::boxed, WindowColour::primary, StringIds::empty),
-        Widgets::Button({ 247, 2 }, { 11, 11 }, WindowColour::primary, StringIds::close_window_cross, StringIds::tooltip_close_window),
-        Widgets::Label({ 2, 17 }, { 256, 12 }, WindowColour::primary, ContentAlign::center, StringIds::empty),
-        Widgets::Button({ 8, 33 }, { 78, 12 }, WindowColour::primary, StringIds::label_button_save),
-        Widgets::Button({ 91, 33 }, { 78, 12 }, WindowColour::primary, StringIds::label_button_dont_save),
-        Widgets::Button({ 174, 33 }, { 78, 12 }, WindowColour::primary, StringIds::label_button_cancel)
+        Widgets::Caption(Widx::kCaption, { 1, 1 }, { 258, 13 }, Widgets::Caption::Style::boxed, WindowColour::primary, StringIds::empty),
+        Widgets::Button(Widx::kCloseButton, { 247, 2 }, { 11, 11 }, WindowColour::primary, StringIds::close_window_cross, StringIds::tooltip_close_window),
+        Widgets::Label(Widx::kPromptLabel, { 2, 17 }, { 256, 12 }, WindowColour::primary, ContentAlign::center, StringIds::empty),
+        Widgets::Button(Widx::kSaveButton, { 8, 33 }, { 78, 12 }, WindowColour::primary, StringIds::label_button_save),
+        Widgets::Button(Widx::kDontSaveButton, { 91, 33 }, { 78, 12 }, WindowColour::primary, StringIds::label_button_dont_save),
+        Widgets::Button(Widx::kCancelButton, { 174, 33 }, { 78, 12 }, WindowColour::primary, StringIds::label_button_cancel)
 
     );
 
@@ -111,12 +121,12 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
     }
 
     // 0x0043C3F4
-    static void onMouseUp([[maybe_unused]] Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp([[maybe_unused]] Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::closeButton:
-            case widx::cancelButton:
+            case Widx::kCloseButton:
+            case Widx::kCancelButton:
             {
                 GameCommands::LoadSaveQuitGameArgs args{};
                 args.loadQuitMode = _savePromptType;
@@ -125,13 +135,13 @@ namespace OpenLoco::Ui::Windows::PromptSaveWindow
                 break;
             }
 
-            case widx::saveButton:
+            case Widx::kSaveButton:
             {
                 Game::confirmSaveGame(_savePromptType);
                 break;
             }
 
-            case widx::dontSaveButton:
+            case Widx::kDontSaveButton:
             {
                 GameCommands::LoadSaveQuitGameArgs args{};
                 args.loadQuitMode = _savePromptType;

--- a/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
@@ -51,17 +51,29 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             tab_scenario,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabChallenge{ "tab_challenge" };
+            constexpr WidgetId kTabCompanies{ "tab_companies" };
+            constexpr WidgetId kTabFinances{ "tab_finances" };
+            constexpr WidgetId kTabScenario{ "tab_scenario" };
+        }
+
         static constexpr auto makeCommonWidgets(int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, { 366, frameHeight }, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { 364, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
-                Widgets::ImageButton({ 351, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { 366, 175 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_scenario_challenge),
-                Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_options),
-                Widgets::Tab({ 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_financial_options),
-                Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_scenario_options));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, { 366, frameHeight }, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { 364, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
+                Widgets::ImageButton(Widx::kCloseButton, { 351, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { 366, 175 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabChallenge, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_scenario_challenge),
+                Widgets::Tab(Widx::kTabCompanies, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_company_options),
+                Widgets::Tab(Widx::kTabFinances, { 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_financial_options),
+                Widgets::Tab(Widx::kTabScenario, { 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_scenario_options));
         }
 
         // 0x00440082
@@ -189,17 +201,34 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             time_limit_value_up,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kObjectiveType{ "objective_type" };
+            constexpr WidgetId kObjectiveTypeBtn{ "objective_type_btn" };
+            constexpr WidgetId kObjectiveValue{ "objective_value" };
+            constexpr WidgetId kObjectiveValueDown{ "objective_value_down" };
+            constexpr WidgetId kObjectiveValueUp{ "objective_value_up" };
+            constexpr WidgetId kObjectiveCargo{ "objective_cargo" };
+            constexpr WidgetId kObjectiveCargoBtn{ "objective_cargo_btn" };
+            constexpr WidgetId kCheckBeTopCompany{ "check_be_top_company" };
+            constexpr WidgetId kCheckBeWithinTopThreeCompanies{ "check_be_within_top_three_companies" };
+            constexpr WidgetId kCheckTimeLimit{ "check_time_limit" };
+            constexpr WidgetId kTimeLimitValue{ "time_limit_value" };
+            constexpr WidgetId kTimeLimitValueDown{ "time_limit_value_down" };
+            constexpr WidgetId kTimeLimitValueUp{ "time_limit_value_up" };
+        }
+
         const uint64_t holdableWidgets = (1 << widx::objective_value_down) | (1 << widx::objective_value_up) | (1 << widx::time_limit_value_down) | (1 << widx::time_limit_value_up);
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(197, StringIds::title_scenario_challenge),
-            Widgets::dropdownWidgets({ 10, 52 }, { 346, 12 }, WindowColour::secondary),
-            Widgets::stepperWidgets({ 10, 67 }, { 163, 12 }, WindowColour::secondary),
-            Widgets::dropdownWidgets({ 193, 67 }, { 163, 12 }, WindowColour::secondary),
-            Widgets::Checkbox({ 10, 83 }, { 346, 12 }, WindowColour::secondary, StringIds::and_be_the_top_company),
-            Widgets::Checkbox({ 10, 98 }, { 346, 12 }, WindowColour::secondary, StringIds::and_be_within_the_top_companies),
-            Widgets::Checkbox({ 10, 113 }, { 346, 12 }, WindowColour::secondary, StringIds::with_a_time_limit),
-            Widgets::stepperWidgets({ 256, 112 }, { 100, 12 }, WindowColour::secondary, StringIds::time_limit_years_value)
+            Widgets::dropdownWidgets(Widx::kObjectiveType, Widx::kObjectiveTypeBtn, { 10, 52 }, { 346, 12 }, WindowColour::secondary),
+            Widgets::stepperWidgets(Widx::kObjectiveValue, Widx::kObjectiveValueDown, Widx::kObjectiveValueUp, { 10, 67 }, { 163, 12 }, WindowColour::secondary),
+            Widgets::dropdownWidgets(Widx::kObjectiveCargo, Widx::kObjectiveCargoBtn, { 193, 67 }, { 163, 12 }, WindowColour::secondary),
+            Widgets::Checkbox(Widx::kCheckBeTopCompany, { 10, 83 }, { 346, 12 }, WindowColour::secondary, StringIds::and_be_the_top_company),
+            Widgets::Checkbox(Widx::kCheckBeWithinTopThreeCompanies, { 10, 98 }, { 346, 12 }, WindowColour::secondary, StringIds::and_be_within_the_top_companies),
+            Widgets::Checkbox(Widx::kCheckTimeLimit, { 10, 113 }, { 346, 12 }, WindowColour::secondary, StringIds::with_a_time_limit),
+            Widgets::stepperWidgets(Widx::kTimeLimitValue, Widx::kTimeLimitValueDown, Widx::kTimeLimitValueUp, { 256, 112 }, { 100, 12 }, WindowColour::secondary, StringIds::time_limit_years_value)
 
         );
 
@@ -231,21 +260,21 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         static int16_t cargoByDropdownIndex[kMaxCargoObjects] = { -1 };
 
         // 0x0043FD51
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
             if (itemIndex == -1)
             {
                 return;
             }
 
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::objective_type_btn:
+                case Widx::kObjectiveTypeBtn:
                     Scenario::getObjective().type = static_cast<Scenario::ObjectiveType>(itemIndex);
                     self.invalidate();
                     break;
 
-                case widx::objective_cargo_btn:
+                case Widx::kObjectiveCargoBtn:
                 {
                     Scenario::getObjective().deliveredCargoType = cargoByDropdownIndex[itemIndex];
                     self.invalidate();
@@ -254,11 +283,11 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043FD14
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::objective_type_btn:
+                case Widx::kObjectiveTypeBtn:
                 {
                     Widget& target = self.widgets[widx::objective_type];
                     Dropdown::show(self.x + target.left, self.y + target.top, target.width() - 4, target.height(), self.getColour(WindowColour::secondary), std::size(objectiveTypeLabelIds), 0x80);
@@ -272,7 +301,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     break;
                 }
 
-                case widx::objective_value_down:
+                case Widx::kObjectiveValueDown:
                 {
                     uint32_t stepSize = Input::getClickRepeatStepSize();
 
@@ -308,7 +337,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     break;
                 }
 
-                case widx::objective_value_up:
+                case Widx::kObjectiveValueUp:
                 {
                     uint32_t stepSize = Input::getClickRepeatStepSize();
 
@@ -343,7 +372,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     break;
                 }
 
-                case widx::objective_cargo_btn:
+                case Widx::kObjectiveCargoBtn:
                 {
                     uint16_t numCargoObjects = 0;
                     for (uint16_t cargoIdx = 0; cargoIdx < kMaxCargoObjects; cargoIdx++)
@@ -380,14 +409,14 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     break;
                 }
 
-                case widx::time_limit_value_down:
+                case Widx::kTimeLimitValueDown:
                 {
                     Scenario::getObjective().timeLimitYears = std::max<uint8_t>(Scenario::getObjective().timeLimitYears - 1, Scenario::kMinObjectiveYearLimit);
                     self.invalidate();
                     break;
                 }
 
-                case widx::time_limit_value_up:
+                case Widx::kTimeLimitValueUp:
                 {
                     Scenario::getObjective().timeLimitYears = std::min<uint8_t>(Scenario::getObjective().timeLimitYears + 1, Scenario::kMaxObjectiveYearLimit);
                     self.invalidate();
@@ -397,32 +426,32 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043FCED
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_challenge:
-                case Common::widx::tab_companies:
-                case Common::widx::tab_finances:
-                case Common::widx::tab_scenario:
+                case Common::Widx::kTabChallenge:
+                case Common::Widx::kTabCompanies:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabScenario:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case check_be_top_company:
+                case Widx::kCheckBeTopCompany:
                     Scenario::getObjective().flags ^= Scenario::ObjectiveFlags::beTopCompany;
                     self.invalidate();
                     break;
 
-                case check_be_within_top_three_companies:
+                case Widx::kCheckBeWithinTopThreeCompanies:
                     Scenario::getObjective().flags ^= Scenario::ObjectiveFlags::beWithinTopThreeCompanies;
                     self.invalidate();
                     break;
 
-                case check_time_limit:
+                case Widx::kCheckTimeLimit:
                     Scenario::getObjective().flags ^= Scenario::ObjectiveFlags::withinTimeLimit;
                     self.invalidate();
                     break;
@@ -593,28 +622,56 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             player_forbid_ships,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kMaxCompetingCompanies{ "max_competing_companies" };
+            constexpr WidgetId kMaxCompetingCompaniesDown{ "max_competing_companies_down" };
+            constexpr WidgetId kMaxCompetingCompaniesUp{ "max_competing_companies_up" };
+            constexpr WidgetId kDelayBeforeCompetingCompaniesStart{ "delay_before_competing_companies_start" };
+            constexpr WidgetId kDelayBeforeCompetingCompaniesStartDown{ "delay_before_competing_companies_start_down" };
+            constexpr WidgetId kDelayBeforeCompetingCompaniesStartUp{ "delay_before_competing_companies_start_up" };
+            constexpr WidgetId kPreferredIntelligence{ "preferred_intelligence" };
+            constexpr WidgetId kPreferredIntelligenceBtn{ "preferred_intelligence_btn" };
+            constexpr WidgetId kPreferredAggressiveness{ "preferred_aggressiveness" };
+            constexpr WidgetId kPreferredAggressivenessBtn{ "preferred_aggressiveness_btn" };
+            constexpr WidgetId kPreferredCompetitiveness{ "preferred_competitiveness" };
+            constexpr WidgetId kPreferredCompetitivenessBtn{ "preferred_competitiveness_btn" };
+            constexpr WidgetId kCompetitorForbidTrains{ "competitor_forbid_trains" };
+            constexpr WidgetId kCompetitorForbidBuses{ "competitor_forbid_buses" };
+            constexpr WidgetId kCompetitorForbidTrucks{ "competitor_forbid_trucks" };
+            constexpr WidgetId kCompetitorForbidTrams{ "competitor_forbid_trams" };
+            constexpr WidgetId kCompetitorForbidAircraft{ "competitor_forbid_aircraft" };
+            constexpr WidgetId kCompetitorForbidShips{ "competitor_forbid_ships" };
+            constexpr WidgetId kPlayerForbidTrains{ "player_forbid_trains" };
+            constexpr WidgetId kPlayerForbidBuses{ "player_forbid_buses" };
+            constexpr WidgetId kPlayerForbidTrucks{ "player_forbid_trucks" };
+            constexpr WidgetId kPlayerForbidTrams{ "player_forbid_trams" };
+            constexpr WidgetId kPlayerForbidAircraft{ "player_forbid_aircraft" };
+            constexpr WidgetId kPlayerForbidShips{ "player_forbid_ships" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(327, StringIds::title_company_options),
-            Widgets::stepperWidgets({ 256, 52 }, { 100, 12 }, WindowColour::secondary, StringIds::max_competing_companies_value),
-            Widgets::stepperWidgets({ 256, 67 }, { 100, 12 }, WindowColour::secondary, StringIds::delay_before_competing_companies_start_months),
+            Widgets::stepperWidgets(Widx::kMaxCompetingCompanies, Widx::kMaxCompetingCompaniesDown, Widx::kMaxCompetingCompaniesUp, { 256, 52 }, { 100, 12 }, WindowColour::secondary, StringIds::max_competing_companies_value),
+            Widgets::stepperWidgets(Widx::kDelayBeforeCompetingCompaniesStart, Widx::kDelayBeforeCompetingCompaniesStartDown, Widx::kDelayBeforeCompetingCompaniesStartUp, { 256, 67 }, { 100, 12 }, WindowColour::secondary, StringIds::delay_before_competing_companies_start_months),
             Widgets::GroupBox({ 5, 102 - 14 - 5 }, { 356, 63 }, WindowColour::secondary, StringIds::selection_of_competing_companies),
-            Widgets::dropdownWidgets({ 246, 102 - 4 }, { 110, 12 }, WindowColour::secondary),
-            Widgets::dropdownWidgets({ 246, 117 - 4 }, { 110, 12 }, WindowColour::secondary),
-            Widgets::dropdownWidgets({ 246, 132 - 4 }, { 110, 12 }, WindowColour::secondary),
+            Widgets::dropdownWidgets(Widx::kPreferredIntelligence, Widx::kPreferredIntelligenceBtn, { 246, 102 - 4 }, { 110, 12 }, WindowColour::secondary),
+            Widgets::dropdownWidgets(Widx::kPreferredAggressiveness, Widx::kPreferredAggressivenessBtn, { 246, 117 - 4 }, { 110, 12 }, WindowColour::secondary),
+            Widgets::dropdownWidgets(Widx::kPreferredCompetitiveness, Widx::kPreferredCompetitivenessBtn, { 246, 132 - 4 }, { 110, 12 }, WindowColour::secondary),
             Widgets::GroupBox({ 5, 150 }, { 356, 50 }, WindowColour::secondary, StringIds::forbid_competing_companies_from_using),
-            Widgets::Checkbox({ 15 + 113 * 0, 166 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_trains),
-            Widgets::Checkbox({ 15 + 113 * 1, 166 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_buses),
-            Widgets::Checkbox({ 15 + 113 * 1, 180 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_trucks),
-            Widgets::Checkbox({ 15 + 113 * 0, 180 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_trams),
-            Widgets::Checkbox({ 15 + 113 * 2, 166 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_aircraft),
-            Widgets::Checkbox({ 15 + 113 * 2, 180 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_ships),
+            Widgets::Checkbox(Widx::kCompetitorForbidTrains, { 15 + 113 * 0, 166 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_trains),
+            Widgets::Checkbox(Widx::kCompetitorForbidBuses, { 15 + 113 * 1, 166 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_buses),
+            Widgets::Checkbox(Widx::kCompetitorForbidTrucks, { 15 + 113 * 1, 180 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_trucks),
+            Widgets::Checkbox(Widx::kCompetitorForbidTrams, { 15 + 113 * 0, 180 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_trams),
+            Widgets::Checkbox(Widx::kCompetitorForbidAircraft, { 15 + 113 * 2, 166 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_aircraft),
+            Widgets::Checkbox(Widx::kCompetitorForbidShips, { 15 + 113 * 2, 180 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_ships),
             Widgets::GroupBox({ 5, 202 }, { 356, 50 }, WindowColour::secondary, StringIds::forbid_player_companies_from_using),
-            Widgets::Checkbox({ 15 + 113 * 0, 219 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_trains),
-            Widgets::Checkbox({ 15 + 113 * 1, 219 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_buses),
-            Widgets::Checkbox({ 15 + 113 * 1, 233 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_trucks),
-            Widgets::Checkbox({ 15 + 113 * 0, 233 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_trams),
-            Widgets::Checkbox({ 15 + 113 * 2, 219 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_aircraft),
-            Widgets::Checkbox({ 15 + 113 * 2, 233 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_ships)
+            Widgets::Checkbox(Widx::kPlayerForbidTrains, { 15 + 113 * 0, 219 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_trains),
+            Widgets::Checkbox(Widx::kPlayerForbidBuses, { 15 + 113 * 1, 219 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_buses),
+            Widgets::Checkbox(Widx::kPlayerForbidTrucks, { 15 + 113 * 1, 233 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_trucks),
+            Widgets::Checkbox(Widx::kPlayerForbidTrams, { 15 + 113 * 0, 233 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_trams),
+            Widgets::Checkbox(Widx::kPlayerForbidAircraft, { 15 + 113 * 2, 219 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_aircraft),
+            Widgets::Checkbox(Widx::kPlayerForbidShips, { 15 + 113 * 2, 233 }, { 110, 12 }, WindowColour::secondary, StringIds::forbid_ships)
 
         );
 
@@ -651,7 +708,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         };
 
         // 0x0043F67C
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
             if (itemIndex == -1)
             {
@@ -660,17 +717,17 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
             auto& state = getGameState();
 
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::preferred_intelligence_btn:
+                case Widx::kPreferredIntelligenceBtn:
                     state.preferredAIIntelligence = itemIndex;
                     break;
 
-                case widx::preferred_aggressiveness_btn:
+                case Widx::kPreferredAggressivenessBtn:
                     state.preferredAIAggressiveness = itemIndex;
                     break;
 
-                case widx::preferred_competitiveness_btn:
+                case Widx::kPreferredCompetitivenessBtn:
                     state.preferredAICompetitiveness = itemIndex;
                     break;
             }
@@ -679,33 +736,33 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043F639
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
             auto& state = getGameState();
 
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::max_competing_companies_down:
+                case Widx::kMaxCompetingCompaniesDown:
                     CompanyManager::setMaxCompetingCompanies(std::max<int8_t>(CompanyManager::getMaxCompetingCompanies() - 1, Scenario::kMinCompetingCompanies));
                     self.invalidate();
                     break;
 
-                case widx::max_competing_companies_up:
+                case Widx::kMaxCompetingCompaniesUp:
                     CompanyManager::setMaxCompetingCompanies(std::min<uint8_t>(CompanyManager::getMaxCompetingCompanies() + 1, Scenario::kMaxCompetingCompanies));
                     self.invalidate();
                     break;
 
-                case widx::delay_before_competing_companies_start_down:
+                case Widx::kDelayBeforeCompetingCompaniesStartDown:
                     CompanyManager::setCompetitorStartDelay(std::max<int8_t>(CompanyManager::getCompetitorStartDelay() - 1, Scenario::kMinCompetitorStartDelay));
                     self.invalidate();
                     break;
 
-                case widx::delay_before_competing_companies_start_up:
+                case Widx::kDelayBeforeCompetingCompaniesStartUp:
                     CompanyManager::setCompetitorStartDelay(std::min<uint8_t>(CompanyManager::getCompetitorStartDelay() + 1, Scenario::kMaxCompetitorStartDelay));
                     self.invalidate();
                     break;
 
-                case widx::preferred_intelligence_btn:
+                case Widx::kPreferredIntelligenceBtn:
                 {
                     Widget& target = self.widgets[widx::preferred_intelligence];
                     Dropdown::show(self.x + target.left, self.y + target.top, target.width() - 4, target.height(), self.getColour(WindowColour::secondary), std::size(preferenceLabelIds), 0x80);
@@ -719,7 +776,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     break;
                 }
 
-                case widx::preferred_aggressiveness_btn:
+                case Widx::kPreferredAggressivenessBtn:
                 {
                     Widget& target = self.widgets[widx::preferred_aggressiveness];
                     Dropdown::show(self.x + target.left, self.y + target.top, target.width() - 4, target.height(), self.getColour(WindowColour::secondary), std::size(preferenceLabelIds), 0x80);
@@ -733,7 +790,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     break;
                 }
 
-                case widx::preferred_competitiveness_btn:
+                case Widx::kPreferredCompetitivenessBtn:
                 {
                     Widget& target = self.widgets[widx::preferred_competitiveness];
                     Dropdown::show(self.x + target.left, self.y + target.top, target.width() - 4, target.height(), self.getColour(WindowColour::secondary), std::size(preferenceLabelIds), 0x80);
@@ -750,29 +807,29 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043F60C
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
             auto& state = getGameState();
 
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_challenge:
-                case Common::widx::tab_companies:
-                case Common::widx::tab_finances:
-                case Common::widx::tab_scenario:
+                case Common::Widx::kTabChallenge:
+                case Common::Widx::kTabCompanies:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabScenario:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::competitor_forbid_trains:
-                case widx::competitor_forbid_buses:
-                case widx::competitor_forbid_trucks:
-                case widx::competitor_forbid_trams:
-                case widx::competitor_forbid_aircraft:
-                case widx::competitor_forbid_ships:
+                case Widx::kCompetitorForbidTrains:
+                case Widx::kCompetitorForbidBuses:
+                case Widx::kCompetitorForbidTrucks:
+                case Widx::kCompetitorForbidTrams:
+                case Widx::kCompetitorForbidAircraft:
+                case Widx::kCompetitorForbidShips:
                 {
                     uint16_t targetVehicle = static_cast<uint16_t>(widgetIndex - widx::competitor_forbid_trains);
                     uint16_t newForbiddenVehicles = state.forbiddenVehiclesCompetitors ^ (1 << targetVehicle);
@@ -790,12 +847,12 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     break;
                 }
 
-                case widx::player_forbid_trains:
-                case widx::player_forbid_buses:
-                case widx::player_forbid_trucks:
-                case widx::player_forbid_trams:
-                case widx::player_forbid_aircraft:
-                case widx::player_forbid_ships:
+                case Widx::kPlayerForbidTrains:
+                case Widx::kPlayerForbidBuses:
+                case Widx::kPlayerForbidTrucks:
+                case Widx::kPlayerForbidTrams:
+                case Widx::kPlayerForbidAircraft:
+                case Widx::kPlayerForbidShips:
                 {
                     uint16_t targetVehicle = static_cast<uint16_t>(widgetIndex - widx::player_forbid_trains);
                     uint16_t newForbiddenVehicles = state.forbiddenVehiclesPlayers ^ (1 << targetVehicle);
@@ -874,11 +931,24 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             loan_interest_rate_up,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kStartingLoan{ "starting_loan" };
+            constexpr WidgetId kStartingLoanDown{ "starting_loan_down" };
+            constexpr WidgetId kStartingLoanUp{ "starting_loan_up" };
+            constexpr WidgetId kMaxLoanSize{ "max_loan_size" };
+            constexpr WidgetId kMaxLoanSizeDown{ "max_loan_size_down" };
+            constexpr WidgetId kMaxLoanSizeUp{ "max_loan_size_up" };
+            constexpr WidgetId kLoanInterestRate{ "loan_interest_rate" };
+            constexpr WidgetId kLoanInterestRateDown{ "loan_interest_rate_down" };
+            constexpr WidgetId kLoanInterestRateUp{ "loan_interest_rate_up" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(217, StringIds::title_financial_options),
-            Widgets::stepperWidgets({ 256, 52 }, { 100, 12 }, WindowColour::secondary, StringIds::starting_loan_value),
-            Widgets::stepperWidgets({ 256, 67 }, { 100, 12 }, WindowColour::secondary, StringIds::max_loan_size_value),
-            Widgets::stepperWidgets({ 256, 82 }, { 100, 12 }, WindowColour::secondary, StringIds::loan_interest_rate_value)
+            Widgets::stepperWidgets(Widx::kStartingLoan, Widx::kStartingLoanDown, Widx::kStartingLoanUp, { 256, 52 }, { 100, 12 }, WindowColour::secondary, StringIds::starting_loan_value),
+            Widgets::stepperWidgets(Widx::kMaxLoanSize, Widx::kMaxLoanSizeDown, Widx::kMaxLoanSizeUp, { 256, 67 }, { 100, 12 }, WindowColour::secondary, StringIds::max_loan_size_value),
+            Widgets::stepperWidgets(Widx::kLoanInterestRate, Widx::kLoanInterestRateDown, Widx::kLoanInterestRateUp, { 256, 82 }, { 100, 12 }, WindowColour::secondary, StringIds::loan_interest_rate_value)
 
         );
 
@@ -901,17 +971,17 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             tr.drawStringLeft(point, Colour::black, StringIds::loan_interest_rate);
         }
 
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
             auto& state = getGameState();
 
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::starting_loan_down:
+                case Widx::kStartingLoanDown:
                     CompanyManager::setStartingLoanSize(std::max<int16_t>(CompanyManager::getStartingLoanSize() - 50, Scenario::kMinStartLoanUnits));
                     break;
 
-                case widx::starting_loan_up:
+                case Widx::kStartingLoanUp:
                     CompanyManager::setStartingLoanSize(std::min<uint16_t>(CompanyManager::getStartingLoanSize() + 50, Scenario::kMaxStartLoanUnits));
                     if (CompanyManager::getStartingLoanSize() > CompanyManager::getMaxLoanSize())
                     {
@@ -919,7 +989,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     }
                     break;
 
-                case widx::max_loan_size_down:
+                case Widx::kMaxLoanSizeDown:
                     CompanyManager::setMaxLoanSize(std::max<int16_t>(CompanyManager::getMaxLoanSize() - 50, Scenario::kMinLoanSizeUnits));
                     if (CompanyManager::getStartingLoanSize() > CompanyManager::getMaxLoanSize())
                     {
@@ -927,15 +997,15 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     }
                     break;
 
-                case widx::max_loan_size_up:
+                case Widx::kMaxLoanSizeUp:
                     CompanyManager::setMaxLoanSize(std::min<uint16_t>(CompanyManager::getMaxLoanSize() + 50, Scenario::kMaxLoanSizeUnits));
                     break;
 
-                case widx::loan_interest_rate_down:
+                case Widx::kLoanInterestRateDown:
                     state.loanInterestRate = std::max<int16_t>(state.loanInterestRate - 1, Scenario::kMinLoanInterestUnits);
                     break;
 
-                case widx::loan_interest_rate_up:
+                case Widx::kLoanInterestRateUp:
                     state.loanInterestRate = std::min<uint16_t>(state.loanInterestRate + 1, Scenario::kMaxLoanInterestUnits);
                     break;
             }
@@ -943,18 +1013,18 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             self.invalidate();
         }
 
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_challenge:
-                case Common::widx::tab_companies:
-                case Common::widx::tab_finances:
-                case Common::widx::tab_scenario:
+                case Common::Widx::kTabChallenge:
+                case Common::Widx::kTabCompanies:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabScenario:
                     Common::switchTab(self, widgetIndex);
                     break;
             }
@@ -1011,11 +1081,19 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             change_details_btn,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kChangeNameBtn{ "change_name_btn" };
+            constexpr WidgetId kScenarioGroup{ "scenario_group" };
+            constexpr WidgetId kScenarioGroupBtn{ "scenario_group_btn" };
+            constexpr WidgetId kChangeDetailsBtn{ "change_details_btn" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(217, StringIds::title_scenario_options),
-            Widgets::Button({ 281, 52 }, { 75, 12 }, WindowColour::secondary, StringIds::change),
-            Widgets::dropdownWidgets({ 196, 67 }, { 160, 12 }, WindowColour::secondary, StringIds::empty),
-            Widgets::Button({ 281, 82 }, { 75, 12 }, WindowColour::secondary, StringIds::change)
+            Widgets::Button(Widx::kChangeNameBtn, { 281, 52 }, { 75, 12 }, WindowColour::secondary, StringIds::change),
+            Widgets::dropdownWidgets(Widx::kScenarioGroup, Widx::kScenarioGroupBtn, { 196, 67 }, { 160, 12 }, WindowColour::secondary, StringIds::empty),
+            Widgets::Button(Widx::kChangeDetailsBtn, { 281, 82 }, { 75, 12 }, WindowColour::secondary, StringIds::change)
 
         );
 
@@ -1097,9 +1175,9 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         };
 
         // 0x0043F14B
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            if (widgetIndex == widx::scenario_group_btn && itemIndex != -1)
+            if (id == Widx::kScenarioGroupBtn && itemIndex != -1)
             {
                 Scenario::getOptions().difficulty = itemIndex;
                 self.invalidate();
@@ -1107,9 +1185,9 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043F140
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            if (widgetIndex == widx::scenario_group_btn)
+            if (id == Widx::kScenarioGroupBtn)
             {
                 Widget& target = self.widgets[widx::scenario_group];
                 Dropdown::show(self.x + target.left, self.y + target.top, target.width() - 4, target.height(), self.getColour(WindowColour::secondary), std::size(scenarioGroupLabelIds), 0x80);
@@ -1124,22 +1202,22 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043F11F
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_challenge:
-                case Common::widx::tab_companies:
-                case Common::widx::tab_finances:
-                case Common::widx::tab_scenario:
+                case Common::Widx::kTabChallenge:
+                case Common::Widx::kTabCompanies:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabScenario:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::change_name_btn:
+                case Widx::kChangeNameBtn:
                 {
                     char* buffer = (char*)StringManager::getString(StringIds::buffer_2039);
                     strncpy(buffer, Scenario::getOptions().scenarioName, 512);
@@ -1149,7 +1227,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     break;
                 }
 
-                case widx::change_details_btn:
+                case Widx::kChangeDetailsBtn:
                 {
                     char* buffer = (char*)StringManager::getString(StringIds::buffer_2039);
                     strncpy(buffer, Scenario::getOptions().scenarioDetails, 512);
@@ -1182,11 +1260,11 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
         }
 
         // 0x0043F156
-        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
+        static void textInput(Window& self, [[maybe_unused]] WidgetIndex_t callingWidget, const WidgetId id, const char* input)
         {
-            switch (callingWidget)
+            switch (id)
             {
-                case widx::change_name_btn:
+                case Widx::kChangeNameBtn:
                 {
                     strncpy(Scenario::getOptions().scenarioName, input, sizeof(Scenario::Options::scenarioName) - 1);
                     Scenario::getOptions().scenarioName[sizeof(Scenario::Options::scenarioName) - 1] = '\0';
@@ -1195,7 +1273,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                     break;
                 }
 
-                case widx::change_details_btn:
+                case Widx::kChangeDetailsBtn:
                 {
                     strncpy(Scenario::getOptions().scenarioDetails, input, sizeof(Scenario::Options::scenarioDetails) - 1);
                     Scenario::getOptions().scenarioDetails[sizeof(Scenario::Options::scenarioDetails) - 1] = '\0';

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -30,22 +30,19 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 {
     static constexpr Ui::Size kWindowSize = { 610, 412 };
 
-    namespace widx
+    enum widx
     {
-        enum
-        {
-            frame,
-            title,
-            close,
-            panel,
-            tab0,
-            tab1,
-            tab2,
-            tab3,
-            tab4,
-            list,
-        };
-    }
+        frame,
+        title,
+        close,
+        panel,
+        tab0,
+        tab1,
+        tab2,
+        tab3,
+        tab4,
+        list,
+    };
 
     static constexpr auto _widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, { 610, 412 }, WindowColour::primary),

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -44,17 +44,29 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
         list,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kClose{ "close" };
+        constexpr WidgetId kPanel{ "panel" };
+        constexpr WidgetId kTab0{ "tab0" };
+        constexpr WidgetId kTab1{ "tab1" };
+        constexpr WidgetId kTab2{ "tab2" };
+        constexpr WidgetId kTab3{ "tab3" };
+        constexpr WidgetId kTab4{ "tab4" };
+        constexpr WidgetId kList{ "list" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, { 610, 412 }, WindowColour::primary),
         Widgets::Caption({ 1, 1 }, { 608, 34 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::select_scenario_for_new_game),
-        Widgets::ImageButton({ 595, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-        Widgets::Wt3Widget({ 0, 48 }, { 610, 364 }, WindowColour::secondary),
-        Widgets::Tab({ 3, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
-        Widgets::Tab({ 94, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
-        Widgets::Tab({ 185, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
-        Widgets::Tab({ 276, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
-        Widgets::Tab({ 367, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
-        Widgets::ScrollView({ 3, 52 }, { 431, 356 }, WindowColour::secondary, Scrollbars::vertical)
+        Widgets::ImageButton(Widx::kClose, { 595, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::Wt3Widget(Widx::kPanel, { 0, 48 }, { 610, 364 }, WindowColour::secondary),
+        Widgets::Tab(Widx::kTab0, { 3, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
+        Widgets::Tab(Widx::kTab1, { 94, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
+        Widgets::Tab(Widx::kTab2, { 185, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
+        Widgets::Tab(Widx::kTab3, { 276, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
+        Widgets::Tab(Widx::kTab4, { 367, 15 }, { 91, 34 }, WindowColour::secondary, ImageIds::wide_tab),
+        Widgets::ScrollView(Widx::kList, { 3, 52 }, { 431, 356 }, WindowColour::secondary, Scrollbars::vertical)
 
     );
 
@@ -446,26 +458,26 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
     }
 
     // 0x00443E9B
-    static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::close:
+            case Widx::kClose:
                 WindowManager::close(&self);
                 break;
         }
     }
 
     // 0x00443EA6
-    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::tab0:
-            case widx::tab1:
-            case widx::tab2:
-            case widx::tab3:
-            case widx::tab4:
+            case Widx::kTab0:
+            case Widx::kTab1:
+            case Widx::kTab2:
+            case Widx::kTab3:
+            case Widx::kTab4:
             {
                 uint8_t selectedCategory = widgetIndex - widx::tab0;
                 if (self.currentTab == selectedCategory)

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -57,23 +57,43 @@ namespace OpenLoco::Ui::Windows::StationList
         status_bar,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kFrame{ "frame" };
+        constexpr WidgetId kCaption{ "caption" };
+        constexpr WidgetId kCloseButton{ "close_button" };
+        constexpr WidgetId kPanel{ "panel" };
+        constexpr WidgetId kTabAllStations{ "tab_all_stations" };
+        constexpr WidgetId kTabRailStations{ "tab_rail_stations" };
+        constexpr WidgetId kTabRoadStations{ "tab_road_stations" };
+        constexpr WidgetId kTabAirports{ "tab_airports" };
+        constexpr WidgetId kTabShipPorts{ "tab_ship_ports" };
+        constexpr WidgetId kCompanySelect{ "company_select" };
+        constexpr WidgetId kSortName{ "sort_name" };
+        constexpr WidgetId kSortStatus{ "sort_status" };
+        constexpr WidgetId kSortTotalWaiting{ "sort_total_waiting" };
+        constexpr WidgetId kSortAccepts{ "sort_accepts" };
+        constexpr WidgetId kScrollview{ "scrollview" };
+        constexpr WidgetId kStatusBar{ "status_bar" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
-        Widgets::Frame({ 0, 0 }, { 600, 197 }, WindowColour::primary),
-        Widgets::Caption({ 1, 1 }, { 598, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, StringIds::stringid_all_stations),
-        Widgets::ImageButton({ 585, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-        Widgets::Panel({ 0, 41 }, { 600, 155 }, WindowColour::secondary),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_all_stations),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_rail_stations),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_road_stations),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_airports),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_ship_ports),
-        Widgets::ImageButton({ 0, 14 }, { 26, 26 }, WindowColour::primary, Widget::kContentNull, StringIds::tooltip_select_company),
-        Widgets::TableHeader({ 4, 43 }, { 200, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_name),
-        Widgets::TableHeader({ 204, 43 }, { 200, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_station_status),
-        Widgets::TableHeader({ 404, 43 }, { 90, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_total_units_waiting),
-        Widgets::TableHeader({ 494, 43 }, { 120, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_cargo_accepted),
-        Widgets::ScrollView({ 3, 56 }, { 594, 126 }, WindowColour::secondary, Scrollbars::vertical),
-        Widgets::Label({ 4, kWindowSize.height - 12 }, { kWindowSize.width - kResizeHandleSize, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid)
+        Widgets::Frame(Widx::kFrame, { 0, 0 }, { 600, 197 }, WindowColour::primary),
+        Widgets::Caption(Widx::kCaption, { 1, 1 }, { 598, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, StringIds::stringid_all_stations),
+        Widgets::ImageButton(Widx::kCloseButton, { 585, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::Panel(Widx::kPanel, { 0, 41 }, { 600, 155 }, WindowColour::secondary),
+        Widgets::Tab(Widx::kTabAllStations, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_all_stations),
+        Widgets::Tab(Widx::kTabRailStations, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_rail_stations),
+        Widgets::Tab(Widx::kTabRoadStations, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_road_stations),
+        Widgets::Tab(Widx::kTabAirports, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_airports),
+        Widgets::Tab(Widx::kTabShipPorts, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_ship_ports),
+        Widgets::ImageButton(Widx::kCompanySelect, { 0, 14 }, { 26, 26 }, WindowColour::primary, Widget::kContentNull, StringIds::tooltip_select_company),
+        Widgets::TableHeader(Widx::kSortName, { 4, 43 }, { 200, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_name),
+        Widgets::TableHeader(Widx::kSortStatus, { 204, 43 }, { 200, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_station_status),
+        Widgets::TableHeader(Widx::kSortTotalWaiting, { 404, 43 }, { 90, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_total_units_waiting),
+        Widgets::TableHeader(Widx::kSortAccepts, { 494, 43 }, { 120, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_cargo_accepted),
+        Widgets::ScrollView(Widx::kScrollview, { 3, 56 }, { 594, 126 }, WindowColour::secondary, Scrollbars::vertical),
+        Widgets::Label(Widx::kStatusBar, { 4, kWindowSize.height - 12 }, { kWindowSize.width - kResizeHandleSize, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid)
 
     );
 
@@ -325,9 +345,9 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x004919A4
-    static Ui::CursorId cursor(Window& window, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId cursor(Window& window, [[maybe_unused]] WidgetIndex_t widgetIdx, const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
     {
-        if (widgetIdx != widx::scrollview)
+        if (id != Widx::kScrollview)
         {
             return fallback;
         }
@@ -554,9 +574,9 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x004917BB
-    static void onDropdown(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+    static void onDropdown(Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
-        if (widgetIndex != widx::company_select)
+        if (id != Widx::kCompanySelect)
         {
             return;
         }
@@ -599,28 +619,28 @@ namespace OpenLoco::Ui::Windows::StationList
     }
 
     // 0x004917B0
-    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        if (widgetIndex == widx::company_select)
+        if (id == Widx::kCompanySelect)
         {
             Dropdown::populateCompanySelect(&window, &window.widgets[widgetIndex]);
         }
     }
 
     // 0x00491785
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::close_button:
+            case Widx::kCloseButton:
                 WindowManager::close(&window);
                 break;
 
-            case tab_all_stations:
-            case tab_rail_stations:
-            case tab_road_stations:
-            case tab_airports:
-            case tab_ship_ports:
+            case Widx::kTabAllStations:
+            case Widx::kTabRailStations:
+            case Widx::kTabRoadStations:
+            case Widx::kTabAirports:
+            case Widx::kTabShipPorts:
             {
                 if (ToolManager::isToolActive(window.type, window.number))
                 {
@@ -644,10 +664,10 @@ namespace OpenLoco::Ui::Windows::StationList
                 break;
             }
 
-            case sort_name:
-            case sort_status:
-            case sort_total_waiting:
-            case sort_accepts:
+            case Widx::kSortName:
+            case Widx::kSortStatus:
+            case Widx::kSortTotalWaiting:
+            case Widx::kSortAccepts:
             {
                 auto sortMode = widgetIndex - widx::sort_name;
                 if (window.sortMode == sortMode)

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -70,22 +70,39 @@ namespace OpenLoco::Ui::Windows::Station
             content_begin,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabStation{ "tab_station" };
+            constexpr WidgetId kTabCargo{ "tab_cargo" };
+            constexpr WidgetId kTabCargoRatings{ "tab_cargo_ratings" };
+            constexpr WidgetId kTabVehiclesTrains{ "tab_vehicles_trains" };
+            constexpr WidgetId kTabVehiclesBuses{ "tab_vehicles_buses" };
+            constexpr WidgetId kTabVehiclesTrucks{ "tab_vehicles_trucks" };
+            constexpr WidgetId kTabVehiclesTrams{ "tab_vehicles_trams" };
+            constexpr WidgetId kTabVehiclesAircraft{ "tab_vehicles_aircraft" };
+            constexpr WidgetId kTabVehiclesShips{ "tab_vehicles_ships" };
+        }
+
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight)
         {
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::blackText, WindowColour::primary, StringIds::title_station),
-                Widgets::ImageButton({ frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { frameWidth, 95 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_station),
-                Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_station_cargo),
-                Widgets::Tab({ 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_station_cargo_ratings),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trains),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_buses),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trucks),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trams),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_aircraft),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_ships));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::blackText, WindowColour::primary, StringIds::title_station),
+                Widgets::ImageButton(Widx::kCloseButton, { frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { frameWidth, 95 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabStation, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_station),
+                Widgets::Tab(Widx::kTabCargo, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_station_cargo),
+                Widgets::Tab(Widx::kTabCargoRatings, { 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_station_cargo_ratings),
+                Widgets::Tab(Widx::kTabVehiclesTrains, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trains),
+                Widgets::Tab(Widx::kTabVehiclesBuses, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_buses),
+                Widgets::Tab(Widx::kTabVehiclesTrucks, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trucks),
+                Widgets::Tab(Widx::kTabVehiclesTrams, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trams),
+                Widgets::Tab(Widx::kTabVehiclesAircraft, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_aircraft),
+                Widgets::Tab(Widx::kTabVehiclesShips, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_ships));
         }
 
         static bool isVehicleTypeAvailable(Window& self, VehicleType vehicleType)
@@ -120,12 +137,19 @@ namespace OpenLoco::Ui::Windows::Station
             centre_on_viewport,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kViewport{ "viewport" };
+            constexpr WidgetId kStatusBar{ "status_bar" };
+            constexpr WidgetId kCentreOnViewport{ "centre_on_viewport" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             // commonWidgets(kWindowSize.width, kWindowSize.height),
             Common::makeCommonWidgets(223, 136),
-            Widgets::Viewport({ 3, 44 }, { 195, 80 }, WindowColour::secondary, Widget::kContentUnk),
-            Widgets::Label({ 3, 115 }, { 195, 21 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid),
-            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this)
+            Widgets::Viewport(Widx::kViewport, { 3, 44 }, { 195, 80 }, WindowColour::secondary, Widget::kContentUnk),
+            Widgets::Label(Widx::kStatusBar, { 3, 115 }, { 195, 21 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid),
+            Widgets::ImageButton(Widx::kCentreOnViewport, { 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this)
 
         );
 
@@ -166,10 +190,10 @@ namespace OpenLoco::Ui::Windows::Station
         // 0x0048E4D4
         static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
                 // 0x0049932D
-                case widx::centre_on_viewport:
+                case Widx::kCentreOnViewport:
                     self.viewportCentreMain();
                     return;
             }
@@ -359,11 +383,18 @@ namespace OpenLoco::Ui::Windows::Station
             station_catchment,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kScrollview{ "scrollview" };
+            constexpr WidgetId kStatusBar{ "status_bar" };
+            constexpr WidgetId kStationCatchment{ "station_catchment" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(223, 136),
-            Widgets::ScrollView({ 3, 44 }, { 217, 80 }, WindowColour::secondary, 2),
-            Widgets::Label({ 3, 125 }, { 195, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::accepted_cargo_separator, StringIds::small_black_string),
-            Widgets::ImageButton({ 198, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::show_station_catchment, StringIds::station_catchment)
+            Widgets::ScrollView(Widx::kScrollview, { 3, 44 }, { 217, 80 }, WindowColour::secondary, 2),
+            Widgets::Label(Widx::kStatusBar, { 3, 125 }, { 195, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::accepted_cargo_separator, StringIds::small_black_string),
+            Widgets::ImageButton(Widx::kStationCatchment, { 198, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::show_station_catchment, StringIds::station_catchment)
 
         );
 
@@ -432,9 +463,9 @@ namespace OpenLoco::Ui::Windows::Station
         // 0x0048EB0B
         static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::station_catchment:
+                case Widx::kStationCatchment:
                 {
                     StationId windowNumber = StationId(self.number);
                     if (windowNumber == _lastSelectedStation)
@@ -477,15 +508,15 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048EB4F
-        static std::optional<FormatArguments> tooltip(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static std::optional<FormatArguments> tooltip(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
             FormatArguments args{};
 
-            if (widgetIndex == widx::scrollview)
+            if (id == Widx::kScrollview)
             {
                 args.push(StringIds::tooltip_scroll_cargo_list);
             }
-            else if (widgetIndex == widx::status_bar)
+            else if (id == Widx::kStatusBar)
             {
                 // First, find out how wide the 'Accepted:' label is
                 const char* acceptedLabel = StringManager::getString(StringIds::accepted_cargo_separator);
@@ -661,10 +692,16 @@ namespace OpenLoco::Ui::Windows::Station
             status_bar,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kScrollview{ "scrollview" };
+            constexpr WidgetId kStatusBar{ "status_bar" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(249, 136),
-            Widgets::ScrollView({ 3, 44 }, { 244, 80 }, WindowColour::secondary, 2),
-            Widgets::Label({ 3, 125 }, { 221, 11 }, WindowColour::secondary, ContentAlign::center)
+            Widgets::ScrollView(Widx::kScrollview, { 3, 44 }, { 244, 80 }, WindowColour::secondary, 2),
+            Widgets::Label(Widx::kStatusBar, { 3, 125 }, { 221, 11 }, WindowColour::secondary, ContentAlign::center)
 
         );
 
@@ -822,10 +859,16 @@ namespace OpenLoco::Ui::Windows::Station
             status_bar,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kScrollview{ "scrollview" };
+            constexpr WidgetId kStatusBar{ "status_bar" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(223, 136),
-            Widgets::ScrollView({ 3, 44 }, { 544, 138 }, WindowColour::secondary, Scrollbars::vertical),
-            Widgets::Label({ 3, kWindowSize.height - 13 }, { kWindowSize.width, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid)
+            Widgets::ScrollView(Widx::kScrollview, { 3, 44 }, { 544, 138 }, WindowColour::secondary, Scrollbars::vertical),
+            Widgets::Label(Widx::kStatusBar, { 3, kWindowSize.height - 13 }, { kWindowSize.width, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid)
 
         );
 
@@ -1065,9 +1108,9 @@ namespace OpenLoco::Ui::Windows::Station
             scrollHeight = self.rowCount * self.rowHeight;
         }
 
-        static CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, CursorId fallback)
+        static CursorId cursor(Window& self, [[maybe_unused]] WidgetIndex_t widgetIdx, const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, CursorId fallback)
         {
-            if (widgetIdx != widx::scrollview)
+            if (id != Widx::kScrollview)
             {
                 return fallback;
             }
@@ -1231,27 +1274,27 @@ namespace OpenLoco::Ui::Windows::Station
         };
         // clang-format on
 
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::caption:
+                case Widx::kCaption:
                     renameStationPrompt(&self, widgetIndex);
                     break;
 
-                case widx::close_button:
+                case Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case widx::tab_station:
-                case widx::tab_cargo:
-                case widx::tab_cargo_ratings:
-                case widx::tab_vehicles_trains:
-                case widx::tab_vehicles_buses:
-                case widx::tab_vehicles_trucks:
-                case widx::tab_vehicles_trams:
-                case widx::tab_vehicles_aircraft:
-                case widx::tab_vehicles_ships:
+                case Widx::kTabStation:
+                case Widx::kTabCargo:
+                case Widx::kTabCargoRatings:
+                case Widx::kTabVehiclesTrains:
+                case Widx::kTabVehiclesBuses:
+                case Widx::kTabVehiclesTrucks:
+                case Widx::kTabVehiclesTrams:
+                case Widx::kTabVehiclesAircraft:
+                case Widx::kTabVehiclesShips:
                     switchTab(self, widgetIndex);
                     break;
             }
@@ -1302,9 +1345,9 @@ namespace OpenLoco::Ui::Windows::Station
         }
 
         // 0x0048E5DF
-        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
+        static void textInput(Window& self, [[maybe_unused]] WidgetIndex_t callingWidget, const WidgetId id, const char* input)
         {
-            if (callingWidget != Common::widx::caption)
+            if (id != Common::Widx::kCaption)
             {
                 return;
             }

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -74,18 +74,31 @@ namespace OpenLoco::Ui::Windows::Terraform
             tab_build_walls,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabClearArea{ "tab_clear_area" };
+            constexpr WidgetId kTabAdjustLand{ "tab_adjust_land" };
+            constexpr WidgetId kTabAdjustWater{ "tab_adjust_water" };
+            constexpr WidgetId kTabPlantTrees{ "tab_plant_trees" };
+            constexpr WidgetId kTabBuildWalls{ "tab_build_walls" };
+        }
+
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, windowCaptionId),
-                Widgets::ImageButton({ frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { 130, 74 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_clear_land),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_adjust_land),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_adjust_water),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_plant_trees),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_walls));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, windowCaptionId),
+                Widgets::ImageButton(Widx::kCloseButton, { frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { 130, 74 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabClearArea, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_clear_land),
+                Widgets::Tab(Widx::kTabAdjustLand, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_adjust_land),
+                Widgets::Tab(Widx::kTabAdjustWater, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_adjust_water),
+                Widgets::Tab(Widx::kTabPlantTrees, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_plant_trees),
+                Widgets::Tab(Widx::kTabBuildWalls, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_walls));
         }
 
         static void switchTab(Window& self, WidgetIndex_t widgetIndex);
@@ -145,15 +158,24 @@ namespace OpenLoco::Ui::Windows::Terraform
             plant_cluster_random,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kScrollview{ "scrollview" };
+            constexpr WidgetId kRotateObject{ "rotate_object" };
+            constexpr WidgetId kObjectColour{ "object_colour" };
+            constexpr WidgetId kPlantClusterSelected{ "plant_cluster_selected" };
+            constexpr WidgetId kPlantClusterRandom{ "plant_cluster_random" };
+        }
+
         const uint64_t holdableWidgets = 0;
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(634, 162, StringIds::title_plant_trees),
-            Widgets::ScrollView({ 3, 45 }, { 605, kRowHeight }, WindowColour::secondary, Scrollbars::vertical),
-            Widgets::ImageButton({ 609, 46 }, { 24, 24 }, WindowColour::secondary, ImageIds::rotate_object, StringIds::rotate_object_90),
-            Widgets::ColourButton({ 609, 70 }, { 24, 24 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_object_colour),
-            Widgets::ImageButton({ 609, 94 }, { 24, 24 }, WindowColour::secondary, ImageIds::plant_cluster_selected_tree, StringIds::plant_cluster_selected_tree),
-            Widgets::ImageButton({ 609, 118 }, { 24, 24 }, WindowColour::secondary, ImageIds::plant_cluster_random_tree, StringIds::plant_cluster_random_tree)
+            Widgets::ScrollView(Widx::kScrollview, { 3, 45 }, { 605, kRowHeight }, WindowColour::secondary, Scrollbars::vertical),
+            Widgets::ImageButton(Widx::kRotateObject, { 609, 46 }, { 24, 24 }, WindowColour::secondary, ImageIds::rotate_object, StringIds::rotate_object_90),
+            Widgets::ColourButton(Widx::kObjectColour, { 609, 70 }, { 24, 24 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_object_colour),
+            Widgets::ImageButton(Widx::kPlantClusterSelected, { 609, 94 }, { 24, 24 }, WindowColour::secondary, ImageIds::plant_cluster_selected_tree, StringIds::plant_cluster_selected_tree),
+            Widgets::ImageButton(Widx::kPlantClusterRandom, { 609, 118 }, { 24, 24 }, WindowColour::secondary, ImageIds::plant_cluster_random_tree, StringIds::plant_cluster_random_tree)
 
         );
 
@@ -271,23 +293,23 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBAB5
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_adjust_land:
-                case Common::widx::tab_adjust_water:
-                case Common::widx::tab_build_walls:
-                case Common::widx::tab_clear_area:
-                case Common::widx::tab_plant_trees:
+                case Common::Widx::kTabAdjustLand:
+                case Common::Widx::kTabAdjustWater:
+                case Common::Widx::kTabBuildWalls:
+                case Common::Widx::kTabClearArea:
+                case Common::Widx::kTabPlantTrees:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::rotate_object:
+                case Widx::kRotateObject:
                 {
                     _treeRotation++;
                     _treeRotation &= 3;
@@ -295,7 +317,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     break;
                 }
 
-                case widx::plant_cluster_selected:
+                case Widx::kPlantClusterSelected:
                 {
                     if (_treeClusterType == treeCluster::selected)
                     {
@@ -309,7 +331,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     break;
                 }
 
-                case widx::plant_cluster_random:
+                case Widx::kPlantClusterRandom:
                 {
                     if (_treeClusterType == treeCluster::random)
                     {
@@ -338,9 +360,9 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBAEA
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            if (widgetIndex == widx::object_colour && self.rowHover != -1)
+            if (id == Widx::kObjectColour && self.rowHover != -1)
             {
                 auto obj = ObjectManager::get<TreeObject>(self.rowHover);
                 Dropdown::showColour(&self, &self.widgets[widgetIndex], obj->colours, _treeColour, self.getColour(WindowColour::secondary));
@@ -348,9 +370,9 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BBAF5
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            if (widgetIndex != widx::object_colour)
+            if (id != Widx::kObjectColour)
             {
                 return;
             }
@@ -972,13 +994,20 @@ namespace OpenLoco::Ui::Windows::Terraform
             increase_area,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kToolArea{ "tool_area" };
+            constexpr WidgetId kDecreaseArea{ "decrease_area" };
+            constexpr WidgetId kIncreaseArea{ "increase_area" };
+        }
+
         const uint64_t holdableWidgets = (1 << decrease_area) | (1 << increase_area);
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(130, 105, StringIds::clear_area),
-            Widgets::Wt3Widget({ 33 + 16, 45 }, { 64, 44 }, WindowColour::secondary, ImageIds::tool_area, StringIds::tooltip_clear_area),
-            Widgets::ImageButton({ 34 + 16, 46 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_clear_area),
-            Widgets::ImageButton({ 80 + 16, 72 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_clear_area)
+            Widgets::Wt3Widget(Widx::kToolArea, { 33 + 16, 45 }, { 64, 44 }, WindowColour::secondary, ImageIds::tool_area, StringIds::tooltip_clear_area),
+            Widgets::ImageButton(Widx::kDecreaseArea, { 34 + 16, 46 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_clear_area),
+            Widgets::ImageButton(Widx::kIncreaseArea, { 80 + 16, 72 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_clear_area)
 
         );
 
@@ -1004,11 +1033,11 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC65C
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::decrease_area:
+                case Widx::kDecreaseArea:
                 {
                     _adjustToolSize--;
                     if (_adjustToolSize < 1)
@@ -1020,7 +1049,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     break;
                 }
 
-                case widx::increase_area:
+                case Widx::kIncreaseArea:
                 {
                     _adjustToolSize++;
                     if (_adjustToolSize > 64)
@@ -1211,18 +1240,28 @@ namespace OpenLoco::Ui::Windows::Terraform
             land_material
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kToolArea{ "tool_area" };
+            constexpr WidgetId kDecreaseArea{ "decrease_area" };
+            constexpr WidgetId kIncreaseArea{ "increase_area" };
+            constexpr WidgetId kMountainMode{ "mountain_mode" };
+            constexpr WidgetId kPaintMode{ "paint_mode" };
+            constexpr WidgetId kLandMaterial{ "land_material" };
+        }
+
         const uint64_t holdableWidgets = (1 << decrease_area) | (1 << increase_area);
         static bool isMountainMode = false;
         static bool isPaintMode = false;
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(130, 105, StringIds::title_adjust_land),
-            Widgets::Wt3Widget({ 49, 45 }, { 64, 44 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_adjust_land_tool),
-            Widgets::ImageButton({ 50, 46 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_adjust_land_area),
-            Widgets::ImageButton({ 96, 72 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_adjust_land_area),
-            Widgets::ImageButton({ 57, 92 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_slope_up, StringIds::mountainModeTooltip),
-            Widgets::ImageButton({ 83, 92 }, { 24, 24 }, WindowColour::secondary, ImageIds::paintbrush, StringIds::tooltip_paint_landscape_tool),
-            Widgets::ImageButton({ 112, 94 }, { 20, 20 }, WindowColour::primary)
+            Widgets::Wt3Widget(Widx::kToolArea, { 49, 45 }, { 64, 44 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_adjust_land_tool),
+            Widgets::ImageButton(Widx::kDecreaseArea, { 50, 46 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_adjust_land_area),
+            Widgets::ImageButton(Widx::kIncreaseArea, { 96, 72 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_adjust_land_area),
+            Widgets::ImageButton(Widx::kMountainMode, { 57, 92 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_slope_up, StringIds::mountainModeTooltip),
+            Widgets::ImageButton(Widx::kPaintMode, { 83, 92 }, { 24, 24 }, WindowColour::secondary, ImageIds::paintbrush, StringIds::tooltip_paint_landscape_tool),
+            Widgets::ImageButton(Widx::kLandMaterial, { 112, 94 }, { 20, 20 }, WindowColour::primary)
 
         );
 
@@ -1325,17 +1364,17 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC9A7
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::land_material:
+                case Widx::kLandMaterial:
                 {
                     showDropdown(&self, widgetIndex);
                     break;
                 }
 
-                case widx::decrease_area:
+                case Widx::kDecreaseArea:
                 {
                     _adjustToolSize--;
                     if (_adjustToolSize < 1)
@@ -1347,7 +1386,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     break;
                 }
 
-                case widx::increase_area:
+                case Widx::kIncreaseArea:
                 {
                     _adjustToolSize++;
                     if (_adjustToolSize > 64)
@@ -1361,23 +1400,23 @@ namespace OpenLoco::Ui::Windows::Terraform
             }
         }
 
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_adjust_land:
-                case Common::widx::tab_adjust_water:
-                case Common::widx::tab_build_walls:
-                case Common::widx::tab_clear_area:
-                case Common::widx::tab_plant_trees:
+                case Common::Widx::kTabAdjustLand:
+                case Common::Widx::kTabAdjustWater:
+                case Common::Widx::kTabBuildWalls:
+                case Common::Widx::kTabClearArea:
+                case Common::Widx::kTabPlantTrees:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::mountain_mode:
+                case Widx::kMountainMode:
                 {
                     isMountainMode = !isMountainMode;
                     isPaintMode = false;
@@ -1386,7 +1425,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     break;
                 }
 
-                case widx::paint_mode:
+                case Widx::kPaintMode:
                 {
                     isMountainMode = false;
                     isPaintMode = !isPaintMode;
@@ -1398,9 +1437,9 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BC9C6
-        static void onDropdown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            if (widgetIndex != widx::land_material)
+            if (id != Widx::kLandMaterial)
             {
                 return;
             }
@@ -1894,13 +1933,20 @@ namespace OpenLoco::Ui::Windows::Terraform
             increase_area,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kToolArea{ "tool_area" };
+            constexpr WidgetId kDecreaseArea{ "decrease_area" };
+            constexpr WidgetId kIncreaseArea{ "increase_area" };
+        }
+
         const uint64_t holdableWidgets = (1 << decrease_area) | (1 << increase_area);
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(130, 105, StringIds::title_adjust_water),
-            Widgets::Wt3Widget({ 33 + 16, 45 }, { 64, 44 }, WindowColour::secondary, ImageIds::tool_area, StringIds::tooltip_adjust_water_tool),
-            Widgets::ImageButton({ 34 + 16, 46 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_adjust_water_area),
-            Widgets::ImageButton({ 80 + 16, 72 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_adjust_water_area)
+            Widgets::Wt3Widget(Widx::kToolArea, { 33 + 16, 45 }, { 64, 44 }, WindowColour::secondary, ImageIds::tool_area, StringIds::tooltip_adjust_water_tool),
+            Widgets::ImageButton(Widx::kDecreaseArea, { 34 + 16, 46 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::decrease_tool_area, Colour::white), StringIds::tooltip_decrease_adjust_water_area),
+            Widgets::ImageButton(Widx::kIncreaseArea, { 80 + 16, 72 }, { 16, 16 }, WindowColour::secondary, Gfx::recolour(ImageIds::increase_tool_area, Colour::white), StringIds::tooltip_increase_adjust_water_area)
 
         );
 
@@ -1927,11 +1973,11 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCD9D
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::decrease_area:
+                case Widx::kDecreaseArea:
                 {
                     _adjustToolSize--;
                     if (_adjustToolSize < 1)
@@ -1943,7 +1989,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     break;
                 }
 
-                case widx::increase_area:
+                case Widx::kIncreaseArea:
                 {
                     _adjustToolSize++;
                     if (_adjustToolSize > 64)
@@ -2243,11 +2289,16 @@ namespace OpenLoco::Ui::Windows::Terraform
             scrollview = 9,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kScrollview{ "scrollview" };
+        }
+
         const uint64_t holdableWidgets = 0;
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(418, 108, StringIds::title_build_walls),
-            Widgets::ScrollView({ 2, 45 }, { 391, kRowHeight }, WindowColour::secondary, Scrollbars::vertical)
+            Widgets::ScrollView(Widx::kScrollview, { 2, 45 }, { 391, kRowHeight }, WindowColour::secondary, Scrollbars::vertical)
 
         );
 
@@ -2783,19 +2834,19 @@ namespace OpenLoco::Ui::Windows::Terraform
         }
 
         // 0x004BCD82
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_adjust_land:
-                case Common::widx::tab_adjust_water:
-                case Common::widx::tab_build_walls:
-                case Common::widx::tab_clear_area:
-                case Common::widx::tab_plant_trees:
+                case Common::Widx::kTabAdjustLand:
+                case Common::Widx::kTabAdjustWater:
+                case Common::Widx::kTabBuildWalls:
+                case Common::Widx::kTabClearArea:
+                case Common::Widx::kTabPlantTrees:
                     Common::switchTab(self, widgetIndex);
                     break;
             }

--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -45,14 +45,23 @@ namespace OpenLoco::Ui::Windows::TextInput
         ok,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kTitle{ "title" };
+        constexpr WidgetId kClose{ "close" };
+        constexpr WidgetId kInput{ "input" };
+        constexpr WidgetId kCharLimit{ "charLimit" };
+        constexpr WidgetId kOk{ "ok" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, { 330, 90 }, WindowColour::primary),
-        Widgets::Caption({ 1, 1 }, { 328, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary),
-        Widgets::ImageButton({ 315, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::Caption(Widx::kTitle, { 1, 1 }, { 328, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary),
+        Widgets::ImageButton(Widx::kClose, { 315, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
         Widgets::Panel({ 0, 15 }, { 330, 75 }, WindowColour::secondary),
-        Widgets::TextBox({ 4, 58 }, { 322, 14 }, WindowColour::secondary),
-        Widgets::Label({ 150, 75 }, { 100, 10 }, WindowColour::secondary, ContentAlign::right, StringIds::num_characters_left_int_int),
-        Widgets::Button({ 256, 74 }, { 70, 12 }, WindowColour::secondary, StringIds::label_button_ok)
+        Widgets::TextBox(Widx::kInput, { 4, 58 }, { 322, 14 }, WindowColour::secondary),
+        Widgets::Label(Widx::kCharLimit, { 150, 75 }, { 100, 10 }, WindowColour::secondary, ContentAlign::right, StringIds::num_characters_left_int_int),
+        Widgets::Button(Widx::kOk, { 256, 74 }, { 70, 12 }, WindowColour::secondary, StringIds::label_button_ok)
 
     );
 
@@ -252,14 +261,14 @@ namespace OpenLoco::Ui::Windows::TextInput
     }
 
     // 0x004CE8B6
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::close:
+            case Widx::kClose:
                 WindowManager::close(&window);
                 break;
-            case widx::ok:
+            case Widx::kOk:
                 inputSession.sanitizeInput();
                 auto caller = WindowManager::find(_callingWindowType, _callingWindowNumber);
                 if (caller != nullptr)

--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -34,19 +34,16 @@ namespace OpenLoco::Ui::Windows::TextInput
 
     static Ui::TextInput::InputSession inputSession;
 
-    namespace Widx
+    enum widx
     {
-        enum
-        {
-            frame,
-            title,
-            close,
-            panel,
-            input,
-            charLimit,
-            ok,
-        };
-    }
+        frame,
+        title,
+        close,
+        panel,
+        input,
+        charLimit,
+        ok,
+    };
 
     static constexpr auto _widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, { 330, 90 }, WindowColour::primary),
@@ -96,7 +93,7 @@ namespace OpenLoco::Ui::Windows::TextInput
         StringManager::formatString(temp, value, valueArgs);
 
         inputSession = Ui::TextInput::InputSession(temp, inputSize);
-        inputSession.calculateTextOffset(window->widgets[Widx::input].width() - 2);
+        inputSession.calculateTextOffset(window->widgets[widx::input].width() - 2);
 
         caller = WindowManager::find(_callingWindowType, _callingWindowNumber);
 
@@ -120,15 +117,15 @@ namespace OpenLoco::Ui::Windows::TextInput
         }
 
         // TODO: Get the correct type and provide getter/setter.
-        window->widgets[Widx::title].styleData = enumValue(Widgets::Caption::Style::whiteText);
+        window->widgets[widx::title].styleData = enumValue(Widgets::Caption::Style::whiteText);
         if (window->owner != CompanyId::null)
         {
             window->flags |= WindowFlags::lighterFrame;
-            window->widgets[Widx::title].styleData = enumValue(Widgets::Caption::Style::colourText);
+            window->widgets[widx::title].styleData = enumValue(Widgets::Caption::Style::colourText);
         }
 
         // Focus the textbox element
-        Input::setFocus(window->type, window->number, Widx::input);
+        Input::setFocus(window->type, window->number, widx::input);
     }
 
     /**
@@ -184,13 +181,13 @@ namespace OpenLoco::Ui::Windows::TextInput
      */
     static void prepareDraw(Ui::Window& self)
     {
-        self.widgets[Widx::title].text = _title;
-        memcpy(self.widgets[Widx::title].textArgs.data(), _formatArgs.data(), 16);
+        self.widgets[widx::title].text = _title;
+        memcpy(self.widgets[widx::title].textArgs.data(), _formatArgs.data(), 16);
 
         const uint16_t numCharacters = static_cast<uint16_t>(inputSession.buffer.length());
         const uint16_t maxNumCharacters = inputSession.inputLenLimit;
 
-        FormatArguments args{ self.widgets[Widx::charLimit].textArgs };
+        FormatArguments args{ self.widgets[widx::charLimit].textArgs };
         args.push<uint16_t>(numCharacters);
         args.push<uint16_t>(maxNumCharacters);
     }
@@ -218,7 +215,7 @@ namespace OpenLoco::Ui::Windows::TextInput
         Ui::Point position = Point(window.x + window.width / 2, window.y + 30);
         tr.drawStringCentredWrapped(position, window.width - 8, Colour::black, StringIds::wcolour2_stringid, args2);
 
-        auto& inputWidget = window.widgets[Widx::input];
+        auto& inputWidget = window.widgets[widx::input];
         auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(inputWidget.left + 1 + window.x, inputWidget.top + 1 + window.y, inputWidget.width() - 2, inputWidget.height() - 2));
         if (!clipped)
         {
@@ -243,7 +240,7 @@ namespace OpenLoco::Ui::Windows::TextInput
             strncpy(drawnBuffer, inputSession.buffer.c_str(), inputSession.cursorPosition);
             drawnBuffer[inputSession.cursorPosition] = '\0';
 
-            if (Input::isFocused(window.type, window.number, Widx::input))
+            if (Input::isFocused(window.type, window.number, widx::input))
             {
                 auto width = tr.getStringWidth(drawnBuffer);
                 auto cursorPos = Point(inputSession.xOffset + width, 1);
@@ -259,10 +256,10 @@ namespace OpenLoco::Ui::Windows::TextInput
     {
         switch (widgetIndex)
         {
-            case Widx::close:
+            case widx::close:
                 WindowManager::close(&window);
                 break;
-            case Widx::ok:
+            case widx::ok:
                 inputSession.sanitizeInput();
                 auto caller = WindowManager::find(_callingWindowType, _callingWindowNumber);
                 if (caller != nullptr)
@@ -289,15 +286,15 @@ namespace OpenLoco::Ui::Windows::TextInput
     {
         if (charCode == SDLK_RETURN)
         {
-            w.callOnMouseUp(Widx::ok, w.widgets[Widx::ok].id);
+            w.callOnMouseUp(widx::ok, w.widgets[widx::ok].id);
             return true;
         }
         else if (charCode == SDLK_ESCAPE)
         {
-            w.callOnMouseUp(Widx::close, w.widgets[Widx::close].id);
+            w.callOnMouseUp(widx::close, w.widgets[widx::close].id);
             return true;
         }
-        else if (!Input::isFocused(w.type, w.number, Widx::input) || !inputSession.handleInput(charCode, keyCode))
+        else if (!Input::isFocused(w.type, w.number, widx::input) || !inputSession.handleInput(charCode, keyCode))
         {
             return false;
         }
@@ -305,7 +302,7 @@ namespace OpenLoco::Ui::Windows::TextInput
         WindowManager::invalidate(WindowType::textInput, 0);
         inputSession.cursorFrame = 0;
 
-        int containerWidth = w.widgets[Widx::input].width() - 2;
+        int containerWidth = w.widgets[widx::input].width() - 2;
         if (inputSession.needsReoffsetting(containerWidth))
         {
             inputSession.calculateTextOffset(containerWidth);

--- a/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
@@ -81,21 +81,40 @@ namespace OpenLoco::Ui::Windows::TileInspector
         detailsGroup,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kClose{ "close" };
+        constexpr WidgetId kPanel{ "panel" };
+        constexpr WidgetId kXPos{ "xPos" };
+        constexpr WidgetId kXPosDecrease{ "xPosDecrease" };
+        constexpr WidgetId kXPosIncrease{ "xPosIncrease" };
+        constexpr WidgetId kYPos{ "yPos" };
+        constexpr WidgetId kYPosDecrease{ "yPosDecrease" };
+        constexpr WidgetId kYPosIncrease{ "yPosIncrease" };
+        constexpr WidgetId kSelect{ "select" };
+        constexpr WidgetId kNameTypeHeader{ "nameTypeHeader" };
+        constexpr WidgetId kBaseHeightHeader{ "baseHeightHeader" };
+        constexpr WidgetId kClearHeightHeader{ "clearHeightHeader" };
+        constexpr WidgetId kDirectionHeader{ "directionHeader" };
+        constexpr WidgetId kGhostHeader{ "ghostHeader" };
+        constexpr WidgetId kDetailsGroup{ "detailsGroup" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, kWindowSize, WindowColour::primary),
         Widgets::Caption({ 1, 1 }, { kWindowSize.width - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, StringIds::tile_inspector),
-        Widgets::ImageButton({ kWindowSize.width - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-        Widgets::Panel({ 0, 15 }, { kWindowSize.width, kWindowSize.height - 15 }, WindowColour::secondary),
-        Widgets::stepperWidgets({ 19, 24 }, { 55, 12 }, WindowColour::secondary),
-        Widgets::stepperWidgets({ 92, 24 }, { 55, 12 }, WindowColour::secondary),
-        Widgets::ImageButton({ kWindowSize.width - 26, 18 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_new_position, StringIds::tile_inspector_select_btn_tooltip),
-        Widgets::TableHeader({ 4, 46 }, { kWindowSize.width - 98, 12 }, WindowColour::secondary, StringIds::tileInspectorHeaderNameType, StringIds::tileInspectorHeaderNameTypeTip), // name
-        Widgets::TableHeader({ kWindowSize.width - 109, 46 }, { 30, 12 }, WindowColour::secondary, StringIds::tileInspectorHeaderBaseHeight, StringIds::tileInspectorHeaderBaseHeightTip),
-        Widgets::TableHeader({ kWindowSize.width - 79, 46 }, { 30, 12 }, WindowColour::secondary, StringIds::tileInspectorHeaderClearHeight, StringIds::tileInspectorHeaderClearHeightTip),
-        Widgets::TableHeader({ kWindowSize.width - 49, 46 }, { 15, 12 }, WindowColour::secondary, StringIds::tileInspectorHeaderDirection, StringIds::tileInspectorHeaderDirectionTip),
-        Widgets::TableHeader({ kWindowSize.width - 34, 46 }, { 30, 12 }, WindowColour::secondary, StringIds::tileInspectorHeaderGhost, StringIds::tileInspectorHeaderGhostTip),
+        Widgets::ImageButton(Widx::kClose, { kWindowSize.width - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::Panel(Widx::kPanel, { 0, 15 }, { kWindowSize.width, kWindowSize.height - 15 }, WindowColour::secondary),
+        Widgets::stepperWidgets(Widx::kXPos, Widx::kXPosDecrease, Widx::kXPosIncrease, { 19, 24 }, { 55, 12 }, WindowColour::secondary),
+        Widgets::stepperWidgets(Widx::kYPos, Widx::kYPosDecrease, Widx::kYPosIncrease, { 92, 24 }, { 55, 12 }, WindowColour::secondary),
+        Widgets::ImageButton(Widx::kSelect, { kWindowSize.width - 26, 18 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_new_position, StringIds::tile_inspector_select_btn_tooltip),
+        Widgets::TableHeader(Widx::kNameTypeHeader, { 4, 46 }, { kWindowSize.width - 98, 12 }, WindowColour::secondary, StringIds::tileInspectorHeaderNameType, StringIds::tileInspectorHeaderNameTypeTip), // name
+        Widgets::TableHeader(Widx::kBaseHeightHeader, { kWindowSize.width - 109, 46 }, { 30, 12 }, WindowColour::secondary, StringIds::tileInspectorHeaderBaseHeight, StringIds::tileInspectorHeaderBaseHeightTip),
+        Widgets::TableHeader(Widx::kClearHeightHeader, { kWindowSize.width - 79, 46 }, { 30, 12 }, WindowColour::secondary, StringIds::tileInspectorHeaderClearHeight, StringIds::tileInspectorHeaderClearHeightTip),
+        Widgets::TableHeader(Widx::kDirectionHeader, { kWindowSize.width - 49, 46 }, { 15, 12 }, WindowColour::secondary, StringIds::tileInspectorHeaderDirection, StringIds::tileInspectorHeaderDirectionTip),
+        Widgets::TableHeader(Widx::kGhostHeader, { kWindowSize.width - 34, 46 }, { 30, 12 }, WindowColour::secondary, StringIds::tileInspectorHeaderGhost, StringIds::tileInspectorHeaderGhostTip),
         Widgets::ScrollView({ 4, 60 }, { kWindowSize.width - 8, 103 }, WindowColour::secondary, Ui::Scrollbars::vertical),
-        Widgets::GroupBox({ 4, 165 }, { kWindowSize.width - 8, 30 }, WindowColour::secondary, StringIds::tile_element_data)
+        Widgets::GroupBox(Widx::kDetailsGroup, { 4, 165 }, { kWindowSize.width - 8, 30 }, WindowColour::secondary, StringIds::tile_element_data)
 
     );
 
@@ -475,40 +494,40 @@ namespace OpenLoco::Ui::Windows::TileInspector
         }
     }
 
-    static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Ui::Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::close:
+            case Widx::kClose:
                 WindowManager::close(self.type);
                 break;
 
-            case widx::select:
+            case Widx::kSelect:
                 activateMapSelectionTool(self);
                 break;
         }
     }
 
-    static void onMouseDown(Ui::Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseDown(Ui::Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::xPosDecrease:
+            case Widx::kXPosDecrease:
                 _currentPosition.x = std::clamp<coord_t>(_currentPosition.x - 1, 1, World::kMapColumns);
                 self.invalidate();
                 break;
 
-            case widx::xPosIncrease:
+            case Widx::kXPosIncrease:
                 _currentPosition.x = std::clamp<coord_t>(_currentPosition.x + 1, 1, World::kMapColumns);
                 self.invalidate();
                 break;
 
-            case widx::yPosDecrease:
+            case Widx::kYPosDecrease:
                 _currentPosition.y = std::clamp<coord_t>(_currentPosition.y - 1, 1, World::kMapRows);
                 self.invalidate();
                 break;
 
-            case widx::yPosIncrease:
+            case Widx::kYPosIncrease:
                 _currentPosition.y = std::clamp<coord_t>(_currentPosition.y + 1, 1, World::kMapRows);
                 self.invalidate();
                 break;

--- a/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TileInspector.cpp
@@ -59,30 +59,27 @@ namespace OpenLoco::Ui::Windows::TileInspector
 
     static constexpr Ui::Size kWindowSize = { 350, 200 };
 
-    namespace widx
+    enum widx
     {
-        enum
-        {
-            frame,
-            title,
-            close,
-            panel,
-            xPos,
-            xPosDecrease,
-            xPosIncrease,
-            yPos,
-            yPosDecrease,
-            yPosIncrease,
-            select,
-            nameTypeHeader,
-            baseHeightHeader,
-            clearHeightHeader,
-            directionHeader,
-            ghostHeader,
-            scrollview,
-            detailsGroup,
-        };
-    }
+        frame,
+        title,
+        close,
+        panel,
+        xPos,
+        xPosDecrease,
+        xPosIncrease,
+        yPos,
+        yPosDecrease,
+        yPosIncrease,
+        select,
+        nameTypeHeader,
+        baseHeightHeader,
+        clearHeightHeader,
+        directionHeader,
+        ghostHeader,
+        scrollview,
+        detailsGroup,
+    };
 
     static constexpr auto _widgets = makeWidgets(
         Widgets::Frame({ 0, 0 }, kWindowSize, WindowColour::primary),

--- a/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
@@ -44,18 +44,30 @@ namespace OpenLoco::Ui::Windows::TimePanel
         extra_fast_forward_btn,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kOuterFrame{ "outer_frame" };
+        constexpr WidgetId kInnerFrame{ "inner_frame" };
+        constexpr WidgetId kMapChatMenu{ "map_chat_menu" };
+        constexpr WidgetId kDateBtn{ "date_btn" };
+        constexpr WidgetId kPauseBtn{ "pause_btn" };
+        constexpr WidgetId kNormalSpeedBtn{ "normal_speed_btn" };
+        constexpr WidgetId kFastForwardBtn{ "fast_forward_btn" };
+        constexpr WidgetId kExtraFastForwardBtn{ "extra_fast_forward_btn" };
+    }
+
     static void formatChallenge(FormatArguments& args);
     static void sendChatMessage(const char* str);
 
     static constexpr auto _widgets = makeWidgets(
-        Widgets::Wt3Widget({ 0, 0 }, { 140, 29 }, WindowColour::primary),
-        Widgets::Wt3Widget({ 2, 2 }, { 136, 25 }, WindowColour::primary),
-        Widgets::ImageButton({ 113, 1 }, { 26, 26 }, WindowColour::primary),
-        Widgets::ImageButton({ 2, 2 }, { 111, 12 }, WindowColour::primary, Widget::kContentNull, StringIds::tooltip_daymonthyear_challenge),
-        Widgets::ImageButton({ 18, 15 }, { 20, 12 }, WindowColour::primary, ImageIds::speed_pause, StringIds::tooltip_speed_pause),
-        Widgets::ImageButton({ 38, 15 }, { 20, 12 }, WindowColour::primary, ImageIds::speed_normal, StringIds::tooltip_speed_normal),
-        Widgets::ImageButton({ 58, 15 }, { 20, 12 }, WindowColour::primary, ImageIds::speed_fast_forward, StringIds::tooltip_speed_fast_forward),
-        Widgets::ImageButton({ 78, 15 }, { 20, 12 }, WindowColour::primary, ImageIds::speed_extra_fast_forward, StringIds::tooltip_speed_extra_fast_forward));
+        Widgets::Wt3Widget(Widx::kOuterFrame, { 0, 0 }, { 140, 29 }, WindowColour::primary),
+        Widgets::Wt3Widget(Widx::kInnerFrame, { 2, 2 }, { 136, 25 }, WindowColour::primary),
+        Widgets::ImageButton(Widx::kMapChatMenu, { 113, 1 }, { 26, 26 }, WindowColour::primary),
+        Widgets::ImageButton(Widx::kDateBtn, { 2, 2 }, { 111, 12 }, WindowColour::primary, Widget::kContentNull, StringIds::tooltip_daymonthyear_challenge),
+        Widgets::ImageButton(Widx::kPauseBtn, { 18, 15 }, { 20, 12 }, WindowColour::primary, ImageIds::speed_pause, StringIds::tooltip_speed_pause),
+        Widgets::ImageButton(Widx::kNormalSpeedBtn, { 38, 15 }, { 20, 12 }, WindowColour::primary, ImageIds::speed_normal, StringIds::tooltip_speed_normal),
+        Widgets::ImageButton(Widx::kFastForwardBtn, { 58, 15 }, { 20, 12 }, WindowColour::primary, ImageIds::speed_fast_forward, StringIds::tooltip_speed_fast_forward),
+        Widgets::ImageButton(Widx::kExtraFastForwardBtn, { 78, 15 }, { 20, 12 }, WindowColour::primary, ImageIds::speed_extra_fast_forward, StringIds::tooltip_speed_extra_fast_forward));
 
     static bool redrawScheduled = false; // 0x0050A004 (2nd bit)
 
@@ -187,23 +199,23 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x004398FB
-    static void onMouseUp([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::date_btn:
+            case Widx::kDateBtn:
                 MessageWindow::open();
                 break;
-            case widx::pause_btn:
+            case Widx::kPauseBtn:
                 GameCommands::doCommand(GameCommands::PauseGameArgs{}, GameCommands::Flags::apply);
                 break;
-            case widx::normal_speed_btn:
+            case Widx::kNormalSpeedBtn:
                 GameCommands::doCommand(GameCommands::SetGameSpeedArgs{ GameSpeed::Normal }, GameCommands::Flags::apply);
                 break;
-            case widx::fast_forward_btn:
+            case Widx::kFastForwardBtn:
                 GameCommands::doCommand(GameCommands::SetGameSpeedArgs{ GameSpeed::FastForward }, GameCommands::Flags::apply);
                 break;
-            case widx::extra_fast_forward_btn:
+            case Widx::kExtraFastForwardBtn:
                 GameCommands::doCommand(GameCommands::SetGameSpeedArgs{ GameSpeed::ExtraFastForward }, GameCommands::Flags::apply);
                 break;
         }
@@ -271,33 +283,33 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x043992E
-    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::map_chat_menu:
+            case Widx::kMapChatMenu:
                 mapMouseDown(&window, widgetIndex);
                 break;
         }
     }
 
     // 0x439939
-    static void onDropdown(Window& w, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t item_index)
+    static void onDropdown(Window& w, WidgetIndex_t widgetIndex, const WidgetId id, int16_t item_index)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::map_chat_menu:
+            case Widx::kMapChatMenu:
                 mapDropdown(&w, widgetIndex, item_index);
                 break;
         }
     }
 
     // 0x00439944
-    static Ui::CursorId onCursor([[maybe_unused]] Ui::Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
+    static Ui::CursorId onCursor([[maybe_unused]] Ui::Window& self, [[maybe_unused]] WidgetIndex_t widgetIdx, const WidgetId id, [[maybe_unused]] int16_t xPos, [[maybe_unused]] int16_t yPos, Ui::CursorId fallback)
     {
-        switch (widgetIdx)
+        switch (id)
         {
-            case widx::date_btn:
+            case Widx::kDateBtn:
                 Ui::ToolTip::setTooltipTimeout(2000);
                 break;
         }
@@ -306,12 +318,12 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x00439955
-    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static std::optional<FormatArguments> tooltip([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
         FormatArguments args{};
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::date_btn:
+            case Widx::kDateBtn:
                 formatChallenge(args);
                 break;
         }
@@ -359,11 +371,11 @@ namespace OpenLoco::Ui::Windows::TimePanel
     }
 
     // 0x00439A15
-    static void textInput([[maybe_unused]] Window& w, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const char* str)
+    static void textInput([[maybe_unused]] Window& w, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, const char* str)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::map_chat_menu:
+            case Widx::kMapChatMenu:
                 sendChatMessage(str);
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
@@ -32,20 +32,17 @@ namespace OpenLoco::Ui::Windows::TimePanel
     // When paused, the time panel will alternate between displaying "* paused *" and the in-game date every this many ticks.
     static constexpr auto kPausedStatusTextDuration = 30;
 
-    namespace Widx
+    enum widx
     {
-        enum
-        {
-            outer_frame,
-            inner_frame,
-            map_chat_menu,
-            date_btn,
-            pause_btn,
-            normal_speed_btn,
-            fast_forward_btn,
-            extra_fast_forward_btn,
-        };
-    }
+        outer_frame,
+        inner_frame,
+        map_chat_menu,
+        date_btn,
+        pause_btn,
+        normal_speed_btn,
+        fast_forward_btn,
+        extra_fast_forward_btn,
+    };
 
     static void formatChallenge(FormatArguments& args);
     static void sendChatMessage(const char* str);
@@ -90,52 +87,52 @@ namespace OpenLoco::Ui::Windows::TimePanel
     // 0x004396A4
     static void prepareDraw([[maybe_unused]] Window& window)
     {
-        window.widgets[Widx::inner_frame].hidden = true;
-        window.widgets[Widx::pause_btn].image = Gfx::recolour(ImageIds::speed_pause);
-        window.widgets[Widx::normal_speed_btn].image = Gfx::recolour(ImageIds::speed_normal);
-        window.widgets[Widx::fast_forward_btn].image = Gfx::recolour(ImageIds::speed_fast_forward);
-        window.widgets[Widx::extra_fast_forward_btn].image = Gfx::recolour(ImageIds::speed_extra_fast_forward);
+        window.widgets[widx::inner_frame].hidden = true;
+        window.widgets[widx::pause_btn].image = Gfx::recolour(ImageIds::speed_pause);
+        window.widgets[widx::normal_speed_btn].image = Gfx::recolour(ImageIds::speed_normal);
+        window.widgets[widx::fast_forward_btn].image = Gfx::recolour(ImageIds::speed_fast_forward);
+        window.widgets[widx::extra_fast_forward_btn].image = Gfx::recolour(ImageIds::speed_extra_fast_forward);
 
         if (SceneManager::isPaused())
         {
-            window.widgets[Widx::pause_btn].image = Gfx::recolour(ImageIds::speed_pause_active);
+            window.widgets[widx::pause_btn].image = Gfx::recolour(ImageIds::speed_pause_active);
         }
         else if (SceneManager::getGameSpeed() == GameSpeed::Normal)
         {
-            window.widgets[Widx::normal_speed_btn].image = Gfx::recolour(ImageIds::speed_normal_active);
+            window.widgets[widx::normal_speed_btn].image = Gfx::recolour(ImageIds::speed_normal_active);
         }
         else if (SceneManager::getGameSpeed() == GameSpeed::FastForward)
         {
-            window.widgets[Widx::fast_forward_btn].image = Gfx::recolour(ImageIds::speed_fast_forward_active);
+            window.widgets[widx::fast_forward_btn].image = Gfx::recolour(ImageIds::speed_fast_forward_active);
         }
         else if (SceneManager::getGameSpeed() == GameSpeed::ExtraFastForward)
         {
-            window.widgets[Widx::extra_fast_forward_btn].image = Gfx::recolour(ImageIds::speed_extra_fast_forward_active);
+            window.widgets[widx::extra_fast_forward_btn].image = Gfx::recolour(ImageIds::speed_extra_fast_forward_active);
         }
 
         if (SceneManager::isNetworked())
         {
-            window.widgets[Widx::fast_forward_btn].hidden = true;
-            window.widgets[Widx::extra_fast_forward_btn].hidden = true;
+            window.widgets[widx::fast_forward_btn].hidden = true;
+            window.widgets[widx::extra_fast_forward_btn].hidden = true;
 
-            window.widgets[Widx::pause_btn].left = 38;
-            window.widgets[Widx::pause_btn].right = 57;
-            window.widgets[Widx::normal_speed_btn].left = 58;
-            window.widgets[Widx::normal_speed_btn].right = 77;
+            window.widgets[widx::pause_btn].left = 38;
+            window.widgets[widx::pause_btn].right = 57;
+            window.widgets[widx::normal_speed_btn].left = 58;
+            window.widgets[widx::normal_speed_btn].right = 77;
         }
         else
         {
-            window.widgets[Widx::fast_forward_btn].hidden = false;
-            window.widgets[Widx::extra_fast_forward_btn].hidden = false;
+            window.widgets[widx::fast_forward_btn].hidden = false;
+            window.widgets[widx::extra_fast_forward_btn].hidden = false;
 
-            window.widgets[Widx::pause_btn].left = 18;
-            window.widgets[Widx::pause_btn].right = 37;
-            window.widgets[Widx::normal_speed_btn].left = 38;
-            window.widgets[Widx::normal_speed_btn].right = 57;
-            window.widgets[Widx::fast_forward_btn].left = 58;
-            window.widgets[Widx::fast_forward_btn].right = 77;
-            window.widgets[Widx::extra_fast_forward_btn].left = 78;
-            window.widgets[Widx::extra_fast_forward_btn].right = 97;
+            window.widgets[widx::pause_btn].left = 18;
+            window.widgets[widx::pause_btn].right = 37;
+            window.widgets[widx::normal_speed_btn].left = 38;
+            window.widgets[widx::normal_speed_btn].right = 57;
+            window.widgets[widx::fast_forward_btn].left = 58;
+            window.widgets[widx::fast_forward_btn].right = 77;
+            window.widgets[widx::extra_fast_forward_btn].left = 78;
+            window.widgets[widx::extra_fast_forward_btn].right = 97;
         }
     }
 
@@ -152,7 +149,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     {
         auto tr = Gfx::TextRenderer(drawingCtx);
 
-        Widget& frame = self.widgets[Widx::outer_frame];
+        Widget& frame = self.widgets[widx::outer_frame];
         drawingCtx.drawRect(self.x + frame.left, self.y + frame.top, frame.width(), frame.height(), enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
 
         // Draw widgets.
@@ -174,19 +171,19 @@ namespace OpenLoco::Ui::Windows::TimePanel
         }
 
         auto c = self.getColour(WindowColour::primary).opaque();
-        if (Input::isHovering(WindowType::timeToolbar, 0, Widx::date_btn))
+        if (Input::isHovering(WindowType::timeToolbar, 0, widx::date_btn))
         {
             c = Colour::white;
         }
 
         {
-            auto& widget = _widgets[Widx::date_btn];
+            auto& widget = _widgets[widx::date_btn];
             auto point = Point(self.x + widget.midX(), self.y + widget.top + 1);
             tr.drawStringCentred(point, c, format, args);
         }
 
         auto skin = ObjectManager::get<InterfaceSkinObject>();
-        drawingCtx.drawImage(ZoomLevel::full, self.x + _widgets[Widx::map_chat_menu].left - 2, self.y + _widgets[Widx::map_chat_menu].top - 1, skin->img + map_sprites_by_rotation[WindowManager::getCurrentRotation()]);
+        drawingCtx.drawImage(ZoomLevel::full, self.x + _widgets[widx::map_chat_menu].left - 2, self.y + _widgets[widx::map_chat_menu].top - 1, skin->img + map_sprites_by_rotation[WindowManager::getCurrentRotation()]);
     }
 
     // 0x004398FB
@@ -194,19 +191,19 @@ namespace OpenLoco::Ui::Windows::TimePanel
     {
         switch (widgetIndex)
         {
-            case Widx::date_btn:
+            case widx::date_btn:
                 MessageWindow::open();
                 break;
-            case Widx::pause_btn:
+            case widx::pause_btn:
                 GameCommands::doCommand(GameCommands::PauseGameArgs{}, GameCommands::Flags::apply);
                 break;
-            case Widx::normal_speed_btn:
+            case widx::normal_speed_btn:
                 GameCommands::doCommand(GameCommands::SetGameSpeedArgs{ GameSpeed::Normal }, GameCommands::Flags::apply);
                 break;
-            case Widx::fast_forward_btn:
+            case widx::fast_forward_btn:
                 GameCommands::doCommand(GameCommands::SetGameSpeedArgs{ GameSpeed::FastForward }, GameCommands::Flags::apply);
                 break;
-            case Widx::extra_fast_forward_btn:
+            case widx::extra_fast_forward_btn:
                 GameCommands::doCommand(GameCommands::SetGameSpeedArgs{ GameSpeed::ExtraFastForward }, GameCommands::Flags::apply);
                 break;
         }
@@ -239,7 +236,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
         args.push(opponent->name);
 
         // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments
-        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::map_chat_menu, args);
+        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, widx::map_chat_menu, args);
     }
 
     // 0x0043A72F
@@ -278,7 +275,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     {
         switch (widgetIndex)
         {
-            case Widx::map_chat_menu:
+            case widx::map_chat_menu:
                 mapMouseDown(&window, widgetIndex);
                 break;
         }
@@ -289,7 +286,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     {
         switch (widgetIndex)
         {
-            case Widx::map_chat_menu:
+            case widx::map_chat_menu:
                 mapDropdown(&w, widgetIndex, item_index);
                 break;
         }
@@ -300,7 +297,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     {
         switch (widgetIdx)
         {
-            case Widx::date_btn:
+            case widx::date_btn:
                 Ui::ToolTip::setTooltipTimeout(2000);
                 break;
         }
@@ -314,7 +311,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
         FormatArguments args{};
         switch (widgetIndex)
         {
-            case Widx::date_btn:
+            case widx::date_btn:
                 formatChallenge(args);
                 break;
         }
@@ -366,7 +363,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
     {
         switch (widgetIndex)
         {
-            case Widx::map_chat_menu:
+            case widx::map_chat_menu:
                 sendChatMessage(str);
                 break;
         }
@@ -411,7 +408,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
             redrawScheduled = false;
 
             // Invalidating the inner frame widget effectively causes the entire time panel to be redrawn.
-            WindowManager::invalidateWidget(WindowType::timeToolbar, 0, Widx::inner_frame);
+            WindowManager::invalidateWidget(WindowType::timeToolbar, 0, widx::inner_frame);
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/TitleExit.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleExit.cpp
@@ -22,8 +22,13 @@ namespace OpenLoco::Ui::Windows::TitleExit
         exit_button
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kExitButton{ "exit_button" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
-        Widgets::ImageButton({ 0, 0 }, kWindowSize, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_exit_from_game)
+        Widgets::ImageButton(Widx::kExitButton, { 0, 0 }, kWindowSize, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_exit_from_game)
 
     );
 
@@ -71,16 +76,16 @@ namespace OpenLoco::Ui::Windows::TitleExit
     }
 
     // 0x00439268
-    static void onMouseUp([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp([[maybe_unused]] Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
         if (Intro::isActive())
         {
             return;
         }
 
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::exit_button:
+            case Widx::kExitButton:
                 // Exit to desktop
                 GameCommands::LoadSaveQuitGameArgs args{};
                 args.loadQuitMode = LoadOrQuitMode::quitGamePrompt;

--- a/src/OpenLoco/src/Ui/Windows/TitleExit.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleExit.cpp
@@ -17,13 +17,10 @@ namespace OpenLoco::Ui::Windows::TitleExit
 {
     static constexpr Ui::Size kWindowSize = { 40, 28 };
 
-    namespace Widx
+    enum widx
     {
-        enum
-        {
-            exit_button
-        };
-    }
+        exit_button
+    };
 
     static constexpr auto _widgets = makeWidgets(
         Widgets::ImageButton({ 0, 0 }, kWindowSize, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_exit_from_game)
@@ -56,7 +53,7 @@ namespace OpenLoco::Ui::Windows::TitleExit
         self.width = Gfx::TextRenderer::getStringWidthNewLined(Gfx::Font::medium_bold, exitString) + 10;
 
         self.x = Ui::width() - self.width;
-        self.widgets[Widx::exit_button].right = self.width;
+        self.widgets[widx::exit_button].right = self.width;
     }
 
     // 0x00439236
@@ -68,7 +65,7 @@ namespace OpenLoco::Ui::Windows::TitleExit
         window.draw(drawingCtx);
 
         int16_t x = window.x + window.width / 2;
-        int16_t y = window.y + window.widgets[Widx::exit_button].top + 8;
+        int16_t y = window.y + window.widgets[widx::exit_button].top + 8;
         Ui::Point origin = { x, y };
         tr.drawStringCentredWrapped(origin, window.width, Colour::black, StringIds::title_exit_game);
     }
@@ -83,7 +80,7 @@ namespace OpenLoco::Ui::Windows::TitleExit
 
         switch (widgetIndex)
         {
-            case Widx::exit_button:
+            case widx::exit_button:
                 // Exit to desktop
                 GameCommands::LoadSaveQuitGameArgs args{};
                 args.loadQuitMode = LoadOrQuitMode::quitGamePrompt;

--- a/src/OpenLoco/src/Ui/Windows/TitleLogo.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleLogo.cpp
@@ -10,13 +10,10 @@ namespace OpenLoco::Ui::Windows::TitleLogo
 {
     static constexpr Ui::Size kWindowSize = { 298, 170 };
 
-    namespace Widx
+    enum widx
     {
-        enum
-        {
-            logo
-        };
-    }
+        logo
+    };
 
     static constexpr auto _widgets = makeWidgets(
         Widgets::Wt3Widget({ 0, 0 }, kWindowSize, WindowColour::primary)
@@ -54,7 +51,7 @@ namespace OpenLoco::Ui::Windows::TitleLogo
     {
         switch (widgetIndex)
         {
-            case Widx::logo:
+            case widx::logo:
                 About::open();
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/TitleLogo.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleLogo.cpp
@@ -15,8 +15,13 @@ namespace OpenLoco::Ui::Windows::TitleLogo
         logo
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kLogo{ "logo" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
-        Widgets::Wt3Widget({ 0, 0 }, kWindowSize, WindowColour::primary)
+        Widgets::Wt3Widget(Widx::kLogo, { 0, 0 }, kWindowSize, WindowColour::primary)
 
     );
 
@@ -47,11 +52,11 @@ namespace OpenLoco::Ui::Windows::TitleLogo
     }
 
     // 0x004392AD
-    static void onMouseUp([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp([[maybe_unused]] Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::logo:
+            case Widx::kLogo:
                 About::open();
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
@@ -118,13 +118,23 @@ namespace OpenLoco::Ui::Windows::TitleMenu
         multiplayer_toggle_btn,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kScenarioListBtn{ "scenario_list_btn" };
+        constexpr WidgetId kLoadGameBtn{ "load_game_btn" };
+        constexpr WidgetId kTutorialBtn{ "tutorial_btn" };
+        constexpr WidgetId kScenarioEditorBtn{ "scenario_editor_btn" };
+        constexpr WidgetId kChatBtn{ "chat_btn" };
+        constexpr WidgetId kMultiplayerToggleBtn{ "multiplayer_toggle_btn" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
-        Widgets::ImageButton({ 0, 0 }, { kBtnMainSize, kBtnMainSize }, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_new_game),
-        Widgets::ImageButton({ kBtnMainSize, 0 }, { kBtnMainSize, kBtnMainSize }, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_load_game),
-        Widgets::ImageButton({ kBtnMainSize * 2, 0 }, { kBtnMainSize, kBtnMainSize }, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_show_tutorial),
-        Widgets::ImageButton({ kBtnMainSize * 3, 0 }, { kBtnMainSize, kBtnMainSize }, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_scenario_editor),
-        Widgets::ImageButton({ kBtnMainSize * 4 - 31, kBtnMainSize - 27 }, { 31, 27 }, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_chat_tooltip),
-        Widgets::ImageButton({ 0, kBtnMainSize }, { kWW, kBtnSubHeight }, WindowColour::secondary, Widget::kContentNull, StringIds::title_multiplayer_toggle_tooltip)
+        Widgets::ImageButton(Widx::kScenarioListBtn, { 0, 0 }, { kBtnMainSize, kBtnMainSize }, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_new_game),
+        Widgets::ImageButton(Widx::kLoadGameBtn, { kBtnMainSize, 0 }, { kBtnMainSize, kBtnMainSize }, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_load_game),
+        Widgets::ImageButton(Widx::kTutorialBtn, { kBtnMainSize * 2, 0 }, { kBtnMainSize, kBtnMainSize }, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_show_tutorial),
+        Widgets::ImageButton(Widx::kScenarioEditorBtn, { kBtnMainSize * 3, 0 }, { kBtnMainSize, kBtnMainSize }, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_scenario_editor),
+        Widgets::ImageButton(Widx::kChatBtn, { kBtnMainSize * 4 - 31, kBtnMainSize - 27 }, { 31, 27 }, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_chat_tooltip),
+        Widgets::ImageButton(Widx::kMultiplayerToggleBtn, { 0, kBtnMainSize }, { kWW, kBtnSubHeight }, WindowColour::secondary, Widget::kContentNull, StringIds::title_multiplayer_toggle_tooltip)
 
     );
 
@@ -288,65 +298,65 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     }
 
     // 0x00439094
-    static void onMouseUp(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
         if (Intro::isActive())
         {
             return;
         }
 
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::scenario_list_btn:
+            case Widx::kScenarioListBtn:
                 sub_4391DA();
                 break;
-            case widx::load_game_btn:
+            case Widx::kLoadGameBtn:
                 sub_4391E2();
                 break;
-            case widx::scenario_editor_btn:
+            case Widx::kScenarioEditorBtn:
                 Title::stop();
                 sub_43910A();
                 break;
-            case widx::chat_btn:
+            case Widx::kChatBtn:
                 beginSendChatMessage(window);
                 break;
-            case widx::multiplayer_toggle_btn:
+            case Widx::kMultiplayerToggleBtn:
                 showMultiplayer(&window);
                 break;
         }
     }
 
     // 0x004390D1
-    static void onMouseDown(Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseDown(Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::tutorial_btn:
+            case Widx::kTutorialBtn:
                 sub_439112(&window);
                 break;
         }
     }
 
     // 0x004390DD
-    static void onDropdown([[maybe_unused]] Ui::Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+    static void onDropdown([[maybe_unused]] Ui::Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::tutorial_btn:
+            case Widx::kTutorialBtn:
                 sub_4391CC(itemIndex);
                 break;
         }
     }
 
     // 0x004390ED
-    static void onTextInput([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const char* input)
+    static void onTextInput([[maybe_unused]] Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, const char* input)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::chat_btn:
+            case Widx::kChatBtn:
                 sub_43918F(input);
                 break;
-            case widx::multiplayer_toggle_btn:
+            case Widx::kMultiplayerToggleBtn:
                 multiplayerConnect(input);
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
@@ -108,18 +108,15 @@ namespace OpenLoco::Ui::Windows::TitleMenu
         ImageIds::title_menu_globe_construct_31,
     };
 
-    namespace Widx
+    enum widx
     {
-        enum
-        {
-            scenario_list_btn,
-            load_game_btn,
-            tutorial_btn,
-            scenario_editor_btn,
-            chat_btn,
-            multiplayer_toggle_btn,
-        };
-    }
+        scenario_list_btn,
+        load_game_btn,
+        tutorial_btn,
+        scenario_editor_btn,
+        chat_btn,
+        multiplayer_toggle_btn,
+    };
 
     static constexpr auto _widgets = makeWidgets(
         Widgets::ImageButton({ 0, 0 }, { kBtnMainSize, kBtnMainSize }, WindowColour::secondary, Widget::kContentNull, StringIds::title_menu_new_game),
@@ -164,36 +161,36 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     static void prepareDraw(Ui::Window& window)
     {
         window.disabledWidgets = 0;
-        window.widgets[Widx::tutorial_btn].hidden = false;
-        window.widgets[Widx::scenario_editor_btn].hidden = false;
+        window.widgets[widx::tutorial_btn].hidden = false;
+        window.widgets[widx::scenario_editor_btn].hidden = false;
 
         // TODO: add widget::set_origin()
-        window.widgets[Widx::scenario_list_btn].left = 0;
-        window.widgets[Widx::scenario_list_btn].right = kBtnMainSize - 1;
-        window.widgets[Widx::load_game_btn].left = kBtnMainSize;
-        window.widgets[Widx::load_game_btn].right = kBtnMainSize * 2 - 1;
-        window.widgets[Widx::tutorial_btn].left = kBtnMainSize * 2;
-        window.widgets[Widx::tutorial_btn].right = kBtnMainSize * 3 - 1;
-        window.widgets[Widx::scenario_editor_btn].left = kBtnMainSize * 3;
-        window.widgets[Widx::scenario_editor_btn].right = kBtnMainSize * 4 - 1;
-        window.widgets[Widx::chat_btn].hidden = true;
+        window.widgets[widx::scenario_list_btn].left = 0;
+        window.widgets[widx::scenario_list_btn].right = kBtnMainSize - 1;
+        window.widgets[widx::load_game_btn].left = kBtnMainSize;
+        window.widgets[widx::load_game_btn].right = kBtnMainSize * 2 - 1;
+        window.widgets[widx::tutorial_btn].left = kBtnMainSize * 2;
+        window.widgets[widx::tutorial_btn].right = kBtnMainSize * 3 - 1;
+        window.widgets[widx::scenario_editor_btn].left = kBtnMainSize * 3;
+        window.widgets[widx::scenario_editor_btn].right = kBtnMainSize * 4 - 1;
+        window.widgets[widx::chat_btn].hidden = true;
 
         auto& config = Config::get();
-        window.widgets[Widx::multiplayer_toggle_btn].hidden = config.network.enabled ? false : true;
+        window.widgets[widx::multiplayer_toggle_btn].hidden = config.network.enabled ? false : true;
 
         if (SceneManager::isNetworked())
         {
-            window.widgets[Widx::tutorial_btn].hidden = true;
-            window.widgets[Widx::scenario_editor_btn].hidden = true;
+            window.widgets[widx::tutorial_btn].hidden = true;
+            window.widgets[widx::scenario_editor_btn].hidden = true;
 
-            window.widgets[Widx::scenario_list_btn].left = kBtnMainSize;
-            window.widgets[Widx::scenario_list_btn].right = kBtnMainSize * 2 - 1;
-            window.widgets[Widx::load_game_btn].left = kBtnMainSize * 2;
-            window.widgets[Widx::load_game_btn].right = kBtnMainSize * 3 - 1;
+            window.widgets[widx::scenario_list_btn].left = kBtnMainSize;
+            window.widgets[widx::scenario_list_btn].right = kBtnMainSize * 2 - 1;
+            window.widgets[widx::load_game_btn].left = kBtnMainSize * 2;
+            window.widgets[widx::load_game_btn].right = kBtnMainSize * 3 - 1;
 
-            window.widgets[Widx::chat_btn].hidden = false;
+            window.widgets[widx::chat_btn].hidden = false;
             auto* skin = ObjectManager::get<InterfaceSkinObject>();
-            window.widgets[Widx::chat_btn].image = skin->img + InterfaceSkin::ImageIds::phone;
+            window.widgets[widx::chat_btn].image = skin->img + InterfaceSkin::ImageIds::phone;
         }
     }
 
@@ -205,13 +202,13 @@ namespace OpenLoco::Ui::Windows::TitleMenu
         // Draw widgets.
         window.draw(drawingCtx);
 
-        if (!window.widgets[Widx::scenario_list_btn].hidden)
+        if (!window.widgets[widx::scenario_list_btn].hidden)
         {
-            int16_t x = window.widgets[Widx::scenario_list_btn].left + window.x;
-            int16_t y = window.widgets[Widx::scenario_list_btn].top + window.y;
+            int16_t x = window.widgets[widx::scenario_list_btn].left + window.x;
+            int16_t y = window.widgets[widx::scenario_list_btn].top + window.y;
 
             uint32_t image_id = ImageIds::title_menu_globe_spin_0;
-            if (Input::isHovering(WindowType::titleMenu, 0, Widx::scenario_list_btn))
+            if (Input::isHovering(WindowType::titleMenu, 0, widx::scenario_list_btn))
             {
                 image_id = kGlobeSpin[((window.var_846 / 2) % kGlobeSpin.size())];
             }
@@ -220,13 +217,13 @@ namespace OpenLoco::Ui::Windows::TitleMenu
             drawingCtx.drawImage(ZoomLevel::full, x, y, ImageIds::title_menu_sparkle);
         }
 
-        if (!window.widgets[Widx::load_game_btn].hidden)
+        if (!window.widgets[widx::load_game_btn].hidden)
         {
-            int16_t x = window.widgets[Widx::load_game_btn].left + window.x;
-            int16_t y = window.widgets[Widx::load_game_btn].top + window.y;
+            int16_t x = window.widgets[widx::load_game_btn].left + window.x;
+            int16_t y = window.widgets[widx::load_game_btn].top + window.y;
 
             uint32_t image_id = ImageIds::title_menu_globe_spin_0;
-            if (Input::isHovering(WindowType::titleMenu, 0, Widx::load_game_btn))
+            if (Input::isHovering(WindowType::titleMenu, 0, widx::load_game_btn))
             {
                 image_id = kGlobeSpin[((window.var_846 / 2) % kGlobeSpin.size())];
             }
@@ -235,13 +232,13 @@ namespace OpenLoco::Ui::Windows::TitleMenu
             drawingCtx.drawImage(ZoomLevel::full, x, y, ImageIds::title_menu_save);
         }
 
-        if (!window.widgets[Widx::tutorial_btn].hidden)
+        if (!window.widgets[widx::tutorial_btn].hidden)
         {
-            int16_t x = window.widgets[Widx::tutorial_btn].left + window.x;
-            int16_t y = window.widgets[Widx::tutorial_btn].top + window.y;
+            int16_t x = window.widgets[widx::tutorial_btn].left + window.x;
+            int16_t y = window.widgets[widx::tutorial_btn].top + window.y;
 
             uint32_t image_id = ImageIds::title_menu_globe_spin_0;
-            if (Input::isHovering(WindowType::titleMenu, 0, Widx::tutorial_btn))
+            if (Input::isHovering(WindowType::titleMenu, 0, widx::tutorial_btn))
             {
                 image_id = kGlobeSpin[((window.var_846 / 2) % kGlobeSpin.size())];
             }
@@ -252,13 +249,13 @@ namespace OpenLoco::Ui::Windows::TitleMenu
             drawingCtx.drawImage(ZoomLevel::full, x, y, ImageIds::title_menu_lesson_l);
         }
 
-        if (!window.widgets[Widx::scenario_editor_btn].hidden)
+        if (!window.widgets[widx::scenario_editor_btn].hidden)
         {
-            int16_t x = window.widgets[Widx::scenario_editor_btn].left + window.x;
-            int16_t y = window.widgets[Widx::scenario_editor_btn].top + window.y;
+            int16_t x = window.widgets[widx::scenario_editor_btn].left + window.x;
+            int16_t y = window.widgets[widx::scenario_editor_btn].top + window.y;
 
             uint32_t image_id = ImageIds::title_menu_globe_construct_24;
-            if (Input::isHovering(WindowType::titleMenu, 0, Widx::scenario_editor_btn))
+            if (Input::isHovering(WindowType::titleMenu, 0, widx::scenario_editor_btn))
             {
                 image_id = kGlobeConstruct[((window.var_846 / 2) % kGlobeConstruct.size())];
             }
@@ -266,9 +263,9 @@ namespace OpenLoco::Ui::Windows::TitleMenu
             drawingCtx.drawImage(ZoomLevel::full, x, y, image_id);
         }
 
-        if (!window.widgets[Widx::multiplayer_toggle_btn].hidden)
+        if (!window.widgets[widx::multiplayer_toggle_btn].hidden)
         {
-            auto& widget = window.widgets[Widx::multiplayer_toggle_btn];
+            auto& widget = window.widgets[widx::multiplayer_toggle_btn];
             auto point = Point(widget.top + 3 + window.y, window.width / 2 + window.x);
             StringId string = StringIds::single_player_mode;
             FormatArguments args{};
@@ -300,20 +297,20 @@ namespace OpenLoco::Ui::Windows::TitleMenu
 
         switch (widgetIndex)
         {
-            case Widx::scenario_list_btn:
+            case widx::scenario_list_btn:
                 sub_4391DA();
                 break;
-            case Widx::load_game_btn:
+            case widx::load_game_btn:
                 sub_4391E2();
                 break;
-            case Widx::scenario_editor_btn:
+            case widx::scenario_editor_btn:
                 Title::stop();
                 sub_43910A();
                 break;
-            case Widx::chat_btn:
+            case widx::chat_btn:
                 beginSendChatMessage(window);
                 break;
-            case Widx::multiplayer_toggle_btn:
+            case widx::multiplayer_toggle_btn:
                 showMultiplayer(&window);
                 break;
         }
@@ -324,7 +321,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     {
         switch (widgetIndex)
         {
-            case Widx::tutorial_btn:
+            case widx::tutorial_btn:
                 sub_439112(&window);
                 break;
         }
@@ -335,7 +332,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     {
         switch (widgetIndex)
         {
-            case Widx::tutorial_btn:
+            case widx::tutorial_btn:
                 sub_4391CC(itemIndex);
                 break;
         }
@@ -346,10 +343,10 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     {
         switch (widgetIndex)
         {
-            case Widx::chat_btn:
+            case widx::chat_btn:
                 sub_43918F(input);
                 break;
-            case Widx::multiplayer_toggle_btn:
+            case widx::multiplayer_toggle_btn:
                 multiplayerConnect(input);
                 break;
         }
@@ -366,7 +363,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
     static void showMultiplayer(Window* window)
     {
         StringManager::setString(StringIds::buffer_2039, "");
-        TextInput::openTextInput(window, StringIds::enter_host_address, StringIds::enter_host_address_description, StringIds::buffer_2039, Widx::multiplayer_toggle_btn, {});
+        TextInput::openTextInput(window, StringIds::enter_host_address, StringIds::enter_host_address_description, StringIds::buffer_2039, widx::multiplayer_toggle_btn, {});
     }
 
     static void multiplayerConnect(std::string_view host)
@@ -385,7 +382,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
         Dropdown::add(1, StringIds::tutorial_2_title);
         Dropdown::add(2, StringIds::tutorial_3_title);
 
-        Widget* widget = &window->widgets[Widx::tutorial_btn];
+        Widget* widget = &window->widgets[widx::tutorial_btn];
         Dropdown::showText(
             window->x + widget->left,
             window->y + widget->top,
@@ -404,7 +401,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
         args.push(StringIds::the_other_player);
 
         // TODO: convert this to a builder pattern, with chainable functions to set the different string ids and arguments
-        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, Widx::chat_btn, args);
+        TextInput::openTextInput(&self, StringIds::chat_title, StringIds::chat_instructions, StringIds::empty, widx::chat_btn, args);
     }
 
     static void sub_43918F(const char* string)

--- a/src/OpenLoco/src/Ui/Windows/TitleOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleOptions.cpp
@@ -19,8 +19,13 @@ namespace OpenLoco::Ui::Windows::TitleOptions
         options_button
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kOptionsButton{ "options_button" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
-        Widgets::ImageButton({ 0, 0 }, kWindowSize, WindowColour::secondary)
+        Widgets::ImageButton(Widx::kOptionsButton, { 0, 0 }, kWindowSize, WindowColour::secondary)
 
     );
 
@@ -62,16 +67,16 @@ namespace OpenLoco::Ui::Windows::TitleOptions
         tr.drawStringCentredWrapped(origin, window.width, Colour::white, StringIds::outlined_wcolour2_stringid, args);
     }
 
-    static void onMouseUp([[maybe_unused]] Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp([[maybe_unused]] Window& window, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
     {
         if (Intro::isActive())
         {
             return;
         }
 
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::options_button:
+            case Widx::kOptionsButton:
                 Ui::Windows::Options::open();
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/TitleOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleOptions.cpp
@@ -14,13 +14,10 @@ namespace OpenLoco::Ui::Windows::TitleOptions
 {
     static constexpr Ui::Size kWindowSize = { 60, 15 };
 
-    namespace Widx
+    enum widx
     {
-        enum
-        {
-            options_button
-        };
-    }
+        options_button
+    };
 
     static constexpr auto _widgets = makeWidgets(
         Widgets::ImageButton({ 0, 0 }, kWindowSize, WindowColour::secondary)
@@ -55,7 +52,7 @@ namespace OpenLoco::Ui::Windows::TitleOptions
         window.draw(drawingCtx);
 
         int16_t x = window.x + window.width / 2;
-        int16_t y = window.y + window.widgets[Widx::options_button].top + 2;
+        int16_t y = window.y + window.widgets[widx::options_button].top + 2;
         Ui::Point origin = { x, y };
 
         auto argsBuf = FormatArgumentsBuffer{};
@@ -74,7 +71,7 @@ namespace OpenLoco::Ui::Windows::TitleOptions
 
         switch (widgetIndex)
         {
-            case Widx::options_button:
+            case widx::options_button:
                 Ui::Windows::Options::open();
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/ToolTip.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolTip.cpp
@@ -114,9 +114,14 @@ namespace OpenLoco::Ui::Windows::ToolTip
         text
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kText{ "text" };
+    }
+
     // 0x005234CC
     static constexpr auto _widgets = makeWidgets(
-        Widgets::Wt3Widget({ 0, 0 }, { 200, 32 }, WindowColour::primary)
+        Widgets::Wt3Widget(Widx::kText, { 0, 0 }, { 200, 32 }, WindowColour::primary)
 
     );
 

--- a/src/OpenLoco/src/Ui/Windows/ToolbarBottomEditor.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarBottomEditor.cpp
@@ -20,13 +20,21 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
         next_button,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kPreviousFrame{ "previous_frame" };
+        constexpr WidgetId kPreviousButton{ "previous_button" };
+        constexpr WidgetId kNextFrame{ "next_frame" };
+        constexpr WidgetId kNextButton{ "next_button" };
+    }
+
     static constexpr uint16_t kWindowHeight = 32;
 
     static constexpr auto _widgets = makeWidgets(
-        Widgets::Wt3Widget({ 0, 0 }, { 200, 34 }, WindowColour::primary),
-        Widgets::ImageButton({ 2, 2 }, { 196, 30 }, WindowColour::primary),
-        Widgets::Wt3Widget({ 440, 0 }, { 200, 34 }, WindowColour::primary),
-        Widgets::ImageButton({ 442, 2 }, { 196, 30 }, WindowColour::primary)
+        Widgets::Wt3Widget(Widx::kPreviousFrame, { 0, 0 }, { 200, 34 }, WindowColour::primary),
+        Widgets::ImageButton(Widx::kPreviousButton, { 2, 2 }, { 196, 30 }, WindowColour::primary),
+        Widgets::Wt3Widget(Widx::kNextFrame, { 440, 0 }, { 200, 34 }, WindowColour::primary),
+        Widgets::ImageButton(Widx::kNextButton, { 442, 2 }, { 196, 30 }, WindowColour::primary)
 
     );
 
@@ -120,15 +128,15 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
     }
 
     // 0x0043D0ED
-    static void onMouseUp(Window&, WidgetIndex_t i, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Window&, [[maybe_unused]] WidgetIndex_t i, const WidgetId id)
     {
-        switch (i)
+        switch (id)
         {
-            case widx::previous_button:
+            case Widx::kPreviousButton:
                 EditorController::goToPreviousStep();
                 break;
 
-            case widx::next_button:
+            case Widx::kNextButton:
                 EditorController::goToNextStep();
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -50,24 +50,29 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         cheats_menu = Common::widx::w2
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kCheatsMenu{ "cheats_menu" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
-        Widgets::ToolbarButton({ 0, 0 }, { 30, 28 }, WindowColour::primary),
-        Widgets::ToolbarButton({ 30, 0 }, { 30, 28 }, WindowColour::primary),
-        Widgets::ToolbarButton({ 60, 0 }, { 30, 28 }, WindowColour::primary),
+        Widgets::ToolbarButton(Common::Widx::kLoadsaveMenu, { 0, 0 }, { 30, 28 }, WindowColour::primary),
+        Widgets::ToolbarButton(Common::Widx::kAudioMenu, { 30, 0 }, { 30, 28 }, WindowColour::primary),
+        Widgets::ToolbarButton(Widx::kCheatsMenu, { 60, 0 }, { 30, 28 }, WindowColour::primary),
 
-        Widgets::ToolbarButton({ 104, 0 }, { 30, 28 }, WindowColour::secondary),
-        Widgets::ToolbarButton({ 134, 0 }, { 30, 28 }, WindowColour::secondary),
-        Widgets::ToolbarButton({ 164, 0 }, { 30, 28 }, WindowColour::secondary),
+        Widgets::ToolbarButton(Common::Widx::kZoomMenu, { 104, 0 }, { 30, 28 }, WindowColour::secondary),
+        Widgets::ToolbarButton(Common::Widx::kRotateMenu, { 134, 0 }, { 30, 28 }, WindowColour::secondary),
+        Widgets::ToolbarButton(Common::Widx::kViewMenu, { 164, 0 }, { 30, 28 }, WindowColour::secondary),
 
-        Widgets::ToolbarButton({ 267, 0 }, { 30, 28 }, WindowColour::tertiary),
-        Widgets::ToolbarButton({ 387, 0 }, { 30, 28 }, WindowColour::tertiary),
-        Widgets::ToolbarButton({ 357, 0 }, { 30, 28 }, WindowColour::tertiary),
-        Widgets::ToolbarButton({ 417, 0 }, { 30, 28 }, WindowColour::tertiary),
-        Widgets::ToolbarButton({ 417, 0 }, { 30, 28 }, WindowColour::tertiary),
+        Widgets::ToolbarButton(Common::Widx::kTerraformMenu, { 267, 0 }, { 30, 28 }, WindowColour::tertiary),
+        Widgets::ToolbarButton(Common::Widx::kRailroadMenu, { 387, 0 }, { 30, 28 }, WindowColour::tertiary),
+        Widgets::ToolbarButton(Common::Widx::kRoadMenu, { 357, 0 }, { 30, 28 }, WindowColour::tertiary),
+        Widgets::ToolbarButton(Common::Widx::kPortMenu, { 417, 0 }, { 30, 28 }, WindowColour::tertiary),
+        Widgets::ToolbarButton(Common::Widx::kBuildVehiclesMenu, { 417, 0 }, { 30, 28 }, WindowColour::tertiary),
 
-        Widgets::ToolbarButton({ 490, 0 }, { 30, 28 }, WindowColour::quaternary),
-        Widgets::ToolbarButton({ 520, 0 }, { 30, 28 }, WindowColour::quaternary),
-        Widgets::ToolbarButton({ 460, 0 }, { 30, 28 }, WindowColour::quaternary)
+        Widgets::ToolbarButton(Common::Widx::kVehiclesMenu, { 490, 0 }, { 30, 28 }, WindowColour::quaternary),
+        Widgets::ToolbarButton(Common::Widx::kStationsMenu, { 520, 0 }, { 30, 28 }, WindowColour::quaternary),
+        Widgets::ToolbarButton(Common::Widx::kTownsMenu, { 460, 0 }, { 30, 28 }, WindowColour::quaternary)
 
     );
 
@@ -727,39 +732,39 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     }
 
     // 0x0043A071
-    static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case Common::widx::loadsave_menu:
+            case Common::Widx::kLoadsaveMenu:
                 loadsaveMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::widx::audio_menu:
+            case Common::Widx::kAudioMenu:
                 audioMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case widx::cheats_menu:
+            case Widx::kCheatsMenu:
                 cheatsMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::widx::railroad_menu:
+            case Common::Widx::kRailroadMenu:
                 railroadMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::widx::port_menu:
+            case Common::Widx::kPortMenu:
                 portMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::widx::build_vehicles_menu:
+            case Common::Widx::kBuildVehiclesMenu:
                 buildVehiclesMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::widx::vehicles_menu:
+            case Common::Widx::kVehiclesMenu:
                 vehiclesMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::widx::stations_menu:
+            case Common::Widx::kStationsMenu:
                 stationsMenuMouseDown(&window, widgetIndex);
                 break;
 
@@ -769,39 +774,39 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         }
     }
 
-    static void onDropdown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+    static void onDropdown(Window& window, WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case Common::widx::loadsave_menu:
+            case Common::Widx::kLoadsaveMenu:
                 loadsaveMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::widx::audio_menu:
+            case Common::Widx::kAudioMenu:
                 audioMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case widx::cheats_menu:
+            case Widx::kCheatsMenu:
                 cheatsMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::widx::railroad_menu:
+            case Common::Widx::kRailroadMenu:
                 railroadMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::widx::port_menu:
+            case Common::Widx::kPortMenu:
                 portMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::widx::build_vehicles_menu:
+            case Common::Widx::kBuildVehiclesMenu:
                 buildVehiclesMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::widx::vehicles_menu:
+            case Common::Widx::kVehiclesMenu:
                 vehiclesMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::widx::stations_menu:
+            case Common::Widx::kStationsMenu:
                 stationsMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -45,13 +45,10 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     // Temporary storage for railroad menu dropdown (populated in mouseDown, consumed in dropdown callback)
     static AvailableTracksAndRoads _railroadMenuObjects;
 
-    namespace Widx
+    enum widx
     {
-        enum
-        {
-            cheats_menu = Common::Widx::w2
-        };
-    }
+        cheats_menu = Common::widx::w2
+    };
 
     static constexpr auto _widgets = makeWidgets(
         Widgets::ToolbarButton({ 0, 0 }, { 30, 28 }, WindowColour::primary),
@@ -734,35 +731,35 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     {
         switch (widgetIndex)
         {
-            case Common::Widx::loadsave_menu:
+            case Common::widx::loadsave_menu:
                 loadsaveMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::Widx::audio_menu:
+            case Common::widx::audio_menu:
                 audioMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Widx::cheats_menu:
+            case widx::cheats_menu:
                 cheatsMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::Widx::railroad_menu:
+            case Common::widx::railroad_menu:
                 railroadMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::Widx::port_menu:
+            case Common::widx::port_menu:
                 portMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::Widx::build_vehicles_menu:
+            case Common::widx::build_vehicles_menu:
                 buildVehiclesMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::Widx::vehicles_menu:
+            case Common::widx::vehicles_menu:
                 vehiclesMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::Widx::stations_menu:
+            case Common::widx::stations_menu:
                 stationsMenuMouseDown(&window, widgetIndex);
                 break;
 
@@ -776,35 +773,35 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     {
         switch (widgetIndex)
         {
-            case Common::Widx::loadsave_menu:
+            case Common::widx::loadsave_menu:
                 loadsaveMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::Widx::audio_menu:
+            case Common::widx::audio_menu:
                 audioMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Widx::cheats_menu:
+            case widx::cheats_menu:
                 cheatsMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::Widx::railroad_menu:
+            case Common::widx::railroad_menu:
                 railroadMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::Widx::port_menu:
+            case Common::widx::port_menu:
                 portMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::Widx::build_vehicles_menu:
+            case Common::widx::build_vehicles_menu:
                 buildVehiclesMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::Widx::vehicles_menu:
+            case Common::widx::vehicles_menu:
                 vehiclesMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::Widx::stations_menu:
+            case Common::widx::stations_menu:
                 stationsMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
@@ -821,10 +818,10 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
 
         const auto companyColour = CompanyManager::getPlayerCompanyColour();
 
-        if (!window.widgets[Common::Widx::railroad_menu].hidden)
+        if (!window.widgets[Common::widx::railroad_menu].hidden)
         {
-            uint32_t x = window.widgets[Common::Widx::railroad_menu].left + window.x;
-            uint32_t y = window.widgets[Common::Widx::railroad_menu].top + window.y;
+            uint32_t x = window.widgets[Common::widx::railroad_menu].left + window.x;
+            uint32_t y = window.widgets[Common::widx::railroad_menu].top + window.y;
             uint32_t fg_image = 0;
 
             // Figure out what icon to show on the button face.
@@ -845,7 +842,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             uint32_t bg_image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_transparent, window.getColour(WindowColour::tertiary).c());
 
             y--;
-            if (Input::isDropdownActive(Ui::WindowType::topToolbar, window.number, Common::Widx::railroad_menu))
+            if (Input::isDropdownActive(Ui::WindowType::topToolbar, window.number, Common::widx::railroad_menu))
             {
                 y++;
                 bg_image++;
@@ -853,13 +850,13 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
 
             drawingCtx.drawImage(ZoomLevel::full, x, y, fg_image);
 
-            y = window.widgets[Common::Widx::railroad_menu].top + window.y;
+            y = window.widgets[Common::widx::railroad_menu].top + window.y;
             drawingCtx.drawImage(ZoomLevel::full, x, y, bg_image);
         }
 
         {
-            uint32_t x = window.widgets[Common::Widx::vehicles_menu].left + window.x;
-            uint32_t y = window.widgets[Common::Widx::vehicles_menu].top + window.y;
+            uint32_t x = window.widgets[Common::widx::vehicles_menu].left + window.x;
+            uint32_t y = window.widgets[Common::widx::vehicles_menu].top + window.y;
 
             static constexpr uint32_t button_face_image_ids[] = {
                 InterfaceSkin::ImageIds::vehicle_train_frame_0,
@@ -875,7 +872,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             uint32_t bg_image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_transparent, window.getColour(WindowColour::quaternary).c());
 
             y--;
-            if (Input::isDropdownActive(Ui::WindowType::topToolbar, window.number, Common::Widx::vehicles_menu))
+            if (Input::isDropdownActive(Ui::WindowType::topToolbar, window.number, Common::widx::vehicles_menu))
             {
                 y++;
                 bg_image++;
@@ -883,13 +880,13 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
 
             drawingCtx.drawImage(ZoomLevel::full, x, y, fg_image);
 
-            y = window.widgets[Common::Widx::vehicles_menu].top + window.y;
+            y = window.widgets[Common::widx::vehicles_menu].top + window.y;
             drawingCtx.drawImage(ZoomLevel::full, x, y, bg_image);
         }
 
         {
-            uint32_t x = window.widgets[Common::Widx::build_vehicles_menu].left + window.x;
-            uint32_t y = window.widgets[Common::Widx::build_vehicles_menu].top + window.y;
+            uint32_t x = window.widgets[Common::widx::build_vehicles_menu].left + window.x;
+            uint32_t y = window.widgets[Common::widx::build_vehicles_menu].top + window.y;
 
             static constexpr uint32_t kBuildVehicleImages[] = {
                 InterfaceSkin::ImageIds::toolbar_build_vehicle_train,
@@ -904,7 +901,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             auto interface = ObjectManager::get<InterfaceSkinObject>();
             uint32_t fg_image = Gfx::recolour(interface->img + kBuildVehicleImages[enumValue(getGameState().lastBuildVehiclesOption)], companyColour);
 
-            if (Input::isDropdownActive(Ui::WindowType::topToolbar, window.number, Common::Widx::build_vehicles_menu))
+            if (Input::isDropdownActive(Ui::WindowType::topToolbar, window.number, Common::widx::build_vehicles_menu))
             {
                 fg_image++;
             }
@@ -920,28 +917,28 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
 
         if (!Audio::isAudioEnabled())
         {
-            window.activatedWidgets |= (1 << Common::Widx::audio_menu);
-            window.widgets[Common::Widx::audio_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_audio_inactive, window.getColour(WindowColour::primary).c());
+            window.activatedWidgets |= (1 << Common::widx::audio_menu);
+            window.widgets[Common::widx::audio_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_audio_inactive, window.getColour(WindowColour::primary).c());
         }
         else
         {
-            window.activatedWidgets &= ~(1 << Common::Widx::audio_menu);
-            window.widgets[Common::Widx::audio_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_audio_active, window.getColour(WindowColour::primary).c());
+            window.activatedWidgets &= ~(1 << Common::widx::audio_menu);
+            window.widgets[Common::widx::audio_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_audio_active, window.getColour(WindowColour::primary).c());
         }
 
         const bool cheatsOn = Config::get().cheatsMenuEnabled;
-        window.widgets[Widx::cheats_menu].hidden = !cheatsOn;
+        window.widgets[widx::cheats_menu].hidden = !cheatsOn;
 
-        const auto& refWidget = window.widgets[cheatsOn ? enumValue(Widx::cheats_menu) : enumValue(Common::Widx::audio_menu)];
+        const auto& refWidget = window.widgets[cheatsOn ? enumValue(widx::cheats_menu) : enumValue(Common::widx::audio_menu)];
         const auto offsetWidget = [&window, refWidget](uint8_t widgetIndex, uint8_t index) {
             auto& widget = window.widgets[widgetIndex];
             widget.left = refWidget.left + 14 + (refWidget.width() * index);
             widget.right = widget.left + refWidget.width() - 1;
         };
 
-        offsetWidget(Common::Widx::zoom_menu, 1);
-        offsetWidget(Common::Widx::rotate_menu, 2);
-        offsetWidget(Common::Widx::view_menu, 3);
+        offsetWidget(Common::widx::zoom_menu, 1);
+        offsetWidget(Common::widx::rotate_menu, 2);
+        offsetWidget(Common::widx::view_menu, 3);
 
         if (_lastPortOption == 0
             && getGameState().lastAirport == 0xFF
@@ -950,57 +947,57 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
             _lastPortOption = 1;
         }
 
-        window.widgets[Common::Widx::loadsave_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_loadsave);
-        window.widgets[Widx::cheats_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_cogwheels);
-        window.widgets[Common::Widx::zoom_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_zoom);
-        window.widgets[Common::Widx::rotate_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_rotate);
-        window.widgets[Common::Widx::view_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_view);
+        window.widgets[Common::widx::loadsave_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_loadsave);
+        window.widgets[widx::cheats_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_cogwheels);
+        window.widgets[Common::widx::zoom_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_zoom);
+        window.widgets[Common::widx::rotate_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_rotate);
+        window.widgets[Common::widx::view_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_view);
 
-        window.widgets[Common::Widx::terraform_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_terraform);
-        window.widgets[Common::Widx::railroad_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_opaque);
-        window.widgets[Common::Widx::road_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_opaque);
-        window.widgets[Common::Widx::port_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_opaque);
-        window.widgets[Common::Widx::build_vehicles_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_opaque);
+        window.widgets[Common::widx::terraform_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_terraform);
+        window.widgets[Common::widx::railroad_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_opaque);
+        window.widgets[Common::widx::road_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_opaque);
+        window.widgets[Common::widx::port_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_opaque);
+        window.widgets[Common::widx::build_vehicles_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_opaque);
 
-        window.widgets[Common::Widx::vehicles_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_opaque);
-        window.widgets[Common::Widx::stations_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_stations);
+        window.widgets[Common::widx::vehicles_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_opaque);
+        window.widgets[Common::widx::stations_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_stations);
 
         Common::prepareTownWidget(window);
 
         if (_lastPortOption == 0)
         {
-            window.widgets[Common::Widx::port_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_airports);
+            window.widgets[Common::widx::port_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_airports);
         }
         else
         {
-            window.widgets[Common::Widx::port_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_ports);
+            window.widgets[Common::widx::port_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_ports);
         }
 
-        window.widgets[Common::Widx::road_menu].hidden = !(getGameState().lastRoadOption != 0xFF);
-        window.widgets[Common::Widx::railroad_menu].hidden = !(getGameState().lastRailroadOption != 0xFF);
-        window.widgets[Common::Widx::port_menu].hidden = !(getGameState().lastAirport != 0xFF || getGameState().lastShipPort != 0xFF);
+        window.widgets[Common::widx::road_menu].hidden = !(getGameState().lastRoadOption != 0xFF);
+        window.widgets[Common::widx::railroad_menu].hidden = !(getGameState().lastRailroadOption != 0xFF);
+        window.widgets[Common::widx::port_menu].hidden = !(getGameState().lastAirport != 0xFF || getGameState().lastShipPort != 0xFF);
 
         uint32_t x = std::max(640, Ui::width()) - 1;
-        Common::rightAlignTabs(&window, x, { Common::Widx::towns_menu, Common::Widx::stations_menu, Common::Widx::vehicles_menu });
+        Common::rightAlignTabs(&window, x, { Common::widx::towns_menu, Common::widx::stations_menu, Common::widx::vehicles_menu });
         x -= 11;
-        Common::rightAlignTabs(&window, x, { Common::Widx::build_vehicles_menu });
+        Common::rightAlignTabs(&window, x, { Common::widx::build_vehicles_menu });
 
-        if (!window.widgets[Common::Widx::port_menu].hidden)
+        if (!window.widgets[Common::widx::port_menu].hidden)
         {
-            Common::rightAlignTabs(&window, x, { Common::Widx::port_menu });
+            Common::rightAlignTabs(&window, x, { Common::widx::port_menu });
         }
 
-        if (!window.widgets[Common::Widx::road_menu].hidden)
+        if (!window.widgets[Common::widx::road_menu].hidden)
         {
-            Common::rightAlignTabs(&window, x, { Common::Widx::road_menu });
+            Common::rightAlignTabs(&window, x, { Common::widx::road_menu });
         }
 
-        if (!window.widgets[Common::Widx::railroad_menu].hidden)
+        if (!window.widgets[Common::widx::railroad_menu].hidden)
         {
-            Common::rightAlignTabs(&window, x, { Common::Widx::railroad_menu });
+            Common::rightAlignTabs(&window, x, { Common::widx::railroad_menu });
         }
 
-        Common::rightAlignTabs(&window, x, { Common::Widx::terraform_menu });
+        Common::rightAlignTabs(&window, x, { Common::widx::terraform_menu });
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
@@ -32,13 +32,10 @@
 
 namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
 {
-    namespace Widx
+    enum widx
     {
-        enum
-        {
-            map_generation_menu = Common::Widx::w2,
-        };
-    }
+        map_generation_menu = Common::widx::w2,
+    };
 
     static constexpr auto _widgets = makeWidgets(
         Widgets::ToolbarButton({ 0, 0 }, { 30, 28 }, WindowColour::primary),  // 0
@@ -259,15 +256,15 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
     {
         switch (widgetIndex)
         {
-            case Common::Widx::loadsave_menu:
+            case Common::widx::loadsave_menu:
                 loadsaveMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::Widx::audio_menu:
+            case Common::widx::audio_menu:
                 audioMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Widx::map_generation_menu:
+            case widx::map_generation_menu:
                 mapGenerationMenuMouseDown(&window, widgetIndex);
                 break;
 
@@ -282,15 +279,15 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
     {
         switch (widgetIndex)
         {
-            case Common::Widx::loadsave_menu:
+            case Common::widx::loadsave_menu:
                 loadsaveMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::Widx::audio_menu:
+            case Common::widx::audio_menu:
                 audioMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Widx::map_generation_menu:
+            case widx::map_generation_menu:
                 mapGenerationMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
@@ -305,40 +302,40 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
     {
         uint32_t x = std::max(640, Ui::width()) - 1;
 
-        Common::rightAlignTabs(&window, x, { Common::Widx::towns_menu });
+        Common::rightAlignTabs(&window, x, { Common::widx::towns_menu });
         x -= 11;
-        Common::rightAlignTabs(&window, x, { Common::Widx::road_menu, Common::Widx::terraform_menu });
+        Common::rightAlignTabs(&window, x, { Common::widx::road_menu, Common::widx::terraform_menu });
 
         const bool isLandscapeEditor = EditorController::getCurrentStep() == EditorController::Step::landscapeEditor;
 
-        window.widgets[Common::Widx::zoom_menu].hidden = !isLandscapeEditor;
-        window.widgets[Common::Widx::rotate_menu].hidden = !isLandscapeEditor;
-        window.widgets[Common::Widx::view_menu].hidden = !isLandscapeEditor;
-        window.widgets[Common::Widx::terraform_menu].hidden = !isLandscapeEditor;
-        window.widgets[Widx::map_generation_menu].hidden = !isLandscapeEditor;
-        window.widgets[Common::Widx::towns_menu].hidden = !isLandscapeEditor;
-        window.widgets[Common::Widx::road_menu].hidden = !(isLandscapeEditor && getGameState().lastRoadOption != 0xFF);
+        window.widgets[Common::widx::zoom_menu].hidden = !isLandscapeEditor;
+        window.widgets[Common::widx::rotate_menu].hidden = !isLandscapeEditor;
+        window.widgets[Common::widx::view_menu].hidden = !isLandscapeEditor;
+        window.widgets[Common::widx::terraform_menu].hidden = !isLandscapeEditor;
+        window.widgets[widx::map_generation_menu].hidden = !isLandscapeEditor;
+        window.widgets[Common::widx::towns_menu].hidden = !isLandscapeEditor;
+        window.widgets[Common::widx::road_menu].hidden = !(isLandscapeEditor && getGameState().lastRoadOption != 0xFF);
 
         auto interface = ObjectManager::get<InterfaceSkinObject>();
         if (!Audio::isAudioEnabled())
         {
-            window.activatedWidgets |= (1 << Common::Widx::audio_menu);
-            window.widgets[Common::Widx::audio_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_audio_inactive, window.getColour(WindowColour::primary).c());
+            window.activatedWidgets |= (1 << Common::widx::audio_menu);
+            window.widgets[Common::widx::audio_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_audio_inactive, window.getColour(WindowColour::primary).c());
         }
         else
         {
-            window.activatedWidgets &= ~(1 << Common::Widx::audio_menu);
-            window.widgets[Common::Widx::audio_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_audio_active, window.getColour(WindowColour::primary).c());
+            window.activatedWidgets &= ~(1 << Common::widx::audio_menu);
+            window.widgets[Common::widx::audio_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_audio_active, window.getColour(WindowColour::primary).c());
         }
 
-        window.widgets[Common::Widx::loadsave_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_loadsave);
-        window.widgets[Common::Widx::zoom_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_zoom);
-        window.widgets[Common::Widx::rotate_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_rotate);
-        window.widgets[Common::Widx::view_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_view);
+        window.widgets[Common::widx::loadsave_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_loadsave);
+        window.widgets[Common::widx::zoom_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_zoom);
+        window.widgets[Common::widx::rotate_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_rotate);
+        window.widgets[Common::widx::view_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_view);
 
-        window.widgets[Common::Widx::terraform_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_terraform);
-        window.widgets[Widx::map_generation_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_cogwheels);
-        window.widgets[Common::Widx::road_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_opaque);
+        window.widgets[Common::widx::terraform_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_terraform);
+        window.widgets[widx::map_generation_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_cogwheels);
+        window.widgets[Common::widx::road_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_opaque);
 
         Common::prepareTownWidget(window);
     }

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
@@ -37,24 +37,29 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
         map_generation_menu = Common::widx::w2,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kMapGenerationMenu{ "map_generation_menu" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
-        Widgets::ToolbarButton({ 0, 0 }, { 30, 28 }, WindowColour::primary),  // 0
-        Widgets::ToolbarButton({ 30, 0 }, { 30, 28 }, WindowColour::primary), // 1
-        Widgets::ToolbarButton({ 60, 0 }, { 30, 28 }, WindowColour::primary), // 2
+        Widgets::ToolbarButton(Common::Widx::kLoadsaveMenu, { 0, 0 }, { 30, 28 }, WindowColour::primary), // 0
+        Widgets::ToolbarButton(Common::Widx::kAudioMenu, { 30, 0 }, { 30, 28 }, WindowColour::primary),   // 1
+        Widgets::ToolbarButton(Widx::kMapGenerationMenu, { 60, 0 }, { 30, 28 }, WindowColour::primary),   // 2
 
-        Widgets::ToolbarButton({ 104, 0 }, { 30, 28 }, WindowColour::secondary), // 3
-        Widgets::ToolbarButton({ 134, 0 }, { 30, 28 }, WindowColour::secondary), // 4
-        Widgets::ToolbarButton({ 164, 0 }, { 30, 28 }, WindowColour::secondary), // 5
+        Widgets::ToolbarButton(Common::Widx::kZoomMenu, { 104, 0 }, { 30, 28 }, WindowColour::secondary),   // 3
+        Widgets::ToolbarButton(Common::Widx::kRotateMenu, { 134, 0 }, { 30, 28 }, WindowColour::secondary), // 4
+        Widgets::ToolbarButton(Common::Widx::kViewMenu, { 164, 0 }, { 30, 28 }, WindowColour::secondary),   // 5
 
-        Widgets::ToolbarButton({ 267, 0 }, { 30, 28 }, WindowColour::tertiary), // 6
-        Widgets::ToolbarButton({ 0, 0 }, { 1, 1 }, WindowColour::primary),      // 7
-        Widgets::ToolbarButton({ 357, 0 }, { 30, 28 }, WindowColour::tertiary), // 8
-        Widgets::ToolbarButton({ 0, 0 }, { 1, 1 }, WindowColour::primary),      // 9
-        Widgets::ToolbarButton({ 0, 0 }, { 1, 1 }, WindowColour::primary),      // 10
+        Widgets::ToolbarButton(Common::Widx::kTerraformMenu, { 267, 0 }, { 30, 28 }, WindowColour::tertiary), // 6
+        Widgets::ToolbarButton(Common::Widx::kRailroadMenu, { 0, 0 }, { 1, 1 }, WindowColour::primary),       // 7
+        Widgets::ToolbarButton(Common::Widx::kRoadMenu, { 357, 0 }, { 30, 28 }, WindowColour::tertiary),      // 8
+        Widgets::ToolbarButton(Common::Widx::kPortMenu, { 0, 0 }, { 1, 1 }, WindowColour::primary),           // 9
+        Widgets::ToolbarButton(Common::Widx::kBuildVehiclesMenu, { 0, 0 }, { 1, 1 }, WindowColour::primary),  // 10
 
-        Widgets::ToolbarButton({ 0, 0 }, { 1, 1 }, WindowColour::primary),       // 11
-        Widgets::ToolbarButton({ 0, 0 }, { 1, 1 }, WindowColour::primary),       // 12
-        Widgets::ToolbarButton({ 460, 0 }, { 30, 28 }, WindowColour::quaternary) // 13
+        Widgets::ToolbarButton(Common::Widx::kVehiclesMenu, { 0, 0 }, { 1, 1 }, WindowColour::primary),    // 11
+        Widgets::ToolbarButton(Common::Widx::kStationsMenu, { 0, 0 }, { 1, 1 }, WindowColour::primary),    // 12
+        Widgets::ToolbarButton(Common::Widx::kTownsMenu, { 460, 0 }, { 30, 28 }, WindowColour::quaternary) // 13
     );
 
     static const WindowEventList& getEvents();
@@ -252,19 +257,19 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
     }
 
     // 0x0043D541
-    static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseDown(Window& window, WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case Common::widx::loadsave_menu:
+            case Common::Widx::kLoadsaveMenu:
                 loadsaveMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case Common::widx::audio_menu:
+            case Common::Widx::kAudioMenu:
                 audioMenuMouseDown(&window, widgetIndex);
                 break;
 
-            case widx::map_generation_menu:
+            case Widx::kMapGenerationMenu:
                 mapGenerationMenuMouseDown(&window, widgetIndex);
                 break;
 
@@ -275,19 +280,19 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
     }
 
     // 0x0043D5A6
-    static void onDropdown(Window& window, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+    static void onDropdown(Window& window, WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case Common::widx::loadsave_menu:
+            case Common::Widx::kLoadsaveMenu:
                 loadsaveMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case Common::widx::audio_menu:
+            case Common::Widx::kAudioMenu:
                 audioMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 
-            case widx::map_generation_menu:
+            case Widx::kMapGenerationMenu:
                 mapGenerationMenuDropdown(&window, widgetIndex, itemIndex);
                 break;
 

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
@@ -488,29 +488,29 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
 
     void onDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex)
     {
-        switch (widgetIndex)
+        switch (window->widgets[widgetIndex].id)
         {
-            case widx::zoom_menu:
+            case Widx::kZoomMenu:
                 zoomMenuDropdown(window, widgetIndex, itemIndex);
                 break;
 
-            case widx::rotate_menu:
+            case Widx::kRotateMenu:
                 rotateMenuDropdown(window, widgetIndex, itemIndex);
                 break;
 
-            case widx::view_menu:
+            case Widx::kViewMenu:
                 viewMenuDropdown(window, widgetIndex, itemIndex);
                 break;
 
-            case widx::terraform_menu:
+            case Widx::kTerraformMenu:
                 terraformMenuDropdown(window, widgetIndex, itemIndex);
                 break;
 
-            case widx::road_menu:
+            case Widx::kRoadMenu:
                 roadMenuDropdown(window, widgetIndex, itemIndex);
                 break;
 
-            case widx::towns_menu:
+            case Widx::kTownsMenu:
                 townsMenuDropdown(window, widgetIndex, itemIndex);
                 break;
         }
@@ -519,29 +519,29 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     // 0x0043A071
     void onMouseDown(Window* window, WidgetIndex_t widgetIndex)
     {
-        switch (widgetIndex)
+        switch (window->widgets[widgetIndex].id)
         {
-            case widx::zoom_menu:
+            case Widx::kZoomMenu:
                 zoomMenuMouseDown(window, widgetIndex);
                 break;
 
-            case widx::rotate_menu:
+            case Widx::kRotateMenu:
                 rotateMenuMouseDown(window, widgetIndex);
                 break;
 
-            case widx::view_menu:
+            case Widx::kViewMenu:
                 viewMenuMouseDown(window, widgetIndex);
                 break;
 
-            case widx::terraform_menu:
+            case Widx::kTerraformMenu:
                 terraformMenuMouseDown(window, widgetIndex);
                 break;
 
-            case widx::road_menu:
+            case Widx::kRoadMenu:
                 roadMenuMouseDown(window, widgetIndex);
                 break;
 
-            case widx::towns_menu:
+            case Widx::kTownsMenu:
                 townsMenuMouseDown(window, widgetIndex);
                 break;
         }

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
@@ -37,11 +37,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
         auto interface = ObjectManager::get<InterfaceSkinObject>();
         if (_lastTownOption == 0)
         {
-            self.widgets[Common::Widx::towns_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_towns);
+            self.widgets[Common::widx::towns_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_towns);
         }
         else
         {
-            self.widgets[Common::Widx::towns_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_industries);
+            self.widgets[Common::widx::towns_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_industries);
         }
     }
 
@@ -55,10 +55,10 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
 
         auto lastRoadOption = getGameState().lastRoadOption;
 
-        if (!self.widgets[Widx::road_menu].hidden && lastRoadOption != 0xFF)
+        if (!self.widgets[widx::road_menu].hidden && lastRoadOption != 0xFF)
         {
-            uint32_t x = self.widgets[Widx::road_menu].left + self.x;
-            uint32_t y = self.widgets[Widx::road_menu].top + self.y;
+            uint32_t x = self.widgets[widx::road_menu].left + self.x;
+            uint32_t y = self.widgets[widx::road_menu].top + self.y;
             uint32_t fgImage = 0;
 
             // Figure out what icon to show on the button face.
@@ -78,7 +78,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
             auto interface = ObjectManager::get<InterfaceSkinObject>();
             uint32_t bgImage = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_transparent, self.getColour(WindowColour::tertiary).c());
 
-            if (Input::isDropdownActive(Ui::WindowType::topToolbar, self.number, Widx::road_menu))
+            if (Input::isDropdownActive(Ui::WindowType::topToolbar, self.number, widx::road_menu))
             {
                 y++;
                 bgImage++;
@@ -86,7 +86,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
 
             drawingCtx.drawImage(ZoomLevel::full, x, y, fgImage);
 
-            y = self.widgets[Widx::road_menu].top + self.y;
+            y = self.widgets[widx::road_menu].top + self.y;
             drawingCtx.drawImage(ZoomLevel::full, x, y, bgImage);
         }
     }
@@ -490,27 +490,27 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     {
         switch (widgetIndex)
         {
-            case Widx::zoom_menu:
+            case widx::zoom_menu:
                 zoomMenuDropdown(window, widgetIndex, itemIndex);
                 break;
 
-            case Widx::rotate_menu:
+            case widx::rotate_menu:
                 rotateMenuDropdown(window, widgetIndex, itemIndex);
                 break;
 
-            case Widx::view_menu:
+            case widx::view_menu:
                 viewMenuDropdown(window, widgetIndex, itemIndex);
                 break;
 
-            case Widx::terraform_menu:
+            case widx::terraform_menu:
                 terraformMenuDropdown(window, widgetIndex, itemIndex);
                 break;
 
-            case Widx::road_menu:
+            case widx::road_menu:
                 roadMenuDropdown(window, widgetIndex, itemIndex);
                 break;
 
-            case Widx::towns_menu:
+            case widx::towns_menu:
                 townsMenuDropdown(window, widgetIndex, itemIndex);
                 break;
         }
@@ -521,27 +521,27 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     {
         switch (widgetIndex)
         {
-            case Widx::zoom_menu:
+            case widx::zoom_menu:
                 zoomMenuMouseDown(window, widgetIndex);
                 break;
 
-            case Widx::rotate_menu:
+            case widx::rotate_menu:
                 rotateMenuMouseDown(window, widgetIndex);
                 break;
 
-            case Widx::view_menu:
+            case widx::view_menu:
                 viewMenuMouseDown(window, widgetIndex);
                 break;
 
-            case Widx::terraform_menu:
+            case widx::terraform_menu:
                 terraformMenuMouseDown(window, widgetIndex);
                 break;
 
-            case Widx::road_menu:
+            case widx::road_menu:
                 roadMenuMouseDown(window, widgetIndex);
                 break;
 
-            case Widx::towns_menu:
+            case widx::towns_menu:
                 townsMenuMouseDown(window, widgetIndex);
                 break;
         }
@@ -564,7 +564,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
         auto main = WindowManager::getMainWindow();
         if (main == nullptr)
         {
-            window.setDisabledWidgetsAndInvalidate(Widx::zoom_menu | Widx::rotate_menu);
+            window.setDisabledWidgetsAndInvalidate(widx::zoom_menu | widx::rotate_menu);
         }
         else
         {

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -66,17 +66,29 @@ namespace OpenLoco::Ui::Windows::TownList
             tab_build_misc_buildings,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabTownList{ "tab_town_list" };
+            constexpr WidgetId kTabBuildTown{ "tab_build_town" };
+            constexpr WidgetId kTabBuildBuildings{ "tab_build_buildings" };
+            constexpr WidgetId kTabBuildMiscBuildings{ "tab_build_misc_buildings" };
+        }
+
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
-                Widgets::ImageButton({ frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { frameWidth, 155 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town_list),
-                Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_town),
-                Widgets::Tab({ 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_buildings),
-                Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_misc_buildings));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
+                Widgets::ImageButton(Widx::kCloseButton, { frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { frameWidth, 155 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabTownList, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town_list),
+                Widgets::Tab(Widx::kTabBuildTown, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_town),
+                Widgets::Tab(Widx::kTabBuildBuildings, { 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_buildings),
+                Widgets::Tab(Widx::kTabBuildMiscBuildings, { 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_build_misc_buildings));
         }
 
         static void prepareDraw(Window& self);
@@ -103,14 +115,24 @@ namespace OpenLoco::Ui::Windows::TownList
             status_bar,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kSortTownName{ "sort_town_name" };
+            constexpr WidgetId kSortTownType{ "sort_town_type" };
+            constexpr WidgetId kSortTownPopulation{ "sort_town_population" };
+            constexpr WidgetId kSortTownStations{ "sort_town_stations" };
+            constexpr WidgetId kScrollview{ "scrollview" };
+            constexpr WidgetId kStatusBar{ "status_bar" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(600, 197, StringIds::title_towns),
-            Widgets::TableHeader({ 4, 43 }, { 200, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_name),
-            Widgets::TableHeader({ 204, 43 }, { 80, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_town_type),
-            Widgets::TableHeader({ 284, 43 }, { 70, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_population),
-            Widgets::TableHeader({ 354, 43 }, { 70, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_stations),
-            Widgets::ScrollView({ 3, 56 }, { 594, 126 }, WindowColour::secondary, 2),
-            Widgets::Label({ 4, kWindowSize.height - 17 }, { kWindowSize.width - kResizeHandleSize, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid)
+            Widgets::TableHeader(Widx::kSortTownName, { 4, 43 }, { 200, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_name),
+            Widgets::TableHeader(Widx::kSortTownType, { 204, 43 }, { 80, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_town_type),
+            Widgets::TableHeader(Widx::kSortTownPopulation, { 284, 43 }, { 70, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_population),
+            Widgets::TableHeader(Widx::kSortTownStations, { 354, 43 }, { 70, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_stations),
+            Widgets::ScrollView(Widx::kScrollview, { 3, 56 }, { 594, 126 }, WindowColour::secondary, 2),
+            Widgets::Label(Widx::kStatusBar, { 4, kWindowSize.height - 17 }, { kWindowSize.width - kResizeHandleSize, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid)
 
         );
 
@@ -246,25 +268,25 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A27F
-        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_town_list:
-                case Common::widx::tab_build_town:
-                case Common::widx::tab_build_buildings:
-                case Common::widx::tab_build_misc_buildings:
+                case Common::Widx::kTabTownList:
+                case Common::Widx::kTabBuildTown:
+                case Common::Widx::kTabBuildBuildings:
+                case Common::Widx::kTabBuildMiscBuildings:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::sort_town_name:
-                case widx::sort_town_type:
-                case widx::sort_town_population:
-                case widx::sort_town_stations:
+                case Widx::kSortTownName:
+                case Widx::kSortTownType:
+                case Widx::kSortTownPopulation:
+                case Widx::kSortTownStations:
                 {
                     auto sortMode = widgetIndex - widx::sort_town_name;
                     if (self.sortMode == sortMode)
@@ -433,9 +455,9 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x004919A4
-        static Ui::CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, [[maybe_unused]] WidgetIndex_t widgetIdx, const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, Ui::CursorId fallback)
         {
-            if (widgetIdx != widx::scrollview)
+            if (id != Widx::kScrollview)
             {
                 return fallback;
             }
@@ -603,9 +625,15 @@ namespace OpenLoco::Ui::Windows::TownList
             select_size,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kCurrentSize{ "current_size" };
+            constexpr WidgetId kSelectSize{ "select_size" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(220, 87, StringIds::title_build_new_towns),
-            Widgets::dropdownWidgets({ 100, 45 }, { 117, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_town_size)
+            Widgets::dropdownWidgets(Widx::kCurrentSize, Widx::kSelectSize, { 100, 45 }, { 117, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_town_size)
 
         );
 
@@ -646,18 +674,18 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A675
-        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_town_list:
-                case Common::widx::tab_build_town:
-                case Common::widx::tab_build_buildings:
-                case Common::widx::tab_build_misc_buildings:
+                case Common::Widx::kTabTownList:
+                case Common::Widx::kTabBuildTown:
+                case Common::Widx::kTabBuildBuildings:
+                case Common::Widx::kTabBuildMiscBuildings:
                     Common::switchTab(self, widgetIndex);
                     break;
             }
@@ -676,9 +704,9 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A697
-        static void onDropdown(Window& self, Ui::WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] Ui::WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            if (widgetIndex != widx::select_size)
+            if (id != Widx::kSelectSize)
             {
                 return;
             }
@@ -745,9 +773,9 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049A690
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            if (widgetIndex == widx::select_size)
+            if (id == Widx::kSelectSize)
             {
                 populateTownSizeSelect(self, &self.widgets[widgetIndex]);
             }
@@ -817,11 +845,18 @@ namespace OpenLoco::Ui::Windows::TownList
             object_colour,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kScrollview{ "scrollview" };
+            constexpr WidgetId kRotateObject{ "rotate_object" };
+            constexpr WidgetId kObjectColour{ "object_colour" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(640, 172, StringIds::title_build_new_buildings),
-            Widgets::ScrollView({ 2, 45 }, { 573, kRowHeight }, WindowColour::secondary, 2),
-            Widgets::ImageButton({ 575, 46 }, { 24, 24 }, WindowColour::secondary, ImageIds::rotate_object, StringIds::rotate_object_90),
-            Widgets::ColourButton({ 579, 91 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_object_colour)
+            Widgets::ScrollView(Widx::kScrollview, { 2, 45 }, { 573, kRowHeight }, WindowColour::secondary, 2),
+            Widgets::ImageButton(Widx::kRotateObject, { 575, 46 }, { 24, 24 }, WindowColour::secondary, ImageIds::rotate_object, StringIds::rotate_object_90),
+            Widgets::ColourButton(Widx::kObjectColour, { 579, 91 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_object_colour)
 
         );
 
@@ -890,22 +925,22 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AB31
-        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Ui::Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_town_list:
-                case Common::widx::tab_build_town:
-                case Common::widx::tab_build_buildings:
-                case Common::widx::tab_build_misc_buildings:
+                case Common::Widx::kTabTownList:
+                case Common::Widx::kTabBuildTown:
+                case Common::Widx::kTabBuildBuildings:
+                case Common::Widx::kTabBuildMiscBuildings:
                     Common::switchTab(self, widgetIndex);
                     break;
 
-                case widx::rotate_object:
+                case Widx::kRotateObject:
                     if (_buildingRotation < 3)
                     {
                         _buildingRotation++;
@@ -983,9 +1018,9 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AB59
-        static void onDropdown(Window& self, Ui::WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] Ui::WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
         {
-            if (widgetIndex != widx::object_colour)
+            if (id != Widx::kObjectColour)
             {
                 return;
             }
@@ -1146,9 +1181,9 @@ namespace OpenLoco::Ui::Windows::TownList
         }
 
         // 0x0049AB52
-        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            if (widgetIndex == widx::object_colour)
+            if (id == Widx::kObjectColour)
             {
                 auto obj = ObjectManager::get<BuildingObject>(self.rowHover);
                 Dropdown::showColour(&self, &self.widgets[widgetIndex], obj->colours, _buildingColour, self.getColour(WindowColour::secondary));

--- a/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
@@ -54,17 +54,29 @@ namespace OpenLoco::Ui::Windows::Town
             tab_transported,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "close_button" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabTown{ "tab_town" };
+            constexpr WidgetId kTabPopulation{ "tab_population" };
+            constexpr WidgetId kTabCompanyRatings{ "tab_company_ratings" };
+            constexpr WidgetId kTabTransported{ "tab_transported" };
+        }
+
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
-                Widgets::ImageButton({ frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { frameWidth, 120 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town),
-                Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_population_graph),
-                Widgets::Tab({ 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town_ratings_each_company),
-                Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_statistics));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, { frameWidth, frameHeight }, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { frameWidth - 2, 13 }, Widgets::Caption::Style::whiteText, WindowColour::primary, windowCaptionId),
+                Widgets::ImageButton(Widx::kCloseButton, { frameWidth - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { frameWidth, 120 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabTown, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town),
+                Widgets::Tab(Widx::kTabPopulation, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_population_graph),
+                Widgets::Tab(Widx::kTabCompanyRatings, { 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_town_ratings_each_company),
+                Widgets::Tab(Widx::kTabTransported, { 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_statistics));
         }
 
         static StringId getTownSizeName(TownSize size)
@@ -100,13 +112,22 @@ namespace OpenLoco::Ui::Windows::Town
             demolish_town,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kViewport{ "viewport" };
+            constexpr WidgetId kStatusBar{ "status_bar" };
+            constexpr WidgetId kCentreOnViewport{ "centre_on_viewport" };
+            constexpr WidgetId kExpandTown{ "expand_town" };
+            constexpr WidgetId kDemolishTown{ "demolish_town" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(223, 161, StringIds::title_town),
-            Widgets::Viewport({ 3, 44 }, { 195, 104 }, WindowColour::secondary, Widget::kContentUnk),
-            Widgets::Label({ 3, 139 }, { 195, 21 }, WindowColour::secondary, ContentAlign::center),
-            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this),
-            Widgets::ImageButton({ 198, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::town_expand, StringIds::expand_this_town),
-            Widgets::ImageButton({ 198, 68 }, { 24, 24 }, WindowColour::secondary, ImageIds::rubbish_bin, StringIds::demolish_this_town)
+            Widgets::Viewport(Widx::kViewport, { 3, 44 }, { 195, 104 }, WindowColour::secondary, Widget::kContentUnk),
+            Widgets::Label(Widx::kStatusBar, { 3, 139 }, { 195, 21 }, WindowColour::secondary, ContentAlign::center),
+            Widgets::ImageButton(Widx::kCentreOnViewport, { 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this),
+            Widgets::ImageButton(Widx::kExpandTown, { 198, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::town_expand, StringIds::expand_this_town),
+            Widgets::ImageButton(Widx::kDemolishTown, { 198, 68 }, { 24, 24 }, WindowColour::secondary, ImageIds::rubbish_bin, StringIds::demolish_this_town)
 
         );
 
@@ -169,32 +190,32 @@ namespace OpenLoco::Ui::Windows::Town
         }
 
         // 0x00499079
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameTownPrompt(self, widgetIndex);
                     break;
 
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_town:
-                case Common::widx::tab_population:
-                case Common::widx::tab_company_ratings:
-                case Common::widx::tab_transported:
+                case Common::Widx::kTabTown:
+                case Common::Widx::kTabPopulation:
+                case Common::Widx::kTabCompanyRatings:
+                case Common::Widx::kTabTransported:
                     Common::switchTab(self, widgetIndex);
                     break;
 
                 // 0x0049932D
-                case widx::centre_on_viewport:
+                case Widx::kCentreOnViewport:
                     self.viewportCentreMain();
                     break;
 
                 // 0x004990B9
-                case widx::expand_town:
+                case Widx::kExpandTown:
                 {
                     auto town = TownManager::get(TownId(self.number));
 
@@ -228,7 +249,7 @@ namespace OpenLoco::Ui::Windows::Town
                 }
 
                 // 0x0049916A
-                case widx::demolish_town:
+                case Widx::kDemolishTown:
                 {
                     GameCommands::setErrorTitle(StringIds::cant_remove_town);
 
@@ -511,22 +532,22 @@ namespace OpenLoco::Ui::Windows::Town
         }
 
         // 0x004996AC
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameTownPrompt(self, widgetIndex);
                     break;
 
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_town:
-                case Common::widx::tab_population:
-                case Common::widx::tab_company_ratings:
-                case Common::widx::tab_transported:
+                case Common::Widx::kTabTown:
+                case Common::Widx::kTabPopulation:
+                case Common::Widx::kTabCompanyRatings:
+                case Common::Widx::kTabTransported:
                     Common::switchTab(self, widgetIndex);
                     break;
             }
@@ -633,22 +654,22 @@ namespace OpenLoco::Ui::Windows::Town
         }
 
         // 0x004998E7
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameTownPrompt(self, widgetIndex);
                     break;
 
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_town:
-                case Common::widx::tab_population:
-                case Common::widx::tab_company_ratings:
-                case Common::widx::tab_transported:
+                case Common::Widx::kTabTown:
+                case Common::Widx::kTabPopulation:
+                case Common::Widx::kTabCompanyRatings:
+                case Common::Widx::kTabTransported:
                     Common::switchTab(self, widgetIndex);
                     break;
             }
@@ -753,22 +774,22 @@ namespace OpenLoco::Ui::Windows::Town
             }
         }
 
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameTownPrompt(self, widgetIndex);
                     break;
 
-                case Common::widx::close_button:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tab_town:
-                case Common::widx::tab_population:
-                case Common::widx::tab_company_ratings:
-                case Common::widx::tab_transported:
+                case Common::Widx::kTabTown:
+                case Common::Widx::kTabPopulation:
+                case Common::Widx::kTabCompanyRatings:
+                case Common::Widx::kTabTransported:
                     Common::switchTab(self, widgetIndex);
                     break;
             }
@@ -837,9 +858,9 @@ namespace OpenLoco::Ui::Windows::Town
         }
 
         // 0x00499287
-        static void textInput(Window& self, WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* input)
+        static void textInput(Window& self, [[maybe_unused]] WidgetIndex_t callingWidget, const WidgetId id, const char* input)
         {
-            if (callingWidget != Common::widx::caption)
+            if (id != Common::Widx::kCaption)
             {
                 return;
             }

--- a/src/OpenLoco/src/Ui/Windows/Tutorial.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Tutorial.cpp
@@ -14,7 +14,7 @@
 
 namespace OpenLoco::Ui::Windows::Tutorial
 {
-    enum Widx
+    enum widx
     {
         frame,
     };
@@ -54,7 +54,7 @@ namespace OpenLoco::Ui::Windows::Tutorial
     // 0x00439B3D
     static void prepareDraw(Window& self)
     {
-        self.widgets[Widx::frame].right = self.width - 1;
+        self.widgets[widx::frame].right = self.width - 1;
     }
 
     // 0x00439B4A
@@ -73,7 +73,7 @@ namespace OpenLoco::Ui::Windows::Tutorial
         FormatArguments args{};
         args.push(titleStringIds[tutorialNumber]);
 
-        auto& widget = self.widgets[Widx::frame];
+        auto& widget = self.widgets[widx::frame];
         auto point = Point(self.x + widget.midX(), self.y + widget.top + 4);
         tr.drawStringCentred(point, Colour::black, StringIds::tutorial_text, args);
 

--- a/src/OpenLoco/src/Ui/Windows/Tutorial.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Tutorial.cpp
@@ -19,10 +19,15 @@ namespace OpenLoco::Ui::Windows::Tutorial
         frame,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kFrame{ "frame" };
+    }
+
     static constexpr Ui::Size kWindowSize = { 140, 29 };
 
     static constexpr auto widgets = makeWidgets(
-        Widgets::Wt3Widget({ 0, 0 }, kWindowSize, WindowColour::primary)
+        Widgets::Wt3Widget(Widx::kFrame, { 0, 0 }, kWindowSize, WindowColour::primary)
 
     );
 

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -112,18 +112,31 @@ namespace OpenLoco::Ui::Windows::Vehicle
             tabRoute = 8,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kFrame{ "frame" };
+            constexpr WidgetId kCaption{ "caption" };
+            constexpr WidgetId kCloseButton{ "closeButton" };
+            constexpr WidgetId kPanel{ "panel" };
+            constexpr WidgetId kTabMain{ "tabMain" };
+            constexpr WidgetId kTabDetails{ "tabDetails" };
+            constexpr WidgetId kTabCargo{ "tabCargo" };
+            constexpr WidgetId kTabFinances{ "tabFinances" };
+            constexpr WidgetId kTabRoute{ "tabRoute" };
+        }
+
         static constexpr auto makeCommonWidgets(int32_t frameWidth, int32_t frameHeight, StringId windowCaptionId)
         {
             return makeWidgets(
-                Widgets::Frame({ 0, 0 }, { (frameWidth), (frameHeight) }, WindowColour::primary),
-                Widgets::Caption({ 1, 1 }, { (frameWidth)-2, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, windowCaptionId),
-                Widgets::ImageButton({ (frameWidth)-15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-                Widgets::Panel({ 0, 41 }, { 265, 136 }, WindowColour::secondary),
-                Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicle_tab_main),
-                Widgets::Tab({ 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicle_tab_details),
-                Widgets::Tab({ 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicle_tab_cargo),
-                Widgets::Tab({ 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicle_tab_finance),
-                Widgets::Tab({ 158, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicle_tab_route));
+                Widgets::Frame(Widx::kFrame, { 0, 0 }, { (frameWidth), (frameHeight) }, WindowColour::primary),
+                Widgets::Caption(Widx::kCaption, { 1, 1 }, { (frameWidth)-2, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary, windowCaptionId),
+                Widgets::ImageButton(Widx::kCloseButton, { (frameWidth)-15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+                Widgets::Panel(Widx::kPanel, { 0, 41 }, { 265, 136 }, WindowColour::secondary),
+                Widgets::Tab(Widx::kTabMain, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicle_tab_main),
+                Widgets::Tab(Widx::kTabDetails, { 34, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicle_tab_details),
+                Widgets::Tab(Widx::kTabCargo, { 65, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicle_tab_cargo),
+                Widgets::Tab(Widx::kTabFinances, { 96, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicle_tab_finance),
+                Widgets::Tab(Widx::kTabRoute, { 158, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_vehicle_tab_route));
         }
 
         static Vehicles::VehicleHead* getVehicle(const Window& self)
@@ -225,6 +238,17 @@ namespace OpenLoco::Ui::Windows::Vehicle
             carList,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kBuildNew{ "buildNew" };
+            constexpr WidgetId kPickup{ "pickup" };
+            constexpr WidgetId kRemove{ "remove" };
+            constexpr WidgetId kPaintBrush{ "paintBrush" };
+            constexpr WidgetId kPaintColourPrimary{ "paintColourPrimary" };
+            constexpr WidgetId kPaintColourSecondary{ "paintColourSecondary" };
+            constexpr WidgetId kCarList{ "carList" };
+        }
+
         struct BodyItem
         {
             uint32_t image;
@@ -242,13 +266,13 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(265, 177, StringIds::title_vehicle_details),
-            Widgets::ImageButton({ 240, 44 }, { 24, 24 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_build_new_vehicle_for),
-            Widgets::ImageButton({ 240, 68 }, { 24, 24 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_remove_from_track),
-            Widgets::ImageButton({ 240, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::rubbish_bin, StringIds::tooltip_sell_or_drag_vehicle),
-            Widgets::ImageButton({ 240, 122 }, { 24, 24 }, WindowColour::secondary, ImageIds::paintbrush, StringIds::vehicleRepaintTooltip),
-            Widgets::ColourButton({ 240, 150 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
-            Widgets::ColourButton({ 258, 150 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
-            Widgets::ScrollView({ 3, 44 }, { 237, 110 }, WindowColour::secondary, Scrollbars::vertical)
+            Widgets::ImageButton(Widx::kBuildNew, { 240, 44 }, { 24, 24 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_build_new_vehicle_for),
+            Widgets::ImageButton(Widx::kPickup, { 240, 68 }, { 24, 24 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_remove_from_track),
+            Widgets::ImageButton(Widx::kRemove, { 240, 96 }, { 24, 24 }, WindowColour::secondary, ImageIds::rubbish_bin, StringIds::tooltip_sell_or_drag_vehicle),
+            Widgets::ImageButton(Widx::kPaintBrush, { 240, 122 }, { 24, 24 }, WindowColour::secondary, ImageIds::paintbrush, StringIds::vehicleRepaintTooltip),
+            Widgets::ColourButton(Widx::kPaintColourPrimary, { 240, 150 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_main_colour),
+            Widgets::ColourButton(Widx::kPaintColourSecondary, { 258, 150 }, { 16, 16 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_select_secondary_colour),
+            Widgets::ScrollView(Widx::kCarList, { 3, 44 }, { 237, 110 }, WindowColour::secondary, Scrollbars::vertical)
 
         );
 
@@ -273,12 +297,18 @@ namespace OpenLoco::Ui::Windows::Vehicle
             cargoList = 10,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kRefit{ "refit" };
+            constexpr WidgetId kCargoList{ "cargoList" };
+        }
+
         constexpr uint64_t holdableWidgets = 0;
 
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(265, 177, StringIds::title_vehicle_cargo),
-            Widgets::ImageButton({ 240, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::refit_cargo_button, StringIds::refit_vehicle_tip),
-            Widgets::ScrollView({ 3, 44 }, { 259, 120 }, WindowColour::secondary, Scrollbars::vertical)
+            Widgets::ImageButton(Widx::kRefit, { 240, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::refit_cargo_button, StringIds::refit_vehicle_tip),
+            Widgets::ScrollView(Widx::kCargoList, { 3, 44 }, { 259, 120 }, WindowColour::secondary, Scrollbars::vertical)
 
         );
     }
@@ -317,6 +347,20 @@ namespace OpenLoco::Ui::Windows::Vehicle
             orderReverse
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kLocalMode{ "localMode" };
+            constexpr WidgetId kExpressMode{ "expressMode" };
+            constexpr WidgetId kRouteList{ "routeList" };
+            constexpr WidgetId kOrderForceUnload{ "orderForceUnload" };
+            constexpr WidgetId kOrderWait{ "orderWait" };
+            constexpr WidgetId kOrderSkip{ "orderSkip" };
+            constexpr WidgetId kOrderDelete{ "orderDelete" };
+            constexpr WidgetId kOrderUp{ "orderUp" };
+            constexpr WidgetId kOrderDown{ "orderDown" };
+            constexpr WidgetId kOrderReverse{ "orderReverse" };
+        }
+
         constexpr uint64_t holdableWidgets = 0;
         constexpr auto lineHeight = 10;
 
@@ -324,16 +368,16 @@ namespace OpenLoco::Ui::Windows::Vehicle
             Common::makeCommonWidgets(265, 189, StringIds::title_vehicle_route),
             // TODO: This is not ideal, this is used for the tool, do this in a better way.
             makeWidget({ 0, 0 }, { 1, 1 }, WidgetType::empty, WindowColour::primary),
-            Widgets::Button({ 3, 44 }, { 118, 12 }, WindowColour::secondary, StringIds::local_mode_button),
-            Widgets::Button({ 121, 44 }, { 119, 12 }, WindowColour::secondary, StringIds::express_mode_button),
-            Widgets::ScrollView({ 3, 58 }, { 237, 120 }, WindowColour::secondary, Scrollbars::vertical, StringIds::tooltip_route_scrollview),
-            Widgets::ImageButton({ 240, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::route_force_unload, StringIds::tooltip_route_insert_force_unload),
-            Widgets::ImageButton({ 240, 68 }, { 24, 24 }, WindowColour::secondary, ImageIds::route_wait, StringIds::tooltip_route_insert_wait_full_cargo),
-            Widgets::ImageButton({ 240, 92 }, { 24, 24 }, WindowColour::secondary, ImageIds::route_skip, StringIds::tooltip_route_skip_next_order),
-            Widgets::ImageButton({ 240, 116 }, { 24, 24 }, WindowColour::secondary, ImageIds::route_delete, StringIds::tooltip_route_delete_order),
-            Widgets::ImageButton({ 240, 140 }, { 24, 12 }, WindowColour::secondary, ImageIds::red_arrow_up, StringIds::tooltip_route_move_order_up),
-            Widgets::ImageButton({ 240, 152 }, { 24, 12 }, WindowColour::secondary, ImageIds::red_arrow_down, StringIds::tooltip_route_move_order_down),
-            Widgets::ImageButton({ 240, 164 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_right_turnaround, StringIds::reverseOrderTableTooltip)
+            Widgets::Button(Widx::kLocalMode, { 3, 44 }, { 118, 12 }, WindowColour::secondary, StringIds::local_mode_button),
+            Widgets::Button(Widx::kExpressMode, { 121, 44 }, { 119, 12 }, WindowColour::secondary, StringIds::express_mode_button),
+            Widgets::ScrollView(Widx::kRouteList, { 3, 58 }, { 237, 120 }, WindowColour::secondary, Scrollbars::vertical, StringIds::tooltip_route_scrollview),
+            Widgets::ImageButton(Widx::kOrderForceUnload, { 240, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::route_force_unload, StringIds::tooltip_route_insert_force_unload),
+            Widgets::ImageButton(Widx::kOrderWait, { 240, 68 }, { 24, 24 }, WindowColour::secondary, ImageIds::route_wait, StringIds::tooltip_route_insert_wait_full_cargo),
+            Widgets::ImageButton(Widx::kOrderSkip, { 240, 92 }, { 24, 24 }, WindowColour::secondary, ImageIds::route_skip, StringIds::tooltip_route_skip_next_order),
+            Widgets::ImageButton(Widx::kOrderDelete, { 240, 116 }, { 24, 24 }, WindowColour::secondary, ImageIds::route_delete, StringIds::tooltip_route_delete_order),
+            Widgets::ImageButton(Widx::kOrderUp, { 240, 140 }, { 24, 12 }, WindowColour::secondary, ImageIds::red_arrow_up, StringIds::tooltip_route_move_order_up),
+            Widgets::ImageButton(Widx::kOrderDown, { 240, 152 }, { 24, 12 }, WindowColour::secondary, ImageIds::red_arrow_down, StringIds::tooltip_route_move_order_down),
+            Widgets::ImageButton(Widx::kOrderReverse, { 240, 164 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_right_turnaround, StringIds::reverseOrderTableTooltip)
 
         );
     }
@@ -362,16 +406,28 @@ namespace OpenLoco::Ui::Windows::Vehicle
             centreViewport = 16,
         };
 
+        namespace Widx
+        {
+            constexpr WidgetId kViewport{ "viewport" };
+            constexpr WidgetId kStatus{ "status" };
+            constexpr WidgetId kSpeedControl{ "speedControl" };
+            constexpr WidgetId kStopStart{ "stopStart" };
+            constexpr WidgetId kPickup{ "pickup" };
+            constexpr WidgetId kPassSignal{ "passSignal" };
+            constexpr WidgetId kChangeDirection{ "changeDirection" };
+            constexpr WidgetId kCentreViewport{ "centreViewport" };
+        }
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(265, 177, StringIds::stringid),
-            Widgets::Viewport({ 3, 44 }, { 237, 120 }, WindowColour::secondary),
-            Widgets::Label({ 3, 155 }, { 237, 21 }, WindowColour::secondary, ContentAlign::center),
-            Widgets::Slider({ 240, 46 }, { 24, 115 }, WindowColour::secondary),
-            Widgets::ImageButton({ 240, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::red_flag, StringIds::tooltip_stop_start),
-            Widgets::ImageButton({ 240, 68 }, { 24, 24 }, WindowColour::secondary, ImageIds::null, StringIds::tooltip_remove_from_track),
-            Widgets::ImageButton({ 240, 92 }, { 24, 24 }, WindowColour::secondary, ImageIds::pass_signal, StringIds::tooltip_pass_signal_at_danger),
-            Widgets::ImageButton({ 240, 116 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_right_turnaround, StringIds::tooltip_change_direction),
-            Widgets::ImageButton({ 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this)
+            Widgets::Viewport(Widx::kViewport, { 3, 44 }, { 237, 120 }, WindowColour::secondary),
+            Widgets::Label(Widx::kStatus, { 3, 155 }, { 237, 21 }, WindowColour::secondary, ContentAlign::center),
+            Widgets::Slider(Widx::kSpeedControl, { 240, 46 }, { 24, 115 }, WindowColour::secondary),
+            Widgets::ImageButton(Widx::kStopStart, { 240, 44 }, { 24, 24 }, WindowColour::secondary, ImageIds::red_flag, StringIds::tooltip_stop_start),
+            Widgets::ImageButton(Widx::kPickup, { 240, 68 }, { 24, 24 }, WindowColour::secondary, ImageIds::null, StringIds::tooltip_remove_from_track),
+            Widgets::ImageButton(Widx::kPassSignal, { 240, 92 }, { 24, 24 }, WindowColour::secondary, ImageIds::pass_signal, StringIds::tooltip_pass_signal_at_danger),
+            Widgets::ImageButton(Widx::kChangeDirection, { 240, 116 }, { 24, 24 }, WindowColour::secondary, ImageIds::construction_right_turnaround, StringIds::tooltip_change_direction),
+            Widgets::ImageButton(Widx::kCentreViewport, { 0, 0 }, { 24, 24 }, WindowColour::secondary, ImageIds::centre_viewport, StringIds::move_main_view_to_show_this)
 
         );
 
@@ -578,30 +634,30 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B24D1
-        static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::closeButton:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameVehicle(self, widgetIndex);
                     break;
-                case Common::widx::tabMain:
-                case Common::widx::tabDetails:
-                case Common::widx::tabCargo:
-                case Common::widx::tabFinances:
-                case Common::widx::tabRoute:
+                case Common::Widx::kTabMain:
+                case Common::Widx::kTabDetails:
+                case Common::Widx::kTabCargo:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabRoute:
                     Common::switchTab(self, widgetIndex);
                     break;
-                case widx::pickup:
+                case Widx::kPickup:
                     Common::onPickup(self, widx::pickup);
                     break;
-                case widx::changeDirection:
+                case Widx::kChangeDirection:
                     onChangeDirection(self);
                     break;
-                case widx::passSignal:
+                case Widx::kPassSignal:
                 {
                     GameCommands::VehiclePassSignalArgs args{};
                     args.head = EntityId(self.number);
@@ -754,17 +810,17 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B251A
-        static void onMouseDown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::stopStart:
+                case Widx::kStopStart:
                     stopStartOpen(self);
                     break;
-                case widx::speedControl:
+                case Widx::kSpeedControl:
                     onSpeedControl(self);
                     break;
-                case widx::centreViewport:
+                case Widx::kCentreViewport:
                     onCentreViewportControl(self);
                     break;
             }
@@ -830,14 +886,14 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B253A
-        static void onDropdown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t itemIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIndex, const WidgetId id, const int16_t itemIndex)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case widx::stopStart:
+                case Widx::kStopStart:
                     onStopStartDropdown(self, itemIndex);
                     break;
-                case widx::centreViewport:
+                case Widx::kCentreViewport:
                     onCentreViewportDropdown(self, itemIndex);
                     break;
             }
@@ -1167,27 +1223,27 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B3823
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::closeButton:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameVehicle(self, widgetIndex);
                     break;
-                case Common::widx::tabMain:
-                case Common::widx::tabDetails:
-                case Common::widx::tabCargo:
-                case Common::widx::tabFinances:
-                case Common::widx::tabRoute:
+                case Common::Widx::kTabMain:
+                case Common::Widx::kTabDetails:
+                case Common::Widx::kTabCargo:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabRoute:
                     Common::switchTab(self, widgetIndex);
                     break;
-                case widx::pickup:
+                case Widx::kPickup:
                     Common::onPickup(self, widx::pickup);
                     break;
-                case widx::remove:
+                case Widx::kRemove:
                 {
                     auto head = Common::getVehicle(self);
                     if (head == nullptr)
@@ -1223,9 +1279,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
             }
         }
 
-        static void onMouseDown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, const WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            if (widgetIndex == widx::buildNew)
+            if (id == Widx::kBuildNew)
             {
                 Dropdown::add(0, StringIds::dropdown_stringid, StringIds::dropdown_modify_vehicle);
                 Dropdown::add(1, StringIds::dropdown_stringid, StringIds::dropdown_clone_vehicle);
@@ -1244,14 +1300,14 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 Dropdown::setHighlightedItem(0);
                 return;
             }
-            if (widgetIndex == widx::paintColourPrimary || widgetIndex == widx::paintColourSecondary)
+            if (id == Widx::kPaintColourPrimary || id == Widx::kPaintColourSecondary)
             {
                 auto availableColours = 0x7FFFFFFF;
                 Colour selectedColour = ImageId::fromUInt32(self.widgets[widgetIndex].image).getPrimary();
                 Dropdown::showColour(&self, &self.widgets[widgetIndex], availableColours, selectedColour, self.getColour(WindowColour::secondary));
                 return;
             }
-            if (widgetIndex == widx::paintBrush)
+            if (id == Widx::kPaintBrush)
             {
                 Dropdown::add(0, StringIds::dropdown_stringid, StringIds::vehicleRepaintTool);
                 Dropdown::add(1, StringIds::dropdown_stringid, StringIds::vehicleRepaintEntireVehicle);
@@ -1273,9 +1329,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B253A
-        static void onDropdown(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, const int16_t itemIndex)
+        static void onDropdown(Window& self, const WidgetIndex_t widgetIndex, const WidgetId id, const int16_t itemIndex)
         {
-            if (widgetIndex == widx::buildNew)
+            if (id == Widx::kBuildNew)
             {
                 if (itemIndex <= 0)
                 {
@@ -1287,7 +1343,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 }
                 return;
             }
-            if (widgetIndex == widx::paintColourPrimary || widgetIndex == widx::paintColourSecondary)
+            if (id == Widx::kPaintColourPrimary || id == Widx::kPaintColourSecondary)
             {
                 if (itemIndex == -1)
                 {
@@ -1298,7 +1354,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 self.invalidate();
                 return;
             }
-            if (widgetIndex == widx::paintBrush)
+            if (id == Widx::kPaintBrush)
             {
                 if (itemIndex == 1 || Input::hasKeyModifier(Input::KeyModifier::shift))
                 {
@@ -1566,9 +1622,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B3B18
-        static Ui::CursorId cursor(Window& self, const WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, const int16_t y, const Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIdx, const WidgetId id, [[maybe_unused]] const int16_t x, const int16_t y, const Ui::CursorId fallback)
         {
-            if (widgetIdx != widx::carList)
+            if (id != Widx::kCarList)
             {
                 return fallback;
             }
@@ -2383,45 +2439,45 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B41BD
-        static void onMouseUp(Window& self, const WidgetIndex_t i, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, const WidgetIndex_t i, const WidgetId id)
         {
-            switch (i)
+            switch (id)
             {
-                case Common::widx::closeButton:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
 
-                case Common::widx::tabMain:
-                case Common::widx::tabDetails:
-                case Common::widx::tabCargo:
-                case Common::widx::tabFinances:
-                case Common::widx::tabRoute:
+                case Common::Widx::kTabMain:
+                case Common::Widx::kTabDetails:
+                case Common::Widx::kTabCargo:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabRoute:
                     Common::switchTab(self, i);
                     break;
 
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameVehicle(self, i);
                     break;
             }
         }
 
         // 0x004B41E2
-        static void onMouseDown(Window& self, const WidgetIndex_t i, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, const WidgetIndex_t i, const WidgetId id)
         {
-            switch (i)
+            switch (id)
             {
-                case widx::refit:
+                case Widx::kRefit:
                     onRefitButton(self, i, id);
                     break;
             }
         }
 
         // 0x004B41E9
-        static void onDropdown(Window& self, const WidgetIndex_t i, [[maybe_unused]] const WidgetId id, const int16_t dropdownIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] const WidgetIndex_t i, const WidgetId id, const int16_t dropdownIndex)
         {
-            switch (i)
+            switch (id)
             {
-                case widx::refit:
+                case Widx::kRefit:
                 {
                     if (dropdownIndex == -1)
                     {
@@ -2777,21 +2833,21 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B5945
-        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
         {
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::closeButton:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameVehicle(self, widgetIndex);
                     break;
-                case Common::widx::tabMain:
-                case Common::widx::tabDetails:
-                case Common::widx::tabCargo:
-                case Common::widx::tabFinances:
-                case Common::widx::tabRoute:
+                case Common::Widx::kTabMain:
+                case Common::Widx::kTabDetails:
+                case Common::Widx::kTabCargo:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabRoute:
                     Common::switchTab(self, widgetIndex);
                     break;
             }
@@ -2962,29 +3018,29 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4B43
-        static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+        static void onMouseUp(Window& self, const WidgetIndex_t widgetIndex, const WidgetId id)
         {
             auto* head = Common::getVehicle(self);
             if (head == nullptr)
             {
                 return;
             }
-            switch (widgetIndex)
+            switch (id)
             {
-                case Common::widx::closeButton:
+                case Common::Widx::kCloseButton:
                     WindowManager::close(&self);
                     break;
-                case Common::widx::caption:
+                case Common::Widx::kCaption:
                     Common::renameVehicle(self, widgetIndex);
                     break;
-                case Common::widx::tabMain:
-                case Common::widx::tabDetails:
-                case Common::widx::tabCargo:
-                case Common::widx::tabFinances:
-                case Common::widx::tabRoute:
+                case Common::Widx::kTabMain:
+                case Common::Widx::kTabDetails:
+                case Common::Widx::kTabCargo:
+                case Common::Widx::kTabFinances:
+                case Common::Widx::kTabRoute:
                     Common::switchTab(self, widgetIndex);
                     break;
-                case widx::orderDelete:
+                case Widx::kOrderDelete:
                 {
 
                     onOrderDelete(head, self.orderTableIndex);
@@ -3003,7 +3059,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     }
                     break;
                 }
-                case widx::localMode:
+                case Widx::kLocalMode:
                 {
                     if (!CompanyManager::isPlayerCompany(head->owner))
                     {
@@ -3021,7 +3077,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     }
                     break;
                 }
-                case widx::expressMode:
+                case Widx::kExpressMode:
                 {
                     if (!CompanyManager::isPlayerCompany(head->owner))
                     {
@@ -3039,7 +3095,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     }
                     break;
                 }
-                case widx::orderSkip:
+                case Widx::kOrderSkip:
                 {
                     GameCommands::setErrorTitle(StringIds::empty);
                     GameCommands::VehicleOrderSkipArgs args{};
@@ -3047,7 +3103,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     GameCommands::doCommand(args, GameCommands::Flags::apply);
                     break;
                 }
-                case widx::orderUp:
+                case Widx::kOrderUp:
                     if (onOrderMove(head, self.orderTableIndex, orderUpCommand))
                     {
                         if (self.orderTableIndex <= 0)
@@ -3057,7 +3113,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                         self.orderTableIndex--;
                     }
                     break;
-                case widx::orderDown:
+                case Widx::kOrderDown:
                     if (onOrderMove(head, self.orderTableIndex, orderDownCommand))
                     {
                         if (self.orderTableIndex < 0)
@@ -3071,7 +3127,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                         }
                     }
                     break;
-                case widx::orderReverse:
+                case Widx::kOrderReverse:
                 {
                     orderReverseCommand(head);
                     break;
@@ -3120,14 +3176,14 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4B8C
-        static void onMouseDown(Window& self, const WidgetIndex_t i, [[maybe_unused]] const WidgetId id)
+        static void onMouseDown(Window& self, const WidgetIndex_t i, const WidgetId id)
         {
-            switch (i)
+            switch (id)
             {
-                case widx::orderForceUnload:
+                case Widx::kOrderForceUnload:
                     createOrderDropdown(self, i, StringIds::orders_unload_all2);
                     break;
-                case widx::orderWait:
+                case Widx::kOrderWait:
                     createOrderDropdown(self, i, StringIds::orders_wait_for_full_load_of2);
                     break;
             }
@@ -3179,22 +3235,22 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B4BAC
-        static void onDropdown(Window& self, const WidgetIndex_t i, [[maybe_unused]] const WidgetId id, const int16_t dropdownIndex)
+        static void onDropdown(Window& self, [[maybe_unused]] const WidgetIndex_t i, const WidgetId id, const int16_t dropdownIndex)
         {
             auto item = dropdownIndex == -1 ? Dropdown::getHighlightedItem() : dropdownIndex;
             if (item == -1)
             {
                 return;
             }
-            switch (i)
+            switch (id)
             {
-                case widx::orderForceUnload:
+                case Widx::kOrderForceUnload:
                 {
                     Vehicles::OrderUnloadAll unload(Dropdown::getItemArgument(item, 3));
                     addNewOrder(self, unload);
                     break;
                 }
-                case widx::orderWait:
+                case Widx::kOrderWait:
                 {
                     Vehicles::OrderWaitFor wait(Dropdown::getItemArgument(item, 3));
                     addNewOrder(self, wait);
@@ -3736,9 +3792,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B5339
-        static Ui::CursorId cursor(Window& self, const WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y, const Ui::CursorId fallback)
+        static Ui::CursorId cursor(Window& self, [[maybe_unused]] const WidgetIndex_t widgetIdx, const WidgetId id, [[maybe_unused]] const int16_t x, [[maybe_unused]] const int16_t y, const Ui::CursorId fallback)
         {
-            if (widgetIdx != widx::routeList)
+            if (id != Widx::kRouteList)
             {
                 return fallback;
             }
@@ -4175,9 +4231,9 @@ namespace OpenLoco::Ui::Windows::Vehicle
         }
 
         // 0x004B26C0
-        static void textInput(Window& self, const WidgetIndex_t callingWidget, [[maybe_unused]] const WidgetId id, const char* const input)
+        static void textInput(Window& self, [[maybe_unused]] const WidgetIndex_t callingWidget, const WidgetId id, const char* const input)
         {
-            if (callingWidget != widx::caption)
+            if (id != Widx::kCaption)
             {
                 return;
             }

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -47,7 +47,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     static constexpr Ui::Size kMaxDimensions = { 1200, 2000 };
     static constexpr Ui::Size kMinDimensions = { 220, 160 };
 
-    enum Widx
+    enum widx
     {
         frame = 0,
         caption = 1,
@@ -96,7 +96,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     );
 
     // clang-format off
-    constexpr uint16_t _tabWidgets = (1 << Widx::tab_trains) | (1 << Widx::tab_buses) | (1 << Widx::tab_trucks) | (1 << Widx::tab_trams) | (1 << Widx::tab_aircraft) | (1 << Widx::tab_ships);
+    constexpr uint16_t _tabWidgets = (1 << widx::tab_trains) | (1 << widx::tab_buses) | (1 << widx::tab_trucks) | (1 << widx::tab_trams) | (1 << widx::tab_aircraft) | (1 << widx::tab_ships);
     // clang-format on
 
     enum SortMode : uint16_t
@@ -122,7 +122,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         36
     };
 
-    static Widx getTabFromType(VehicleType type);
+    static widx getTabFromType(VehicleType type);
 
     constexpr bool isCargoFilterActive(const Window& self, bool checkSelection = true)
     {
@@ -274,7 +274,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         auto companyColour = CompanyManager::getCompanyColour(CompanyId(self.number));
 
         static constexpr std::pair<WidgetIndex_t, std::array<uint32_t, 8>> tabAnimations[] = {
-            { Widx::tab_trains, {
+            { widx::tab_trains, {
                                     InterfaceSkin::ImageIds::vehicle_train_frame_0,
                                     InterfaceSkin::ImageIds::vehicle_train_frame_1,
                                     InterfaceSkin::ImageIds::vehicle_train_frame_2,
@@ -284,7 +284,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
                                     InterfaceSkin::ImageIds::vehicle_train_frame_6,
                                     InterfaceSkin::ImageIds::vehicle_train_frame_7,
                                 } },
-            { Widx::tab_aircraft, {
+            { widx::tab_aircraft, {
                                       InterfaceSkin::ImageIds::vehicle_aircraft_frame_0,
                                       InterfaceSkin::ImageIds::vehicle_aircraft_frame_1,
                                       InterfaceSkin::ImageIds::vehicle_aircraft_frame_2,
@@ -294,7 +294,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
                                       InterfaceSkin::ImageIds::vehicle_aircraft_frame_6,
                                       InterfaceSkin::ImageIds::vehicle_aircraft_frame_7,
                                   } },
-            { Widx::tab_buses, {
+            { widx::tab_buses, {
                                    InterfaceSkin::ImageIds::vehicle_buses_frame_0,
                                    InterfaceSkin::ImageIds::vehicle_buses_frame_1,
                                    InterfaceSkin::ImageIds::vehicle_buses_frame_2,
@@ -304,7 +304,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
                                    InterfaceSkin::ImageIds::vehicle_buses_frame_6,
                                    InterfaceSkin::ImageIds::vehicle_buses_frame_7,
                                } },
-            { Widx::tab_trams, {
+            { widx::tab_trams, {
                                    InterfaceSkin::ImageIds::vehicle_trams_frame_0,
                                    InterfaceSkin::ImageIds::vehicle_trams_frame_1,
                                    InterfaceSkin::ImageIds::vehicle_trams_frame_2,
@@ -314,7 +314,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
                                    InterfaceSkin::ImageIds::vehicle_trams_frame_6,
                                    InterfaceSkin::ImageIds::vehicle_trams_frame_7,
                                } },
-            { Widx::tab_trucks, {
+            { widx::tab_trucks, {
                                     InterfaceSkin::ImageIds::vehicle_trucks_frame_0,
                                     InterfaceSkin::ImageIds::vehicle_trucks_frame_1,
                                     InterfaceSkin::ImageIds::vehicle_trucks_frame_2,
@@ -324,7 +324,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
                                     InterfaceSkin::ImageIds::vehicle_trucks_frame_6,
                                     InterfaceSkin::ImageIds::vehicle_trucks_frame_7,
                                 } },
-            { Widx::tab_ships, {
+            { widx::tab_ships, {
                                    InterfaceSkin::ImageIds::vehicle_ships_frame_0,
                                    InterfaceSkin::ImageIds::vehicle_ships_frame_1,
                                    InterfaceSkin::ImageIds::vehicle_ships_frame_2,
@@ -343,7 +343,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
                 continue;
             }
 
-            auto isActive = tab == self.currentTab + Widx::tab_trains;
+            auto isActive = tab == self.currentTab + widx::tab_trains;
             auto imageId = isActive ? frames[self.frameNo / 2 % 8] : frames[0];
 
             uint32_t image = Gfx::recolour(skin->img + imageId, companyColour);
@@ -358,7 +358,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         auto* company = CompanyManager::get(CompanyId(self.number));
 
         // Disable the tabs for the vehicles that are _not_ available for this company.
-        self.disabledWidgets = (static_cast<uint64_t>(company->availableVehicles ^ 0x3F)) << Widx::tab_trains;
+        self.disabledWidgets = (static_cast<uint64_t>(company->availableVehicles ^ 0x3F)) << widx::tab_trains;
     }
 
     static const WindowEventList& getEvents();
@@ -433,7 +433,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         }
     }
 
-    static Widx getTabFromType(VehicleType type)
+    static widx getTabFromType(VehicleType type)
     {
         auto tabIndex = static_cast<uint8_t>(type);
         if (tabIndex > 5)
@@ -441,7 +441,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
             throw Exception::RuntimeError("Unexpected vehicle type");
         }
 
-        static constexpr Widx type_to_widx[] = {
+        static constexpr widx type_to_widx[] = {
             tab_trains,
             tab_buses,
             tab_trucks,
@@ -459,13 +459,13 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
         // The original game was setting widget sets here. As all tabs are the same, this has been omitted.
         self.activatedWidgets &= ~_tabWidgets;
-        self.activatedWidgets |= 1ULL << (self.currentTab + Widx::tab_trains);
+        self.activatedWidgets |= 1ULL << (self.currentTab + widx::tab_trains);
 
         auto company = CompanyManager::get(CompanyId(self.number));
 
         {
             // Set company in title
-            auto args = FormatArguments(self.widgets[Widx::caption].textArgs);
+            auto args = FormatArguments(self.widgets[widx::caption].textArgs);
             args.push(company->name);
         }
 
@@ -478,22 +478,22 @@ namespace OpenLoco::Ui::Windows::VehicleList
             StringIds::stringid_ships,
         };
 
-        self.widgets[Widx::caption].text = kTypeToCaption[self.currentTab];
+        self.widgets[widx::caption].text = kTypeToCaption[self.currentTab];
 
         // Set header button captions.
-        self.widgets[Widx::sort_name].text = self.sortMode == SortMode::Name ? StringIds::table_header_name_desc : StringIds::table_header_name;
-        self.widgets[Widx::sort_profit].text = self.sortMode == SortMode::Profit ? StringIds::table_header_monthly_profit_desc : StringIds::table_header_monthly_profit;
-        self.widgets[Widx::sort_age].text = self.sortMode == SortMode::Age ? StringIds::table_header_age_desc : StringIds::table_header_age;
-        self.widgets[Widx::sort_reliability].text = self.sortMode == SortMode::Reliability ? StringIds::table_header_reliability_desc : StringIds::table_header_reliability;
+        self.widgets[widx::sort_name].text = self.sortMode == SortMode::Name ? StringIds::table_header_name_desc : StringIds::table_header_name;
+        self.widgets[widx::sort_profit].text = self.sortMode == SortMode::Profit ? StringIds::table_header_monthly_profit_desc : StringIds::table_header_monthly_profit;
+        self.widgets[widx::sort_age].text = self.sortMode == SortMode::Age ? StringIds::table_header_age_desc : StringIds::table_header_age;
+        self.widgets[widx::sort_reliability].text = self.sortMode == SortMode::Reliability ? StringIds::table_header_reliability_desc : StringIds::table_header_reliability;
 
         // Disable cargo dropdown if not applicable
         if (self.var_850 != FilterMode::transportingCargo)
         {
-            self.disabledWidgets |= (1 << Widx::cargo_type) | (1 << Widx::cargo_type_btn);
+            self.disabledWidgets |= (1 << widx::cargo_type) | (1 << widx::cargo_type_btn);
         }
         else
         {
-            self.disabledWidgets &= ~((1 << Widx::cargo_type) | (1 << Widx::cargo_type_btn));
+            self.disabledWidgets &= ~((1 << widx::cargo_type) | (1 << widx::cargo_type_btn));
         }
 
         // Set appropriate tooltip
@@ -502,9 +502,9 @@ namespace OpenLoco::Ui::Windows::VehicleList
             StringIds::tooltip_open_station_window_to_filter,
             StringIds::tooltip_select_cargo_type,
         };
-        self.widgets[Widx::cargo_type_btn].tooltip = kFilterTooltipByType[self.var_850];
+        self.widgets[widx::cargo_type_btn].tooltip = kFilterTooltipByType[self.var_850];
 
-        Widget::leftAlignTabs(self, Widx::tab_trains, Widx::tab_ships);
+        Widget::leftAlignTabs(self, widx::tab_trains, widx::tab_ships);
 
         static constexpr std::pair<StringId, StringId> kTypeToFooterStringIds[]{
             { StringIds::num_trains_singular, StringIds::num_trains_plural },
@@ -517,7 +517,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
         {
             // Set status bar text
-            auto& widget = self.widgets[Widx::status_bar];
+            auto& widget = self.widgets[widx::status_bar];
             FormatArguments args{ widget.textArgs };
             auto& footerStringPair = kTypeToFooterStringIds[self.currentTab];
             args.push(self.rowCount == 1 ? footerStringPair.first : footerStringPair.second);
@@ -531,12 +531,12 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
         {
             // Set current filter type
-            auto& widget = self.widgets[Widx::filter_type];
+            auto& widget = self.widgets[widx::filter_type];
             FormatArguments args{ widget.textArgs };
             args.push(kTypeToFilterStringIds[self.var_850]);
         }
 
-        auto& widget = self.widgets[Widx::cargo_type];
+        auto& widget = self.widgets[widx::cargo_type];
         bool filterActive = false;
         FormatArguments args{ widget.textArgs };
 
@@ -570,8 +570,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
         auto company = CompanyManager::get(CompanyId(self.number));
         auto competitorObj = ObjectManager::get<CompetitorObject>(company->competitorId);
         uint32_t image = Gfx::recolour(competitorObj->images[enumValue(company->ownerEmotion)], company->mainColours.primary);
-        uint16_t x = self.x + self.widgets[Widx::company_select].left + 1;
-        uint16_t y = self.y + self.widgets[Widx::company_select].top + 1;
+        uint16_t x = self.x + self.widgets[widx::company_select].left + 1;
+        uint16_t y = self.y + self.widgets[widx::company_select].top + 1;
         drawingCtx.drawImage(ZoomLevel::full, x, y, image);
     }
 
@@ -619,7 +619,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
             drawTrainInline(drawingCtx, vehicle, Ui::Point(0, yPos + (self.rowHeight - 28) / 2 + 6));
 
             // Draw vehicle status
-            auto& statusHeader = self.widgets[Widx::sort_name];
+            auto& statusHeader = self.widgets[widx::sort_name];
             {
                 // Prepare status for drawing
                 auto status = head->getStatus();
@@ -644,7 +644,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
             }
 
             // Vehicle profit
-            auto& profitHeader = self.widgets[Widx::sort_profit];
+            auto& profitHeader = self.widgets[widx::sort_profit];
             {
                 StringId format = StringIds::vehicle_list_profit_pos;
                 currency32_t profit = vehicle.veh2->totalRecentProfit() / 4;
@@ -660,7 +660,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
             }
 
             // Vehicle age
-            auto& ageHeader = self.widgets[Widx::sort_age];
+            auto& ageHeader = self.widgets[widx::sort_age];
             {
                 StringId format = StringIds::vehicle_list_age_years;
                 auto age = (getCurrentDay() - vehicle.veh1->dayCreated) / 365;
@@ -675,7 +675,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
             }
 
             // Vehicle reliability
-            auto& reliabilityHeader = self.widgets[Widx::sort_reliability];
+            auto& reliabilityHeader = self.widgets[widx::sort_reliability];
             {
                 int16_t reliability = vehicle.veh2->reliability;
                 auto args = FormatArguments::common(reliability);
@@ -735,28 +735,28 @@ namespace OpenLoco::Ui::Windows::VehicleList
     {
         switch (widgetIndex)
         {
-            case Widx::close_button:
+            case widx::close_button:
                 WindowManager::close(&self);
                 break;
 
-            case Widx::tab_trains:
-            case Widx::tab_buses:
-            case Widx::tab_trucks:
-            case Widx::tab_trams:
-            case Widx::tab_aircraft:
-            case Widx::tab_ships:
+            case widx::tab_trains:
+            case widx::tab_buses:
+            case widx::tab_trucks:
+            case widx::tab_trams:
+            case widx::tab_aircraft:
+            case widx::tab_ships:
             {
-                auto vehicleType = VehicleType(widgetIndex - Widx::tab_trains);
+                auto vehicleType = VehicleType(widgetIndex - widx::tab_trains);
                 switchTab(self, vehicleType);
                 break;
             }
 
-            case Widx::sort_name:
-            case Widx::sort_profit:
-            case Widx::sort_age:
-            case Widx::sort_reliability:
+            case widx::sort_name:
+            case widx::sort_profit:
+            case widx::sort_age:
+            case widx::sort_reliability:
             {
-                auto sortMode = widgetIndex - Widx::sort_name;
+                auto sortMode = widgetIndex - widx::sort_name;
                 if (self.sortMode == sortMode)
                 {
                     return;
@@ -773,21 +773,21 @@ namespace OpenLoco::Ui::Windows::VehicleList
     // 0x004C2434
     static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
     {
-        if (widgetIndex == Widx::company_select)
+        if (widgetIndex == widx::company_select)
         {
             Dropdown::populateCompanySelect(&self, &self.widgets[widgetIndex]);
         }
 
-        else if (widgetIndex == Widx::filter_type_btn)
+        else if (widgetIndex == widx::filter_type_btn)
         {
-            Widget dropdown = self.widgets[Widx::filter_type];
+            Widget dropdown = self.widgets[widx::filter_type];
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 2, 0x80);
 
             Dropdown::add(0, StringIds::dropdown_stringid, StringIds::all_vehicles);
             Dropdown::add(1, StringIds::dropdown_stringid, StringIds::transporting_cargo);
             Dropdown::setItemSelected(self.var_850);
         }
-        else if (widgetIndex == Widx::cargo_type_btn)
+        else if (widgetIndex == widx::cargo_type_btn)
         {
             auto index = 0;
             auto selectedIndex = -1;
@@ -813,7 +813,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
                 index++;
             }
 
-            Widget dropdown = self.widgets[Widx::cargo_type];
+            Widget dropdown = self.widgets[widx::cargo_type];
             Dropdown::showText(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), index, 0);
             if (selectedIndex != -1)
             {
@@ -864,7 +864,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
     static void onDropdown(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
     {
-        if (widgetIndex == Widx::company_select)
+        if (widgetIndex == widx::company_select)
         {
             return onCompanyDropdown(self, itemIndex);
         }
@@ -919,7 +919,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     // 0x004C266D
     static CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, CursorId fallback)
     {
-        if (widgetIdx != Widx::scrollview)
+        if (widgetIdx != widx::scrollview)
         {
             return fallback;
         }
@@ -959,12 +959,12 @@ namespace OpenLoco::Ui::Windows::VehicleList
         char* tooltipBuffer = const_cast<char*>(StringManager::getString(StringIds::buffer_337));
 
         // Have we already got the right tooltip?
-        if (tooltipBuffer[0] != '\0' && self.widgets[Widx::scrollview].tooltip == tooltipId && self.rowHover == self.var_85C)
+        if (tooltipBuffer[0] != '\0' && self.widgets[widx::scrollview].tooltip == tooltipId && self.rowHover == self.var_85C)
         {
             return;
         }
 
-        self.widgets[Widx::scrollview].tooltip = tooltipId;
+        self.widgets[widx::scrollview].tooltip = tooltipId;
         self.var_85C = self.rowHover;
         Ui::Windows::ToolTip::closeAndReset();
 
@@ -1066,80 +1066,80 @@ namespace OpenLoco::Ui::Windows::VehicleList
         }
 
         // Basic frame widget dimensions
-        self.widgets[Widx::frame].right = self.width - 1;
-        self.widgets[Widx::frame].bottom = self.height - 1;
+        self.widgets[widx::frame].right = self.width - 1;
+        self.widgets[widx::frame].bottom = self.height - 1;
 
-        self.widgets[Widx::panel].right = self.width - 1;
-        self.widgets[Widx::panel].bottom = self.height - 1;
+        self.widgets[widx::panel].right = self.width - 1;
+        self.widgets[widx::panel].bottom = self.height - 1;
 
-        self.widgets[Widx::caption].right = self.width - 2;
+        self.widgets[widx::caption].right = self.width - 2;
 
-        self.widgets[Widx::close_button].left = self.width - 15;
-        self.widgets[Widx::close_button].right = self.width - 3;
+        self.widgets[widx::close_button].left = self.width - 15;
+        self.widgets[widx::close_button].right = self.width - 3;
 
-        auto nameHeaderWidth = _widgets[Widx::sort_name].width();
-        auto profitHeaderWidth = _widgets[Widx::sort_profit].width();
-        auto ageHeaderWidth = _widgets[Widx::sort_age].width();
-        auto reliabilityHeaderWidth = _widgets[Widx::sort_reliability].width();
+        auto nameHeaderWidth = _widgets[widx::sort_name].width();
+        auto profitHeaderWidth = _widgets[widx::sort_profit].width();
+        auto ageHeaderWidth = _widgets[widx::sort_age].width();
+        auto reliabilityHeaderWidth = _widgets[widx::sort_reliability].width();
 
         nameHeaderWidth = std::max<uint16_t>(nameHeaderWidth, self.width - profitHeaderWidth - ageHeaderWidth - reliabilityHeaderWidth);
 
         // Reposition table headers
-        self.widgets[Widx::sort_name].right = std::min<uint16_t>(nameHeaderWidth, self.width - 4);
+        self.widgets[widx::sort_name].right = std::min<uint16_t>(nameHeaderWidth, self.width - 4);
 
-        self.widgets[Widx::sort_profit].left = std::min<uint16_t>(self.widgets[Widx::sort_name].right + 1, self.width - 4);
-        self.widgets[Widx::sort_profit].right = std::min<uint16_t>(self.widgets[Widx::sort_profit].left + profitHeaderWidth, self.width - 4);
+        self.widgets[widx::sort_profit].left = std::min<uint16_t>(self.widgets[widx::sort_name].right + 1, self.width - 4);
+        self.widgets[widx::sort_profit].right = std::min<uint16_t>(self.widgets[widx::sort_profit].left + profitHeaderWidth, self.width - 4);
 
-        self.widgets[Widx::sort_age].left = std::min<uint16_t>(self.widgets[Widx::sort_profit].right + 1, self.width - 4);
-        self.widgets[Widx::sort_age].right = std::min<uint16_t>(self.widgets[Widx::sort_age].left + ageHeaderWidth, self.width - 4);
+        self.widgets[widx::sort_age].left = std::min<uint16_t>(self.widgets[widx::sort_profit].right + 1, self.width - 4);
+        self.widgets[widx::sort_age].right = std::min<uint16_t>(self.widgets[widx::sort_age].left + ageHeaderWidth, self.width - 4);
 
-        self.widgets[Widx::sort_reliability].left = std::min<uint16_t>(self.widgets[Widx::sort_age].right + 1, self.width - 4);
-        self.widgets[Widx::sort_reliability].right = std::min<uint16_t>(self.widgets[Widx::sort_reliability].left + reliabilityHeaderWidth, self.width - 4);
+        self.widgets[widx::sort_reliability].left = std::min<uint16_t>(self.widgets[widx::sort_age].right + 1, self.width - 4);
+        self.widgets[widx::sort_reliability].right = std::min<uint16_t>(self.widgets[widx::sort_reliability].left + reliabilityHeaderWidth, self.width - 4);
 
         // Reposition company selection
-        self.widgets[Widx::company_select].left = self.width - 28;
-        self.widgets[Widx::company_select].right = self.width - 3;
+        self.widgets[widx::company_select].left = self.width - 28;
+        self.widgets[widx::company_select].right = self.width - 3;
 
-        auto filterWidth = _widgets[Widx::filter_type].width();
-        auto cargoTypeWidth = _widgets[Widx::cargo_type].width();
+        auto filterWidth = _widgets[widx::filter_type].width();
+        auto cargoTypeWidth = _widgets[widx::cargo_type].width();
         bool enoughSpaceForCargoFilters = self.width > cargoTypeWidth + filterWidth + 50;
 
-        self.widgets[Widx::cargo_type].hidden = !enoughSpaceForCargoFilters;
-        self.widgets[Widx::cargo_type_btn].hidden = !enoughSpaceForCargoFilters;
-        self.widgets[Widx::filter_type].hidden = !enoughSpaceForCargoFilters;
-        self.widgets[Widx::filter_type_btn].hidden = !enoughSpaceForCargoFilters;
+        self.widgets[widx::cargo_type].hidden = !enoughSpaceForCargoFilters;
+        self.widgets[widx::cargo_type_btn].hidden = !enoughSpaceForCargoFilters;
+        self.widgets[widx::filter_type].hidden = !enoughSpaceForCargoFilters;
+        self.widgets[widx::filter_type_btn].hidden = !enoughSpaceForCargoFilters;
 
         // Reposition filter/cargo dropdowns, starting from the right
         if (enoughSpaceForCargoFilters)
         {
-            self.widgets[Widx::cargo_type].top = self.height - 14;
-            self.widgets[Widx::cargo_type].bottom = self.height - 3;
-            self.widgets[Widx::cargo_type].right = self.width - kResizeHandleSize - 2;
-            self.widgets[Widx::cargo_type].left = self.widgets[Widx::cargo_type].right - cargoTypeWidth;
+            self.widgets[widx::cargo_type].top = self.height - 14;
+            self.widgets[widx::cargo_type].bottom = self.height - 3;
+            self.widgets[widx::cargo_type].right = self.width - kResizeHandleSize - 2;
+            self.widgets[widx::cargo_type].left = self.widgets[widx::cargo_type].right - cargoTypeWidth;
 
-            self.widgets[Widx::cargo_type_btn].top = self.height - 13;
-            self.widgets[Widx::cargo_type_btn].bottom = self.height - 4;
-            self.widgets[Widx::cargo_type_btn].right = self.widgets[Widx::cargo_type].right - 1;
-            self.widgets[Widx::cargo_type_btn].left = self.widgets[Widx::cargo_type].right - 10;
+            self.widgets[widx::cargo_type_btn].top = self.height - 13;
+            self.widgets[widx::cargo_type_btn].bottom = self.height - 4;
+            self.widgets[widx::cargo_type_btn].right = self.widgets[widx::cargo_type].right - 1;
+            self.widgets[widx::cargo_type_btn].left = self.widgets[widx::cargo_type].right - 10;
 
-            self.widgets[Widx::filter_type].top = self.height - 14;
-            self.widgets[Widx::filter_type].bottom = self.height - 3;
-            self.widgets[Widx::filter_type].right = self.widgets[Widx::cargo_type].left - 2;
-            self.widgets[Widx::filter_type].left = self.widgets[Widx::filter_type].right - filterWidth;
+            self.widgets[widx::filter_type].top = self.height - 14;
+            self.widgets[widx::filter_type].bottom = self.height - 3;
+            self.widgets[widx::filter_type].right = self.widgets[widx::cargo_type].left - 2;
+            self.widgets[widx::filter_type].left = self.widgets[widx::filter_type].right - filterWidth;
 
-            self.widgets[Widx::filter_type_btn].top = self.height - 13;
-            self.widgets[Widx::filter_type_btn].bottom = self.height - 4;
-            self.widgets[Widx::filter_type_btn].right = self.widgets[Widx::filter_type].right - 1;
-            self.widgets[Widx::filter_type_btn].left = self.widgets[Widx::filter_type].right - 10;
+            self.widgets[widx::filter_type_btn].top = self.height - 13;
+            self.widgets[widx::filter_type_btn].bottom = self.height - 4;
+            self.widgets[widx::filter_type_btn].right = self.widgets[widx::filter_type].right - 1;
+            self.widgets[widx::filter_type_btn].left = self.widgets[widx::filter_type].right - 10;
         }
 
-        self.widgets[Widx::scrollview].right = self.width - 4;
-        self.widgets[Widx::scrollview].bottom = self.height - 15;
+        self.widgets[widx::scrollview].right = self.width - 4;
+        self.widgets[widx::scrollview].bottom = self.height - 15;
 
         // Use remaining space for status bar
-        self.widgets[Widx::status_bar].top = self.height - 13;
-        self.widgets[Widx::status_bar].bottom = self.height - 4;
-        self.widgets[Widx::status_bar].right = self.width - kResizeHandleSize - 1;
+        self.widgets[widx::status_bar].top = self.height - 13;
+        self.widgets[widx::status_bar].bottom = self.height - 4;
+        self.widgets[widx::status_bar].right = self.width - kResizeHandleSize - 1;
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -72,26 +72,51 @@ namespace OpenLoco::Ui::Windows::VehicleList
         cargo_type_btn,
     };
 
+    namespace Widx
+    {
+        constexpr WidgetId kFrame{ "frame" };
+        constexpr WidgetId kCaption{ "caption" };
+        constexpr WidgetId kCloseButton{ "close_button" };
+        constexpr WidgetId kPanel{ "panel" };
+        constexpr WidgetId kTabTrains{ "tab_trains" };
+        constexpr WidgetId kTabBuses{ "tab_buses" };
+        constexpr WidgetId kTabTrucks{ "tab_trucks" };
+        constexpr WidgetId kTabTrams{ "tab_trams" };
+        constexpr WidgetId kTabAircraft{ "tab_aircraft" };
+        constexpr WidgetId kTabShips{ "tab_ships" };
+        constexpr WidgetId kCompanySelect{ "company_select" };
+        constexpr WidgetId kSortName{ "sort_name" };
+        constexpr WidgetId kSortProfit{ "sort_profit" };
+        constexpr WidgetId kSortAge{ "sort_age" };
+        constexpr WidgetId kSortReliability{ "sort_reliability" };
+        constexpr WidgetId kScrollview{ "scrollview" };
+        constexpr WidgetId kStatusBar{ "status_bar" };
+        constexpr WidgetId kFilterType{ "filter_type" };
+        constexpr WidgetId kFilterTypeBtn{ "filter_type_btn" };
+        constexpr WidgetId kCargoType{ "cargo_type" };
+        constexpr WidgetId kCargoTypeBtn{ "cargo_type_btn" };
+    }
+
     static constexpr auto _widgets = makeWidgets(
-        Widgets::Frame({ 0, 0 }, { 550, 213 }, WindowColour::primary),
-        Widgets::Caption({ 1, 1 }, { 548, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary),
-        Widgets::ImageButton({ 535, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
-        Widgets::Panel({ 0, 41 }, { 550, 172 }, WindowColour::secondary),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trains),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_buses),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trucks),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trams),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_aircraft),
-        Widgets::Tab({ 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_ships),
-        Widgets::ImageButton({ 0, 14 }, { 26, 26 }, WindowColour::primary, Widget::kContentNull, StringIds::tooltip_select_company),
-        Widgets::TableHeader({ 4, 43 }, { 310, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_name),
-        Widgets::TableHeader({ 314, 43 }, { 100, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_profit),
-        Widgets::TableHeader({ 414, 43 }, { 65, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_age),
-        Widgets::TableHeader({ 479, 43 }, { 67, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_reliability),
-        Widgets::ScrollView({ 3, 56 }, { 544, 138 }, WindowColour::secondary, Scrollbars::vertical),
-        Widgets::Label({ 3, kWindowSize.height - 13 }, { kWindowSize.width - kResizeHandleSize, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid),
-        Widgets::dropdownWidgets({ 280 - 16, 200 }, { 120, 12 }, WindowColour::secondary, StringIds::wcolour2_stringid),
-        Widgets::dropdownWidgets({ 402 - 16, 200 }, { 150, 12 }, WindowColour::secondary, StringIds::wcolour2_stringid)
+        Widgets::Frame(Widx::kFrame, { 0, 0 }, { 550, 213 }, WindowColour::primary),
+        Widgets::Caption(Widx::kCaption, { 1, 1 }, { 548, 13 }, Widgets::Caption::Style::colourText, WindowColour::primary),
+        Widgets::ImageButton(Widx::kCloseButton, { 535, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
+        Widgets::Panel(Widx::kPanel, { 0, 41 }, { 550, 172 }, WindowColour::secondary),
+        Widgets::Tab(Widx::kTabTrains, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trains),
+        Widgets::Tab(Widx::kTabBuses, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_buses),
+        Widgets::Tab(Widx::kTabTrucks, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trucks),
+        Widgets::Tab(Widx::kTabTrams, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_trams),
+        Widgets::Tab(Widx::kTabAircraft, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_aircraft),
+        Widgets::Tab(Widx::kTabShips, { 3, 15 }, { 31, 27 }, WindowColour::secondary, ImageIds::tab, StringIds::tooltip_ships),
+        Widgets::ImageButton(Widx::kCompanySelect, { 0, 14 }, { 26, 26 }, WindowColour::primary, Widget::kContentNull, StringIds::tooltip_select_company),
+        Widgets::TableHeader(Widx::kSortName, { 4, 43 }, { 310, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_name),
+        Widgets::TableHeader(Widx::kSortProfit, { 314, 43 }, { 100, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_profit),
+        Widgets::TableHeader(Widx::kSortAge, { 414, 43 }, { 65, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_age),
+        Widgets::TableHeader(Widx::kSortReliability, { 479, 43 }, { 67, 12 }, WindowColour::secondary, Widget::kContentNull, StringIds::tooltip_sort_by_reliability),
+        Widgets::ScrollView(Widx::kScrollview, { 3, 56 }, { 544, 138 }, WindowColour::secondary, Scrollbars::vertical),
+        Widgets::Label(Widx::kStatusBar, { 3, kWindowSize.height - 13 }, { kWindowSize.width - kResizeHandleSize, 10 }, WindowColour::secondary, ContentAlign::left, StringIds::black_stringid),
+        Widgets::dropdownWidgets(Widx::kFilterType, Widx::kFilterTypeBtn, { 280 - 16, 200 }, { 120, 12 }, WindowColour::secondary, StringIds::wcolour2_stringid),
+        Widgets::dropdownWidgets(Widx::kCargoType, Widx::kCargoTypeBtn, { 402 - 16, 200 }, { 150, 12 }, WindowColour::secondary, StringIds::wcolour2_stringid)
 
     );
 
@@ -731,30 +756,30 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C2409
-    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        switch (widgetIndex)
+        switch (id)
         {
-            case widx::close_button:
+            case Widx::kCloseButton:
                 WindowManager::close(&self);
                 break;
 
-            case widx::tab_trains:
-            case widx::tab_buses:
-            case widx::tab_trucks:
-            case widx::tab_trams:
-            case widx::tab_aircraft:
-            case widx::tab_ships:
+            case Widx::kTabTrains:
+            case Widx::kTabBuses:
+            case Widx::kTabTrucks:
+            case Widx::kTabTrams:
+            case Widx::kTabAircraft:
+            case Widx::kTabShips:
             {
                 auto vehicleType = VehicleType(widgetIndex - widx::tab_trains);
                 switchTab(self, vehicleType);
                 break;
             }
 
-            case widx::sort_name:
-            case widx::sort_profit:
-            case widx::sort_age:
-            case widx::sort_reliability:
+            case Widx::kSortName:
+            case Widx::kSortProfit:
+            case Widx::kSortAge:
+            case Widx::kSortReliability:
             {
                 auto sortMode = widgetIndex - widx::sort_name;
                 if (self.sortMode == sortMode)
@@ -771,14 +796,14 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C2434
-    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id)
+    static void onMouseDown(Window& self, WidgetIndex_t widgetIndex, const WidgetId id)
     {
-        if (widgetIndex == widx::company_select)
+        if (id == Widx::kCompanySelect)
         {
             Dropdown::populateCompanySelect(&self, &self.widgets[widgetIndex]);
         }
 
-        else if (widgetIndex == widx::filter_type_btn)
+        else if (id == Widx::kFilterTypeBtn)
         {
             Widget dropdown = self.widgets[widx::filter_type];
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 2, 0x80);
@@ -787,7 +812,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
             Dropdown::add(1, StringIds::dropdown_stringid, StringIds::transporting_cargo);
             Dropdown::setItemSelected(self.var_850);
         }
-        else if (widgetIndex == widx::cargo_type_btn)
+        else if (id == Widx::kCargoTypeBtn)
         {
             auto index = 0;
             auto selectedIndex = -1;
@@ -862,14 +887,14 @@ namespace OpenLoco::Ui::Windows::VehicleList
         self.invalidate();
     }
 
-    static void onDropdown(Ui::Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id, int16_t itemIndex)
+    static void onDropdown(Ui::Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
-        if (widgetIndex == widx::company_select)
+        if (id == Widx::kCompanySelect)
         {
             return onCompanyDropdown(self, itemIndex);
         }
 
-        if (widgetIndex == filter_type_btn && itemIndex != -1)
+        if (id == Widx::kFilterTypeBtn && itemIndex != -1)
         {
             if (self.var_850 != itemIndex)
             {
@@ -879,7 +904,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
             }
         }
 
-        else if (widgetIndex == cargo_type_btn && itemIndex != -1)
+        else if (id == Widx::kCargoTypeBtn && itemIndex != -1)
         {
             auto newCargo = Dropdown::getItemArgument(itemIndex, 3);
             if (self.var_852 != newCargo)
@@ -917,9 +942,9 @@ namespace OpenLoco::Ui::Windows::VehicleList
     }
 
     // 0x004C266D
-    static CursorId cursor(Window& self, WidgetIndex_t widgetIdx, [[maybe_unused]] const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, CursorId fallback)
+    static CursorId cursor(Window& self, [[maybe_unused]] WidgetIndex_t widgetIdx, const WidgetId id, [[maybe_unused]] int16_t xPos, int16_t yPos, CursorId fallback)
     {
-        if (widgetIdx != widx::scrollview)
+        if (id != Widx::kScrollview)
         {
             return fallback;
         }


### PR DESCRIPTION
In order to move forward to a new tutorial system and also better UI system this is one of the required things to allow tutorials to address widgets by id rather than index which is error prone, I just went and did all of them, that was quite annoying but it has to be done, it doesn't fully eliminate the old widget index definitions just yet, it still addresses widgets with the index instead of ids, that will come in the next PR.