### PR TITLE
Replace breakpad integration with crashpad and enable ARM64 Windows b…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,49 @@ else()
 endif()
 option(OPENLOCO_USE_VCPKG "Use vcpkg for dependencies and toolchain" ${OPENLOCO_USE_VCPKG_DEFAULT})
 
+set(OPENLOCO_CRASH_REPORTING "auto" CACHE STRING "Crash reporting backend (auto|off|crashpad)")
+set_property(CACHE OPENLOCO_CRASH_REPORTING PROPERTY STRINGS auto off crashpad)
+
+set(_openloco_crash_reporting "${OPENLOCO_CRASH_REPORTING}")
+string(TOLOWER "${_openloco_crash_reporting}" _openloco_crash_reporting)
+
+set(_openloco_valid_crash_reporting_values auto off crashpad)
+if (NOT _openloco_crash_reporting IN_LIST _openloco_valid_crash_reporting_values)
+    message(FATAL_ERROR "Invalid OPENLOCO_CRASH_REPORTING value: '${OPENLOCO_CRASH_REPORTING}'. Valid values: auto, off, crashpad")
+endif()
+
+set(_openloco_is_windows_arm64 FALSE)
+if (CMAKE_VS_PLATFORM_NAME STREQUAL "ARM64"
+    OR CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64"
+    OR CMAKE_SYSTEM_PROCESSOR MATCHES "^[Aa][Rr][Mm]64$"
+    OR CMAKE_SYSTEM_PROCESSOR MATCHES "^[Aa][Aa][Rr][Cc][Hh]64$")
+    set(_openloco_is_windows_arm64 TRUE)
+endif()
+
+set(OPENLOCO_CRASH_PROVIDER "${_openloco_crash_reporting}")
+if (OPENLOCO_CRASH_PROVIDER STREQUAL "auto")
+    if (WIN32)
+        set(OPENLOCO_CRASH_PROVIDER "crashpad")
+    else()
+        set(OPENLOCO_CRASH_PROVIDER "off")
+    endif()
+endif()
+
+if (OPENLOCO_CRASH_PROVIDER STREQUAL "crashpad")
+    if (NOT WIN32)
+        message(WARNING "Crashpad is currently enabled only for Windows builds in this project. Falling back to OPENLOCO_CRASH_REPORTING=off.")
+        set(OPENLOCO_CRASH_PROVIDER "off")
+    endif()
+endif()
+
+if (OPENLOCO_USE_VCPKG)
+    if (OPENLOCO_CRASH_PROVIDER STREQUAL "crashpad")
+        set(VCPKG_MANIFEST_FEATURES "crashpad" CACHE STRING "Enabled vcpkg manifest features" FORCE)
+    else()
+        set(VCPKG_MANIFEST_FEATURES "" CACHE STRING "Enabled vcpkg manifest features" FORCE)
+    endif()
+endif()
+
 
 # On windows VCPKG is used to get all dependencies other platforms can use it as well by setting OPENLOCO_USE_VCPKG
 if (OPENLOCO_USE_VCPKG)
@@ -94,6 +137,12 @@ include(OpenLocoUtility)
 option(STRICT "Build with warnings as errors" YES)
 option(OPENLOCO_BUILD_TESTS "Build tests" YES)
 option(OPENLOCO_HEADER_CHECK "Verify all public interfaces are standalone" NO)
+
+set(OPENLOCO_USE_CRASHPAD OFF)
+if (OPENLOCO_CRASH_PROVIDER STREQUAL "crashpad")
+    set(OPENLOCO_USE_CRASHPAD ON)
+endif()
+message(STATUS "Crash reporting provider: ${OPENLOCO_CRASH_PROVIDER}")
 
 if (APPLE)
     # Enable the use of e.g. std::execution::par

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -24,6 +24,14 @@ loco_add_executable(App
 
 set_target_properties(App PROPERTIES OUTPUT_NAME OpenLoco)
 
+if (WIN32 AND OPENLOCO_USE_CRASHPAD)
+    add_custom_command(TARGET App POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/tools/crashpad/crashpad_handler${CMAKE_EXECUTABLE_SUFFIX}"
+            "$<TARGET_FILE_DIR:App>/crashpad_handler${CMAKE_EXECUTABLE_SUFFIX}"
+        COMMENT "Copying Crashpad handler executable")
+endif()
+
 if (APPLE)
     target_link_options(App PRIVATE "-framework" "Cocoa")
 

--- a/src/Platform/CMakeLists.txt
+++ b/src/Platform/CMakeLists.txt
@@ -26,8 +26,11 @@ set(public_link_libraries
 )
 
 if (MSVC)
-    list(APPEND public_link_libraries ${BREAKPAD_LIBRARIES})
     list(APPEND public_link_libraries "Winmm.lib")
+endif()
+
+if (MSVC AND OPENLOCO_USE_CRASHPAD)
+    list(APPEND public_link_libraries ${CRASHPAD_LIBRARIES})
 endif()
 
 loco_add_library(Platform STATIC
@@ -39,8 +42,8 @@ loco_add_library(Platform STATIC
         ${public_link_libraries}
 )
 
-if (MSVC)
+if (MSVC AND OPENLOCO_USE_CRASHPAD)
     target_compile_definitions(Platform
         PRIVATE
-            USE_BREAKPAD)
+            USE_CRASHPAD)
 endif()

--- a/src/Platform/src/Crash.cpp
+++ b/src/Platform/src/Crash.cpp
@@ -1,6 +1,6 @@
 #include "Crash.h"
 
-#if defined(USE_CRASHPAD)
+#if defined(USE_CRASHPAD) && defined(_WIN32)
 #include "Platform.h"
 #include <OpenLoco/Utility/String.hpp>
 #include <base/files/file_path.h>
@@ -12,7 +12,7 @@
 
 namespace OpenLoco::CrashHandler
 {
-#if defined(USE_CRASHPAD)
+#if defined(USE_CRASHPAD) && defined(_WIN32)
     [[maybe_unused]] static std::wstring getDumpDirectory()
     {
         auto crashDir = Platform::getUserDirectory() / "crashes";

--- a/src/Platform/src/Crash.cpp
+++ b/src/Platform/src/Crash.cpp
@@ -5,9 +5,9 @@
 #include <OpenLoco/Utility/String.hpp>
 #include <base/files/file_path.h>
 #include <client/crashpad_client.h>
-#include <windows.h>
 #include <map>
 #include <vector>
+#include <windows.h>
 #endif
 
 namespace OpenLoco::CrashHandler

--- a/src/Platform/src/Crash.cpp
+++ b/src/Platform/src/Crash.cpp
@@ -39,7 +39,7 @@ namespace OpenLoco::CrashHandler
 
     Handle init([[maybe_unused]] const AppInfo& appInfo)
     {
-#if !defined(DEBUG) && defined(USE_CRASHPAD)
+#if !defined(DEBUG) && defined(USE_CRASHPAD) && defined(_WIN32)
         const auto handlerPath = getHandlerPath();
         const auto crashDir = getDumpDirectory();
 
@@ -81,7 +81,7 @@ namespace OpenLoco::CrashHandler
 
     void shutdown([[maybe_unused]] Handle exHandler)
     {
-#if !defined(DEBUG) && defined(USE_CRASHPAD)
+#if !defined(DEBUG) && defined(USE_CRASHPAD) && defined(_WIN32)
         if (exHandler == nullptr)
         {
             return;

--- a/src/Platform/src/Crash.cpp
+++ b/src/Platform/src/Crash.cpp
@@ -1,83 +1,18 @@
 #include "Crash.h"
 
-#if defined(USE_BREAKPAD)
+#if defined(USE_CRASHPAD)
 #include "Platform.h"
 #include <OpenLoco/Utility/String.hpp>
-#include <ShlObj.h>
-#include <client/windows/handler/exception_handler.h>
+#include <base/files/file_path.h>
+#include <client/crashpad_client.h>
+#include <windows.h>
+#include <map>
+#include <vector>
 #endif
 
 namespace OpenLoco::CrashHandler
 {
-#if defined(USE_BREAKPAD)
-    static AppInfo _appInfo;
-
-    [[maybe_unused]] static bool onCrash(
-        const wchar_t* dumpPath, const wchar_t* miniDumpId,
-        [[maybe_unused]] void* context,
-        [[maybe_unused]] EXCEPTION_POINTERS* exinfo,
-        [[maybe_unused]] MDRawAssertionInfo* assertion,
-        bool succeeded)
-    {
-        if (!succeeded)
-        {
-            constexpr const char* dumpFailedMessage = "Failed to create the dump. Please file an issue with OpenLoco on GitHub and "
-                                                      "provide latest save, and provide "
-                                                      "information about what you did before the crash occurred.";
-            printf("%s\n", dumpFailedMessage);
-            MessageBoxA(nullptr, dumpFailedMessage, "OpenLoco", MB_OK | MB_ICONERROR);
-            return succeeded;
-        }
-        wchar_t dumpFilePath[MAX_PATH];
-        swprintf_s(dumpFilePath, std::size(dumpFilePath), L"%s\\%s.dmp", dumpPath, miniDumpId);
-
-        std::wstring version = Utility::toUtf16(_appInfo.version);
-
-        wchar_t dumpFilePathNew[MAX_PATH];
-        swprintf_s(
-            dumpFilePathNew, std::size(dumpFilePathNew), L"%s\\%s(%s).dmp", dumpPath, miniDumpId, version.c_str());
-
-        // Try to rename the files
-        if (_wrename(dumpFilePath, dumpFilePathNew) == 0)
-        {
-            wcscpy_s(dumpFilePath, dumpFilePathNew);
-        }
-
-        // Log information to output
-        wprintf(L"Dump Path: %s\n", dumpPath);
-        wprintf(L"Dump File Path: %s\n", dumpFilePath);
-        wprintf(L"Dump Id: %s\n", miniDumpId);
-        wprintf(L"Version: %s\n", version.c_str());
-
-        constexpr const wchar_t* MessageFormat = L"A crash has occurred and a dump was created at\n%s.\n\nPlease file an issue "
-                                                 L"with %S on GitHub and provide "
-                                                 L"the dump and most recently saved game there.\n\n\nVersion: %s\n\n";
-        wchar_t message[MAX_PATH * 2];
-        swprintf_s(message, MessageFormat, dumpFilePath, _appInfo.name.c_str(), version.c_str());
-        MessageBoxW(nullptr, message, L"OpenLoco", MB_OK | MB_ICONERROR);
-
-        HRESULT coInitializeResult = CoInitialize(nullptr);
-        if (SUCCEEDED(coInitializeResult))
-        {
-            LPITEMIDLIST pidl = ILCreateFromPathW(dumpPath);
-            LPITEMIDLIST files[6];
-            uint32_t numFiles = 0;
-
-            files[numFiles++] = ILCreateFromPathW(dumpFilePath);
-            if (pidl != nullptr)
-            {
-                SHOpenFolderAndSelectItems(pidl, numFiles, (LPCITEMIDLIST*)files, 0);
-                ILFree(pidl);
-                for (uint32_t i = 0; i < numFiles; i++)
-                {
-                    ILFree(files[i]);
-                }
-            }
-            CoUninitialize();
-        }
-        return succeeded;
-    }
-
+#if defined(USE_CRASHPAD)
     [[maybe_unused]] static std::wstring getDumpDirectory()
     {
         auto crashDir = Platform::getUserDirectory() / "crashes";
@@ -88,18 +23,56 @@ namespace OpenLoco::CrashHandler
         return crashDir.wstring();
     }
 
-#endif // USE_BREAKPAD
+    [[maybe_unused]] static std::wstring getHandlerPath()
+    {
+        wchar_t modulePath[MAX_PATH] = {};
+        auto length = GetModuleFileNameW(nullptr, modulePath, static_cast<DWORD>(std::size(modulePath)));
+        if (length == 0 || length == std::size(modulePath))
+        {
+            return {};
+        }
+        fs::path exePath(modulePath);
+        return (exePath.parent_path() / L"crashpad_handler.exe").wstring();
+    }
+
+#endif // USE_CRASHPAD
 
     Handle init([[maybe_unused]] const AppInfo& appInfo)
     {
-#if !defined(DEBUG) && defined(USE_BREAKPAD)
-        _appInfo = appInfo;
+#if !defined(DEBUG) && defined(USE_CRASHPAD)
+        const auto handlerPath = getHandlerPath();
+        const auto crashDir = getDumpDirectory();
 
-        const auto pipeName = Utility::toUtf16(appInfo.name + "_breakpad");
+        if (handlerPath.empty() || !fs::exists(handlerPath))
+        {
+            wprintf(L"Crashpad handler not found at '%s'\n", handlerPath.c_str());
+            return nullptr;
+        }
 
-        // Path must exist and be RW!
-        auto exHandler = new google_breakpad::ExceptionHandler(
-            getDumpDirectory(), 0, onCrash, 0, google_breakpad::ExceptionHandler::HANDLER_ALL, MiniDumpWithDataSegs, pipeName.c_str(), 0);
+        auto exHandler = new crashpad::CrashpadClient();
+
+        std::map<std::string, std::string> annotations = {
+            { "prod", appInfo.name },
+            { "ver", appInfo.version },
+        };
+
+        const bool started = exHandler->StartHandler(
+            base::FilePath(handlerPath),
+            base::FilePath(crashDir),
+            base::FilePath(crashDir),
+            std::string(),
+            annotations,
+            std::vector<std::string>(),
+            true,
+            true);
+
+        if (!started || !exHandler->WaitForHandlerStart(INFINITE))
+        {
+            wprintf(L"Crashpad failed to start from '%s'\n", handlerPath.c_str());
+            delete exHandler;
+            return nullptr;
+        }
+
         return exHandler;
 #else
         return nullptr;
@@ -108,13 +81,13 @@ namespace OpenLoco::CrashHandler
 
     void shutdown([[maybe_unused]] Handle exHandler)
     {
-#if !defined(DEBUG) && defined(USE_BREAKPAD)
+#if !defined(DEBUG) && defined(USE_CRASHPAD)
         if (exHandler == nullptr)
         {
             return;
         }
 
-        delete static_cast<google_breakpad::ExceptionHandler*>(exHandler);
+        delete static_cast<crashpad::CrashpadClient*>(exHandler);
 #endif
     }
 }

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -48,10 +48,10 @@ else()
     set(OPENAL_LIBRARIES OpenAL::OpenAL)
 endif()
 
-# breakpad is also required
-if (MSVC)
-    find_package(unofficial-breakpad CONFIG REQUIRED)
-    set(BREAKPAD_LIBRARIES unofficial::breakpad::libbreakpad unofficial::breakpad::libbreakpad_client)
+# crashpad is optional and selected through OPENLOCO_CRASH_REPORTING.
+if (MSVC AND OPENLOCO_USE_CRASHPAD)
+    find_package(crashpad CONFIG REQUIRED)
+    set(CRASHPAD_LIBRARIES crashpad::crashpad)
 endif()
 
 find_package(fmt QUIET)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,12 +1,19 @@
 {
   "name": "openloco",
   "version-string": "22.02",
+  "features": {
+    "crashpad": {
+      "description": "Enable Crashpad crash reporting dependency on supported Windows targets",
+      "dependencies": [
+        {
+          "name": "crashpad",
+          "platform": "windows & !uwp"
+        }
+      ]
+    }
+  },
   "dependencies": [
     "benchmark",
-    {
-      "name": "breakpad",
-      "platform": "windows"
-    },
     "gtest",
     "libpng",
     "openal-soft",


### PR DESCRIPTION
This pull request introduces support for Crashpad as the crash reporting backend on Windows, replacing Breakpad. The changes add a configurable CMake option to select the crash reporting provider, update build scripts to handle Crashpad dependencies, and refactor platform code to use Crashpad instead of Breakpad. Crashpad is enabled by default on Windows when crash reporting is set to "auto".

**Crash reporting backend selection and configuration:**

* Added the `OPENLOCO_CRASH_REPORTING` CMake cache variable to select the crash reporting backend (`auto`, `off`, or `crashpad`). The build system validates this option and defaults to Crashpad on Windows (`CMakeLists.txt`).
* The build now sets `OPENLOCO_USE_CRASHPAD` and configures the appropriate vcpkg manifest features based on the selected crash reporting provider (`CMakeLists.txt`).

**Crashpad integration and build changes:**

* Added logic to copy the Crashpad handler executable into the output directory after building the Windows executable (`src/App/CMakeLists.txt`).
* Updated third-party dependency handling to require Crashpad (instead of Breakpad) when enabled, and to link the correct libraries (`thirdparty/CMakeLists.txt`, `vcpkg.json`). [[1]](diffhunk://#diff-63349b1a36da563bdafd8d31c8f86eb55bc49e0c8daf68d7b817daace0ee09abL51-R54) [[2]](diffhunk://#diff-dbbb1b147126744a5eee012901d2b9a29cc478be03677f67825b9b2794f5d283R4-R16)
* Updated platform library linking and preprocessor definitions to use Crashpad when enabled on MSVC (`src/Platform/CMakeLists.txt`). [[1]](diffhunk://#diff-8decacddcf7172ae3c5873fe626e4fa9f345be3ae55bacfeb1d36daa3ce48ab3L29-R35) [[2]](diffhunk://#diff-8decacddcf7172ae3c5873fe626e4fa9f345be3ae55bacfeb1d36daa3ce48ab3L42-R48)

**Platform code refactor:**

* Replaced Breakpad-specific crash handler code with Crashpad implementation in `Crash.cpp`, including handler startup, dump directory management, and shutdown logic (`src/Platform/src/Crash.cpp`). [[1]](diffhunk://#diff-1ca643c2538718e82e2f54697ec3dc5c94776abe059d69240f3c572fd3d42ad8L3-L102) [[2]](diffhunk://#diff-1ca643c2538718e82e2f54697ec3dc5c94776abe059d69240f3c572fd3d42ad8L111-R90)…uild path