### PR TITLE
Rework window resizing and bounds setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 26.07.1+ (???)
 ------------------------------------------------------------------------
+- Fix: [#2082] Scrollbars can be overdrawn when certain windows are resized but their scrollview is not.
+- Fix: [#3858] Save file details can overflow the file browser window at minimum height.
 
 26.07.1 (2026-07-27)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -247,7 +247,7 @@ namespace OpenLoco::Ui
             widgets.insert(widgets.end(), newWidgets.begin(), newWidgets.end());
         }
 
-        constexpr bool setSize(Ui::Size minSize, Ui::Size maxSize)
+        constexpr bool setSizeBounds(Ui::Size minSize, Ui::Size maxSize)
         {
             bool hasResized = false;
 
@@ -287,9 +287,9 @@ namespace OpenLoco::Ui
             return hasResized;
         }
 
-        constexpr bool setSize(Ui::Size size)
+        constexpr bool setSizeBounds(Ui::Size size)
         {
-            return setSize(size, size);
+            return setSizeBounds(size, size);
         }
 
         constexpr AdvancedColour getColour(WindowColour index) const

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -348,7 +348,7 @@ namespace OpenLoco::Ui
 
         void callClose();                                                                                                 // 0
         void callOnMouseUp(WidgetIndex_t widgetIndex, WidgetId id);                                                       // 1
-        Ui::Window* callOnResize();                                                                                       // 2
+        void callOnResize();                                                                                              // 2
         void callOnMouseHover(WidgetIndex_t widgetIndex, WidgetId id);                                                    // 3
         void callOnMouseDown(WidgetIndex_t widgetIndex, WidgetId id);                                                     // 4
         void callOnDropdown(WidgetIndex_t widgetIndex, WidgetId id, int16_t itemIndex);                                   // 5

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -320,7 +320,6 @@ namespace OpenLoco::Ui
         bool isActivated(WidgetIndex_t index);
         bool isHoldable(WidgetIndex_t index);
         bool canResize();
-        void capSize(int32_t minWidth, int32_t minHeight, int32_t maxWidth, int32_t maxHeight);
         void viewportsUpdatePosition();
         void invalidatePressedImageButtons();
         void invalidate();

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -247,20 +247,27 @@ namespace OpenLoco::Ui
             widgets.insert(widgets.end(), newWidgets.begin(), newWidgets.end());
         }
 
-        constexpr void setSize(Ui::Size size)
+        constexpr bool setSize(Ui::Size size)
         {
             if (width == size.width && height == size.height)
             {
-                return;
+                return false;
             }
 
             invalidate();
             width = size.width;
             height = size.height;
-            callOnResize();
+
+            if (!clampSizeToBounds())
+            {
+                // We resized the window, even if `clampSizeToBounds` didn't
+                callOnResize();
+            }
+
+            return true;
         }
 
-        constexpr void setSizeBounds(Ui::Size minSize, Ui::Size maxSize)
+        constexpr bool setSizeBounds(Ui::Size minSize, Ui::Size maxSize)
         {
             minWidth = minSize.width;
             minHeight = minSize.height;
@@ -268,48 +275,29 @@ namespace OpenLoco::Ui
             maxWidth = maxSize.width;
             maxHeight = maxSize.height;
 
-            clampSizeToBounds();
+            return clampSizeToBounds();
         }
 
-        constexpr void clampSizeToBounds()
+        constexpr bool clampSizeToBounds()
         {
-            bool hasResized = false;
-
-            if (width < minWidth)
+            if (minWidth == 0 || minHeight == 0 || maxWidth == 0 || maxHeight == 0)
             {
-                width = minWidth;
-                invalidate();
-                hasResized = true;
-            }
-            else if (width > maxWidth)
-            {
-                invalidate();
-                width = maxWidth;
-                invalidate();
-                hasResized = true;
+                printf("Error: attempting to clamp window of type %d (number %d) with no bounds set!\n", type, number);
             }
 
-            if (height < minHeight)
-            {
-                height = minHeight;
-                invalidate();
-                hasResized = true;
-            }
-            else if (height > maxHeight)
-            {
-                invalidate();
-                height = maxHeight;
-                invalidate();
-                hasResized = true;
-            }
+            auto newWidth = std::clamp(width, minWidth, maxWidth);
+            auto newHeight = std::clamp(height, minHeight, maxHeight);
+            bool hasResized = setSize({ newWidth, newHeight });
 
             if (hasResized)
             {
                 callOnResize();
             }
+
+            return hasResized;
         }
 
-        constexpr void setSizeBounds(Ui::Size size)
+        constexpr bool setSizeBounds(Ui::Size size)
         {
             return setSizeBounds(size, size);
         }

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -280,13 +280,8 @@ namespace OpenLoco::Ui
 
         constexpr bool clampSizeToBounds()
         {
-            if (minWidth == 0 || minHeight == 0 || maxWidth == 0 || maxHeight == 0)
-            {
-                printf("Error: attempting to clamp window of type %d (number %d) with no bounds set!\n", type, number);
-            }
-
-            auto newWidth = std::clamp(width, minWidth, maxWidth);
-            auto newHeight = std::clamp(height, minHeight, maxHeight);
+            auto newWidth = maxWidth > 0 ? std::clamp(width, minWidth, maxWidth) : width;
+            auto newHeight = maxHeight > 0 ? std::clamp(height, minHeight, maxHeight) : height;
             bool hasResized = setSize({ newWidth, newHeight });
 
             if (hasResized)

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -249,21 +249,19 @@ namespace OpenLoco::Ui
 
         constexpr bool setSize(Ui::Size size)
         {
-            if (width == size.width && height == size.height)
+            const auto newWidth = maxWidth > 0 ? std::clamp(size.width, minWidth, maxWidth) : size.width;
+            const auto newHeight = maxHeight > 0 ? std::clamp(size.height, minHeight, maxHeight) : size.height;
+
+            if (width == newWidth && height == newHeight)
             {
                 return false;
             }
 
             invalidate();
-            width = size.width;
-            height = size.height;
-
-            if (!clampSizeToBounds())
-            {
-                // We resized the window, even if `clampSizeToBounds` didn't
-                callOnResize();
-            }
-
+            width = newWidth;
+            height = newHeight;
+            invalidate();
+            callOnResize();
             return true;
         }
 
@@ -271,25 +269,10 @@ namespace OpenLoco::Ui
         {
             minWidth = minSize.width;
             minHeight = minSize.height;
-
             maxWidth = maxSize.width;
             maxHeight = maxSize.height;
 
-            return clampSizeToBounds();
-        }
-
-        constexpr bool clampSizeToBounds()
-        {
-            auto newWidth = maxWidth > 0 ? std::clamp(width, minWidth, maxWidth) : width;
-            auto newHeight = maxHeight > 0 ? std::clamp(height, minHeight, maxHeight) : height;
-            bool hasResized = setSize({ newWidth, newHeight });
-
-            if (hasResized)
-            {
-                callOnResize();
-            }
-
-            return hasResized;
+            return setSize({ width, height });
         }
 
         constexpr bool setSizeBounds(Ui::Size size)

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -249,12 +249,18 @@ namespace OpenLoco::Ui
 
         constexpr void setSize(Ui::Size size)
         {
+            if (width == size.width && height == size.height)
+            {
+                printf("Called setSize without needing to\n");
+                return;
+            }
+
             width = size.width;
             height = size.height;
             callOnResize();
         }
 
-        constexpr bool setSizeBounds(Ui::Size minSize, Ui::Size maxSize)
+        constexpr void setSizeBounds(Ui::Size minSize, Ui::Size maxSize)
         {
             bool hasResized = false;
 
@@ -291,10 +297,14 @@ namespace OpenLoco::Ui
                 invalidate();
                 hasResized = true;
             }
-            return hasResized;
+
+            if (hasResized)
+            {
+                callOnResize();
+            }
         }
 
-        constexpr bool setSizeBounds(Ui::Size size)
+        constexpr void setSizeBounds(Ui::Size size)
         {
             return setSizeBounds(size, size);
         }

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -247,6 +247,13 @@ namespace OpenLoco::Ui
             widgets.insert(widgets.end(), newWidgets.begin(), newWidgets.end());
         }
 
+        constexpr void setSize(Ui::Size size)
+        {
+            width = size.width;
+            height = size.height;
+            callOnResize();
+        }
+
         constexpr bool setSizeBounds(Ui::Size minSize, Ui::Size maxSize)
         {
             bool hasResized = false;

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -245,6 +245,10 @@ namespace OpenLoco::Ui
         {
             widgets.clear();
             widgets.insert(widgets.end(), newWidgets.begin(), newWidgets.end());
+
+            // Ensure initial widget positions are assigned through event function
+            invalidate();
+            callOnResize();
         }
 
         constexpr bool setSize(Ui::Size size)

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -262,13 +262,18 @@ namespace OpenLoco::Ui
 
         constexpr void setSizeBounds(Ui::Size minSize, Ui::Size maxSize)
         {
-            bool hasResized = false;
-
             minWidth = minSize.width;
             minHeight = minSize.height;
 
             maxWidth = maxSize.width;
             maxHeight = maxSize.height;
+
+            clampSizeToBounds();
+        }
+
+        constexpr void clampSizeToBounds()
+        {
+            bool hasResized = false;
 
             if (width < minWidth)
             {

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -275,7 +275,7 @@ namespace OpenLoco::Ui
             return setSize({ width, height });
         }
 
-        constexpr bool setSizeBounds(Ui::Size size)
+        constexpr bool setSizeFixed(Ui::Size size)
         {
             return setSizeBounds(size, size);
         }

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -254,6 +254,7 @@ namespace OpenLoco::Ui
                 return;
             }
 
+            invalidate();
             width = size.width;
             height = size.height;
             callOnResize();

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -251,7 +251,6 @@ namespace OpenLoco::Ui
         {
             if (width == size.width && height == size.height)
             {
-                printf("Called setSize without needing to\n");
                 return;
             }
 

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -807,10 +807,8 @@ namespace OpenLoco::Input
 
         w->invalidate();
 
-        w->width = std::clamp(w->width + dx, w->minWidth, w->maxWidth);
-        w->height = std::clamp(w->height + dy, w->minHeight, w->maxHeight);
+        w->setSize({ w->width + dx, w->height + dy });
         w->flags |= Ui::WindowFlags::hasBeenResized;
-        w->callOnResize();
         w->callPrepareDraw();
 
         w->scrollAreas[0].contentWidth = -1;

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -43,49 +43,6 @@ namespace OpenLoco::Ui
         return this->hasFlags(WindowFlags::resizable) && (this->minWidth != this->maxWidth || this->minHeight != this->maxHeight);
     }
 
-    void Window::capSize(int32_t newMinWidth, int32_t newMinHeight, int32_t newMaxWidth, int32_t newMaxHeight)
-    {
-        auto w = this->width;
-        auto h = this->height;
-        auto shouldInvalidateBefore = false;
-        auto shouldInvalidateAfter = false;
-        if (w < newMinWidth)
-        {
-            w = newMinWidth;
-            shouldInvalidateAfter = true;
-        }
-        if (h < newMinHeight)
-        {
-            h = newMinHeight;
-            shouldInvalidateAfter = true;
-        }
-        if (w > newMaxWidth)
-        {
-            shouldInvalidateBefore = true;
-            w = newMaxWidth;
-        }
-        if (h > newMaxHeight)
-        {
-            shouldInvalidateBefore = true;
-            h = newMaxHeight;
-        }
-
-        if (shouldInvalidateBefore)
-        {
-            invalidate();
-        }
-        this->width = w;
-        this->height = h;
-        this->minWidth = newMinWidth;
-        this->minHeight = newMinHeight;
-        this->maxWidth = newMaxWidth;
-        this->maxHeight = newMaxHeight;
-        if (shouldInvalidateAfter)
-        {
-            invalidate();
-        }
-    }
-
     bool Window::isVisible()
     {
         return true;

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -1062,15 +1062,14 @@ namespace OpenLoco::Ui
         eventHandlers->onMouseUp(*this, widgetIndex, id);
     }
 
-    Ui::Window* Window::callOnResize()
+    void Window::callOnResize()
     {
         if (eventHandlers->onResize == nullptr)
         {
-            return this;
+            return;
         }
 
         eventHandlers->onResize(*this);
-        return this;
     }
 
     void Window::callOnMouseHover(WidgetIndex_t widgetIndex, const WidgetId id)

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -1064,6 +1064,8 @@ namespace OpenLoco::Ui
 
     void Window::callOnResize()
     {
+        printf("calling onresize for window type %d\n", type);
+
         if (eventHandlers->onResize == nullptr)
         {
             return;

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -1064,8 +1064,6 @@ namespace OpenLoco::Ui
 
     void Window::callOnResize()
     {
-        printf("calling onresize for window type %d\n", type);
-
         if (eventHandlers->onResize == nullptr)
         {
             return;

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -231,11 +231,6 @@ namespace OpenLoco::Ui::WindowManager
                 }
             }
 
-            if (w.callOnResize() == nullptr)
-            {
-                return findAt(x, y);
-            }
-
             return &w;
         }
         return nullptr;
@@ -278,11 +273,6 @@ namespace OpenLoco::Ui::WindowManager
                 {
                     continue;
                 }
-            }
-
-            if (w.callOnResize() == nullptr)
-            {
-                return findAt(x, y);
             }
 
             return &w;

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -347,7 +347,7 @@ namespace OpenLoco::Ui::WindowManager
         std::for_each(_windows.rbegin(), _windows.rend(), [](Ui::Window& w) {
             w.updateScrollWidgets();
             w.invalidatePressedImageButtons();
-            w.callOnResize();
+            // w.callOnResize();
         });
     }
 

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -347,7 +347,6 @@ namespace OpenLoco::Ui::WindowManager
         std::for_each(_windows.rbegin(), _windows.rend(), [](Ui::Window& w) {
             w.updateScrollWidgets();
             w.invalidatePressedImageButtons();
-            // w.callOnResize();
         });
     }
 

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -1132,7 +1132,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         window.flags |= WindowFlags::resizable;
 
         auto minWidth = std::max<uint16_t>(_numTrackTypeTabs * 31 + 195, 380);
-        window.setSize({ minWidth, 233 }, kMaxWindowSize);
+        window.setSizeBounds({ minWidth, 233 }, kMaxWindowSize);
 
         auto& scrollArea = window.scrollAreas[scrollIdx::vehicle_selection];
         auto& scrollWidget = window.widgets[widx::scrollview_vehicle_selection];

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -403,8 +403,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         else
         {
             window = create(CompanyManager::getControllingId());
-            window->width = kWindowSize.width;
-            window->height = kWindowSize.height;
+            window->setSize(kWindowSize);
             _buildTargetVehicle = -1;
             if (!isTabId)
             {

--- a/src/OpenLoco/src/Ui/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Cheats.cpp
@@ -991,7 +991,7 @@ namespace OpenLoco::Ui::Windows::Cheats
 
             self.invalidate();
 
-            self.setSize(tabInfo.kWindowSize);
+            self.setSizeBounds(tabInfo.kWindowSize);
             self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Cheats.cpp
@@ -991,7 +991,7 @@ namespace OpenLoco::Ui::Windows::Cheats
 
             self.invalidate();
 
-            self.setSizeBounds(tabInfo.kWindowSize);
+            self.setSizeFixed(tabInfo.kWindowSize);
             self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -190,7 +190,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x004363CB
         static void onResize(Window& self)
         {
-            self.setSize(Common::kMinWindowSize, Common::kMaxWindowSize);
+            self.setSizeBounds(Common::kMinWindowSize, Common::kMaxWindowSize);
         }
 
         // 0x00437BA0
@@ -637,7 +637,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x004366D7
         static void onResize(Window& self)
         {
-            self.setSize(kWindowSize, Common::kMaxWindowSize);
+            self.setSizeBounds(kWindowSize, Common::kMaxWindowSize);
         }
 
         // 0x00436490
@@ -730,7 +730,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x004369FB
         static void onResize(Window& self)
         {
-            self.setSize(kWindowSize, Common::kMaxWindowSize);
+            self.setSizeBounds(kWindowSize, Common::kMaxWindowSize);
         }
 
         // 0x004367B4
@@ -823,7 +823,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x00436D1F
         static void onResize(Window& self)
         {
-            self.setSize(kWindowSize, Common::kMaxWindowSize);
+            self.setSizeBounds(kWindowSize, Common::kMaxWindowSize);
         }
 
         // 0x00436AD8
@@ -916,7 +916,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x00437043
         static void onResize(Window& self)
         {
-            self.setSize(kWindowSize, Common::kMaxWindowSize);
+            self.setSizeBounds(kWindowSize, Common::kMaxWindowSize);
         }
 
         // 0x00436DFC
@@ -1009,7 +1009,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x0043737D
         static void onResize(Window& self)
         {
-            self.setSize(kWindowSize, Common::kMaxWindowSize);
+            self.setSizeBounds(kWindowSize, Common::kMaxWindowSize);
         }
 
         // 0x004F9442
@@ -1269,7 +1269,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x00437591
         static void onResize(Window& self)
         {
-            self.setSize(kWindowSize, kWindowSize);
+            self.setSizeBounds(kWindowSize, kWindowSize);
         }
 
         // 0x0043745A

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -511,12 +511,8 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x00436198
         static void tabReset(Window& self)
         {
-            self.minWidth = Common::kMinWindowSize.width;
-            self.minHeight = Common::kMinWindowSize.height;
-            self.maxWidth = Common::kMaxWindowSize.width;
-            self.maxHeight = Common::kMaxWindowSize.height;
-            self.width = kWindowSize.width;
-            self.height = kWindowSize.height;
+            self.setSize(kWindowSize);
+            self.setSizeBounds(Common::kMinWindowSize, Common::kMaxWindowSize);
             self.rowCount = 0;
             self.rowHover = -1;
             Common::populateCompanyList(self);
@@ -696,12 +692,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x004361D8
         static void tabReset(Window& self)
         {
-            self.minWidth = kWindowSize.width;
-            self.minHeight = kWindowSize.height;
-            self.maxWidth = kWindowSize.width;
-            self.maxHeight = kWindowSize.height;
-            self.width = kWindowSize.width;
-            self.height = kWindowSize.height;
+            self.setSizeBounds(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -789,12 +780,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x00436201
         static void tabReset(Window& self)
         {
-            self.minWidth = kWindowSize.width;
-            self.minHeight = kWindowSize.height;
-            self.maxWidth = kWindowSize.width;
-            self.maxHeight = kWindowSize.height;
-            self.width = kWindowSize.width;
-            self.height = kWindowSize.height;
+            self.setSizeBounds(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -882,12 +868,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x00436227
         static void tabReset(Window& self)
         {
-            self.minWidth = kWindowSize.width;
-            self.minHeight = kWindowSize.height;
-            self.maxWidth = kWindowSize.width;
-            self.maxHeight = kWindowSize.height;
-            self.width = kWindowSize.width;
-            self.height = kWindowSize.height;
+            self.setSizeBounds(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -975,12 +956,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x0043624D
         static void tabReset(Window& self)
         {
-            self.minWidth = kWindowSize.width;
-            self.minHeight = kWindowSize.height;
-            self.maxWidth = kWindowSize.width;
-            self.maxHeight = kWindowSize.height;
-            self.width = kWindowSize.width;
-            self.height = kWindowSize.height;
+            self.setSizeBounds(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -1234,12 +1210,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x00436273
         static void tabReset(Window& self)
         {
-            self.minWidth = kWindowSize.width;
-            self.minHeight = kWindowSize.height;
-            self.maxWidth = kWindowSize.width;
-            self.maxHeight = kWindowSize.height;
-            self.width = kWindowSize.width;
-            self.height = kWindowSize.height;
+            self.setSizeBounds(kWindowSize);
             Economy::buildDeliveredCargoPaymentsTable();
         }
 

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -577,10 +577,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         }
 
         window->currentTab = 0;
-        window->minWidth = Common::kMinWindowSize.width;
-        window->minHeight = Common::kMinWindowSize.height;
-        window->maxWidth = Common::kMaxWindowSize.width;
-        window->maxHeight = Common::kMaxWindowSize.height;
+        window->setSizeBounds(Common::kMinWindowSize, Common::kMaxWindowSize);
 
         window->invalidate();
 

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -689,7 +689,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x004361D8
         static void tabReset(Window& self)
         {
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -777,7 +777,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x00436201
         static void tabReset(Window& self)
         {
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -865,7 +865,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x00436227
         static void tabReset(Window& self)
         {
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -953,7 +953,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x0043624D
         static void tabReset(Window& self)
         {
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -1207,7 +1207,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         // 0x00436273
         static void tabReset(Window& self)
         {
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
             Economy::buildDeliveredCargoPaymentsTable();
         }
 

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -441,7 +441,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         {
             Common::enableRenameByCaption(&self);
 
-            self.setSize(Status::kWindowSize, { 640, 400 });
+            self.setSizeBounds(Status::kWindowSize, { 640, 400 });
 
             if (self.viewports[0] != nullptr)
             {
@@ -1143,7 +1143,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void onResize(Window& self)
         {
             Common::enableRenameByCaption(&self);
-            self.setSize(kWindowSize);
+            self.setSizeBounds(kWindowSize);
             self.callViewportRotate();
         }
 
@@ -1746,7 +1746,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void onResize(Window& self)
         {
             Common::enableRenameByCaption(&self);
-            self.setSize(kWindowSize);
+            self.setSizeBounds(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -2249,7 +2249,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void onResize(Window& self)
         {
             Common::enableRenameByCaption(&self);
-            self.setSize(kWindowSize);
+            self.setSizeBounds(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -2479,7 +2479,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             const uint16_t kWindowHeight = std::max<int16_t>(cargoHeight, 50) + 62;
 
-            self.setSize({ kWindowSize.width, kWindowHeight });
+            self.setSizeBounds({ kWindowSize.width, kWindowHeight });
         }
 
         static constexpr WindowEventList kEvents = {
@@ -2667,7 +2667,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         // 0x00434048
         static void onResize(Window& self)
         {
-            self.setSize(kWindowSize);
+            self.setSizeBounds(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -2832,7 +2832,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             Common::disableChallengeTab(&self);
             self.invalidate();
-            self.setSize(*tabInfo.kWindowSize);
+            self.setSizeBounds(*tabInfo.kWindowSize);
             self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -1142,7 +1142,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void onResize(Window& self)
         {
             Common::enableRenameByCaption(&self);
-            self.setSizeFixed(kWindowSize);
             self.callViewportRotate();
         }
 
@@ -1745,7 +1744,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void onResize(Window& self)
         {
             Common::enableRenameByCaption(&self);
-            self.setSizeFixed(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -2248,7 +2246,6 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void onResize(Window& self)
         {
             Common::enableRenameByCaption(&self);
-            self.setSizeFixed(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -2290,7 +2287,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         window->currentTab = Common::tab_finances - Common::tab_status;
-        window->setSize(Finances::kWindowSize);
+        window->setSizeFixed(Finances::kWindowSize);
         window->invalidate();
 
         window->setWidgets(Finances::widgets);
@@ -2662,15 +2659,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             WindowManager::invalidate(WindowType::company, self.number);
         }
 
-        // 0x00434048
-        static void onResize(Window& self)
-        {
-            self.setSizeFixed(kWindowSize);
-        }
-
         static constexpr WindowEventList kEvents = {
             .onMouseUp = onMouseUp,
-            .onResize = onResize,
             .onUpdate = onUpdate,
             .textInput = textInput,
             .prepareDraw = prepareDraw,
@@ -2702,7 +2692,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         window->currentTab = Common::tab_challenge - Common::tab_status;
-        window->setSize(Challenge::kWindowSize);
+        window->setSizeFixed(Challenge::kWindowSize);
         window->invalidate();
 
         window->setWidgets(Challenge::widgets);

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -1142,7 +1142,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void onResize(Window& self)
         {
             Common::enableRenameByCaption(&self);
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
             self.callViewportRotate();
         }
 
@@ -1745,7 +1745,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void onResize(Window& self)
         {
             Common::enableRenameByCaption(&self);
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -2248,7 +2248,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         static void onResize(Window& self)
         {
             Common::enableRenameByCaption(&self);
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -2477,7 +2477,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             const uint16_t kWindowHeight = std::max<int16_t>(cargoHeight, 50) + 62;
 
-            self.setSizeBounds({ kWindowSize.width, kWindowHeight });
+            self.setSizeFixed({ kWindowSize.width, kWindowHeight });
         }
 
         static constexpr WindowEventList kEvents = {
@@ -2665,7 +2665,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         // 0x00434048
         static void onResize(Window& self)
         {
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -2829,7 +2829,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             Common::disableChallengeTab(&self);
             self.invalidate();
-            self.setSizeBounds(*tabInfo.kWindowSize);
+            self.setSizeFixed(*tabInfo.kWindowSize);
             self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -668,8 +668,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         window->currentTab = 0;
-        window->width = Status::kWindowSize.width;
-        window->height = Status::kWindowSize.height;
+        window->setSize(Status::kWindowSize);
         window->invalidate();
 
         window->setWidgets(Status::widgets);
@@ -2291,8 +2290,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         window->currentTab = Common::tab_finances - Common::tab_status;
-        window->width = Finances::kWindowSize.width;
-        window->height = Finances::kWindowSize.height;
+        window->setSize(Finances::kWindowSize);
         window->invalidate();
 
         window->setWidgets(Finances::widgets);
@@ -2704,8 +2702,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         }
 
         window->currentTab = Common::tab_challenge - Common::tab_status;
-        window->width = Challenge::kWindowSize.width;
-        window->height = Challenge::kWindowSize.height;
+        window->setSize(Challenge::kWindowSize);
         window->invalidate();
 
         window->setWidgets(Challenge::widgets);

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -777,8 +777,7 @@ namespace OpenLoco::Ui::Windows::Construction
 
             setDisabledWidgets(&self);
 
-            self.width = self.widgets[widx::frame].right + 1;
-            self.height = self.widgets[widx::frame].bottom + 1;
+            self.setSize({ self.widgets[widx::frame].right + 1, self.widgets[widx::frame].bottom + 1 });
         }
 
         void setNextAndPreviousTrackTile(const TrackElement& elTrack, const World::Pos2& pos)

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -1180,7 +1180,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         auto& baseFrame = kWidgets[Common::widx::frame];
         auto newHeight = baseFrame.height() + 1 + (numAcceptedCargoTypes + numProducedCargoTypes) * 11;
         auto newSize = Size{ baseFrame.width(), newHeight };
-        self.setSize(newSize, newSize);
+        self.setSizeBounds(newSize, newSize);
 
         self.widgets[Common::widx::frame].bottom = self.height - 1;
         self.widgets[Common::widx::panel].bottom = self.height - 1;

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -908,13 +908,13 @@ namespace OpenLoco::Ui::Windows::IndustryList
                                 {
                                     newHeight = std::min(newHeight, 276);
                                 }
-                                hasResized |= self.setSize({ kWindowSize.width, newHeight });
+                                hasResized |= self.setSizeBounds({ kWindowSize.width, newHeight });
                             }
                             else
                             {
                                 if (Input::state() != Input::State::scrollLeft)
                                 {
-                                    hasResized |= self.setSize(kWindowSize);
+                                    hasResized |= self.setSizeBounds(kWindowSize);
                                 }
                             }
                         }
@@ -925,7 +925,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     self.expandContentCounter = 0;
                     if (Input::state() != Input::State::scrollLeft)
                     {
-                        hasResized |= self.setSize(kWindowSize);
+                        hasResized |= self.setSizeBounds(kWindowSize);
                     }
                 }
             }
@@ -1283,7 +1283,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
             self.invalidate();
             Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
             Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
-            bool hasResized = self.setSize(kMinWindowSize, kMaxWindowSize);
+            bool hasResized = self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
             if (hasResized)
             {
                 updateActiveThumb(self);

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -1271,10 +1271,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
             Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
             Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
             self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-            // if (hasResized)
-            {
-                updateActiveThumb(self);
-            }
+
+            updateActiveThumb(self);
         }
 
         static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -1243,10 +1243,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
         // 0x00457FFE
         static void tabReset(Window& self)
         {
-            self.minWidth = NewIndustries::kWindowSize.width;
-            self.minHeight = NewIndustries::kWindowSize.height;
-            self.maxWidth = NewIndustries::kWindowSize.width;
-            self.maxHeight = NewIndustries::kWindowSize.height;
+            self.setSizeBounds(NewIndustries::kWindowSize);
+
             ToolManager::toolSet(self, Common::widx::tab_new_industry, CursorId::placeFactory);
 
             Input::setFlag(Input::Flags::flag6);
@@ -1268,10 +1266,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         static void onResize(Window& self)
         {
             self.invalidate();
-            Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
-            Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
-            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-
+            self.clampSizeToBounds();
             updateActiveThumb(self);
         }
 

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -1262,8 +1262,6 @@ namespace OpenLoco::Ui::Windows::IndustryList
         // 0x004589E8
         static void onResize(Window& self)
         {
-            self.invalidate();
-            self.clampSizeToBounds();
             updateActiveThumb(self);
         }
 

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -581,10 +581,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
             WindowManager::moveOtherWindowsDown(*window);
 
-            window->minWidth = IndustryList::kMinDimensions.width;
-            window->minHeight = IndustryList::kMinDimensions.height;
-            window->maxWidth = IndustryList::kMaxDimensions.width;
-            window->maxHeight = IndustryList::kMaxDimensions.height;
+            window->setSizeBounds(IndustryList::kMinDimensions, IndustryList::kMaxDimensions);
             window->flags |= WindowFlags::resizable;
 
             auto skin = ObjectManager::get<InterfaceSkinObject>();

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -897,13 +897,13 @@ namespace OpenLoco::Ui::Windows::IndustryList
                                 {
                                     newHeight = std::min(newHeight, 276);
                                 }
-                                self.setSizeBounds({ kWindowSize.width, newHeight });
+                                self.setSizeFixed({ kWindowSize.width, newHeight });
                             }
                             else
                             {
                                 if (Input::state() != Input::State::scrollLeft)
                                 {
-                                    self.setSizeBounds(kWindowSize);
+                                    self.setSizeFixed(kWindowSize);
                                 }
                             }
                         }
@@ -914,7 +914,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     self.expandContentCounter = 0;
                     if (Input::state() != Input::State::scrollLeft)
                     {
-                        self.setSizeBounds(kWindowSize);
+                        self.setSizeFixed(kWindowSize);
                     }
                 }
             }
@@ -1240,7 +1240,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         // 0x00457FFE
         static void tabReset(Window& self)
         {
-            self.setSizeBounds(NewIndustries::kWindowSize);
+            self.setSizeFixed(NewIndustries::kWindowSize);
 
             ToolManager::toolSet(self, Common::widx::tab_new_industry, CursorId::placeFactory);
 

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -522,12 +522,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
         static void tabReset(Window& self)
         {
             self.invalidate();
-            self.minWidth = kMinDimensions.width;
-            self.minHeight = kMinDimensions.height;
-            self.maxWidth = kMaxDimensions.width;
-            self.maxHeight = kMaxDimensions.height;
-            self.width = kWindowSize.width;
-            self.height = kWindowSize.height;
+            self.setSize(kWindowSize);
+            self.setSizeBounds(kMinDimensions, kMaxDimensions);
             self.rowCount = 0;
             self.rowHover = -1;
             Common::populateIndustryList(self);
@@ -597,8 +593,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
             // 0x00457878 end
 
-            window->width = IndustryList::kWindowSize.width;
-            window->height = IndustryList::kWindowSize.height;
+            window->setSize(IndustryList::kWindowSize);
 
             window->invalidate();
 
@@ -881,12 +876,9 @@ namespace OpenLoco::Ui::Windows::IndustryList
             }
         }
 
-        static void updateActiveThumb(Window& self);
-
         // 0x004585B8
         static void onUpdate(Window& self)
         {
-            bool hasResized = false;
             if (!Input::hasFlag(Input::Flags::rightMousePressed))
             {
                 auto cursor = Input::getMouseLocation();
@@ -908,13 +900,13 @@ namespace OpenLoco::Ui::Windows::IndustryList
                                 {
                                     newHeight = std::min(newHeight, 276);
                                 }
-                                hasResized |= self.setSizeBounds({ kWindowSize.width, newHeight });
+                                self.setSizeBounds({ kWindowSize.width, newHeight });
                             }
                             else
                             {
                                 if (Input::state() != Input::State::scrollLeft)
                                 {
-                                    hasResized |= self.setSizeBounds(kWindowSize);
+                                    self.setSizeBounds(kWindowSize);
                                 }
                             }
                         }
@@ -925,18 +917,13 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     self.expandContentCounter = 0;
                     if (Input::state() != Input::State::scrollLeft)
                     {
-                        hasResized |= self.setSizeBounds(kWindowSize);
+                        self.setSizeBounds(kWindowSize);
                     }
                 }
             }
             self.frameNo++;
 
             self.callPrepareDraw();
-            if (hasResized)
-            {
-                updateActiveThumb(self);
-            }
-
             WindowManager::invalidateWidget(WindowType::industryList, self.number, self.currentTab + Common::widx::tab_industry_list);
 
             if (!ToolManager::isToolActive(self.type, self.number))
@@ -1283,8 +1270,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
             self.invalidate();
             Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
             Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
-            bool hasResized = self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-            if (hasResized)
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
+            // if (hasResized)
             {
                 updateActiveThumb(self);
             }

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -222,7 +222,7 @@ namespace OpenLoco::Ui::Windows::Industry
         // 0x00455F1A
         static void onResize(Window& self)
         {
-            self.setSize(kMinWindowSize, kMaxWindowSize);
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
 
             if (self.viewports[0] != nullptr)
             {
@@ -398,7 +398,7 @@ namespace OpenLoco::Ui::Windows::Industry
         static void onResize(Window& self)
         {
             {
-                self.setSize(kMinWindowSize, kMaxWindowSize);
+                self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
             }
         }
 
@@ -440,7 +440,7 @@ namespace OpenLoco::Ui::Windows::Industry
         static void onResize(Window& self)
         {
             {
-                self.setSize(kMinWindowSize, kMaxWindowSize);
+                self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
             }
         }
 
@@ -619,7 +619,7 @@ namespace OpenLoco::Ui::Windows::Industry
         static void onResize(Window& self)
         {
             {
-                self.setSize(kWindowSize, kWindowSize);
+                self.setSizeBounds(kWindowSize, kWindowSize);
             }
         }
 
@@ -913,7 +913,7 @@ namespace OpenLoco::Ui::Windows::Industry
 
             self.invalidate();
 
-            self.setSize(Industry::kWindowSize);
+            self.setSizeBounds(Industry::kWindowSize);
             self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -908,7 +908,7 @@ namespace OpenLoco::Ui::Windows::Industry
 
             self.invalidate();
 
-            self.setSizeBounds(Industry::kWindowSize);
+            self.setSizeFixed(Industry::kWindowSize);
             self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -90,9 +90,7 @@ namespace OpenLoco::Ui::Windows::Industry
     namespace Industry
     {
         static constexpr Ui::Size kWindowSize = { 223, 137 };
-
         static constexpr Ui::Size kMinWindowSize = { 192, 137 };
-
         static constexpr Ui::Size kMaxWindowSize = { 600, 440 };
 
         enum widx
@@ -347,10 +345,7 @@ namespace OpenLoco::Ui::Windows::Industry
             const WindowFlags newFlags = WindowFlags::viewportNoShiftPixels | WindowFlags::resizable;
             window = WindowManager::createWindow(WindowType::industry, Industry::kWindowSize, newFlags, Industry::getEvents());
             window->number = enumValue(industryId);
-            window->minWidth = 192;
-            window->minHeight = 137;
-            window->maxWidth = 600;
-            window->maxHeight = 440;
+            window->setSizeBounds(Industry::kMinWindowSize, Industry::kMaxWindowSize);
 
             auto skin = ObjectManager::get<InterfaceSkinObject>();
             if (skin != nullptr)

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -220,8 +220,6 @@ namespace OpenLoco::Ui::Windows::Industry
         // 0x00455F1A
         static void onResize(Window& self)
         {
-            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-
             if (self.viewports[0] != nullptr)
             {
                 uint16_t newWidth = self.width - 30;
@@ -389,15 +387,8 @@ namespace OpenLoco::Ui::Windows::Industry
             Widget::leftAlignTabs(self, Common::widx::tab_industry, Common::widx::tab_transported);
         }
 
-        // 0x0045654F
-        static void onResize(Window& self)
-        {
-            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-        }
-
         static constexpr WindowEventList kEvents = {
             .onMouseUp = Common::onMouseUp,
-            .onResize = onResize,
             .onUpdate = Common::update,
             .textInput = Common::textInput,
             .prepareDraw = prepareDraw,
@@ -429,15 +420,8 @@ namespace OpenLoco::Ui::Windows::Industry
             Widget::leftAlignTabs(self, Common::widx::tab_industry, Common::widx::tab_transported);
         }
 
-        // 0x004565FF
-        static void onResize(Window& self)
-        {
-            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-        }
-
         static constexpr WindowEventList kEvents = {
             .onMouseUp = Common::onMouseUp,
-            .onResize = onResize,
             .onUpdate = Common::update,
             .textInput = Common::textInput,
             .prepareDraw = prepareDraw,
@@ -606,15 +590,8 @@ namespace OpenLoco::Ui::Windows::Industry
             }
         }
 
-        // 0x004569C2
-        static void onResize(Window& self)
-        {
-            self.setSizeFixed(kWindowSize);
-        }
-
         static constexpr WindowEventList kEvents = {
             .onMouseUp = Common::onMouseUp,
-            .onResize = onResize,
             .onUpdate = Common::update,
             .textInput = Common::textInput,
             .prepareDraw = prepareDraw,
@@ -634,13 +611,15 @@ namespace OpenLoco::Ui::Windows::Industry
             std::span<const Widget> widgets;
             const widx widgetIndex;
             const WindowEventList& events;
+            const Size minSize;
+            const Size maxSize;
         };
 
         static TabInformation tabInformationByTabOffset[] = {
-            { Industry::widgets, widx::tab_industry, Industry::getEvents() },
-            { Production2::widgets, widx::tab_production, Production::getEvents() },
-            { Production2::widgets, widx::tab_production_2, Production2::getEvents() },
-            { Transported::widgets, widx::tab_transported, Transported::getEvents() }
+            { Industry::widgets, widx::tab_industry, Industry::getEvents(), Industry::kWindowSize, Industry::kWindowSize },
+            { Production2::widgets, widx::tab_production, Production::getEvents(), Production::kMinWindowSize, Production::kMaxWindowSize },
+            { Production2::widgets, widx::tab_production_2, Production2::getEvents(), Production2::kMinWindowSize, Production2::kMaxWindowSize },
+            { Transported::widgets, widx::tab_transported, Transported::getEvents(), Transported::kWindowSize, Transported::kWindowSize }
         };
 
         static void setDisabledWidgets(Window& self)
@@ -902,7 +881,7 @@ namespace OpenLoco::Ui::Windows::Industry
 
             self.invalidate();
 
-            self.setSizeFixed(Industry::kWindowSize);
+            self.setSizeBounds(tabInfo.minSize, tabInfo.maxSize);
             self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -392,9 +392,7 @@ namespace OpenLoco::Ui::Windows::Industry
         // 0x0045654F
         static void onResize(Window& self)
         {
-            {
-                self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-            }
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -434,9 +432,7 @@ namespace OpenLoco::Ui::Windows::Industry
         // 0x004565FF
         static void onResize(Window& self)
         {
-            {
-                self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-            }
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -613,9 +609,7 @@ namespace OpenLoco::Ui::Windows::Industry
         // 0x004569C2
         static void onResize(Window& self)
         {
-            {
-                self.setSizeBounds(kWindowSize, kWindowSize);
-            }
+            self.setSizeFixed(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -1772,7 +1772,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                 }
             }();
 
-            self.setSize(newSize);
+            self.setSizeBounds(newSize);
 
             self.callOnResize();
             self.callPrepareDraw();

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -1772,8 +1772,6 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
             }();
 
             self.setSizeFixed(newSize);
-
-            self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();
             self.invalidate();

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -602,8 +602,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
         }
         // End of 0x0043DAEA
 
-        window->width = kWindowSize.width;
-        window->height = kWindowSize.height;
+        window->setSize(kWindowSize);
 
         window->invalidate();
 

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -1771,7 +1771,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
                 }
             }();
 
-            self.setSizeBounds(newSize);
+            self.setSizeFixed(newSize);
 
             self.callOnResize();
             self.callPrepareDraw();

--- a/src/OpenLoco/src/Ui/Windows/MapToolTip.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapToolTip.cpp
@@ -53,7 +53,7 @@ namespace OpenLoco::Ui::Windows::MapToolTip
             return;
         }
 
-        auto height = 55;
+        const auto height = 55;
         auto maxY = Ui::height() - height;
         int16_t y = cursor.y + 15; // Normally, we'd display the tooltip 15 lower
         if (y > maxY)
@@ -63,7 +63,7 @@ namespace OpenLoco::Ui::Windows::MapToolTip
             y -= height + 19;
         }
 
-        auto width = 240;
+        const auto width = 240;
         int16_t x = width <= Ui::width() ? std::clamp(cursor.x - (width / 2), 0, Ui::width() - width) : 0;
 
         auto* window = WindowManager::find(WindowType::mapTooltip);
@@ -72,8 +72,7 @@ namespace OpenLoco::Ui::Windows::MapToolTip
             window->invalidate();
             window->x = x;
             window->y = y;
-            window->width = width;
-            window->height = height;
+            window->setSize({ width, height });
         }
         else
         {

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -241,7 +241,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
         self.flags |= WindowFlags::resizable;
         self.minWidth = kMinWindowSize.width;
 
-        self.setSize(kMinWindowSize, kMaxWindowSize);
+        self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
 
         auto& widget = self.widgets[widx::scrollview];
         auto& map = self.scrollAreas[0];

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -2411,7 +2411,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
         if (Ui::getLastMapWindowAttributes().flags != WindowFlags::none)
         {
-            size = { Ui::getLastMapWindowAttributes().size.width, Ui::getLastMapWindowAttributes().size.height };
+            size = Ui::getLastMapWindowAttributes().size;
             size.width = std::clamp<uint16_t>(size.width, 350, Ui::width());
             size.height = std::clamp<uint16_t>(size.height, 272, Ui::height() - 56);
         }

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -239,8 +239,6 @@ namespace OpenLoco::Ui::Windows::MapWindow
     static void onResize(Window& self)
     {
         self.flags |= WindowFlags::resizable;
-        self.minWidth = kMinWindowSize.width;
-
         self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
 
         auto& widget = self.widgets[widx::scrollview];
@@ -2420,6 +2418,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
 
         window = WindowManager::createWindow(WindowType::map, size, WindowFlags::none, getEvents());
         window->setWidgets(kWidgets);
+        window->callOnResize();
         window->initScrollWidgets();
         window->frameNo = 0;
 

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -336,10 +336,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
 
             WindowManager::moveOtherWindowsDown(*window);
 
-            window->minWidth = Messages::kMinWindowSize.width;
-            window->minHeight = Messages::kMinWindowSize.height;
-            window->maxWidth = Messages::kMaxWindowSize.width;
-            window->maxHeight = Messages::kMaxWindowSize.height;
+            window->setSizeBounds(Messages::kMinWindowSize, Messages::kMaxWindowSize);
             window->flags |= WindowFlags::resizable;
 
             window->owner = CompanyManager::getControllingId();

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -578,7 +578,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         // 0x0042A7E8
         static void tabReset(Window& self)
         {
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -276,12 +276,8 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         // 0x0042A7B9
         static void tabReset(Window& self)
         {
-            self.minWidth = kMinWindowSize.width;
-            self.minHeight = kMinWindowSize.height;
-            self.maxWidth = kMaxWindowSize.width;
-            self.maxHeight = kMaxWindowSize.height;
-            self.width = kMinWindowSize.width;
-            self.height = kMinWindowSize.height;
+            self.setSize(kMinWindowSize);
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
             self.rowHover = -1;
         }
 
@@ -350,8 +346,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
             auto skin = ObjectManager::get<InterfaceSkinObject>();
             window->setColour(WindowColour::secondary, skin->windowPlayerColor);
 
-            window->width = Messages::kMinWindowSize.width;
-            window->height = Messages::kMinWindowSize.height;
+            window->setSize(Messages::kMinWindowSize);
         }
 
         window->currentTab = 0;
@@ -586,12 +581,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
         // 0x0042A7E8
         static void tabReset(Window& self)
         {
-            self.minWidth = kWindowSize.width;
-            self.minHeight = kWindowSize.height;
-            self.maxWidth = kWindowSize.width;
-            self.maxHeight = kWindowSize.height;
-            self.width = kWindowSize.width;
-            self.height = kWindowSize.height;
+            self.setSizeBounds(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
@@ -163,7 +163,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
 
     static void onResize(Ui::Window& self)
     {
-        self.setSize(kWindowSizeMin, kWindowSizeMax);
+        self.setSizeBounds(kWindowSizeMin, kWindowSizeMax);
 
         // Resize & reposition widgets
         self.widgets[widx::frame].right = self.width - 1;

--- a/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
@@ -51,17 +51,15 @@ namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
     // 0x00429FE4
     static void onResize(Window& self)
     {
-        auto y = Ui::height() - kWindowSize.height + 1;
+        auto y = Ui::height() - kWindowSize.height;
         auto x = Ui::width() - kWindowSize.width - 27;
-        auto height = kWindowSize.height - 1;
 
-        if (y != self.y || x != self.x || kWindowSize.width != self.width || height != self.height)
+        if (y != self.y || x != self.x)
         {
             self.invalidate();
             self.y = y;
             self.x = x;
-            self.width = kWindowSize.width;
-            self.height = height;
+            self.setSize(kWindowSize);
             self.invalidate();
         }
     }

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -552,7 +552,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         window = WindowManager::createWindowCentred(WindowType::objectSelection, { kWindowSizeMin }, WindowFlags::resizable, getEvents());
         window->setWidgets(widgets);
-        window->setSize(kWindowSizeMin, kWindowSizeMax);
+        window->setSizeBounds(kWindowSizeMin, kWindowSizeMax);
         window->initScrollWidgets();
         window->frameNo = 0;
         window->rowHover = -1;

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -409,7 +409,6 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             auto widgetIndex = widx::primaryTab1 + i;
             if (shouldShowPrimaryTab(i, FilterLevel(self->filterLevel)))
             {
-                self->disabledWidgets &= ~(1ULL << widgetIndex);
                 self->widgets[widgetIndex].hidden = false;
                 self->widgets[widgetIndex].left = xPos;
                 self->widgets[widgetIndex].right = xPos + 31;
@@ -417,7 +416,6 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             }
             else
             {
-                self->disabledWidgets |= (1ULL << widgetIndex);
                 self->widgets[widgetIndex].hidden = true;
             }
         }
@@ -542,7 +540,6 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
     static Ui::Window* internalOpen(std::optional<ObjectType> optionalObjectType)
     {
         auto window = WindowManager::bringToFront(WindowType::objectSelection);
-
         if (window != nullptr)
         {
             return window;
@@ -550,7 +547,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
         auto& selection = ObjectManager::prepareSelectionList(true);
 
-        window = WindowManager::createWindowCentred(WindowType::objectSelection, { kWindowSizeMin }, WindowFlags::resizable, getEvents());
+        window = WindowManager::createWindowCentred(WindowType::objectSelection, kWindowSizeMin, WindowFlags::resizable, getEvents());
         window->setWidgets(widgets);
         window->setSizeBounds(kWindowSizeMin, kWindowSizeMax);
         window->initScrollWidgets();
@@ -643,23 +640,6 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         self.widgets[widx::scrollviewFrame].bottom = self.widgets[widx::scrollview].bottom + 1;
         self.widgets[widx::scrollviewFrame].right = self.widgets[widx::scrollview].right + 1;
 
-        const auto& currentTab = kMainTabInfo[self.currentTab];
-        const auto& subTabs = currentTab.subTabs;
-        const bool showSecondaryTabs = !subTabs.empty() && FilterLevel(self.filterLevel) != FilterLevel::beginner;
-
-        // Secondary tabs reduce the amount of space for the scroll view
-        if (showSecondaryTabs)
-        {
-            self.widgets[widx::scrollview].top = 62 + 28;
-            self.widgets[widx::scrollviewFrame].hidden = false;
-            self.widgets[widx::scrollviewFrame].top = self.widgets[widx::scrollview].top - 2;
-        }
-        else
-        {
-            self.widgets[widx::scrollview].top = 62;
-            self.widgets[widx::scrollviewFrame].hidden = true;
-        }
-
         // Reposition preview area in the centre of the second half
         self.widgets[widx::objectImage].left = self.width / 4 * 3 - kObjectPreviewSize.width / 2;
         self.widgets[widx::objectImage].right = self.widgets[widx::objectImage].left + kObjectPreviewSize.width;
@@ -676,11 +656,6 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             self.widgets[widx::closeButton].hidden = true;
         }
 
-        self.activatedWidgets |= 1ULL << (widx::primaryTab1 + self.currentTab);
-        const auto& currentTab = kMainTabInfo[self.currentTab];
-        const auto& subTabs = currentTab.subTabs;
-        const bool showSecondaryTabs = !subTabs.empty() && FilterLevel(self.filterLevel) != FilterLevel::beginner;
-
         static constexpr std::array<StringId, 3> kFilterLevelStringIds = {
             StringIds::objSelectionFilterBeginner,
             StringIds::objSelectionFilterAdvanced,
@@ -692,6 +667,11 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             FormatArguments args{ widget.textArgs };
             args.push(kFilterLevelStringIds[self.filterLevel]);
         }
+
+        self.activatedWidgets |= 1ULL << (widx::primaryTab1 + self.currentTab);
+        const auto& currentTab = kMainTabInfo[self.currentTab];
+        const auto& subTabs = currentTab.subTabs;
+        const bool showSecondaryTabs = !subTabs.empty() && FilterLevel(self.filterLevel) != FilterLevel::beginner;
 
         // Update page title
         auto args = FormatArguments(self.widgets[widx::caption].textArgs);
@@ -710,14 +690,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             const auto widgetIndex = i + widx::secondaryTab1;
 
             const bool subTabIsVisible = showSecondaryTabs && i < subTabs.size() && shouldShowSubTab(subTabs, i, FilterLevel(self.filterLevel));
-            if (subTabIsVisible)
-            {
-                self.disabledWidgets &= ~(1ULL << widgetIndex);
-            }
-            else
-            {
-                self.disabledWidgets |= (1ULL << widgetIndex);
-            }
+            self.widgets[widgetIndex].hidden = !subTabIsVisible;
 
             if (self.currentSecondaryTab == i)
             {
@@ -727,6 +700,19 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
             {
                 self.activatedWidgets &= ~(1ULL << widgetIndex);
             }
+        }
+
+        // Secondary tabs reduce the amount of space for the scroll view
+        if (showSecondaryTabs)
+        {
+            self.widgets[widx::scrollview].top = 62 + 28;
+            self.widgets[widx::scrollviewFrame].hidden = false;
+            self.widgets[widx::scrollviewFrame].top = self.widgets[widx::scrollview].top - 2;
+        }
+        else
+        {
+            self.widgets[widx::scrollview].top = 62;
+            self.widgets[widx::scrollviewFrame].hidden = true;
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -2919,7 +2919,7 @@ namespace OpenLoco::Ui::Windows::Options
         self.eventHandlers = &tabInfo.events;
         self.setWidgets(tabInfo.widgets);
         self.invalidate();
-        self.setSize(tabInfo.kWindowSize);
+        self.setSizeBounds(tabInfo.kWindowSize);
 
         if ((Common::tab)self.currentTab == Common::tab::display)
         {

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -2919,7 +2919,7 @@ namespace OpenLoco::Ui::Windows::Options
         self.eventHandlers = &tabInfo.events;
         self.setWidgets(tabInfo.widgets);
         self.invalidate();
-        self.setSizeBounds(tabInfo.kWindowSize);
+        self.setSizeFixed(tabInfo.kWindowSize);
 
         if ((Common::tab)self.currentTab == Common::tab::display)
         {

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -220,7 +220,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     // 0x004467F6
     static void onResize(Window& window)
     {
-        window.setSize({ 400, 300 }, { 640, 800 });
+        window.setSizeBounds({ 400, 300 }, { 640, 800 });
     }
 
     // 0x00446465

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -220,7 +220,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     // 0x004467F6
     static void onResize(Window& window)
     {
-        window.capSize(400, 300, 640, 800);
+        window.setSize({ 400, 300 }, { 640, 800 });
     }
 
     // 0x00446465

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -39,6 +39,10 @@ using namespace OpenLoco::Diagnostics;
 
 namespace OpenLoco::Ui::Windows::PromptBrowse
 {
+    constexpr Size kWindowSize = { 500, 380 };
+    constexpr Size kMinWindowSize = { 400, 340 };
+    constexpr Size kMaxWindowSize = { 640, 800 };
+
     enum BrowseFileType : uint8_t
     {
         savedGame,
@@ -154,13 +158,14 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
 
         auto window = WindowManager::createWindowCentred(
             WindowType::fileBrowserPrompt,
-            { 500, 380 },
+            kWindowSize,
             Ui::WindowFlags::stickToFront | Ui::WindowFlags::resizable | Ui::WindowFlags::playSoundOnOpen,
             getEvents());
 
         if (window != nullptr)
         {
             window->setWidgets(widgets);
+            window->callOnResize();
             window->widgets[widx::caption].text = titleId;
             window->initScrollWidgets();
 
@@ -220,7 +225,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
     // 0x004467F6
     static void onResize(Window& window)
     {
-        window.setSizeBounds({ 400, 300 }, { 640, 800 });
+        window.setSizeBounds(kMinWindowSize, kMaxWindowSize);
     }
 
     // 0x00446465

--- a/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
@@ -1379,7 +1379,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                 }
             }();
 
-            self.setSize(newSize);
+            self.setSizeBounds(newSize);
             self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
@@ -1378,7 +1378,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
                 }
             }();
 
-            self.setSizeBounds(newSize);
+            self.setSizeFixed(newSize);
             self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
@@ -570,8 +570,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
             }
             // 0x0043EEFF end
 
-            window->width = kOtherWindowSize.width;
-            window->height = kOtherWindowSize.height;
+            window->setSize(kOtherWindowSize);
         }
 
         window->currentTab = 0;

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -306,10 +306,7 @@ namespace OpenLoco::Ui::Windows::StationList
 
             populateStationList(*window);
 
-            window->minWidth = kMinDimensions.width;
-            window->minHeight = kMinDimensions.height;
-            window->maxWidth = kMaxDimensions.width;
-            window->maxHeight = kMaxDimensions.height;
+            window->setSizeBounds(kMinDimensions, kMaxDimensions);
             window->flags |= WindowFlags::resizable;
 
             auto interface = ObjectManager::get<InterfaceSkinObject>();

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -208,7 +208,7 @@ namespace OpenLoco::Ui::Windows::Station
         {
             Common::enableRenameByCaption(&self);
 
-            self.setSize(kWindowSize, Common::kMaxWindowSize);
+            self.setSizeBounds(kWindowSize, Common::kMaxWindowSize);
 
             if (self.viewports[0] != nullptr)
             {
@@ -486,7 +486,7 @@ namespace OpenLoco::Ui::Windows::Station
         {
             Common::enableRenameByCaption(&self);
 
-            self.setSize(Common::kMinWindowSize, Common::kMaxWindowSize);
+            self.setSizeBounds(Common::kMinWindowSize, Common::kMaxWindowSize);
         }
 
         // 0x0048EB64
@@ -732,7 +732,7 @@ namespace OpenLoco::Ui::Windows::Station
         {
             Common::enableRenameByCaption(&self);
 
-            self.setSize(kWindowSize, kMaxWindowSize);
+            self.setSizeBounds(kWindowSize, kMaxWindowSize);
         }
 
         // 0x0048EE4A
@@ -1173,7 +1173,7 @@ namespace OpenLoco::Ui::Windows::Station
         {
             Common::enableRenameByCaption(&self);
 
-            self.setSize(kWindowSize, kMaxWindowSize);
+            self.setSizeBounds(kWindowSize, kMaxWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -338,13 +338,11 @@ namespace OpenLoco::Ui::Windows::Station
             const WindowFlags newFlags = WindowFlags::resizable | WindowFlags::lighterFrame;
             window = WindowManager::createWindow(WindowType::station, Station::kWindowSize, newFlags, Station::getEvents());
             window->number = enumValue(stationId);
+
             auto station = StationManager::get(stationId);
             window->owner = station->owner;
-            window->minWidth = Common::kMinWindowSize.width;
-            window->minHeight = Common::kMinWindowSize.height;
-            window->maxWidth = Common::kMaxWindowSize.width;
-            window->maxHeight = Common::kMaxWindowSize.height;
 
+            window->setSizeBounds(Common::kMinWindowSize, Common::kMaxWindowSize);
             window->savedView.clear();
 
             auto skin = ObjectManager::get<InterfaceSkinObject>();

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -352,7 +352,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             self.invalidate();
             Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
             Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
-            bool hasResized = self.setSize(kMinWindowSize, kMaxWindowSize);
+            bool hasResized = self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
             if (hasResized)
             {
                 updateActiveThumb(self);
@@ -420,13 +420,13 @@ namespace OpenLoco::Ui::Windows::Terraform
                                 {
                                     newHeight = std::min(newHeight, 358);
                                 }
-                                hasResized |= self.setSize({ kWindowSize.width, newHeight });
+                                hasResized |= self.setSizeBounds({ kWindowSize.width, newHeight });
                             }
                             else
                             {
                                 if (Input::state() != Input::State::scrollLeft)
                                 {
-                                    hasResized |= self.setSize(kWindowSize);
+                                    hasResized |= self.setSizeBounds(kWindowSize);
                                 }
                             }
                         }
@@ -437,7 +437,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     self.expandContentCounter = 0;
                     if (Input::state() != Input::State::scrollLeft)
                     {
-                        hasResized |= self.setSize(kWindowSize);
+                        hasResized |= self.setSizeBounds(kWindowSize);
                     }
                 }
             }
@@ -2396,7 +2396,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             self.invalidate();
             Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
             Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
-            bool hasResized = self.setSize(kMinWindowSize, kMaxWindowSize);
+            bool hasResized = self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
             if (hasResized)
             {
                 updateActiveThumb(self);
@@ -2438,13 +2438,13 @@ namespace OpenLoco::Ui::Windows::Terraform
                                 {
                                     newHeight = std::min(newHeight, 358);
                                 }
-                                hasResized |= self.setSize({ kWindowSize.width, newHeight });
+                                hasResized |= self.setSizeBounds({ kWindowSize.width, newHeight });
                             }
                             else
                             {
                                 if (Input::state() != Input::State::scrollLeft)
                                 {
-                                    hasResized |= self.setSize(kWindowSize);
+                                    hasResized |= self.setSizeBounds(kWindowSize);
                                 }
                             }
                         }
@@ -2455,7 +2455,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     self.expandContentCounter = 0;
                     if (Input::state() != Input::State::scrollLeft)
                     {
-                        hasResized |= self.setSize(kWindowSize);
+                        hasResized |= self.setSizeBounds(kWindowSize);
                     }
                 }
             }
@@ -2812,7 +2812,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             // CHANGE: width set to 161 to include building walls tab
             uint16_t width = 161;
             Ui::Size kWindowSize = { width, height };
-            self.setSize(kWindowSize, kWindowSize);
+            self.setSizeBounds(kWindowSize, kWindowSize);
         }
 
         // 0x004BC78A, 0x004BCB0B

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -105,7 +105,6 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void drawTabs(Window& self, Gfx::DrawingContext& drawingCtx);
         static void prepareDraw(Window& self);
         static void onUpdate(Window& self);
-        static void onResize(Window& self, uint8_t height);
         static void onMouseUp(Window& self, WidgetIndex_t widgetIndex, [[maybe_unused]] const WidgetId id);
         static void sub_4A69DD();
 
@@ -1010,12 +1009,6 @@ namespace OpenLoco::Ui::Windows::Terraform
             _adjustToolSize = _clearAreaToolSize;
         }
 
-        // 0x004BC7C6
-        static void onResize(Window& self)
-        {
-            Common::onResize(self, 105);
-        }
-
         // 0x004BC65C
         static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
@@ -1195,7 +1188,6 @@ namespace OpenLoco::Ui::Windows::Terraform
         static constexpr WindowEventList kEvents = {
             .onClose = onClose,
             .onMouseUp = Common::onMouseUp,
-            .onResize = onResize,
             .onMouseDown = onMouseDown,
             .onUpdate = Common::onUpdate,
             .onToolUpdate = onToolUpdate,
@@ -1293,12 +1285,11 @@ namespace OpenLoco::Ui::Windows::Terraform
         {
             if (SceneManager::isEditorMode())
             {
-                Common::onResize(self, 115);
+                self.setSizeFixed({ 161, 115 });
             }
             else
             {
-                // CHANGE: Resizes window to allow Dropdown and cost string to be drawn separately
-                Common::onResize(self, 140);
+                self.setSizeFixed({ 161, 140 });
             }
         }
 
@@ -1950,12 +1941,6 @@ namespace OpenLoco::Ui::Windows::Terraform
             _adjustToolSize = _adjustWaterToolSize;
         }
 
-        // 0x004BCEB4
-        static void onResize(Window& self)
-        {
-            Common::onResize(self, 115);
-        }
-
         // 0x004BCD9D
         static void onMouseDown(Window& self, [[maybe_unused]] WidgetIndex_t widgetIndex, const WidgetId id)
         {
@@ -2243,7 +2228,6 @@ namespace OpenLoco::Ui::Windows::Terraform
         static constexpr WindowEventList kEvents = {
             .onClose = onClose,
             .onMouseUp = Common::onMouseUp,
-            .onResize = onResize,
             .onMouseDown = onMouseDown,
             .onUpdate = Common::onUpdate,
             .onToolUpdate = onToolUpdate,
@@ -2760,31 +2744,18 @@ namespace OpenLoco::Ui::Windows::Terraform
             const widx widgetIndex;
             const WindowEventList& events;
             const uint64_t holdableWidgets;
+            const Size windowSize;
         };
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { ClearArea::widgets,   widx::tab_clear_area,   ClearArea::getEvents(),   ClearArea::holdableWidgets },
-            { AdjustLand::widgets,  widx::tab_adjust_land,  AdjustLand::getEvents(),  AdjustLand::holdableWidgets },
-            { AdjustWater::widgets, widx::tab_adjust_water, AdjustWater::getEvents(), AdjustWater::holdableWidgets },
-            { PlantTrees::widgets,  widx::tab_plant_trees,  PlantTrees::getEvents(),  PlantTrees::holdableWidgets },
-            { BuildWalls::widgets,  widx::tab_build_walls,  BuildWalls::getEvents(),  BuildWalls::holdableWidgets },
+            { ClearArea::widgets,   widx::tab_clear_area,   ClearArea::getEvents(),   ClearArea::holdableWidgets,   { 161, 105 } },
+            { AdjustLand::widgets,  widx::tab_adjust_land,  AdjustLand::getEvents(),  AdjustLand::holdableWidgets,  { 161, 140 } },
+            { AdjustWater::widgets, widx::tab_adjust_water, AdjustWater::getEvents(), AdjustWater::holdableWidgets, { 161, 115 } },
+            { PlantTrees::widgets,  widx::tab_plant_trees,  PlantTrees::getEvents(),  PlantTrees::holdableWidgets,  PlantTrees::kWindowSize },
+            { BuildWalls::widgets,  widx::tab_build_walls,  BuildWalls::getEvents(),  BuildWalls::holdableWidgets,  BuildWalls::kWindowSize },
         };
         // clang-format on
-
-        static void onResize(Window& self, uint8_t height)
-        {
-            self.flags |= WindowFlags::resizable;
-
-            /*auto width = 130;
-            if (isEditorMode())
-                width += 31;*/
-
-            // CHANGE: width set to 161 to include building walls tab
-            uint16_t width = 161;
-            Ui::Size kWindowSize = { width, height };
-            self.setSizeFixed(kWindowSize);
-        }
 
         // 0x004BC78A, 0x004BCB0B
         static void onUpdate(Window& self)
@@ -2907,14 +2878,10 @@ namespace OpenLoco::Ui::Windows::Terraform
             self.activatedWidgets = 0;
             self.setWidgets(tabInfo.widgets);
 
-            auto disabledWidgets = 0;
-
-            // CHANGE: Disabled so the build walls tab shows outside of editor mode
-            /*if (!isEditorMode() && !isSandboxMode())
-                disabledWidgets |= common::widx::tab_build_walls;*/
-
-            self.disabledWidgets = disabledWidgets;
+            self.disabledWidgets = 0;
             self.invalidate();
+
+            self.setSizeFixed(tabInfo.windowSize);
 
             switch (widgetIndex)
             {

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -350,10 +350,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void onResize(Window& self)
         {
             self.invalidate();
-            Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
-            Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
-            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-
+            self.clampSizeToBounds();
             updateActiveThumb(self);
         }
 
@@ -2386,10 +2383,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         static void onResize(Window& self)
         {
             self.invalidate();
-            Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
-            Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
-            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-
+            self.clampSizeToBounds();
             updateActiveThumb(self);
         }
 
@@ -2796,7 +2790,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             // CHANGE: width set to 161 to include building walls tab
             uint16_t width = 161;
             Ui::Size kWindowSize = { width, height };
-            self.setSizeBounds(kWindowSize, kWindowSize);
+            self.setSizeBounds(kWindowSize);
         }
 
         // 0x004BC78A, 0x004BCB0B

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -353,10 +353,8 @@ namespace OpenLoco::Ui::Windows::Terraform
             Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
             Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
             self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-            // if (hasResized)
-            {
-                updateActiveThumb(self);
-            }
+
+            updateActiveThumb(self);
         }
 
         // 0x004BBAEA
@@ -2390,11 +2388,9 @@ namespace OpenLoco::Ui::Windows::Terraform
             self.invalidate();
             Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
             Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
-            bool hasResized = self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-            if (hasResized)
-            {
-                updateActiveThumb(self);
-            }
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
+
+            updateActiveThumb(self);
         }
 
         // 0x004BC23D

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -412,13 +412,13 @@ namespace OpenLoco::Ui::Windows::Terraform
                                 {
                                     newHeight = std::min(newHeight, 358);
                                 }
-                                self.setSizeBounds({ kWindowSize.width, newHeight });
+                                self.setSizeFixed({ kWindowSize.width, newHeight });
                             }
                             else
                             {
                                 if (Input::state() != Input::State::scrollLeft)
                                 {
-                                    self.setSizeBounds(kWindowSize);
+                                    self.setSizeFixed(kWindowSize);
                                 }
                             }
                         }
@@ -429,7 +429,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     self.expandContentCounter = 0;
                     if (Input::state() != Input::State::scrollLeft)
                     {
-                        self.setSizeBounds(kWindowSize);
+                        self.setSizeFixed(kWindowSize);
                     }
                 }
             }
@@ -935,7 +935,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             WindowManager::moveOtherWindowsDown(*window);
 
-            window->setSizeBounds(PlantTrees::kWindowSize);
+            window->setSizeFixed(PlantTrees::kWindowSize);
 
             auto skin = ObjectManager::get<InterfaceSkinObject>();
             window->setColour(WindowColour::secondary, skin->windowTerraFormColour);
@@ -2414,13 +2414,13 @@ namespace OpenLoco::Ui::Windows::Terraform
                                 {
                                     newHeight = std::min(newHeight, 358);
                                 }
-                                self.setSizeBounds({ kWindowSize.width, newHeight });
+                                self.setSizeFixed({ kWindowSize.width, newHeight });
                             }
                             else
                             {
                                 if (Input::state() != Input::State::scrollLeft)
                                 {
-                                    self.setSizeBounds(kWindowSize);
+                                    self.setSizeFixed(kWindowSize);
                                 }
                             }
                         }
@@ -2431,7 +2431,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                     self.expandContentCounter = 0;
                     if (Input::state() != Input::State::scrollLeft)
                     {
-                        self.setSizeBounds(kWindowSize);
+                        self.setSizeFixed(kWindowSize);
                     }
                 }
             }
@@ -2783,7 +2783,7 @@ namespace OpenLoco::Ui::Windows::Terraform
             // CHANGE: width set to 161 to include building walls tab
             uint16_t width = 161;
             Ui::Size kWindowSize = { width, height };
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
         }
 
         // 0x004BC78A, 0x004BCB0B

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -352,8 +352,8 @@ namespace OpenLoco::Ui::Windows::Terraform
             self.invalidate();
             Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
             Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
-            bool hasResized = self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-            if (hasResized)
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
+            // if (hasResized)
             {
                 updateActiveThumb(self);
             }
@@ -398,7 +398,6 @@ namespace OpenLoco::Ui::Windows::Terraform
                 WindowManager::close(&self);
             }
 
-            bool hasResized = false;
             if (!Input::hasFlag(Input::Flags::rightMousePressed))
             {
                 auto cursor = Input::getMouseLocation();
@@ -420,13 +419,13 @@ namespace OpenLoco::Ui::Windows::Terraform
                                 {
                                     newHeight = std::min(newHeight, 358);
                                 }
-                                hasResized |= self.setSizeBounds({ kWindowSize.width, newHeight });
+                                self.setSizeBounds({ kWindowSize.width, newHeight });
                             }
                             else
                             {
                                 if (Input::state() != Input::State::scrollLeft)
                                 {
-                                    hasResized |= self.setSizeBounds(kWindowSize);
+                                    self.setSizeBounds(kWindowSize);
                                 }
                             }
                         }
@@ -437,18 +436,13 @@ namespace OpenLoco::Ui::Windows::Terraform
                     self.expandContentCounter = 0;
                     if (Input::state() != Input::State::scrollLeft)
                     {
-                        hasResized |= self.setSizeBounds(kWindowSize);
+                        self.setSizeBounds(kWindowSize);
                     }
                 }
             }
             self.frameNo++;
 
             self.callPrepareDraw();
-            if (hasResized)
-            {
-                updateActiveThumb(self);
-            }
-
             WindowManager::invalidateWidget(WindowType::terraform, self.number, self.currentTab + Common::widx::tab_clear_area);
         }
 
@@ -2416,7 +2410,6 @@ namespace OpenLoco::Ui::Windows::Terraform
                 WindowManager::close(&self);
             }
 
-            bool hasResized = false;
             if (!Input::hasFlag(Input::Flags::rightMousePressed))
             {
                 auto cursor = Input::getMouseLocation();
@@ -2438,13 +2431,13 @@ namespace OpenLoco::Ui::Windows::Terraform
                                 {
                                     newHeight = std::min(newHeight, 358);
                                 }
-                                hasResized |= self.setSizeBounds({ kWindowSize.width, newHeight });
+                                self.setSizeBounds({ kWindowSize.width, newHeight });
                             }
                             else
                             {
                                 if (Input::state() != Input::State::scrollLeft)
                                 {
-                                    hasResized |= self.setSizeBounds(kWindowSize);
+                                    self.setSizeBounds(kWindowSize);
                                 }
                             }
                         }
@@ -2455,18 +2448,13 @@ namespace OpenLoco::Ui::Windows::Terraform
                     self.expandContentCounter = 0;
                     if (Input::state() != Input::State::scrollLeft)
                     {
-                        hasResized |= self.setSizeBounds(kWindowSize);
+                        self.setSizeBounds(kWindowSize);
                     }
                 }
             }
             self.frameNo++;
 
             self.callPrepareDraw();
-            if (hasResized)
-            {
-                updateActiveThumb(self);
-            }
-
             WindowManager::invalidateWidget(WindowType::terraform, self.number, self.currentTab + Common::widx::tab_clear_area);
         }
 

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -349,8 +349,6 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BBFBD
         static void onResize(Window& self)
         {
-            self.invalidate();
-            self.clampSizeToBounds();
             updateActiveThumb(self);
         }
 
@@ -2379,8 +2377,6 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BC44B
         static void onResize(Window& self)
         {
-            self.invalidate();
-            self.clampSizeToBounds();
             updateActiveThumb(self);
         }
 

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -937,10 +937,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             WindowManager::moveOtherWindowsDown(*window);
 
-            window->minWidth = PlantTrees::kWindowSize.width;
-            window->minHeight = PlantTrees::kWindowSize.height;
-            window->maxWidth = PlantTrees::kWindowSize.width;
-            window->maxHeight = PlantTrees::kWindowSize.height;
+            window->setSizeBounds(PlantTrees::kWindowSize);
 
             auto skin = ObjectManager::get<InterfaceSkinObject>();
             window->setColour(WindowColour::secondary, skin->windowTerraFormColour);

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -784,7 +784,7 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049A844
         static void onResize(Window& self)
         {
-            self.setSize(kWindowSize, kWindowSize);
+            self.setSizeBounds(kWindowSize, kWindowSize);
         }
 
         // 0x0049A7C7
@@ -981,13 +981,13 @@ namespace OpenLoco::Ui::Windows::TownList
                                 {
                                     newHeight = std::min(newHeight, 276);
                                 }
-                                hasResized |= self.setSize({ kWindowSize.width, newHeight });
+                                hasResized |= self.setSizeBounds({ kWindowSize.width, newHeight });
                             }
                             else
                             {
                                 if (Input::state() != Input::State::scrollLeft)
                                 {
-                                    hasResized |= self.setSize(kWindowSize);
+                                    hasResized |= self.setSizeBounds(kWindowSize);
                                 }
                             }
                         }
@@ -998,7 +998,7 @@ namespace OpenLoco::Ui::Windows::TownList
                     self.expandContentCounter = 0;
                     if (Input::state() != Input::State::scrollLeft)
                     {
-                        hasResized |= self.setSize(kWindowSize);
+                        hasResized |= self.setSizeBounds(kWindowSize);
                     }
                 }
             }
@@ -1224,7 +1224,7 @@ namespace OpenLoco::Ui::Windows::TownList
             self.invalidate();
             Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
             Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
-            bool hasResized = self.setSize(kMinWindowSize, kMaxWindowSize);
+            bool hasResized = self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
             if (hasResized)
             {
                 updateActiveThumb(self);

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -474,12 +474,8 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049A37E
         static void tabReset(Window& self)
         {
-            self.minWidth = kMinDimensions.width;
-            self.minHeight = kMinDimensions.height;
-            self.maxWidth = kMaxDimensions.width;
-            self.maxHeight = kMaxDimensions.height;
-            self.width = kWindowSize.width;
-            self.height = kWindowSize.height;
+            self.setSize(kWindowSize);
+            self.setSizeBounds(kMinDimensions, kMaxDimensions);
             self.rowCount = 0;
             self.rowHover = -1;
 
@@ -798,12 +794,7 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049A3BE
         static void tabReset(Window& self)
         {
-            self.minWidth = kWindowSize.width;
-            self.minHeight = kWindowSize.height;
-            self.maxWidth = kWindowSize.width;
-            self.maxWidth = kWindowSize.height;
-            self.width = kWindowSize.width;
-            self.height = kWindowSize.height;
+            self.setSizeBounds(kWindowSize);
             ToolManager::toolSet(self, Common::widx::tab_build_town, CursorId::placeTown);
             Input::setFlag(Input::Flags::flag6);
             Ui::Windows::Main::showGridlines();
@@ -1213,9 +1204,7 @@ namespace OpenLoco::Ui::Windows::TownList
         static void onResize(Window& self)
         {
             self.invalidate();
-            Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
-            Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
-            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
+            self.clampSizeToBounds();
 
             updateActiveThumb(self);
         }
@@ -1468,12 +1457,7 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049A3FF
         static void tabReset(Window& self)
         {
-            self.minWidth = kWindowSize.width;
-            self.minHeight = kWindowSize.height;
-            self.maxWidth = kWindowSize.width;
-            self.maxWidth = kWindowSize.height;
-            self.width = kWindowSize.width;
-            self.height = kWindowSize.height;
+            self.setSizeBounds(kWindowSize);
 
             auto tab = Common::widx::tab_build_buildings;
             if (self.currentTab == Common::widx::tab_build_misc_buildings - Common::widx::tab_town_list)

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -791,7 +791,7 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049A3BE
         static void tabReset(Window& self)
         {
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
             ToolManager::toolSet(self, Common::widx::tab_build_town, CursorId::placeTown);
             Input::setFlag(Input::Flags::flag6);
             Ui::Windows::Main::showGridlines();
@@ -965,13 +965,13 @@ namespace OpenLoco::Ui::Windows::TownList
                                 {
                                     newHeight = std::min(newHeight, 276);
                                 }
-                                self.setSizeBounds({ kWindowSize.width, newHeight });
+                                self.setSizeFixed({ kWindowSize.width, newHeight });
                             }
                             else
                             {
                                 if (Input::state() != Input::State::scrollLeft)
                                 {
-                                    self.setSizeBounds(kWindowSize);
+                                    self.setSizeFixed(kWindowSize);
                                 }
                             }
                         }
@@ -982,7 +982,7 @@ namespace OpenLoco::Ui::Windows::TownList
                     self.expandContentCounter = 0;
                     if (Input::state() != Input::State::scrollLeft)
                     {
-                        self.setSizeBounds(kWindowSize);
+                        self.setSizeFixed(kWindowSize);
                     }
                 }
             }
@@ -1451,7 +1451,7 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049A3FF
         static void tabReset(Window& self)
         {
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
 
             auto tab = Common::widx::tab_build_buildings;
             if (self.currentTab == Common::widx::tab_build_misc_buildings - Common::widx::tab_town_list)

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -1215,11 +1215,9 @@ namespace OpenLoco::Ui::Windows::TownList
             self.invalidate();
             Ui::Size kMinWindowSize = { self.minWidth, self.minHeight };
             Ui::Size kMaxWindowSize = { self.maxWidth, self.maxHeight };
-            bool hasResized = self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-            if (hasResized)
-            {
-                updateActiveThumb(self);
-            }
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
+
+            updateActiveThumb(self);
         }
 
         // 0x0049AE83

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -550,8 +550,7 @@ namespace OpenLoco::Ui::Windows::TownList
 
             // 0x00499CFC end
 
-            window->width = TownList::kWindowSize.width;
-            window->height = TownList::kWindowSize.height;
+            window->setSize(TownList::kWindowSize);
             window->invalidate();
 
             window->setWidgets(TownList::widgets);
@@ -954,12 +953,9 @@ namespace OpenLoco::Ui::Windows::TownList
             }
         }
 
-        static void updateActiveThumb(Window& self);
-
         // 0x0049AD51
         static void onUpdate(Window& self)
         {
-            bool hasResized = false;
             if (!Input::hasFlag(Input::Flags::rightMousePressed))
             {
                 auto cursor = Input::getMouseLocation();
@@ -981,13 +977,13 @@ namespace OpenLoco::Ui::Windows::TownList
                                 {
                                     newHeight = std::min(newHeight, 276);
                                 }
-                                hasResized |= self.setSizeBounds({ kWindowSize.width, newHeight });
+                                self.setSizeBounds({ kWindowSize.width, newHeight });
                             }
                             else
                             {
                                 if (Input::state() != Input::State::scrollLeft)
                                 {
-                                    hasResized |= self.setSizeBounds(kWindowSize);
+                                    self.setSizeBounds(kWindowSize);
                                 }
                             }
                         }
@@ -998,18 +994,13 @@ namespace OpenLoco::Ui::Windows::TownList
                     self.expandContentCounter = 0;
                     if (Input::state() != Input::State::scrollLeft)
                     {
-                        hasResized |= self.setSizeBounds(kWindowSize);
+                        self.setSizeBounds(kWindowSize);
                     }
                 }
             }
             self.frameNo++;
 
             self.callPrepareDraw();
-            if (hasResized)
-            {
-                updateActiveThumb(self);
-            }
-
             WindowManager::invalidateWidget(WindowType::townList, self.number, self.currentTab + Common::widx::tab_town_list);
             if (!ToolManager::isToolActive(self.type, self.number))
             {

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -534,10 +534,7 @@ namespace OpenLoco::Ui::Windows::TownList
 
             WindowManager::moveOtherWindowsDown(*window);
 
-            window->minWidth = TownList::kMinDimensions.width;
-            window->minHeight = TownList::kMinDimensions.height;
-            window->maxWidth = TownList::kMaxDimensions.width;
-            window->maxHeight = TownList::kMaxDimensions.height;
+            window->setSizeBounds(TownList::kMinDimensions, TownList::kMaxDimensions);
             window->flags |= WindowFlags::resizable;
 
             auto skin = ObjectManager::get<InterfaceSkinObject>();

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -1200,9 +1200,6 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049AF98
         static void onResize(Window& self)
         {
-            self.invalidate();
-            self.clampSizeToBounds();
-
             updateActiveThumb(self);
         }
 

--- a/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
@@ -273,7 +273,7 @@ namespace OpenLoco::Ui::Windows::Town
         {
             // Call to sub_498E9B has been deliberately omitted.
 
-            self.setSize({ 192, 161 }, { 600, 440 });
+            self.setSizeBounds({ 192, 161 }, { 600, 440 });
 
             if (self.viewports[0] != nullptr)
             {
@@ -558,7 +558,7 @@ namespace OpenLoco::Ui::Windows::Town
         {
             // Call to sub_498E9B has been deliberately omitted.
 
-            self.setSize({ 299, 172 }, { 299, 327 });
+            self.setSizeBounds({ 299, 172 }, { 299, 327 });
         }
 
         static constexpr WindowEventList kEvents = {
@@ -680,7 +680,7 @@ namespace OpenLoco::Ui::Windows::Town
         {
             // Call to sub_498E9B has been deliberately omitted.
 
-            self.setSize({ 340, 208 }, { 340, 208 });
+            self.setSizeBounds({ 340, 208 }, { 340, 208 });
         }
 
         static constexpr WindowEventList kEvents = {
@@ -797,7 +797,7 @@ namespace OpenLoco::Ui::Windows::Town
 
         static void onResize(Window& self)
         {
-            self.setSize(kTransportedWindowSize, kTransportedWindowSize);
+            self.setSizeBounds(kTransportedWindowSize, kTransportedWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -935,7 +935,7 @@ namespace OpenLoco::Ui::Windows::Town
 
             self.invalidate();
 
-            self.setSize(kWindowSize);
+            self.setSizeBounds(kWindowSize);
             self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
@@ -685,7 +685,7 @@ namespace OpenLoco::Ui::Windows::Town
         {
             // Call to sub_498E9B has been deliberately omitted.
 
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -802,7 +802,7 @@ namespace OpenLoco::Ui::Windows::Town
 
         static void onResize(Window& self)
         {
-            self.setSizeBounds(kTransportedWindowSize);
+            self.setSizeFixed(kTransportedWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -940,7 +940,7 @@ namespace OpenLoco::Ui::Windows::Town
 
             self.invalidate();
 
-            self.setSizeBounds(kWindowSize);
+            self.setSizeFixed(kWindowSize);
             self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
@@ -103,6 +103,9 @@ namespace OpenLoco::Ui::Windows::Town
 
     namespace Town
     {
+        static constexpr Size kMinWindowSize = { 192, 161 };
+        static constexpr Size kMaxWindowSize = { 600, 440 };
+
         enum widx
         {
             viewport = 8,
@@ -273,7 +276,7 @@ namespace OpenLoco::Ui::Windows::Town
         {
             // Call to sub_498E9B has been deliberately omitted.
 
-            self.setSizeBounds({ 192, 161 }, { 600, 440 });
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
 
             if (self.viewports[0] != nullptr)
             {
@@ -399,10 +402,7 @@ namespace OpenLoco::Ui::Windows::Town
             const WindowFlags newFlags = WindowFlags::viewportNoShiftPixels | WindowFlags::resizable;
             window = WindowManager::createWindow(WindowType::town, kWindowSize, newFlags, Town::getEvents());
             window->number = townId;
-            window->minWidth = 192;
-            window->minHeight = 161;
-            window->maxWidth = 600;
-            window->maxHeight = 440;
+            window->setSizeBounds(Town::kMinWindowSize, Town::kMaxWindowSize);
 
             auto skin = ObjectManager::get<InterfaceSkinObject>();
             if (skin != nullptr)
@@ -431,6 +431,9 @@ namespace OpenLoco::Ui::Windows::Town
 
     namespace Population
     {
+        static constexpr Size kMinWindowSize = { 299, 172 };
+        static constexpr Size kMaxWindowSize = { 299, 327 };
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(223, 161, StringIds::title_town_population)
 
@@ -558,7 +561,7 @@ namespace OpenLoco::Ui::Windows::Town
         {
             // Call to sub_498E9B has been deliberately omitted.
 
-            self.setSizeBounds({ 299, 172 }, { 299, 327 });
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -578,6 +581,8 @@ namespace OpenLoco::Ui::Windows::Town
 
     namespace CompanyRatings
     {
+        constexpr Size kWindowSize = { 340, 208 };
+
         static constexpr auto widgets = makeWidgets(
             Common::makeCommonWidgets(340, 208, StringIds::title_town_local_authority));
 
@@ -680,7 +685,7 @@ namespace OpenLoco::Ui::Windows::Town
         {
             // Call to sub_498E9B has been deliberately omitted.
 
-            self.setSizeBounds({ 340, 208 }, { 340, 208 });
+            self.setSizeBounds(kWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -797,7 +802,7 @@ namespace OpenLoco::Ui::Windows::Town
 
         static void onResize(Window& self)
         {
-            self.setSizeBounds(kTransportedWindowSize, kTransportedWindowSize);
+            self.setSizeBounds(kTransportedWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
@@ -38,8 +38,6 @@ using namespace OpenLoco::GameCommands;
 
 namespace OpenLoco::Ui::Windows::Town
 {
-    static constexpr Ui::Size kWindowSize = { 223, 161 };
-
     namespace Common
     {
         enum widx
@@ -103,6 +101,7 @@ namespace OpenLoco::Ui::Windows::Town
 
     namespace Town
     {
+        static constexpr Ui::Size kWindowSize = { 223, 161 };
         static constexpr Size kMinWindowSize = { 192, 161 };
         static constexpr Size kMaxWindowSize = { 600, 440 };
 
@@ -276,8 +275,6 @@ namespace OpenLoco::Ui::Windows::Town
         {
             // Call to sub_498E9B has been deliberately omitted.
 
-            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-
             if (self.viewports[0] != nullptr)
             {
                 uint16_t newWidth = self.width - 30;
@@ -400,7 +397,7 @@ namespace OpenLoco::Ui::Windows::Town
         {
             // 0x00499C0D start
             const WindowFlags newFlags = WindowFlags::viewportNoShiftPixels | WindowFlags::resizable;
-            window = WindowManager::createWindow(WindowType::town, kWindowSize, newFlags, Town::getEvents());
+            window = WindowManager::createWindow(WindowType::town, Town::kWindowSize, newFlags, Town::getEvents());
             window->number = townId;
             window->setSizeBounds(Town::kMinWindowSize, Town::kMaxWindowSize);
 
@@ -705,13 +702,13 @@ namespace OpenLoco::Ui::Windows::Town
 
     namespace Transported
     {
-        static constexpr Size kTransportedWindowSize = { 340, 228 };
+        static constexpr Size kWindowSize = { 340, 228 };
 
         static constexpr auto kNumRows = 16;
         static constexpr auto kColumnSpacing = 160;
 
         static constexpr auto widgets = makeWidgets(
-            Common::makeCommonWidgets(kTransportedWindowSize.width, kTransportedWindowSize.height, StringIds::title_statistics));
+            Common::makeCommonWidgets(kWindowSize.width, kWindowSize.height, StringIds::title_statistics));
 
         static void prepareDraw(Window& self)
         {
@@ -800,14 +797,8 @@ namespace OpenLoco::Ui::Windows::Town
             }
         }
 
-        static void onResize(Window& self)
-        {
-            self.setSizeFixed(kTransportedWindowSize);
-        }
-
         static constexpr WindowEventList kEvents = {
             .onMouseUp = onMouseUp,
-            .onResize = onResize,
             .onUpdate = Common::update,
             .textInput = Common::textInput,
             .prepareDraw = prepareDraw,
@@ -827,14 +818,16 @@ namespace OpenLoco::Ui::Windows::Town
             std::span<const Widget> widgets;
             const widx widgetIndex;
             const WindowEventList& events;
+            const Size minSize;
+            const Size maxSize;
         };
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { Town::widgets,           widx::tab_town,            Town::getEvents()           },
-            { Population::widgets,     widx::tab_population,      Population::getEvents()     },
-            { CompanyRatings::widgets, widx::tab_company_ratings, CompanyRatings::getEvents() },
-            { Transported::widgets, widx::tab_transported, Transported::getEvents() }
+            { Town::widgets,           widx::tab_town,            Town::getEvents(),           Town::kMinWindowSize, Town::kMaxWindowSize                      },
+            { Population::widgets,     widx::tab_population,      Population::getEvents(),     Population::kMinWindowSize, Population::kMaxWindowSize                },
+            { CompanyRatings::widgets, widx::tab_company_ratings, CompanyRatings::getEvents(), CompanyRatings::kWindowSize, CompanyRatings::kWindowSize            },
+            { Transported::widgets,    widx::tab_transported,     Transported::getEvents(),    Transported::kWindowSize, Transported::kWindowSize            }
         };
         // clang-format on
 
@@ -940,7 +933,7 @@ namespace OpenLoco::Ui::Windows::Town
 
             self.invalidate();
 
-            self.setSizeFixed(kWindowSize);
+            self.setSizeBounds(tabInfo.minSize, tabInfo.maxSize);
             self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -718,7 +718,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void onResize(Window& self)
         {
             Common::setCaptionEnableState(self);
-            self.setSize(kMinWindowSize, kMaxWindowSize);
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
 
             if (self.viewports[0] != nullptr)
             {
@@ -1271,11 +1271,11 @@ namespace OpenLoco::Ui::Windows::Vehicle
             Common::setCaptionEnableState(self);
             if (CompanyManager::getControllingId() == self.owner)
             {
-                self.setSize(kMinWindowSizeWithPaintEnabled, kMaxWindowSize);
+                self.setSizeBounds(kMinWindowSizeWithPaintEnabled, kMaxWindowSize);
             }
             else
             {
-                self.setSize(kMinWindowSize, kMaxWindowSize);
+                self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
             }
         }
 
@@ -2676,7 +2676,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void onResize(Window& self)
         {
             Common::setCaptionEnableState(self);
-            self.setSize(kMinWindowSize, kMaxWindowSize);
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -2879,7 +2879,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void onResize(Window& self)
         {
             Common::setCaptionEnableState(self);
-            self.setSize(kMinWindowSize, kMaxWindowSize);
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
         }
 
         static constexpr WindowEventList kEvents = {
@@ -3139,7 +3139,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void onResize(Window& self)
         {
             Common::setCaptionEnableState(self);
-            self.setSize(kMinWindowSize, kMaxWindowSize);
+            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
         }
 
         // 0x004B4DD3

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -717,9 +717,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
         // 0x004B3210
         static void onResize(Window& self)
         {
-            Common::setCaptionEnableState(self);
-            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-
             if (self.viewports[0] != nullptr)
             {
                 auto head = Common::getVehicle(self);
@@ -948,6 +945,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void prepareDraw(Window& self)
         {
             Common::setActiveTabs(self);
+            Common::setCaptionEnableState(self);
+
             auto head = Common::getVehicle(self);
             if (head == nullptr)
             {
@@ -1268,7 +1267,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
         // 0x004B3D73
         static void onResize(Window& self)
         {
-            Common::setCaptionEnableState(self);
             if (CompanyManager::getControllingId() == self.owner)
             {
                 self.setSizeBounds(kMinWindowSizeWithPaintEnabled, kMaxWindowSize);
@@ -1674,6 +1672,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void prepareDraw(Window& self)
         {
             Common::setActiveTabs(self);
+            Common::setCaptionEnableState(self);
 
             auto head = Common::getVehicle(self);
             if (head == nullptr)
@@ -2279,6 +2278,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void prepareDraw(Window& self)
         {
             Common::setActiveTabs(self);
+            Common::setCaptionEnableState(self);
 
             auto* headVehicle = Common::getVehicle(self);
             if (headVehicle == nullptr)
@@ -2672,16 +2672,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             WindowManager::invalidateWidget(self.type, self.number, 6);
         }
 
-        // 0x004B4621
-        static void onResize(Window& self)
-        {
-            Common::setCaptionEnableState(self);
-            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-        }
-
         static constexpr WindowEventList kEvents = {
             .onMouseUp = onMouseUp,
-            .onResize = onResize,
             .onMouseDown = onMouseDown,
             .onDropdown = onDropdown,
             .onUpdate = onUpdate,
@@ -2708,6 +2700,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void prepareDraw(Window& self)
         {
             Common::setActiveTabs(self);
+            Common::setCaptionEnableState(self);
 
             auto vehicle = Common::getVehicle(self);
             if (vehicle == nullptr)
@@ -2875,16 +2868,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             WindowManager::invalidateWidget(self.type, self.number, Common::widx::tabFinances);
         }
 
-        // 0x004B59AF
-        static void onResize(Window& self)
-        {
-            Common::setCaptionEnableState(self);
-            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
-        }
-
         static constexpr WindowEventList kEvents = {
             .onMouseUp = onMouseUp,
-            .onResize = onResize,
             .onUpdate = onUpdate,
             .textInput = Common::textInput,
             .tooltip = tooltip,
@@ -3133,13 +3118,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     break;
                 }
             }
-        }
-
-        // 0x004B564E
-        static void onResize(Window& self)
-        {
-            Common::setCaptionEnableState(self);
-            self.setSizeBounds(kMinWindowSize, kMaxWindowSize);
         }
 
         // 0x004B4DD3
@@ -3821,6 +3799,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static void prepareDraw(Window& self)
         {
             Common::setActiveTabs(self);
+            Common::setCaptionEnableState(self);
+
             auto head = Common::getVehicle(self);
             if (head == nullptr)
             {
@@ -4129,7 +4109,6 @@ namespace OpenLoco::Ui::Windows::Vehicle
         static constexpr WindowEventList kEvents = {
             .onClose = close,
             .onMouseUp = onMouseUp,
-            .onResize = onResize,
             .onMouseDown = onMouseDown,
             .onDropdown = onDropdown,
             .onUpdate = onUpdate,
@@ -4164,16 +4143,18 @@ namespace OpenLoco::Ui::Windows::Vehicle
             const widx widgetIndex;
             std::span<const Widget> widgets;
             const WindowEventList& events;
-            const uint64_t* holdableWidgets;
+            const uint64_t holdableWidgets;
+            const Size minSize;
+            const Size maxSize;
         };
 
         // clang-format off
         static TabInformation tabInformationByTabOffset[] = {
-            { widx::tabMain,     Main::widgets,     Main::getEvents(),     &Main::holdableWidgets },
-            { widx::tabDetails,  Details::widgets,  Details::getEvents(),  &Details::holdableWidgets },
-            { widx::tabCargo,    Cargo::widgets,    Cargo::getEvents(),    &Cargo::holdableWidgets },
-            { widx::tabFinances, Finances::widgets, Finances::getEvents(), &Finances::holdableWidgets },
-            { widx::tabRoute,    Route::widgets,    Route::getEvents(),    &Route::holdableWidgets }
+            { widx::tabMain,     Main::widgets,     Main::getEvents(),     Main::holdableWidgets,     Main::kMinWindowSize,     Main::kMaxWindowSize     },
+            { widx::tabDetails,  Details::widgets,  Details::getEvents(),  Details::holdableWidgets,  Details::kMinWindowSize,  Details::kMaxWindowSize  },
+            { widx::tabCargo,    Cargo::widgets,    Cargo::getEvents(),    Cargo::holdableWidgets,    Cargo::kMinWindowSize,    Cargo::kMaxWindowSize    },
+            { widx::tabFinances, Finances::widgets, Finances::getEvents(), Finances::holdableWidgets, Finances::kMinWindowSize, Finances::kMaxWindowSize },
+            { widx::tabRoute,    Route::widgets,    Route::getEvents(),    Route::holdableWidgets,    Route::kMinWindowSize,    Route::kMaxWindowSize    }
         };
         // clang-format on
 
@@ -5029,7 +5010,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self.viewportRemove(0);
 
             auto tabInfo = tabInformationByTabOffset[widgetIndex - widx::tabMain];
-            self.holdableWidgets = *tabInfo.holdableWidgets;
+            self.holdableWidgets = tabInfo.holdableWidgets;
             self.eventHandlers = &tabInfo.events;
             self.activatedWidgets = 0;
             self.setWidgets(tabInfo.widgets);
@@ -5039,6 +5020,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
             self.invalidate();
             self.rowHover = -1;
             self.orderTableIndex = -1;
+
+            self.setSizeBounds(tabInfo.minSize, tabInfo.maxSize);
             self.callOnResize();
             self.callPrepareDraw();
             self.initScrollWidgets();

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -426,8 +426,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         auto tabIndex = static_cast<uint8_t>(type);
         self->currentTab = tabIndex;
         self->rowHeight = row_heights[tabIndex];
-        self->width = kWindowSize.width;
-        self->height = kWindowSize.height;
+        self->setSize(kWindowSize);
         self->sortMode = 0;
         self->rowHover = -1;
         self->var_850 = static_cast<int16_t>(FilterMode::allVehicles);
@@ -736,11 +735,6 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
         disableUnavailableVehicleTypes(self);
         self.invalidate();
-
-        if (self.width < 220)
-        {
-            self.width = 220;
-        }
 
         self.rowCount = 0;
         populateVehicleList(self);
@@ -1072,23 +1066,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     {
         self.flags |= WindowFlags::resizable;
 
-        self.minWidth = kMinDimensions.width;
-        self.minHeight = kMinDimensions.height;
-
-        self.maxWidth = kMaxDimensions.width;
-        self.maxHeight = kMaxDimensions.height;
-
-        if (self.width < self.minWidth)
-        {
-            self.width = self.minWidth;
-            self.invalidate();
-        }
-
-        if (self.height < self.minHeight)
-        {
-            self.height = self.minHeight;
-            self.invalidate();
-        }
+        self.setSizeBounds(kMinDimensions, kMaxDimensions);
 
         // Basic frame widget dimensions
         self.widgets[widx::frame].right = self.width - 1;


### PR DESCRIPTION
This PR reworks how windows are resized and clamped to bounds. Instead of just assigning the relevant properties, this is now done through two helper functions: `Window::setSize` and `Window::setSizeBounds`. The latter sets minimum and maximum bounds, applying and invalidating as needed. More importantly, both functions consistently trigger `onResize` after a resize has happened. This removes the burden of having to do so from the window in question.

Note that `Window::setSizeBounds` is an old function, formerly known as `Window::setSize`. This PR renames the old function to reflect its actual purpose, and introduces a new `Window::setSize` instead.

Further, `Window::capSize` was a duplicate implementation of `Window::setSizeBounds`, and is therefore consolidated into the latter.