### PR TITLE
Rework grid scrollviews and fix 'jitter'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Change: [#3740] Options that interfere with tutorial operation are temporarily disabled options during playback.
 - Change: [#3777] Jukebox can now be toggled and opened from the options window, grouped together with the title screen music toggle.
 - Fix: [#2956] Roads drawn over cliffs can have a visible gap (original bug).
+- Fix: [#3524] Jittery window height in the 'gridded' tabs of the industry list, town list, and terraform windows.
 - Fix: [#3525] The grid cell borders in the terraform window overlap subtly with their contents.
 - Fix: [#3573] Town population graphs values draw overflow if the line is outside the viewable part of the window.
 - Fix: [#3776] Unchecking "Play Music" from the top toolbar does not invalidate Jukebox window.

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -1158,23 +1158,24 @@ namespace OpenLoco::Ui::Windows::IndustryList
             self.callGetScrollSize(0, scrollWidth, scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
-            auto i = 0;
-            for (; i <= self.rowCount; i++)
+            auto activeCell = 0;
+            for (; activeCell <= self.rowCount; activeCell++)
             {
-                if (self.rowInfo[i] == self.rowHover)
+                if (self.rowInfo[activeCell] == self.rowHover)
                 {
                     break;
                 }
             }
 
-            if (i >= self.rowCount)
+            if (activeCell >= self.rowCount)
             {
-                i = 0;
+                activeCell = 0;
             }
 
-            i = (i / kColsPerRow) * kRowHeight;
+            auto focusRow = activeCell / kColsPerRow;
+            auto offsetY = focusRow * kRowHeight;
 
-            self.scrollAreas[0].contentOffsetY = i;
+            self.scrollAreas[0].contentOffsetY = offsetY;
             Ui::ScrollView::updateThumbs(self, widx::scrollview);
         }
 

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -637,7 +637,9 @@ namespace OpenLoco::Ui::Windows::IndustryList
     {
         static constexpr Ui::Size kWindowSize = { 578, 172 };
 
+        static constexpr uint8_t kColumnWidth = 112;
         static constexpr uint8_t kRowHeight = 112;
+        static constexpr uint8_t kColsPerRow = 5;
 
         enum widx
         {
@@ -753,7 +755,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
         static int getRowIndex(int16_t x, int16_t y)
         {
-            return (x / 112) + (y / kRowHeight) * 5;
+            return (x / 112) + (y / kRowHeight) * kColsPerRow;
         }
 
         // 0x00458966
@@ -937,7 +939,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         // 0x004586EA
         static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            scrollHeight = (4 + self.rowCount) / 5;
+            scrollHeight = (self.rowCount + (kColsPerRow - 1)) / kColsPerRow;
             if (scrollHeight == 0)
             {
                 scrollHeight += 1;
@@ -959,8 +961,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
             {
                 if (yPos + kRowHeight < rt.y)
                 {
-                    xPos += kRowHeight;
-                    if (xPos >= kRowHeight * 5) // full row
+                    xPos += kColumnWidth;
+                    if (xPos >= kColumnWidth * kColsPerRow) // full row
                     {
                         xPos = 0;
                         yPos += kRowHeight;
@@ -976,12 +978,12 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 {
                     if (self.rowInfo[i] == self.var_846)
                     {
-                        drawingCtx.drawRectInset(xPos, yPos, kRowHeight, kRowHeight, self.getColour(WindowColour::secondary), Gfx::RectInsetFlags::colourLight);
+                        drawingCtx.drawRectInset(xPos, yPos, kColumnWidth, kRowHeight, self.getColour(WindowColour::secondary), Gfx::RectInsetFlags::colourLight);
                     }
                 }
                 else
                 {
-                    drawingCtx.drawRectInset(xPos, yPos, kRowHeight, kRowHeight, self.getColour(WindowColour::secondary), (Gfx::RectInsetFlags::colourLight | Gfx::RectInsetFlags::borderInset));
+                    drawingCtx.drawRectInset(xPos, yPos, kColumnWidth, kRowHeight, self.getColour(WindowColour::secondary), (Gfx::RectInsetFlags::colourLight | Gfx::RectInsetFlags::borderInset));
                 }
 
                 auto industryObj = ObjectManager::get<IndustryObject>(self.rowInfo[i]);
@@ -994,9 +996,9 @@ namespace OpenLoco::Ui::Windows::IndustryList
                     drawingCtx.popRenderTarget();
                 }
 
-                xPos += kRowHeight;
+                xPos += kColumnWidth;
 
-                if (xPos >= kRowHeight * 5) // full row
+                if (xPos >= kColumnWidth * kColsPerRow) // full row
                 {
                     xPos = 0;
                     yPos += kRowHeight;
@@ -1170,7 +1172,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 i = 0;
             }
 
-            i = (i / 5) * kRowHeight;
+            i = (i / kColsPerRow) * kRowHeight;
 
             self.scrollAreas[0].contentOffsetY = i;
             Ui::ScrollView::updateThumbs(self, widx::scrollview);

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -939,6 +939,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
         // 0x004586EA
         static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
+            scrollWidth = kColumnWidth * kColsPerRow;
             scrollHeight = (self.rowCount + (kColsPerRow - 1)) / kColsPerRow;
             if (scrollHeight == 0)
             {

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -988,11 +988,11 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
                 auto industryObj = ObjectManager::get<IndustryObject>(self.rowInfo[i]);
 
-                auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(xPos + 1, yPos + 1, 110, 110));
+                auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(xPos + 1, yPos + 1, kColumnWidth - 2, kRowHeight - 2));
                 if (clipped)
                 {
                     drawingCtx.pushRenderTarget(*clipped);
-                    industryObj->drawIndustry(drawingCtx, 56, 96);
+                    industryObj->drawIndustry(drawingCtx, kColumnWidth / 2, kRowHeight / 2 + 40);
                     drawingCtx.popRenderTarget();
                 }
 

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -755,7 +755,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
 
         static int getRowIndex(int16_t x, int16_t y)
         {
-            return (x / 112) + (y / kRowHeight) * kColsPerRow;
+            return (x / kColumnWidth) + (y / kRowHeight) * kColsPerRow;
         }
 
         // 0x00458966

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -134,6 +134,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
         static constexpr uint8_t kRowHeight = 102;
         static constexpr uint8_t kColumnWidth = 66;
+        static constexpr uint8_t kColsPerRow = 9;
 
         enum widx
         {
@@ -199,7 +200,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 i = 0;
             }
 
-            i = (i / 9) * kRowHeight;
+            i = (i / kColsPerRow) * kRowHeight;
 
             self.scrollAreas[0].contentOffsetY = i;
             Ui::ScrollView::updateThumbs(self, widx::scrollview);
@@ -635,7 +636,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BBEC1
         static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            scrollHeight = (self.rowCount + 8) / 9;
+            scrollHeight = (self.rowCount + (kColsPerRow - 1)) / kColsPerRow;
             if (scrollHeight == 0)
             {
                 scrollHeight += 1;
@@ -645,7 +646,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
         static int getRowIndex(int16_t x, int16_t y)
         {
-            return (x / kColumnWidth) + (y / kRowHeight) * 9;
+            return (x / kColumnWidth) + (y / kRowHeight) * kColsPerRow;
         }
 
         // 0x004BBF3B
@@ -869,7 +870,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
                 xPos += kColumnWidth;
 
-                if (xPos >= kColumnWidth * 9) // full row
+                if (xPos >= kColumnWidth * kColsPerRow) // full row
                 {
                     xPos = 0;
                     yPos += kRowHeight;
@@ -2243,6 +2244,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
         static constexpr uint8_t kColumnWidth = 40;
         static constexpr uint8_t kRowHeight = 48;
+        static constexpr uint8_t kColsPerRow = 10;
 
         enum widx
         {
@@ -2278,7 +2280,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 i = 0;
             }
 
-            i = (i / 10) * kRowHeight;
+            i = (i / kColsPerRow) * kRowHeight;
 
             self.scrollAreas[0].contentOffsetY = i;
             Ui::ScrollView::updateThumbs(self, widx::scrollview);
@@ -2565,7 +2567,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BC359
         static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            scrollHeight = (self.rowCount + 9) / 10;
+            scrollHeight = (self.rowCount + (kColsPerRow - 1)) / kColsPerRow;
             if (scrollHeight == 0)
             {
                 scrollHeight += 1;
@@ -2575,7 +2577,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
         static int getRowIndex(int16_t x, int16_t y)
         {
-            return (x / 40) + (y / kRowHeight) * 10;
+            return (x / kColumnWidth) + (y / kRowHeight) * kColsPerRow;
         }
 
         // 0x004BC3D3
@@ -2712,7 +2714,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
                 xPos += kColumnWidth;
 
-                if (xPos >= kColumnWidth * 10) // full row
+                if (xPos >= kColumnWidth * kColsPerRow) // full row
                 {
                     xPos = 0;
                     yPos += kRowHeight;

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -2707,7 +2707,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 {
                     drawingCtx.pushRenderTarget(*clipped);
 
-                    drawingCtx.drawImage(34, 28, wallObj->sprite);
+                    drawingCtx.drawImage(kColumnWidth - 6, kRowHeight - 20, wallObj->sprite);
 
                     drawingCtx.popRenderTarget();
                 }

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -637,6 +637,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BBEC1
         static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
+            scrollWidth = kColumnWidth * kColsPerRow;
             scrollHeight = (self.rowCount + (kColsPerRow - 1)) / kColsPerRow;
             if (scrollHeight == 0)
             {
@@ -2569,6 +2570,7 @@ namespace OpenLoco::Ui::Windows::Terraform
         // 0x004BC359
         static void getScrollSize(Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
+            scrollWidth = kColumnWidth * kColsPerRow;
             scrollHeight = (self.rowCount + (kColsPerRow - 1)) / kColsPerRow;
             if (scrollHeight == 0)
             {

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -186,23 +186,24 @@ namespace OpenLoco::Ui::Windows::Terraform
             self.callGetScrollSize(0, scrollWidth, scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
-            auto i = 0;
-            for (; i <= self.rowCount; i++)
+            auto activeCell = 0;
+            for (; activeCell <= self.rowCount; activeCell++)
             {
-                if (self.rowInfo[i] == self.rowHover)
+                if (self.rowInfo[activeCell] == self.rowHover)
                 {
                     break;
                 }
             }
 
-            if (i >= self.rowCount)
+            if (activeCell >= self.rowCount)
             {
-                i = 0;
+                activeCell = 0;
             }
 
-            i = (i / kColsPerRow) * kRowHeight;
+            auto focusRow = activeCell / kColsPerRow;
+            auto offsetY = focusRow * kRowHeight;
 
-            self.scrollAreas[0].contentOffsetY = i;
+            self.scrollAreas[0].contentOffsetY = offsetY;
             Ui::ScrollView::updateThumbs(self, widx::scrollview);
         }
 
@@ -2266,23 +2267,24 @@ namespace OpenLoco::Ui::Windows::Terraform
             self.callGetScrollSize(0, scrollWidth, scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
-            auto i = 0;
-            for (; i <= self.rowCount; i++)
+            auto activeCell = 0;
+            for (; activeCell <= self.rowCount; activeCell++)
             {
-                if (self.rowInfo[i] == self.rowHover)
+                if (self.rowInfo[activeCell] == self.rowHover)
                 {
                     break;
                 }
             }
 
-            if (i >= self.rowCount)
+            if (activeCell >= self.rowCount)
             {
-                i = 0;
+                activeCell = 0;
             }
 
-            i = (i / kColsPerRow) * kRowHeight;
+            auto focusRow = activeCell / kColsPerRow;
+            auto offsetY = focusRow * kRowHeight;
 
-            self.scrollAreas[0].contentOffsetY = i;
+            self.scrollAreas[0].contentOffsetY = offsetY;
             Ui::ScrollView::updateThumbs(self, widx::scrollview);
         }
 

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -1206,6 +1206,7 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049AE83
         static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
+            scrollWidth = kColumnWidth * kColsPerRow;
             scrollHeight = (self.rowCount + (kColsPerRow - 1)) / kColsPerRow;
             if (scrollHeight == 0)
             {

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -806,7 +806,9 @@ namespace OpenLoco::Ui::Windows::TownList
     {
         static constexpr Ui::Size kWindowSize = { 600, 172 };
 
+        static constexpr uint8_t kColumnWidth = 112;
         static constexpr uint8_t kRowHeight = 112;
+        static constexpr uint8_t kColsPerRow = 5;
 
         enum widx
         {
@@ -1181,7 +1183,7 @@ namespace OpenLoco::Ui::Windows::TownList
                 i = 0;
             }
 
-            i = (i / 5) * kRowHeight;
+            i = (i / kColsPerRow) * kRowHeight;
 
             self.scrollAreas[0].contentOffsetY = i;
 
@@ -1204,7 +1206,7 @@ namespace OpenLoco::Ui::Windows::TownList
         // 0x0049AE83
         static void getScrollSize(Ui::Window& self, [[maybe_unused]] uint32_t scrollIndex, [[maybe_unused]] int32_t& scrollWidth, int32_t& scrollHeight)
         {
-            scrollHeight = (4 + self.rowCount) / 5;
+            scrollHeight = (self.rowCount + (kColsPerRow - 1)) / kColsPerRow;
             if (scrollHeight == 0)
             {
                 scrollHeight += 1;
@@ -1234,8 +1236,8 @@ namespace OpenLoco::Ui::Windows::TownList
             {
                 if (yPos + kRowHeight < rt.y)
                 {
-                    xPos += kRowHeight;
-                    if (xPos >= kRowHeight * 5) // full row
+                    xPos += kColumnWidth;
+                    if (xPos >= kColumnWidth * kColsPerRow) // full row
                     {
                         xPos = 0;
                         yPos += kRowHeight;
@@ -1251,12 +1253,12 @@ namespace OpenLoco::Ui::Windows::TownList
                 {
                     if (self.rowInfo[i] == self.var_846)
                     {
-                        drawingCtx.drawRectInset(xPos, yPos, kRowHeight, kRowHeight, self.getColour(WindowColour::secondary), Gfx::RectInsetFlags::colourLight);
+                        drawingCtx.drawRectInset(xPos, yPos, kColumnWidth, kRowHeight, self.getColour(WindowColour::secondary), Gfx::RectInsetFlags::colourLight);
                     }
                 }
                 else
                 {
-                    drawingCtx.drawRectInset(xPos, yPos, kRowHeight, kRowHeight, self.getColour(WindowColour::secondary), (Gfx::RectInsetFlags::colourLight | Gfx::RectInsetFlags::borderInset));
+                    drawingCtx.drawRectInset(xPos, yPos, kColumnWidth, kRowHeight, self.getColour(WindowColour::secondary), (Gfx::RectInsetFlags::colourLight | Gfx::RectInsetFlags::borderInset));
                 }
 
                 auto buildingObj = ObjectManager::get<BuildingObject>(self.rowInfo[i]);
@@ -1280,7 +1282,7 @@ namespace OpenLoco::Ui::Windows::TownList
 
                 xPos += kRowHeight;
 
-                if (xPos >= kRowHeight * 5) // full row
+                if (xPos >= kRowHeight * kColsPerRow) // full row
                 {
                     xPos = 0;
                     yPos += kRowHeight;
@@ -1305,7 +1307,7 @@ namespace OpenLoco::Ui::Windows::TownList
 
         static int getRowIndex(int16_t x, int16_t y)
         {
-            return (x / 112) + (y / 112) * 5;
+            return (x / kColumnWidth) + (y / kRowHeight) * kColsPerRow;
         }
 
         // 0x0049AEFD

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -1263,7 +1263,7 @@ namespace OpenLoco::Ui::Windows::TownList
 
                 auto buildingObj = ObjectManager::get<BuildingObject>(self.rowInfo[i]);
 
-                auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(xPos + 1, yPos + 1, 110, 110));
+                auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(xPos + 1, yPos + 1, kColumnWidth - 2, kRowHeight - 2));
                 if (clipped)
                 {
                     drawingCtx.pushRenderTarget(*clipped);
@@ -1275,7 +1275,7 @@ namespace OpenLoco::Ui::Windows::TownList
                         colour = bit == -1 ? Colour::black : static_cast<Colour>(bit);
                     }
 
-                    buildingObj->drawBuilding(drawingCtx, _buildingRotation, 56, 96, colour);
+                    buildingObj->drawBuilding(drawingCtx, _buildingRotation, kColumnWidth / 2, kRowHeight / 2 + 40, colour);
 
                     drawingCtx.popRenderTarget();
                 }

--- a/src/OpenLoco/src/Ui/Windows/TownList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownList.cpp
@@ -1169,24 +1169,24 @@ namespace OpenLoco::Ui::Windows::TownList
             self.callGetScrollSize(0, scrollWidth, scrollHeight);
             self.scrollAreas[0].contentHeight = scrollHeight;
 
-            auto i = 0;
-            for (; i <= self.rowCount; i++)
+            auto activeCell = 0;
+            for (; activeCell <= self.rowCount; activeCell++)
             {
-                if (self.rowInfo[i] == self.rowHover)
+                if (self.rowInfo[activeCell] == self.rowHover)
                 {
                     break;
                 }
             }
 
-            if (i >= self.rowCount)
+            if (activeCell >= self.rowCount)
             {
-                i = 0;
+                activeCell = 0;
             }
 
-            i = (i / kColsPerRow) * kRowHeight;
+            auto focusRow = activeCell / kColsPerRow;
+            auto offsetY = focusRow * kRowHeight;
 
-            self.scrollAreas[0].contentOffsetY = i;
-
+            self.scrollAreas[0].contentOffsetY = offsetY;
             Ui::ScrollView::updateThumbs(self, widx::scrollview);
         }
 


### PR DESCRIPTION
This PR reworks the 'object grid' scrollviews to use constants in more places. This was done primarily to investigate the 'jittering' issue with their vertical scrollbars, #3524. This issue was ultimately solved in 94f2ccc by assigning an explicit 'scroll width' to these particular scrollview instances.

Given these scrollviews only scroll vertically, not horizontally, there would normally not be a problem. However, the underlying issue is that the parent windows to these 'object grid' scrollviews expand and collapse depending on whether they are hovered. This means their scroll positions need to be recalculated when the window height changes, i.e. outside of 'normal' operations -- and they do.

The issue appears to occurs because we underflow our calculations (0 - 1). This was not an issue in vanilla, as vanilla always had the scrollbar width to account for. We hide scrollbars when not applicable, so we don't have that buffer.