### PR TITLE
Fix/breakpad arm64

### DIFF
--- a/src/Platform/CMakeLists.txt
+++ b/src/Platform/CMakeLists.txt
@@ -26,8 +26,10 @@ set(public_link_libraries
 )
 
 if (MSVC)
-    list(APPEND public_link_libraries ${BREAKPAD_LIBRARIES})
     list(APPEND public_link_libraries "Winmm.lib")
+endif()
+if (MSVC AND NOT CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64")
+    list(APPEND public_link_libraries ${BREAKPAD_LIBRARIES})
 endif()
 
 loco_add_library(Platform STATIC
@@ -39,7 +41,7 @@ loco_add_library(Platform STATIC
         ${public_link_libraries}
 )
 
-if (MSVC)
+if (MSVC AND NOT CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64")
     target_compile_definitions(Platform
         PRIVATE
             USE_BREAKPAD)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -48,8 +48,8 @@ else()
     set(OPENAL_LIBRARIES OpenAL::OpenAL)
 endif()
 
-# breakpad is also required
-if (MSVC)
+# breakpad is not supported on ARM64
+if (MSVC AND NOT CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64")
     find_package(unofficial-breakpad CONFIG REQUIRED)
     set(BREAKPAD_LIBRARIES unofficial::breakpad::libbreakpad unofficial::breakpad::libbreakpad_client)
 endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,7 @@
     "benchmark",
     {
       "name": "breakpad",
-      "platform": "windows"
+      "platform": "windows & !arm64"
     },
     "gtest",
     "libpng",


### PR DESCRIPTION
This pull request updates the build configuration to exclude Breakpad support on Windows ARM64 platforms. The changes ensure that Breakpad is only included and used when building for non-ARM64 Windows targets, addressing compatibility issues.

**Build system updates for Breakpad support:**

* [`thirdparty/CMakeLists.txt`](diffhunk://#diff-63349b1a36da563bdafd8d31c8f86eb55bc49e0c8daf68d7b817daace0ee09abL51-R52): Modified to only find and set `BREAKPAD_LIBRARIES` when building for MSVC and not targeting ARM64 (`CMAKE_GENERATOR_PLATFORM` not equal to "ARM64").
* [`src/Platform/CMakeLists.txt`](diffhunk://#diff-8decacddcf7172ae3c5873fe626e4fa9f345be3ae55bacfeb1d36daa3ce48ab3L29-R33): Updated to append `BREAKPAD_LIBRARIES` to `public_link_libraries` and define `USE_BREAKPAD` only for MSVC builds that are not targeting ARM64. [[1]](diffhunk://#diff-8decacddcf7172ae3c5873fe626e4fa9f345be3ae55bacfeb1d36daa3ce48ab3L29-R33) [[2]](diffhunk://#diff-8decacddcf7172ae3c5873fe626e4fa9f345be3ae55bacfeb1d36daa3ce48ab3L42-R44)

**Dependency specification update:**

* [`vcpkg.json`](diffhunk://#diff-dbbb1b147126744a5eee012901d2b9a29cc478be03677f67825b9b2794f5d283L8-R8): Changed the Breakpad dependency to only apply on Windows platforms that are not ARM64 (`"platform": "windows & !arm64"`).