### PR TITLE
Extra zoom levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Feature: [#3768] Add tab to town window to show delivered cargo last month.
 - Feature: [#3805] Keyboard shortcuts can now combine multiple modifiers, including left and right Ctrl and Alt.
 - Feature: [#3813] Add OpenGraphics replacements for town names, trams, tracks, roads and a large number of trains.
+- Feature: [#3836] Add new double and quadruple viewport zoom levels.
 - Change: [#3740] Options that interfere with tutorial operation are temporarily disabled options during playback.
 - Change: [#3777] Jukebox can now be toggled and opened from the options window, grouped together with the title screen music toggle.
 - Fix: [#2956] Roads drawn over cliffs can have a visible gap (original bug).

--- a/src/OpenLoco/include/OpenLoco/Graphics/DrawSprite.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/DrawSprite.h
@@ -4,6 +4,7 @@
 #include <OpenLoco/Core/EnumFlags.hpp>
 #include <OpenLoco/Engine/Ui/Point.hpp>
 #include <OpenLoco/Engine/Ui/Size.hpp>
+#include <OpenLoco/ZoomLevel.hpp>
 
 namespace OpenLoco::Gfx
 {
@@ -70,4 +71,7 @@ namespace OpenLoco::Gfx
 
     template<uint8_t TZoomLevel, bool TIsRLE>
     void drawSpriteToBuffer(const RenderTarget& rt, const DrawSpriteArgs& args, const DrawBlendOp op);
+
+    template<bool TIsRLE>
+    void drawSpriteToBufferMagnify(const RenderTarget& rt, ZoomLevel zoom, const DrawSpriteArgs& args, const DrawBlendOp op);
 }

--- a/src/OpenLoco/include/OpenLoco/Graphics/DrawSpriteBMP.hpp
+++ b/src/OpenLoco/include/OpenLoco/Graphics/DrawSpriteBMP.hpp
@@ -16,7 +16,7 @@ namespace OpenLoco::Gfx
         const int32_t width = args.size.width;
         int32_t height = args.size.height;
         const size_t srcLineWidth = g1.width << TZoomLevel;
-        const size_t dstLineWidth = (static_cast<size_t>(rt.width) >> TZoomLevel) + rt.pitch;
+        const size_t dstLineWidth = static_cast<size_t>(rt.width) + rt.pitch;
         auto* dst = rt.bits;
         // Move the pointer to the start point of the destination
         dst += dstLineWidth * args.dstPos.y + args.dstPos.x;

--- a/src/OpenLoco/include/OpenLoco/Graphics/DrawSpriteBMP.hpp
+++ b/src/OpenLoco/include/OpenLoco/Graphics/DrawSpriteBMP.hpp
@@ -7,6 +7,44 @@
 
 namespace OpenLoco::Gfx
 {
+    template<DrawBlendOp TBlendOp>
+    inline void drawBMPSpriteMagnify(const RenderTarget& rt, ZoomLevel zoom, const DrawSpriteArgs& args)
+    {
+        const auto& g1 = args.sourceImage;
+        const auto& paletteMap = args.palMap;
+        const int32_t width = args.size.width;
+        const int32_t height = args.size.height;
+        const size_t srcLineWidth = g1.width;
+        const size_t dstLineWidth = static_cast<size_t>(rt.width) + rt.pitch;
+        auto* dst = rt.bits + dstLineWidth * args.dstPos.y + args.dstPos.x;
+
+        for (int32_t y = 0; y < height; y++)
+        {
+            auto* nextDst = dst + dstLineWidth;
+            const auto srcY = zoom.applyTo(args.srcPos.y + y);
+            const auto* srcLine = g1.offset + srcLineWidth * srcY;
+
+            if constexpr ((TBlendOp & DrawBlendOp::noiseMask) != DrawBlendOp::none)
+            {
+                const auto* noiseLine = args.noiseImage->offset + srcLineWidth * srcY;
+                for (int32_t x = 0; x < width; x++, dst++)
+                {
+                    const auto srcX = zoom.applyTo(args.srcPos.x + x);
+                    blitPixel<TBlendOp>(srcLine[srcX], *dst, paletteMap, noiseLine[srcX]);
+                }
+            }
+            else
+            {
+                for (int32_t x = 0; x < width; x++, dst++)
+                {
+                    const auto srcX = zoom.applyTo(args.srcPos.x + x);
+                    blitPixel<TBlendOp>(srcLine[srcX], *dst, paletteMap, 0xFF);
+                }
+            }
+            dst = nextDst;
+        }
+    }
+
     template<DrawBlendOp TBlendOp, uint8_t TZoomLevel>
     inline void drawBMPSprite(const RenderTarget& rt, const DrawSpriteArgs& args)
     {

--- a/src/OpenLoco/include/OpenLoco/Graphics/DrawSpriteRLE.hpp
+++ b/src/OpenLoco/include/OpenLoco/Graphics/DrawSpriteRLE.hpp
@@ -7,6 +7,54 @@
 
 namespace OpenLoco::Gfx
 {
+    template<DrawBlendOp TBlendOp>
+    inline void drawRLESpriteMagnify(const RenderTarget& rt, ZoomLevel zoom, const DrawSpriteArgs& args)
+    {
+        const auto* src0 = args.sourceImage.offset;
+        const int32_t width = args.size.width;
+        const int32_t height = args.size.height;
+        const auto dstLineWidth = static_cast<size_t>(rt.width) + rt.pitch;
+        auto* dst = rt.bits + dstLineWidth * args.dstPos.y + args.dstPos.x;
+        const auto& paletteMap = args.palMap;
+
+        for (int32_t y = 0; y < height; y++)
+        {
+            auto* nextDst = dst + dstLineWidth;
+
+            const auto srcY = zoom.applyTo(args.srcPos.y + y);
+            const uint16_t lineOffset = src0[srcY * 2] | (src0[srcY * 2 + 1] << 8);
+            const auto* nextRun = src0 + lineOffset;
+
+            auto isEndOfLine = false;
+            int32_t firstPixelX = 0;
+            int32_t numPixels = 0;
+            const uint8_t* runData = nullptr;
+
+            for (int32_t x = 0; x < width; x++, dst++)
+            {
+                const auto srcX = zoom.applyTo(args.srcPos.x + x);
+
+                while (srcX >= firstPixelX + numPixels && !isEndOfLine)
+                {
+                    const auto* src = nextRun;
+                    auto dataSize = *src++;
+                    firstPixelX = *src++;
+                    isEndOfLine = (dataSize & 0x80) != 0;
+                    dataSize &= 0x7F;
+                    numPixels = dataSize;
+                    runData = src;
+                    nextRun = src + dataSize;
+                }
+
+                if (runData != nullptr && srcX >= firstPixelX && srcX < firstPixelX + numPixels)
+                {
+                    blitPixel<TBlendOp>(runData[srcX - firstPixelX], *dst, paletteMap, 0xFF);
+                }
+            }
+            dst = nextDst;
+        }
+    }
+
     template<DrawBlendOp TBlendOp, uint8_t TZoomLevel>
     inline void drawRLESprite(const RenderTarget& rt, const DrawSpriteArgs& args)
     {

--- a/src/OpenLoco/include/OpenLoco/Graphics/DrawSpriteRLE.hpp
+++ b/src/OpenLoco/include/OpenLoco/Graphics/DrawSpriteRLE.hpp
@@ -16,7 +16,7 @@ namespace OpenLoco::Gfx
         const int32_t width = args.size.width;
         int32_t height = args.size.height;
         constexpr auto zoom = 1 << TZoomLevel;
-        auto dstLineWidth = (static_cast<size_t>(rt.width) >> TZoomLevel) + rt.pitch;
+        auto dstLineWidth = static_cast<size_t>(rt.width) + rt.pitch;
         auto* dst0 = rt.bits;
         // Move the pointer to the start point of the destination
         dst0 += dstLineWidth * args.dstPos.y + args.dstPos.x;

--- a/src/OpenLoco/include/OpenLoco/Graphics/DrawingContext.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/DrawingContext.h
@@ -49,28 +49,28 @@ namespace OpenLoco::Gfx
 
         virtual void clearSingle(uint8_t paletteId) = 0;
 
-        virtual void fillRect(int16_t left, int16_t top, int16_t right, int16_t bottom, uint8_t colour, RectFlags flags) = 0;
+        virtual void fillRect(int32_t left, int32_t top, int32_t right, int32_t bottom, uint8_t colour, RectFlags flags) = 0;
 
         void fillRect(const Ui::Point& origin, const Ui::Size& size, uint8_t colour, RectFlags flags)
         {
             fillRect(origin.x, origin.y, origin.x + size.width - 1, origin.y + size.height - 1, colour, flags);
         }
 
-        virtual void drawRect(int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint8_t colour, RectFlags flags) = 0;
+        virtual void drawRect(int32_t x, int32_t y, int32_t dx, int32_t dy, uint8_t colour, RectFlags flags) = 0;
 
         void drawRect(const Ui::Point& origin, const Ui::Size& size, uint8_t colour, RectFlags flags)
         {
             drawRect(origin.x, origin.y, size.width, size.height, colour, flags);
         }
 
-        virtual void fillRectInset(int16_t left, int16_t top, int16_t right, int16_t bottom, AdvancedColour colour, RectInsetFlags flags) = 0;
+        virtual void fillRectInset(int32_t left, int32_t top, int32_t right, int32_t bottom, AdvancedColour colour, RectInsetFlags flags) = 0;
 
         void fillRectInset(const Ui::Point& origin, const Ui::Size& size, AdvancedColour colour, RectInsetFlags flags)
         {
             fillRectInset(origin.x, origin.y, origin.x + size.width - 1, origin.y + size.height - 1, colour, flags);
         }
 
-        virtual void drawRectInset(int16_t x, int16_t y, uint16_t dx, uint16_t dy, AdvancedColour colour, RectInsetFlags flags) = 0;
+        virtual void drawRectInset(int32_t x, int32_t y, int32_t dx, int32_t dy, AdvancedColour colour, RectInsetFlags flags) = 0;
 
         void drawRectInset(const Ui::Point& origin, const Ui::Size& size, AdvancedColour colour, RectInsetFlags flags)
         {
@@ -83,7 +83,7 @@ namespace OpenLoco::Gfx
 
         virtual void drawImage(ZoomLevel zoom, const Ui::Point& pos, const ImageId& image) = 0;
 
-        void drawImage(ZoomLevel zoom, int16_t x, int16_t y, uint32_t image)
+        void drawImage(ZoomLevel zoom, int32_t x, int32_t y, uint32_t image)
         {
             drawImage(zoom, Ui::Point(x, y), ImageId::fromUInt32(image));
         }

--- a/src/OpenLoco/include/OpenLoco/Graphics/DrawingContext.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/DrawingContext.h
@@ -7,6 +7,7 @@
 #include "Types.hpp"
 #include <OpenLoco/Core/EnumFlags.hpp>
 #include <OpenLoco/Engine/Ui/Rect.hpp>
+#include <OpenLoco/ZoomLevel.hpp>
 #include <cstdint>
 
 namespace OpenLoco::Gfx
@@ -80,16 +81,19 @@ namespace OpenLoco::Gfx
 
         virtual void drawCircle(const Ui::Point& centre, int32_t radius, int32_t lineWidth, PaletteIndex_t colour) = 0;
 
-        virtual void drawImage(int16_t x, int16_t y, uint32_t image) = 0;
+        virtual void drawImage(ZoomLevel zoom, const Ui::Point& pos, const ImageId& image) = 0;
 
-        void drawImage(const Ui::Point& pos, uint32_t image)
+        void drawImage(ZoomLevel zoom, int16_t x, int16_t y, uint32_t image)
         {
-            drawImage(pos, ImageId::fromUInt32(image));
+            drawImage(zoom, Ui::Point(x, y), ImageId::fromUInt32(image));
         }
 
-        virtual void drawImage(const Ui::Point& pos, const ImageId& image) = 0;
+        void drawImage(ZoomLevel zoom, const Ui::Point& pos, uint32_t image)
+        {
+            drawImage(zoom, pos, ImageId::fromUInt32(image));
+        }
 
-        virtual void drawImageMasked(const Ui::Point& pos, const ImageId& image, const ImageId& maskImage) = 0;
+        virtual void drawImageMasked(ZoomLevel zoom, const Ui::Point& pos, const ImageId& image, const ImageId& maskImage) = 0;
 
         virtual void drawImageSolid(const Ui::Point& pos, const ImageId& image, PaletteIndex_t paletteIndex) = 0;
 

--- a/src/OpenLoco/include/OpenLoco/Graphics/RenderTarget.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/RenderTarget.h
@@ -12,11 +12,11 @@ namespace OpenLoco::Gfx
     struct RenderTarget
     {
         uint8_t* bits;
-        int16_t x;
-        int16_t y;
-        int16_t width;
-        int16_t height;
-        int16_t pitch; // note: this is actually (pitch - width)
+        int32_t x;
+        int32_t y;
+        int32_t width;
+        int32_t height;
+        int32_t pitch; // note: this is actually (pitch - width)
 
         Ui::Rect getUiRect() const;
     };

--- a/src/OpenLoco/include/OpenLoco/Graphics/RenderTarget.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/RenderTarget.h
@@ -8,18 +8,17 @@ namespace OpenLoco::Gfx
 {
     // TODO: Convert this to a handle once everything is implemented.
     // Depending on the rendering engine this could be a buffer on GPU or RAM.
+    // All coordinates are in screen space.
     struct RenderTarget
     {
-        uint8_t* bits;      // 0x00
-        int16_t x;          // 0x04
-        int16_t y;          // 0x06
-        int16_t width;      // 0x08
-        int16_t height;     // 0x0A
-        int16_t pitch;      // 0x0C note: this is actually (pitch - width)
-        uint16_t zoomLevel; // 0x0E
+        uint8_t* bits;
+        int16_t x;
+        int16_t y;
+        int16_t width;
+        int16_t height;
+        int16_t pitch; // note: this is actually (pitch - width)
 
         Ui::Rect getUiRect() const;
-        Ui::Rect getDrawableRect() const;
     };
 
     std::optional<RenderTarget> clipRenderTarget(const RenderTarget& src, const Ui::Rect& newRect);

--- a/src/OpenLoco/include/OpenLoco/Graphics/SoftwareDrawingContext.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/SoftwareDrawingContext.h
@@ -28,10 +28,10 @@ namespace OpenLoco::Gfx
         const RenderTarget& currentRenderTarget() const override;
         void clear(uint32_t fill) override;
         void clearSingle(uint8_t paletteId) override;
-        void fillRect(int16_t left, int16_t top, int16_t right, int16_t bottom, uint8_t colour, RectFlags flags) override;
-        void drawRect(int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint8_t colour, RectFlags flags) override;
-        void fillRectInset(int16_t left, int16_t top, int16_t right, int16_t bottom, AdvancedColour colour, RectInsetFlags flags) override;
-        void drawRectInset(int16_t x, int16_t y, uint16_t dx, uint16_t dy, AdvancedColour colour, RectInsetFlags flags) override;
+        void fillRect(int32_t left, int32_t top, int32_t right, int32_t bottom, uint8_t colour, RectFlags flags) override;
+        void drawRect(int32_t x, int32_t y, int32_t dx, int32_t dy, uint8_t colour, RectFlags flags) override;
+        void fillRectInset(int32_t left, int32_t top, int32_t right, int32_t bottom, AdvancedColour colour, RectInsetFlags flags) override;
+        void drawRectInset(int32_t x, int32_t y, int32_t dx, int32_t dy, AdvancedColour colour, RectInsetFlags flags) override;
         void drawLine(const Ui::Point& a, const Ui::Point& b, PaletteIndex_t colour) override;
         void drawCircle(const Ui::Point& centre, int32_t radius, int32_t lineWidth, PaletteIndex_t colour) override;
         void drawImage(ZoomLevel zoom, const Ui::Point& worldPos, const ImageId& image) override;

--- a/src/OpenLoco/include/OpenLoco/Graphics/SoftwareDrawingContext.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/SoftwareDrawingContext.h
@@ -34,9 +34,8 @@ namespace OpenLoco::Gfx
         void drawRectInset(int16_t x, int16_t y, uint16_t dx, uint16_t dy, AdvancedColour colour, RectInsetFlags flags) override;
         void drawLine(const Ui::Point& a, const Ui::Point& b, PaletteIndex_t colour) override;
         void drawCircle(const Ui::Point& centre, int32_t radius, int32_t lineWidth, PaletteIndex_t colour) override;
-        void drawImage(int16_t x, int16_t y, uint32_t image) override;
-        void drawImage(const Ui::Point& pos, const ImageId& image) override;
-        void drawImageMasked(const Ui::Point& pos, const ImageId& image, const ImageId& maskImage) override;
+        void drawImage(ZoomLevel zoom, const Ui::Point& worldPos, const ImageId& image) override;
+        void drawImageMasked(ZoomLevel zoom, const Ui::Point& worldPos, const ImageId& image, const ImageId& maskImage) override;
         void drawImageSolid(const Ui::Point& pos, const ImageId& image, PaletteIndex_t paletteIndex) override;
         void drawImagePaletteSet(const Ui::Point& pos, const ImageId& image, PaletteMap::View palette, const G1Element* noiseImage) override;
     };

--- a/src/OpenLoco/include/OpenLoco/LabelFrame.h
+++ b/src/OpenLoco/include/OpenLoco/LabelFrame.h
@@ -8,26 +8,27 @@ namespace OpenLoco
 #pragma pack(push, 1)
     struct LabelFrame
     {
-        int16_t left[ZoomLevel::max]{};
-        int16_t right[ZoomLevel::max]{};
-        int16_t top[ZoomLevel::max]{};
-        int16_t bottom[ZoomLevel::max]{};
+        int32_t left[ZoomLevel::count]{};
+        int32_t right[ZoomLevel::count]{};
+        int32_t top[ZoomLevel::count]{};
+        int32_t bottom[ZoomLevel::count]{};
 
-        [[nodiscard]] bool contains(const Ui::Rect& rec, uint8_t zoom) const
+        [[nodiscard]] bool contains(const Ui::Rect& rec, ZoomLevel zoom) const
         {
-            if (rec.top() > bottom[zoom])
+            const auto index = zoom.index();
+            if (rec.top() > bottom[index])
             {
                 return false;
             }
-            if (rec.bottom() < top[zoom])
+            if (rec.bottom() < top[index])
             {
                 return false;
             }
-            if (rec.left() > right[zoom])
+            if (rec.left() > right[index])
             {
                 return false;
             }
-            if (rec.right() < left[zoom])
+            if (rec.right() < left[index])
             {
                 return false;
             }

--- a/src/OpenLoco/include/OpenLoco/Paint/Paint.h
+++ b/src/OpenLoco/include/OpenLoco/Paint/Paint.h
@@ -7,6 +7,7 @@
 #include <OpenLoco/Core/EnumFlags.hpp>
 #include <OpenLoco/Engine/Ui/Point.hpp>
 #include <OpenLoco/Engine/World.hpp>
+#include <OpenLoco/ZoomLevel.hpp>
 #include <array>
 #include <sfl/segmented_vector.hpp>
 #include <span>
@@ -233,7 +234,7 @@ namespace OpenLoco::Paint
     struct PaintSession
     {
     public:
-        PaintSession(const Gfx::RenderTarget& rt, const SessionOptions& options);
+        PaintSession(const Gfx::RenderTarget& rt, ZoomLevel zoom, const SessionOptions& options);
 
         void generate();
         void arrangeStructs();
@@ -244,6 +245,11 @@ namespace OpenLoco::Paint
         [[nodiscard]] Ui::ViewportInteraction::InteractionArg getStationNameInteractionInfo(const Ui::ViewportInteraction::InteractionItemFlags flags) const;
         [[nodiscard]] Ui::ViewportInteraction::InteractionArg getTownNameInteractionInfo(const Ui::ViewportInteraction::InteractionItemFlags flags) const;
         const Gfx::RenderTarget* getRenderTarget() const { return _renderTarget; }
+        ZoomLevel getZoom() const { return _zoom; }
+        int32_t getWorldX() const;
+        int32_t getWorldY() const;
+        int32_t getWorldWidth() const;
+        int32_t getWorldHeight() const;
         uint8_t getRotation() const { return currentRotation; }
         void setRotation(uint8_t rotation) { currentRotation = rotation; }
         int16_t getMaxHeight() const { return _maxHeight; }
@@ -445,6 +451,7 @@ namespace OpenLoco::Paint
         sfl::segmented_vector<PaintEntry, 128> _paintEntries;
 
         const Gfx::RenderTarget* _renderTarget{};
+        ZoomLevel _zoom{};
         PaintStruct* _paintHead{};
         coord_t _spritePositionX{};
         coord_t _unkPositionX{};

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -380,7 +380,7 @@ namespace OpenLoco::Ui
         WidgetIndex_t nextAvailableWidgetInRange(WidgetIndex_t minIndex, WidgetIndex_t maxIndex);
     };
 
-    World::Pos2 viewportCoordToMapCoord(int16_t x, int16_t y, int16_t z, int32_t rotation);
+    World::Pos2 viewportCoordToMapCoord(int32_t x, int32_t y, int32_t z, int32_t rotation);
     std::optional<World::Pos2> screenGetMapXyWithZ(const Point& mouse, const int16_t z);
     void listWindowOnHandleInputBegin(Window& window);
     void listWindowOnHandleInputEnd(Window& window);

--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -330,7 +330,7 @@ namespace OpenLoco::Ui
         void viewportSetUndergroundFlag(bool underground, Ui::Viewport* vp);
         void moveWindowToLocation(viewport_pos pos);
         void viewportCentreOnTile(const World::Pos3& loc);
-        void viewportZoomSet(int8_t zoomLevel, bool toCursor);
+        void viewportZoomSet(ZoomLevel zoomLevel, bool toCursor);
         void viewportZoomIn(bool toCursor);
         void viewportZoomOut(bool toCursor);
         void viewportRotateRight();

--- a/src/OpenLoco/include/OpenLoco/Viewport.hpp
+++ b/src/OpenLoco/include/OpenLoco/Viewport.hpp
@@ -3,6 +3,7 @@
 #include "Graphics/Gfx.h"
 #include "Location.hpp"
 #include "Types.hpp"
+#include "ZoomLevel.hpp"
 #include <OpenLoco/Core/EnumFlags.hpp>
 #include <OpenLoco/Engine/World.hpp>
 #include <algorithm>
@@ -88,7 +89,7 @@ namespace OpenLoco::Ui
         int32_t viewY;       // 0x0A
         int32_t viewWidth;   // 0x0C
         int32_t viewHeight;  // 0x0E
-        uint8_t zoom;        // 0x10
+        ZoomLevel zoom;      // 0x10
         uint8_t pad_11;      // 0x11
         ViewportFlags flags; // 0x12
 
@@ -212,7 +213,7 @@ namespace OpenLoco::Ui
 
         [[nodiscard]] constexpr Point scaleTransform(const Point& uiPoint, const Viewport& vp)
         {
-            return uiPoint << vp.zoom;
+            return Point{ vp.zoom.applyTo(uiPoint.x), vp.zoom.applyTo(uiPoint.y) };
         }
 
         [[nodiscard]] constexpr Point viewOffsetTransform(const Point& point, const Viewport& vp)
@@ -235,7 +236,7 @@ namespace OpenLoco::Ui
 
         [[nodiscard]] constexpr Point scaleTransform(const Point& uiPoint, const Viewport& vp)
         {
-            return uiPoint >> vp.zoom;
+            return Point{ vp.zoom.applyInversedTo(uiPoint.x), vp.zoom.applyInversedTo(uiPoint.y) };
         }
 
         [[nodiscard]] constexpr Point viewOffsetTransform(const Point& point, const Viewport& vp)

--- a/src/OpenLoco/include/OpenLoco/World/Station.h
+++ b/src/OpenLoco/include/OpenLoco/World/Station.h
@@ -190,5 +190,5 @@ namespace OpenLoco
 
     void sub_48D794(const Station& station);
 
-    void drawStationName(Gfx::DrawingContext& drawingCtx, const Station& station, uint8_t zoom, bool isHovered);
+    void drawStationName(Gfx::DrawingContext& drawingCtx, const Station& station, ZoomLevel zoom, bool isHovered);
 }

--- a/src/OpenLoco/include/OpenLoco/World/Town.h
+++ b/src/OpenLoco/include/OpenLoco/World/Town.h
@@ -81,7 +81,7 @@ namespace OpenLoco
         bool empty() const;
         TownId id() const;
         void update();
-        void drawLabel(Gfx::DrawingContext& drawingCtx, const Gfx::RenderTarget& rt);
+        void drawLabel(Gfx::DrawingContext& drawingCtx, ZoomLevel zoom);
         void updateLabel();
         void updateMonthly();
         void adjustCompanyRating(CompanyId cid, int amount);

--- a/src/OpenLoco/include/OpenLoco/ZoomLevel.hpp
+++ b/src/OpenLoco/include/OpenLoco/ZoomLevel.hpp
@@ -8,30 +8,70 @@ namespace OpenLoco
 #pragma pack(push, 1)
     class ZoomLevel
     {
-        uint8_t level{};
+        int8_t level{};
 
     public:
-        static constexpr uint8_t full = 0;
-        static constexpr uint8_t half = 1;
-        static constexpr uint8_t quarter = 2;
-        static constexpr uint8_t eighth = 3;
-        static constexpr uint8_t max = 4;
+        static constexpr int8_t quadrupled = -2;
+        static constexpr int8_t doubled = -1;
+        static constexpr int8_t full = 0;
+        static constexpr int8_t half = 1;
+        static constexpr int8_t quarter = 2;
+        static constexpr int8_t eighth = 3;
+
+        static constexpr int8_t min = quadrupled;
+        static constexpr int8_t max = eighth;
+        static constexpr uint8_t count = max - min + 1;
 
         constexpr ZoomLevel() = default;
-        constexpr ZoomLevel(uint8_t zoom)
+        constexpr ZoomLevel(int8_t zoom)
             : level(zoom)
         {
         }
 
-        constexpr operator uint8_t() const
+        constexpr operator int8_t() const
         {
             return level;
+        }
+
+        constexpr ZoomLevel& operator++()
+        {
+            ++level;
+            return *this;
+        }
+
+        constexpr ZoomLevel operator++(int)
+        {
+            const auto previous = *this;
+            ++level;
+            return previous;
+        }
+
+        constexpr ZoomLevel& operator--()
+        {
+            --level;
+            return *this;
+        }
+
+        constexpr ZoomLevel operator--(int)
+        {
+            const auto previous = *this;
+            --level;
+            return previous;
+        }
+
+        constexpr uint8_t index() const
+        {
+            return static_cast<uint8_t>(level - min);
         }
 
         // Converts a value from screen space into world space.
         template<typename T>
         constexpr T applyTo(const T value) const
         {
+            if (level < 0)
+            {
+                return static_cast<T>(value >> -level);
+            }
             return static_cast<T>(value << level);
         }
 
@@ -39,10 +79,14 @@ namespace OpenLoco
         template<typename T>
         constexpr T applyInversedTo(const T value) const
         {
+            if (level < 0)
+            {
+                return static_cast<T>(value << -level);
+            }
             return static_cast<T>(value >> level);
         }
     };
 #pragma pack(pop)
 
-    static_assert(sizeof(ZoomLevel) == sizeof(uint8_t));
+    static_assert(sizeof(ZoomLevel) == sizeof(int8_t));
 }

--- a/src/OpenLoco/include/OpenLoco/ZoomLevel.hpp
+++ b/src/OpenLoco/include/OpenLoco/ZoomLevel.hpp
@@ -28,9 +28,18 @@ namespace OpenLoco
             return level;
         }
 
-        constexpr bool operator==(const ZoomLevel other) const
+        // Converts a value from screen space into world space.
+        template<typename T>
+        constexpr T applyTo(const T value) const
         {
-            return level == other.level;
+            return static_cast<T>(value << level);
+        }
+
+        // Converts a value from world space into screen space.
+        template<typename T>
+        constexpr T applyInversedTo(const T value) const
+        {
+            return static_cast<T>(value >> level);
         }
     };
 #pragma pack(pop)

--- a/src/OpenLoco/include/OpenLoco/ZoomLevel.hpp
+++ b/src/OpenLoco/include/OpenLoco/ZoomLevel.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <compare>
 #include <cstdint>
 
 namespace OpenLoco
@@ -28,9 +29,21 @@ namespace OpenLoco
         {
         }
 
-        constexpr operator int8_t() const
+        explicit constexpr operator int8_t() const
         {
             return level;
+        }
+
+        constexpr auto operator<=>(const ZoomLevel& other) const = default;
+
+        constexpr ZoomLevel operator+(int8_t rhs) const
+        {
+            return ZoomLevel{ static_cast<int8_t>(level + rhs) };
+        }
+
+        constexpr ZoomLevel operator-(int8_t rhs) const
+        {
+            return ZoomLevel{ static_cast<int8_t>(level - rhs) };
         }
 
         constexpr ZoomLevel& operator++()

--- a/src/OpenLoco/src/Audio/AmbientAudio.cpp
+++ b/src/OpenLoco/src/Audio/AmbientAudio.cpp
@@ -28,10 +28,10 @@ namespace OpenLoco::Audio
     static constexpr auto kAmbientNumTreeTilesForForest = 30;
     static constexpr auto kAmbientNumMountainTilesForWilderness = 60;
 
-    static constexpr int32_t getAmbientMaxVolume(uint8_t zoom)
+    static constexpr int32_t getAmbientMaxVolume(ZoomLevel zoom)
     {
-        constexpr int32_t _volumes[]{ -1200, -2000, -3000, -3000 };
-        return _volumes[zoom];
+        constexpr int32_t _volumes[ZoomLevel::count]{ -1200, -1200, -1200, -2000, -3000, -3000 };
+        return _volumes[zoom.index()];
     }
 
     void updateAmbientNoise()

--- a/src/OpenLoco/src/Audio/Audio.cpp
+++ b/src/OpenLoco/src/Audio/Audio.cpp
@@ -420,7 +420,8 @@ namespace OpenLoco::Audio
                     zVol = 8;
                 }
             }
-            volume = ((-1024 * viewport.zoom - 1) << zVol) + 1;
+            const auto zoomAttenuation = std::max<int8_t>(static_cast<int8_t>(viewport.zoom), ZoomLevel::full);
+            volume = ((-1024 * zoomAttenuation - 1) << zVol) + 1;
         }
         return volume;
     }

--- a/src/OpenLoco/src/Audio/VehicleAudio.cpp
+++ b/src/OpenLoco/src/Audio/VehicleAudio.cpp
@@ -30,9 +30,9 @@ namespace OpenLoco::Audio
     constexpr int32_t kPanFalloffStart = 2048;
     constexpr int32_t kPanFalloffEnd = 3072;
 
-    static int8_t getZoomVolumeModifier(uint8_t zoom)
+    static int8_t getZoomVolumeModifier(ZoomLevel zoom)
     {
-        return std::min<uint8_t>(zoom, 2) * kVolumeModifierZoomIncrement;
+        return std::clamp<int8_t>(zoom, 0, 2) * kVolumeModifierZoomIncrement;
     }
 
     static bool isUnderground(const World::Pos3& pos)

--- a/src/OpenLoco/src/Audio/VehicleAudio.cpp
+++ b/src/OpenLoco/src/Audio/VehicleAudio.cpp
@@ -32,7 +32,7 @@ namespace OpenLoco::Audio
 
     static int8_t getZoomVolumeModifier(ZoomLevel zoom)
     {
-        return std::clamp<int8_t>(zoom, 0, 2) * kVolumeModifierZoomIncrement;
+        return std::clamp<int8_t>(static_cast<int8_t>(zoom), 0, 2) * kVolumeModifierZoomIncrement;
     }
 
     static bool isUnderground(const World::Pos3& pos)

--- a/src/OpenLoco/src/Graphics/DrawSprite.cpp
+++ b/src/OpenLoco/src/Graphics/DrawSprite.cpp
@@ -47,6 +47,7 @@ namespace OpenLoco::Gfx
         }
         return op;
     }
+
 #pragma warning(push)
 #pragma warning(disable : 4063) // not a valid value for a switch of this enum
 #pragma GCC diagnostic push
@@ -112,8 +113,81 @@ namespace OpenLoco::Gfx
             }
         }
     }
+
+    template<bool TIsRLE>
+    inline void drawSpriteToBufferMagnifyHelper(const RenderTarget& rt, ZoomLevel zoom, const DrawSpriteArgs& args, const DrawBlendOp op)
+    {
+        if constexpr (!TIsRLE)
+        {
+            switch (op)
+            {
+                case DrawBlendOp::transparent | DrawBlendOp::src | DrawBlendOp::dst:
+                    drawBMPSpriteMagnify<DrawBlendOp::transparent | DrawBlendOp::src | DrawBlendOp::dst>(rt, zoom, args);
+                    break;
+                case DrawBlendOp::transparent | DrawBlendOp::src:
+                    drawBMPSpriteMagnify<DrawBlendOp::transparent | DrawBlendOp::src>(rt, zoom, args);
+                    break;
+                case DrawBlendOp::transparent | DrawBlendOp::dst:
+                    drawBMPSpriteMagnify<DrawBlendOp::transparent | DrawBlendOp::dst>(rt, zoom, args);
+                    break;
+                case DrawBlendOp::none:
+                    drawBMPSpriteMagnify<DrawBlendOp::none>(rt, zoom, args);
+                    break;
+                case DrawBlendOp::transparent:
+                    drawBMPSpriteMagnify<DrawBlendOp::transparent>(rt, zoom, args);
+                    break;
+                case DrawBlendOp::transparent | DrawBlendOp::src | DrawBlendOp::noiseMask:
+                    drawBMPSpriteMagnify<DrawBlendOp::transparent | DrawBlendOp::src | DrawBlendOp::noiseMask>(rt, zoom, args);
+                    break;
+                case DrawBlendOp::none | DrawBlendOp::noiseMask:
+                    drawBMPSpriteMagnify<DrawBlendOp::none | DrawBlendOp::noiseMask>(rt, zoom, args);
+                    break;
+                case DrawBlendOp::transparent | DrawBlendOp::noiseMask:
+                    drawBMPSpriteMagnify<DrawBlendOp::transparent | DrawBlendOp::noiseMask>(rt, zoom, args);
+                    break;
+                default:
+                    assert(false);
+                    break;
+            }
+        }
+        else
+        {
+            switch (op)
+            {
+                case DrawBlendOp::transparent | DrawBlendOp::src | DrawBlendOp::dst:
+                    drawRLESpriteMagnify<DrawBlendOp::transparent | DrawBlendOp::src | DrawBlendOp::dst>(rt, zoom, args);
+                    break;
+                case DrawBlendOp::transparent | DrawBlendOp::src:
+                    drawRLESpriteMagnify<DrawBlendOp::transparent | DrawBlendOp::src>(rt, zoom, args);
+                    break;
+                case DrawBlendOp::transparent | DrawBlendOp::dst:
+                    drawRLESpriteMagnify<DrawBlendOp::transparent | DrawBlendOp::dst>(rt, zoom, args);
+                    break;
+                case DrawBlendOp::none:
+                    drawRLESpriteMagnify<DrawBlendOp::none>(rt, zoom, args);
+                    break;
+                case DrawBlendOp::transparent:
+                    drawRLESpriteMagnify<DrawBlendOp::transparent>(rt, zoom, args);
+                    break;
+                default:
+                    assert(false);
+                    break;
+            }
+        }
+    }
 #pragma GCC diagnostic pop
 #pragma warning(pop)
+
+    template<>
+    void drawSpriteToBufferMagnify<false>(const RenderTarget& rt, ZoomLevel zoom, const DrawSpriteArgs& args, const DrawBlendOp op)
+    {
+        drawSpriteToBufferMagnifyHelper<false>(rt, zoom, args, op);
+    }
+    template<>
+    void drawSpriteToBufferMagnify<true>(const RenderTarget& rt, ZoomLevel zoom, const DrawSpriteArgs& args, const DrawBlendOp op)
+    {
+        drawSpriteToBufferMagnifyHelper<true>(rt, zoom, args, op);
+    }
 
     template<>
     void drawSpriteToBuffer<0, false>(const RenderTarget& rt, const DrawSpriteArgs& args, const DrawBlendOp op)

--- a/src/OpenLoco/src/Graphics/Gfx.cpp
+++ b/src/OpenLoco/src/Graphics/Gfx.cpp
@@ -399,7 +399,6 @@ namespace OpenLoco::Gfx
             /*.width = */ 200,
             /*.height = */ 200,
             /*.pitch = */ 0,
-            /*.zoom_level = */ 0,
         };
 
         auto& drawingCtx = Gfx::getDrawingEngine().getDrawingContext();
@@ -408,7 +407,7 @@ namespace OpenLoco::Gfx
         // Draw all the images on top of the one bitmap
         for (size_t i = 0; i < numImages; ++i)
         {
-            drawingCtx.drawImage({ 0, 0 }, baseImageId.withIndexOffset(static_cast<int32_t>(i)));
+            drawingCtx.drawImage(ZoomLevel::full, { 0, 0 }, baseImageId.withIndexOffset(static_cast<int32_t>(i)));
         }
 
         drawingCtx.popRenderTarget();

--- a/src/OpenLoco/src/Graphics/RenderTarget.cpp
+++ b/src/OpenLoco/src/Graphics/RenderTarget.cpp
@@ -13,11 +13,11 @@ namespace OpenLoco::Gfx
         const Ui::Rect oldRect = src.getUiRect();
         Ui::Rect intersect = oldRect.intersection(newRect);
         const auto stride = oldRect.size.width + src.pitch;
-        const int16_t newPitch = stride - intersect.size.width;
+        const auto newPitch = stride - intersect.size.width;
         auto* newBits = src.bits + (stride * (intersect.origin.y - oldRect.origin.y) + (intersect.origin.x - oldRect.origin.x));
         intersect.origin.x = std::max(0, oldRect.origin.x - newRect.origin.x);
         intersect.origin.y = std::max(0, oldRect.origin.y - newRect.origin.y);
-        RenderTarget newRT{ newBits, static_cast<int16_t>(intersect.origin.x), static_cast<int16_t>(intersect.origin.y), static_cast<int16_t>(intersect.size.width), static_cast<int16_t>(intersect.size.height), newPitch };
+        RenderTarget newRT{ newBits, intersect.origin.x, intersect.origin.y, intersect.size.width, intersect.size.height, newPitch };
 
         if (newRT.width <= 0 || newRT.height <= 0)
         {

--- a/src/OpenLoco/src/Graphics/RenderTarget.cpp
+++ b/src/OpenLoco/src/Graphics/RenderTarget.cpp
@@ -2,16 +2,6 @@
 
 namespace OpenLoco::Gfx
 {
-    Ui::Rect RenderTarget::getDrawableRect() const
-    {
-        auto zoom = zoomLevel;
-        auto left = x >> zoom;
-        auto top = y >> zoom;
-        auto right = (width >> zoom) + left;
-        auto bottom = (height >> zoom) + top;
-        return Ui::Rect::fromLTRB(left, top, right, bottom);
-    }
-
     Ui::Rect RenderTarget::getUiRect() const
     {
         return Ui::Rect::fromLTRB(x, y, x + width, y + height);
@@ -27,7 +17,7 @@ namespace OpenLoco::Gfx
         auto* newBits = src.bits + (stride * (intersect.origin.y - oldRect.origin.y) + (intersect.origin.x - oldRect.origin.x));
         intersect.origin.x = std::max(0, oldRect.origin.x - newRect.origin.x);
         intersect.origin.y = std::max(0, oldRect.origin.y - newRect.origin.y);
-        RenderTarget newRT{ newBits, static_cast<int16_t>(intersect.origin.x), static_cast<int16_t>(intersect.origin.y), static_cast<int16_t>(intersect.size.width), static_cast<int16_t>(intersect.size.height), newPitch, 0 };
+        RenderTarget newRT{ newBits, static_cast<int16_t>(intersect.origin.x), static_cast<int16_t>(intersect.origin.y), static_cast<int16_t>(intersect.size.width), static_cast<int16_t>(intersect.size.height), newPitch };
 
         if (newRT.width <= 0 || newRT.height <= 0)
         {

--- a/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
@@ -41,7 +41,7 @@ namespace OpenLoco::Gfx
             ImageIds::noise_mask_7,
         };
 
-        static void drawRect(const RenderTarget& rt, int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint8_t colour, RectFlags flags);
+        static void drawRect(const RenderTarget& rt, int32_t x, int32_t y, int32_t dx, int32_t dy, uint8_t colour, RectFlags flags);
         static void drawImageSolid(const RenderTarget& rt, const Ui::Point& pos, const ImageId& image, PaletteIndex_t paletteIndex);
 
         // 0x00447485
@@ -683,7 +683,7 @@ namespace OpenLoco::Gfx
         // dx: bottom
         // ebp: colour | enumValue(flags)
         // edi: rt
-        static void drawRectImpl(const RenderTarget& rt, int16_t left, int16_t top, int16_t right, int16_t bottom, uint8_t colour, RectFlags flags)
+        static void drawRectImpl(const RenderTarget& rt, int32_t left, int32_t top, int32_t right, int32_t bottom, uint8_t colour, RectFlags flags)
         {
             if (left > right)
             {
@@ -811,18 +811,18 @@ namespace OpenLoco::Gfx
             drawRectImpl(rt, rect.left(), rect.top(), rect.right(), rect.bottom(), colour, flags);
         }
 
-        static void fillRect(const RenderTarget& rt, int16_t left, int16_t top, int16_t right, int16_t bottom, uint8_t colour, RectFlags flags)
+        static void fillRect(const RenderTarget& rt, int32_t left, int32_t top, int32_t right, int32_t bottom, uint8_t colour, RectFlags flags)
         {
             drawRectImpl(rt, left, top, right, bottom, colour, flags);
         }
 
-        static void drawRect(const RenderTarget& rt, int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint8_t colour, RectFlags flags)
+        static void drawRect(const RenderTarget& rt, int32_t x, int32_t y, int32_t dx, int32_t dy, uint8_t colour, RectFlags flags)
         {
             // This makes the function signature more like a drawing application
             drawRectImpl(rt, x, y, x + dx - 1, y + dy - 1, colour, flags);
         }
 
-        static void fillRectInset(const RenderTarget& rt, int16_t left, int16_t top, int16_t right, int16_t bottom, AdvancedColour colour, RectInsetFlags flags)
+        static void fillRectInset(const RenderTarget& rt, int32_t left, int32_t top, int32_t right, int32_t bottom, AdvancedColour colour, RectInsetFlags flags)
         {
             const auto rect = Ui::Rect::fromLTRB(left, top, right, bottom);
             const auto baseColour = static_cast<Colour>(colour);
@@ -927,7 +927,7 @@ namespace OpenLoco::Gfx
             }
         }
 
-        static void drawRectInset(const RenderTarget& rt, int16_t x, int16_t y, uint16_t dx, uint16_t dy, AdvancedColour colour, RectInsetFlags flags)
+        static void drawRectInset(const RenderTarget& rt, int32_t x, int32_t y, int32_t dx, int32_t dy, AdvancedColour colour, RectInsetFlags flags)
         {
             // This makes the function signature more like a drawing application
             fillRectInset(rt, x, y, x + dx - 1, y + dy - 1, colour, flags);
@@ -1132,25 +1132,25 @@ namespace OpenLoco::Gfx
         return Impl::clearSingle(rt, paletteId);
     }
 
-    void SoftwareDrawingContext::fillRect(int16_t left, int16_t top, int16_t right, int16_t bottom, uint8_t colour, RectFlags flags)
+    void SoftwareDrawingContext::fillRect(int32_t left, int32_t top, int32_t right, int32_t bottom, uint8_t colour, RectFlags flags)
     {
         auto& rt = currentRenderTarget();
         return Impl::fillRect(rt, left, top, right, bottom, colour, flags);
     }
 
-    void SoftwareDrawingContext::drawRect(int16_t x, int16_t y, uint16_t dx, uint16_t dy, uint8_t colour, RectFlags flags)
+    void SoftwareDrawingContext::drawRect(int32_t x, int32_t y, int32_t dx, int32_t dy, uint8_t colour, RectFlags flags)
     {
         auto& rt = currentRenderTarget();
         return Impl::drawRect(rt, x, y, dx, dy, colour, flags);
     }
 
-    void SoftwareDrawingContext::fillRectInset(int16_t left, int16_t top, int16_t right, int16_t bottom, AdvancedColour colour, RectInsetFlags flags)
+    void SoftwareDrawingContext::fillRectInset(int32_t left, int32_t top, int32_t right, int32_t bottom, AdvancedColour colour, RectInsetFlags flags)
     {
         auto& rt = currentRenderTarget();
         return Impl::fillRectInset(rt, left, top, right, bottom, colour, flags);
     }
 
-    void SoftwareDrawingContext::drawRectInset(int16_t x, int16_t y, uint16_t dx, uint16_t dy, AdvancedColour colour, RectInsetFlags flags)
+    void SoftwareDrawingContext::drawRectInset(int32_t x, int32_t y, int32_t dx, int32_t dy, AdvancedColour colour, RectInsetFlags flags)
     {
         auto& rt = currentRenderTarget();
         return Impl::drawRectInset(rt, x, y, dx, dy, colour, flags);

--- a/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
@@ -287,14 +287,14 @@ namespace OpenLoco::Gfx
             {
                 const auto zoomCoords = Ui::Point(pos.x >> 1, pos.y >> 1);
                 drawImagePaletteSet(
-                    rt, static_cast<uint8_t>(zoom - 1), zoomCoords, image.withIndexOffset(-element->zoomOffset), palette, noiseImage);
+                    rt, zoom - 1, zoomCoords, image.withIndexOffset(-element->zoomOffset), palette, noiseImage);
                 return;
             }
 
             const bool isRLE = element->hasFlags(G1ElementFlags::isRLECompressed);
             if (isRLE)
             {
-                switch (zoom)
+                switch (static_cast<int8_t>(zoom))
                 {
                     default:
                         drawImagePaletteSet<0, true>(rt, pos, image, *element, palette, noiseImage);
@@ -312,7 +312,7 @@ namespace OpenLoco::Gfx
             }
             else
             {
-                switch (zoom)
+                switch (static_cast<int8_t>(zoom))
                 {
                     default:
                         drawImagePaletteSet<0, false>(rt, pos, image, *element, palette, noiseImage);
@@ -461,7 +461,7 @@ namespace OpenLoco::Gfx
                     {
                         drawImageMaskedZoom<TZoomLevel - 1>(
                             rt,
-                            static_cast<uint8_t>(zoom - 1),
+                            zoom - 1,
                             { static_cast<int16_t>(pos.x >> 1), static_cast<int16_t>(pos.y >> 1) },
                             image.withIndexOffset(-g1Image->zoomOffset),
                             maskImage.withIndexOffset(-g1ImageMask->zoomOffset));
@@ -643,7 +643,7 @@ namespace OpenLoco::Gfx
                 return;
             }
 
-            switch (zoom)
+            switch (static_cast<int8_t>(zoom))
             {
                 case 0:
                     drawImageMaskedZoom<0>(rt, zoom, pos, image, maskImage);

--- a/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
@@ -49,8 +49,8 @@ namespace OpenLoco::Gfx
         // ebp: fill
         static void clear(const RenderTarget& rt, uint32_t fill)
         {
-            int32_t w = rt.width / (1 << rt.zoomLevel);
-            int32_t h = rt.height / (1 << rt.zoomLevel);
+            int32_t w = rt.width;
+            int32_t h = rt.height;
             uint8_t* ptr = rt.bits;
 
             for (int32_t y = 0; y < h; y++)
@@ -95,6 +95,11 @@ namespace OpenLoco::Gfx
                 }
             }
 
+            const int32_t rtWorldX = (static_cast<int32_t>(rt.x) << TZoomLevel);
+            const int32_t rtWorldY = (static_cast<int32_t>(rt.y) << TZoomLevel);
+            const int32_t rtWorldWidth = static_cast<int32_t>(rt.width) << TZoomLevel;
+            const int32_t rtWorldHeight = static_cast<int32_t>(rt.height) << TZoomLevel;
+
             auto dispPos{ pos };
             // Its used super often so we will define it to a separate variable.
             constexpr auto zoomMask = static_cast<uint32_t>(0xFFFFFFFFULL << TZoomLevel);
@@ -115,11 +120,11 @@ namespace OpenLoco::Gfx
             // the zoom mask on the y coordinate but does on x.
             if constexpr (TIsRLE)
             {
-                dstTop -= rt.y;
+                dstTop -= rtWorldY;
             }
             else
             {
-                dstTop = (dstTop & zoomMask) - rt.y;
+                dstTop = (dstTop & zoomMask) - rtWorldY;
             }
             // This is the start y coordinate on the source
             auto srcY = 0;
@@ -150,11 +155,11 @@ namespace OpenLoco::Gfx
 
             auto dstBottom = dstTop + height;
 
-            if (dstBottom > rt.height)
+            if (dstBottom > rtWorldHeight)
             {
                 // If the destination y is outside of the drawing
                 // image reduce the height of the image
-                height -= dstBottom - rt.height;
+                height -= dstBottom - rtWorldHeight;
             }
             // If the image no longer has anything to draw
             if (height <= 0)
@@ -170,7 +175,7 @@ namespace OpenLoco::Gfx
             // This is the source start x coordinate
             auto srcX = 0;
             // This is the destination start x coordinate
-            int32_t dstLeft = ((dispPos.x + element.xOffset + ~zoomMask) & zoomMask) - rt.x;
+            int32_t dstLeft = ((dispPos.x + element.xOffset + ~zoomMask) & zoomMask) - rtWorldX;
 
             if (dstLeft < 0)
             {
@@ -197,11 +202,11 @@ namespace OpenLoco::Gfx
 
             const auto dstRight = dstLeft + width;
 
-            if (dstRight > rt.width)
+            if (dstRight > rtWorldWidth)
             {
                 // If the destination x is outside of the drawing area
                 // reduce the image width.
-                width -= dstRight - rt.width;
+                width -= dstRight - rtWorldWidth;
                 // If there is no image to draw.
                 if (width <= 0)
                 {
@@ -227,7 +232,7 @@ namespace OpenLoco::Gfx
         }
 
         // 0x00448D90
-        static void drawImagePaletteSet(const RenderTarget& rt, const Ui::Point& pos, const ImageId& image, const PaletteMap::View palette, const G1Element* noiseImage)
+        static void drawImagePaletteSet(const RenderTarget& rt, ZoomLevel zoom, const Ui::Point& pos, const ImageId& image, const PaletteMap::View palette, const G1Element* noiseImage)
         {
             const auto* element = getG1Element(image.getIndex());
             if (element == nullptr)
@@ -235,27 +240,18 @@ namespace OpenLoco::Gfx
                 return;
             }
 
-            if (rt.zoomLevel > 0 && (element->hasFlags(G1ElementFlags::hasZoomSprites)))
+            if (zoom > 0 && (element->hasFlags(G1ElementFlags::hasZoomSprites)))
             {
-                auto zoomedrt{ rt };
-                zoomedrt.bits = rt.bits;
-                zoomedrt.x = rt.x >> 1;
-                zoomedrt.y = rt.y >> 1;
-                zoomedrt.height = rt.height >> 1;
-                zoomedrt.width = rt.width >> 1;
-                zoomedrt.pitch = rt.pitch;
-                zoomedrt.zoomLevel = rt.zoomLevel - 1;
-
                 const auto zoomCoords = Ui::Point(pos.x >> 1, pos.y >> 1);
                 drawImagePaletteSet(
-                    zoomedrt, zoomCoords, image.withIndexOffset(-element->zoomOffset), palette, noiseImage);
+                    rt, static_cast<uint8_t>(zoom - 1), zoomCoords, image.withIndexOffset(-element->zoomOffset), palette, noiseImage);
                 return;
             }
 
             const bool isRLE = element->hasFlags(G1ElementFlags::isRLECompressed);
             if (isRLE)
             {
-                switch (rt.zoomLevel)
+                switch (zoom)
                 {
                     default:
                         drawImagePaletteSet<0, true>(rt, pos, image, *element, palette, noiseImage);
@@ -273,7 +269,7 @@ namespace OpenLoco::Gfx
             }
             else
             {
-                switch (rt.zoomLevel)
+                switch (zoom)
                 {
                     default:
                         drawImagePaletteSet<0, false>(rt, pos, image, *element, palette, noiseImage);
@@ -292,25 +288,19 @@ namespace OpenLoco::Gfx
         }
 
         // 0x00448C79
-        static void drawImage(const RenderTarget& rt, const Ui::Point& pos, const ImageId& image)
+        static void drawImage(const RenderTarget& rt, ZoomLevel zoom, const Ui::Point& pos, const ImageId& image)
         {
             const auto* noiseImage = getNoiseMaskImageFromImage(image);
             const auto palette = PaletteMap::getForImage(image);
 
             if (!palette.has_value())
             {
-                drawImagePaletteSet(rt, pos, image, PaletteMap::getDefault(), noiseImage);
+                drawImagePaletteSet(rt, zoom, pos, image, PaletteMap::getDefault(), noiseImage);
             }
             else
             {
-                drawImagePaletteSet(rt, pos, image, *palette, noiseImage);
+                drawImagePaletteSet(rt, zoom, pos, image, *palette, noiseImage);
             }
-        }
-
-        // 0x00448C79
-        static void drawImage(const RenderTarget* rt, int16_t x, int16_t y, uint32_t image)
-        {
-            drawImage(*rt, { x, y }, ImageId::fromUInt32(image));
         }
 
         // 0x00450890, 0x00450F87, 0x00450D1E, 0x00450ABA
@@ -382,7 +372,7 @@ namespace OpenLoco::Gfx
         }
 
         template<int32_t TZoomLevel>
-        static void drawImageMaskedZoom(const RenderTarget& rt, const Ui::Point& pos, const ImageId& image, const ImageId& maskImage)
+        static void drawImageMaskedZoom(const RenderTarget& rt, ZoomLevel zoom, const Ui::Point& pos, const ImageId& image, const ImageId& maskImage)
         {
             const auto* g1Image = Gfx::getG1Element(image.getIndex());
             if (g1Image == nullptr)
@@ -426,14 +416,9 @@ namespace OpenLoco::Gfx
 
                     if (g1ImageMask->hasFlags(G1ElementFlags::hasZoomSprites))
                     {
-                        auto newRt = rt;
-                        --newRt.zoomLevel;
-                        newRt.x >>= 1;
-                        newRt.y >>= 1;
-                        newRt.width >>= 1;
-                        newRt.height >>= 1;
                         drawImageMaskedZoom<TZoomLevel - 1>(
-                            newRt,
+                            rt,
+                            static_cast<uint8_t>(zoom - 1),
                             { static_cast<int16_t>(pos.x >> 1), static_cast<int16_t>(pos.y >> 1) },
                             image.withIndexOffset(-g1Image->zoomOffset),
                             maskImage.withIndexOffset(-g1ImageMask->zoomOffset));
@@ -451,11 +436,15 @@ namespace OpenLoco::Gfx
             constexpr uint16_t zoomMask = static_cast<uint16_t>(~0ULL << TZoomLevel);
             constexpr int16_t offsetX = (1 << TZoomLevel) - 1;
 
-            int16_t dstTop = ((g1Image->yOffset + pos.y) & zoomMask) - rt.y;
+            const int32_t rtWorldX = (static_cast<int32_t>(rt.x) << TZoomLevel);
+            const int32_t rtWorldY = (static_cast<int32_t>(rt.y) << TZoomLevel);
+            const int32_t rtWorldWidth = static_cast<int32_t>(rt.width) << TZoomLevel;
+            const int32_t rtWorldHeight = static_cast<int32_t>(rt.height) << TZoomLevel;
+
+            int16_t dstTop = ((g1Image->yOffset + pos.y) & zoomMask) - rtWorldY;
             if (dstTop >= 0)
             {
-                auto scaledWidth = rt.width >> TZoomLevel;
-                scaledWidth = rt.pitch + scaledWidth;
+                const auto scaledWidth = rt.pitch + rt.width;
                 dstBuf += (dstTop >> TZoomLevel) * scaledWidth;
             }
             else
@@ -479,9 +468,9 @@ namespace OpenLoco::Gfx
             }
 
             int16_t dstBottom = imageHeight + dstTop;
-            if (dstBottom > rt.height)
+            if (dstBottom > rtWorldHeight)
             {
-                imageHeight -= dstBottom - rt.height;
+                imageHeight -= dstBottom - rtWorldHeight;
 
                 if (imageHeight <= 0)
                 {
@@ -490,14 +479,14 @@ namespace OpenLoco::Gfx
             }
 
             int16_t rowSize = 0;
-            int16_t dstWrap = rt.pitch + (rt.width >> TZoomLevel);
+            int16_t dstWrap = rt.pitch + rt.width;
 
             if constexpr (TZoomLevel == 0)
             {
                 dstWrap -= g1Image->width;
             }
 
-            int16_t dstLeft = ((g1Image->xOffset + pos.x + offsetX) & zoomMask) - rt.x;
+            int16_t dstLeft = ((g1Image->xOffset + pos.x + offsetX) & zoomMask) - rtWorldX;
             if (dstLeft < 0)
             {
                 imageWidth += dstLeft;
@@ -517,8 +506,8 @@ namespace OpenLoco::Gfx
                 dstLeft = 0;
             }
 
-            int16_t dstRight = imageWidth + dstLeft - rt.width;
-            if (imageWidth + dstLeft > rt.width)
+            int16_t dstRight = imageWidth + dstLeft - rtWorldWidth;
+            if (imageWidth + dstLeft > rtWorldWidth)
             {
                 imageWidth -= dstRight;
                 if (imageWidth <= 0)
@@ -548,21 +537,21 @@ namespace OpenLoco::Gfx
         }
 
         // 0x00450705
-        static void drawImageMasked(const RenderTarget& rt, const Ui::Point& pos, const ImageId& image, const ImageId& maskImage)
+        static void drawImageMasked(const RenderTarget& rt, ZoomLevel zoom, const Ui::Point& pos, const ImageId& image, const ImageId& maskImage)
         {
-            switch (rt.zoomLevel)
+            switch (zoom)
             {
                 case 0:
-                    drawImageMaskedZoom<0>(rt, pos, image, maskImage);
+                    drawImageMaskedZoom<0>(rt, zoom, pos, image, maskImage);
                     return;
                 case 1:
-                    drawImageMaskedZoom<1>(rt, pos, image, maskImage);
+                    drawImageMaskedZoom<1>(rt, zoom, pos, image, maskImage);
                     return;
                 case 2:
-                    drawImageMaskedZoom<2>(rt, pos, image, maskImage);
+                    drawImageMaskedZoom<2>(rt, zoom, pos, image, maskImage);
                     return;
                 case 3:
-                    drawImageMaskedZoom<3>(rt, pos, image, maskImage);
+                    drawImageMaskedZoom<3>(rt, zoom, pos, image, maskImage);
                     return;
                 default:
                     break;
@@ -579,7 +568,7 @@ namespace OpenLoco::Gfx
             palette[0] = 0;
 
             // Set the image primary flag to tell drawImagePaletteSet to recolour with the palette (Colour::black is not actually used)
-            drawImagePaletteSet(rt, pos, image.withPrimary(Colour::black), PaletteMap::View{ palette }, {});
+            drawImagePaletteSet(rt, ZoomLevel::full, pos, image.withPrimary(Colour::black), PaletteMap::View{ palette }, {});
         }
 
         // 0x004474BA
@@ -661,21 +650,19 @@ namespace OpenLoco::Gfx
             else if ((flags & RectFlags::transparent) != RectFlags::none)
             {
                 auto* dst = rt.bits
-                    + static_cast<uint32_t>((drawRect.top() >> rt.zoomLevel) * ((rt.width >> rt.zoomLevel) + rt.pitch) + (drawRect.left() >> rt.zoomLevel));
+                    + static_cast<uint32_t>(drawRect.top() * (rt.width + rt.pitch) + drawRect.left());
 
                 auto paletteMap = PaletteMap::getForColour(static_cast<ExtColour>(colour));
                 if (paletteMap.has_value())
                 {
                     const auto& paletteEntries = paletteMap.value();
-                    const auto scaledWidth = drawRect.width() >> rt.zoomLevel;
-                    const auto scaledHeight = drawRect.height() >> rt.zoomLevel;
-                    const auto step = (rt.width >> rt.zoomLevel) + rt.pitch;
+                    const auto step = rt.width + rt.pitch;
 
                     // Fill the rectangle with the colours from the colour table
-                    for (auto y = 0; y < scaledHeight; y++)
+                    for (auto y = 0; y < drawRect.height(); y++)
                     {
                         auto* nextDst = dst + step * y;
-                        for (auto x = 0; x < scaledWidth; x++)
+                        for (auto x = 0; x < drawRect.width(); x++)
                         {
                             auto index = *(nextDst + x);
                             *(nextDst + x) = paletteEntries[index];
@@ -1077,22 +1064,16 @@ namespace OpenLoco::Gfx
         return Impl::drawCircle(rt, centre, radius, lineWidth, colour);
     }
 
-    void SoftwareDrawingContext::drawImage(int16_t x, int16_t y, uint32_t image)
+    void SoftwareDrawingContext::drawImage(ZoomLevel zoom, const Ui::Point& worldPos, const ImageId& image)
     {
         auto& rt = currentRenderTarget();
-        return Impl::drawImage(&rt, x, y, image);
+        return Impl::drawImage(rt, zoom, worldPos, image);
     }
 
-    void SoftwareDrawingContext::drawImage(const Ui::Point& pos, const ImageId& image)
+    void SoftwareDrawingContext::drawImageMasked(ZoomLevel zoom, const Ui::Point& worldPos, const ImageId& image, const ImageId& maskImage)
     {
         auto& rt = currentRenderTarget();
-        return Impl::drawImage(rt, pos, image);
-    }
-
-    void SoftwareDrawingContext::drawImageMasked(const Ui::Point& pos, const ImageId& image, const ImageId& maskImage)
-    {
-        auto& rt = currentRenderTarget();
-        return Impl::drawImageMasked(rt, pos, image, maskImage);
+        return Impl::drawImageMasked(rt, zoom, worldPos, image, maskImage);
     }
 
     void SoftwareDrawingContext::drawImageSolid(const Ui::Point& pos, const ImageId& image, PaletteIndex_t paletteIndex)
@@ -1104,7 +1085,7 @@ namespace OpenLoco::Gfx
     void SoftwareDrawingContext::drawImagePaletteSet(const Ui::Point& pos, const ImageId& image, PaletteMap::View palette, const G1Element* noiseImage)
     {
         auto& rt = currentRenderTarget();
-        return Impl::drawImagePaletteSet(rt, pos, image, palette, noiseImage);
+        return Impl::drawImagePaletteSet(rt, ZoomLevel::full, pos, image, palette, noiseImage);
     }
 
     void SoftwareDrawingContext::pushRenderTarget(const RenderTarget& rt)

--- a/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingContext.cpp
@@ -231,12 +231,55 @@ namespace OpenLoco::Gfx
             }
         }
 
+        static void drawImageMagnify(const RenderTarget& rt, ZoomLevel zoom, const Ui::Point& pos, const ImageId& image, const G1Element& element, const PaletteMap::View palette, const G1Element* noiseImage)
+        {
+            const auto left = zoom.applyInversedTo(pos.x + element.xOffset);
+            const auto top = zoom.applyInversedTo(pos.y + element.yOffset);
+            const auto right = zoom.applyInversedTo(pos.x + element.xOffset + element.width);
+            const auto bottom = zoom.applyInversedTo(pos.y + element.yOffset + element.height);
+
+            const auto width = std::min<int32_t>(right, rt.x + rt.width) - std::max<int32_t>(left, rt.x);
+            const auto height = std::min<int32_t>(bottom, rt.y + rt.height) - std::max<int32_t>(top, rt.y);
+            if (width <= 0 || height <= 0)
+            {
+                return;
+            }
+
+            const auto offsetX = rt.x - left;
+            const auto offsetY = rt.y - top;
+
+            const DrawSpriteArgs args{
+                palette,
+                element,
+                Ui::Point{ std::max(0, offsetX), std::max(0, offsetY) },
+                Ui::Point{ std::max(0, -offsetX), std::max(0, -offsetY) },
+                Ui::Size(width, height),
+                noiseImage
+            };
+            const auto op = getDrawBlendOp(image, args);
+
+            if (element.hasFlags(G1ElementFlags::isRLECompressed))
+            {
+                drawSpriteToBufferMagnify<true>(rt, zoom, args, op);
+            }
+            else
+            {
+                drawSpriteToBufferMagnify<false>(rt, zoom, args, op);
+            }
+        }
+
         // 0x00448D90
         static void drawImagePaletteSet(const RenderTarget& rt, ZoomLevel zoom, const Ui::Point& pos, const ImageId& image, const PaletteMap::View palette, const G1Element* noiseImage)
         {
             const auto* element = getG1Element(image.getIndex());
             if (element == nullptr)
             {
+                return;
+            }
+
+            if (zoom < ZoomLevel::full)
+            {
+                drawImageMagnify(rt, zoom, pos, image, *element, palette, noiseImage);
                 return;
             }
 
@@ -536,9 +579,70 @@ namespace OpenLoco::Gfx
                 imageDataPos);
         }
 
+        static void drawImageMaskedMagnify(const RenderTarget& rt, ZoomLevel zoom, const Ui::Point& pos, const ImageId& image, const ImageId& maskImage)
+        {
+            const auto* g1Image = Gfx::getG1Element(image.getIndex());
+            const auto* g1ImageMask = Gfx::getG1Element(maskImage.getIndex());
+            if (g1Image == nullptr || g1ImageMask == nullptr)
+            {
+                return;
+            }
+            if (g1Image->hasFlags(G1ElementFlags::isRLECompressed) || g1ImageMask->hasFlags(G1ElementFlags::isRLECompressed))
+            {
+                assert(false);
+
+                return;
+            }
+
+            const auto left = zoom.applyInversedTo(pos.x + g1Image->xOffset);
+            const auto top = zoom.applyInversedTo(pos.y + g1Image->yOffset);
+            const auto right = zoom.applyInversedTo(pos.x + g1Image->xOffset + g1Image->width);
+            const auto bottom = zoom.applyInversedTo(pos.y + g1Image->yOffset + g1Image->height);
+
+            const auto width = std::min<int32_t>(right, rt.x + rt.width) - std::max<int32_t>(left, rt.x);
+            const auto height = std::min<int32_t>(bottom, rt.y + rt.height) - std::max<int32_t>(top, rt.y);
+            if (width <= 0 || height <= 0)
+            {
+                return;
+            }
+
+            const auto offsetX = rt.x - left;
+            const auto offsetY = rt.y - top;
+            const auto srcX = std::max(0, offsetX);
+            const auto srcY = std::max(0, offsetY);
+
+            const auto dstLineWidth = static_cast<size_t>(rt.width) + rt.pitch;
+            auto* dst = rt.bits + dstLineWidth * std::max(0, -offsetY) + std::max(0, -offsetX);
+
+            for (auto y = 0; y < height; y++)
+            {
+                auto* nextDst = dst + dstLineWidth;
+                const auto imageY = zoom.applyTo(srcY + y);
+                const auto* imageLine = &g1Image->offset[static_cast<size_t>(g1Image->width) * imageY];
+                const auto* maskLine = &g1ImageMask->offset[static_cast<size_t>(g1ImageMask->width) * imageY];
+
+                for (auto x = 0; x < width; x++, dst++)
+                {
+                    const auto imageX = zoom.applyTo(srcX + x);
+                    const auto masked = imageLine[imageX] & maskLine[imageX];
+                    if (masked)
+                    {
+                        *dst = masked;
+                    }
+                }
+                dst = nextDst;
+            }
+        }
+
         // 0x00450705
         static void drawImageMasked(const RenderTarget& rt, ZoomLevel zoom, const Ui::Point& pos, const ImageId& image, const ImageId& maskImage)
         {
+            if (zoom < ZoomLevel::full)
+            {
+                drawImageMaskedMagnify(rt, zoom, pos, image, maskImage);
+                return;
+            }
+
             switch (zoom)
             {
                 case 0:

--- a/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.cpp
@@ -279,7 +279,6 @@ namespace OpenLoco::Gfx
         rt.y = rect.top();
         rt.bits = _screenRT.bits + rect.left() + ((_screenRT.width + _screenRT.pitch) * rect.top());
         rt.pitch = _screenRT.width + _screenRT.pitch - rect.width();
-        rt.zoomLevel = 0;
 
         // Set the render target to the screen rt.
         _ctx.pushRenderTarget(rt);

--- a/src/OpenLoco/src/Graphics/TextRenderer.cpp
+++ b/src/OpenLoco/src/Graphics/TextRenderer.cpp
@@ -199,7 +199,7 @@ namespace OpenLoco::Gfx
                         }
                         else
                         {
-                            ctx.drawImage(pos.x, pos.y, image);
+                            ctx.drawImage(ZoomLevel::full, pos.x, pos.y, image);
                         }
 
                         pos.x += getG1Element(imageId.getIndex())->width;
@@ -1148,7 +1148,7 @@ namespace OpenLoco::Gfx
                         ImageId imageId{ image & 0x7FFFF };
                         str += 4;
 
-                        ctx.drawImage(pos.x, pos.y, image);
+                        ctx.drawImage(ZoomLevel::full, pos.x, pos.y, image);
 
                         // For some reason the wrapStringTicker doesn't do this??
                         numChars--;

--- a/src/OpenLoco/src/Gui.cpp
+++ b/src/OpenLoco/src/Gui.cpp
@@ -66,8 +66,8 @@ namespace OpenLoco::Gui
             {
                 window->viewports[0]->width = uiWidth;
                 window->viewports[0]->height = uiHeight;
-                window->viewports[0]->viewWidth = uiWidth << window->viewports[0]->zoom;
-                window->viewports[0]->viewHeight = uiHeight << window->viewports[0]->zoom;
+                window->viewports[0]->viewWidth = window->viewports[0]->zoom.applyTo(uiWidth);
+                window->viewports[0]->viewHeight = window->viewports[0]->zoom.applyTo(uiHeight);
             }
         }
 

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -488,8 +488,8 @@ namespace OpenLoco::Input
             return;
         }
 
-        delta.x *= 1 << viewport->zoom;
-        delta.y *= 1 << viewport->zoom;
+        delta.x = viewport->zoom.applyTo(delta.x);
+        delta.y = viewport->zoom.applyTo(delta.y);
         main->viewportConfigurations[0].savedViewX += delta.x;
         main->viewportConfigurations[0].savedViewY += delta.y;
         Input::setFlag(Flags::viewportScrolling);
@@ -556,8 +556,8 @@ namespace OpenLoco::Input
             return;
         }
 
-        delta.x *= 1 << viewport->zoom;
-        delta.y *= 1 << viewport->zoom;
+        delta.x = viewport->zoom.applyTo(delta.x);
+        delta.y = viewport->zoom.applyTo(delta.y);
         main->viewportConfigurations[0].savedViewX += delta.x;
         main->viewportConfigurations[0].savedViewY += delta.y;
         Input::setFlag(Flags::viewportScrolling);

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -599,7 +599,7 @@ namespace OpenLoco::Input
                     }
                     else
                     {
-                        const auto panZoom = ZoomLevel{ static_cast<int8_t>(vp->zoom + 1) };
+                        const auto panZoom = vp->zoom + 1;
                         const auto offsetX = -panZoom.applyTo(-std::abs(dragOffset.x)) * (dragOffset.x < 0 ? -1 : 1);
                         const auto offsetY = -panZoom.applyTo(-std::abs(dragOffset.y)) * (dragOffset.y < 0 ? -1 : 1);
 

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -599,8 +599,9 @@ namespace OpenLoco::Input
                     }
                     else
                     {
-                        const auto offsetX = dragOffset.x << (vp->zoom + 1);
-                        const auto offsetY = dragOffset.y << (vp->zoom + 1);
+                        const auto panZoom = ZoomLevel{ static_cast<int8_t>(vp->zoom + 1) };
+                        const auto offsetX = -panZoom.applyTo(-std::abs(dragOffset.x)) * (dragOffset.x < 0 ? -1 : 1);
+                        const auto offsetY = -panZoom.applyTo(-std::abs(dragOffset.y)) * (dragOffset.y < 0 ? -1 : 1);
 
                         const auto invert = Config::get().invertRightMouseViewPan ? -1 : 1;
 

--- a/src/OpenLoco/src/Intro.cpp
+++ b/src/OpenLoco/src/Intro.cpp
@@ -71,8 +71,8 @@ namespace OpenLoco::Intro
         drawingCtx.clearSingle(PaletteIndex::mutedDarkRed5); // this isn't actually mutedDarkRed5 as the atari palette is different
 
         const auto pos = Ui::Point(Ui::width() / 2 - 216, Ui::height() / 2 - 54);
-        drawingCtx.drawImage(pos, ImageId(ImageIds::atari_logo_intro_left));
-        drawingCtx.drawImage(pos + Ui::Point(216, 0), ImageId(ImageIds::atari_logo_intro_right));
+        drawingCtx.drawImage(ZoomLevel::full, pos, ImageId(ImageIds::atari_logo_intro_left));
+        drawingCtx.drawImage(ZoomLevel::full, pos + Ui::Point(216, 0), ImageId(ImageIds::atari_logo_intro_right));
         _introTicks = -24;
         _state = State::displayAtari;
     }
@@ -100,8 +100,8 @@ namespace OpenLoco::Intro
             drawingCtx.clearSingle(PaletteIndex::black0);
 
             const auto pos = Ui::Point(Ui::width() / 2 - 320 + 70, Ui::height() / 2 - 58);
-            drawingCtx.drawImage(pos, ImageId(ImageIds::chris_sawyer_logo_intro_left));
-            drawingCtx.drawImage(pos + Ui::Point(250, 0), ImageId(ImageIds::chris_sawyer_logo_intro_right));
+            drawingCtx.drawImage(ZoomLevel::full, pos, ImageId(ImageIds::chris_sawyer_logo_intro_left));
+            drawingCtx.drawImage(ZoomLevel::full, pos + Ui::Point(250, 0), ImageId(ImageIds::chris_sawyer_logo_intro_right));
 
             _introTicks = 0;
             _state = State::displayCS;

--- a/src/OpenLoco/src/Objects/AirportObject.cpp
+++ b/src/OpenLoco/src/Objects/AirportObject.cpp
@@ -12,7 +12,7 @@ namespace OpenLoco
     void AirportObject::drawPreviewImage(Gfx::DrawingContext& drawingCtx, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
-        drawingCtx.drawImage(x - 34, y - 34, colourImage);
+        drawingCtx.drawImage(ZoomLevel::full, x - 34, y - 34, colourImage);
     }
 
     // 0x00490DE7

--- a/src/OpenLoco/src/Objects/BridgeObject.cpp
+++ b/src/OpenLoco/src/Objects/BridgeObject.cpp
@@ -12,7 +12,7 @@ namespace OpenLoco
     void BridgeObject::drawPreviewImage(Gfx::DrawingContext& drawingCtx, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
-        drawingCtx.drawImage(x - 21, y - 9, colourImage);
+        drawingCtx.drawImage(ZoomLevel::full, x - 21, y - 9, colourImage);
     }
 
     // 0x0042C651

--- a/src/OpenLoco/src/Objects/BuildingObject.cpp
+++ b/src/OpenLoco/src/Objects/BuildingObject.cpp
@@ -28,7 +28,7 @@ namespace OpenLoco
         for (const auto part : getBuildingParts(0))
         {
             auto partImage = baseImage.withIndexOffset(part * 4 + buildingRotation);
-            drawingCtx.drawImage(pos, partImage);
+            drawingCtx.drawImage(ZoomLevel::full, pos, partImage);
             pos.y -= partHeights[part];
         }
     }

--- a/src/OpenLoco/src/Objects/CliffEdgeObject.cpp
+++ b/src/OpenLoco/src/Objects/CliffEdgeObject.cpp
@@ -38,7 +38,7 @@ namespace OpenLoco
     // 0x00469A06
     void CliffEdgeObject::drawPreviewImage(Gfx::DrawingContext& drawingCtx, const int16_t x, const int16_t y) const
     {
-        drawingCtx.drawImage(x - 30, y, image);
-        drawingCtx.drawImage(x - 30, y, image + 16);
+        drawingCtx.drawImage(ZoomLevel::full, x - 30, y, image);
+        drawingCtx.drawImage(ZoomLevel::full, x - 30, y, image + 16);
     }
 }

--- a/src/OpenLoco/src/Objects/CompetitorObject.cpp
+++ b/src/OpenLoco/src/Objects/CompetitorObject.cpp
@@ -20,7 +20,7 @@ namespace OpenLoco
         drawingCtx.drawRect(0, 0, kObjectPreviewSize.width, kObjectPreviewSize.height, Colours::getShade(Colour::mutedSeaGreen, 1), Gfx::RectFlags::none);
 
         auto image = Gfx::recolour(images[0] + 1, Colour::mutedSeaGreen);
-        drawingCtx.drawImage(x - 32, y - 32, image);
+        drawingCtx.drawImage(ZoomLevel::full, x - 32, y - 32, image);
     }
 
     // 0x00434DA7

--- a/src/OpenLoco/src/Objects/DockObject.cpp
+++ b/src/OpenLoco/src/Objects/DockObject.cpp
@@ -12,7 +12,7 @@ namespace OpenLoco
     void DockObject::drawPreviewImage(Gfx::DrawingContext& drawingCtx, const int16_t x, const int16_t y) const
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
-        drawingCtx.drawImage(x - 34, y - 34, colourImage);
+        drawingCtx.drawImage(ZoomLevel::full, x - 34, y - 34, colourImage);
     }
 
     // 0x00490F2C

--- a/src/OpenLoco/src/Objects/HillShapesObject.cpp
+++ b/src/OpenLoco/src/Objects/HillShapesObject.cpp
@@ -13,7 +13,7 @@ namespace OpenLoco
     void HillShapesObject::drawPreviewImage(Gfx::DrawingContext& drawingCtx, const int16_t x, const int16_t y) const
     {
         auto imageId = image + hillHeightMapCount + mountainHeightMapCount;
-        drawingCtx.drawImage(x, y, imageId);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, imageId);
     }
 
     // 0x00463B70

--- a/src/OpenLoco/src/Objects/IndustryObject.cpp
+++ b/src/OpenLoco/src/Objects/IndustryObject.cpp
@@ -112,7 +112,7 @@ namespace OpenLoco
         for (const auto part : getBuildingParts(0))
         {
             auto image = baseImage.withIndexOffset(part * 4 + 1);
-            drawingCtx.drawImage(pos, image);
+            drawingCtx.drawImage(ZoomLevel::full, pos, image);
             pos.y -= partHeights[part];
         }
     }

--- a/src/OpenLoco/src/Objects/InterfaceSkinObject.cpp
+++ b/src/OpenLoco/src/Objects/InterfaceSkinObject.cpp
@@ -30,6 +30,6 @@ namespace OpenLoco
     void InterfaceSkinObject::drawPreviewImage(Gfx::DrawingContext& drawingCtx, const int16_t x, const int16_t y) const
     {
         auto image = Gfx::recolour(img + InterfaceSkin::ImageIds::preview_image, Colour::mutedSeaGreen);
-        drawingCtx.drawImage(x - 32, y - 32, image);
+        drawingCtx.drawImage(ZoomLevel::full, x - 32, y - 32, image);
     }
 }

--- a/src/OpenLoco/src/Objects/LandObject.cpp
+++ b/src/OpenLoco/src/Objects/LandObject.cpp
@@ -103,6 +103,6 @@ namespace OpenLoco
     void LandObject::drawPreviewImage(Gfx::DrawingContext& drawingCtx, const int16_t x, const int16_t y) const
     {
         uint32_t imageId = image + (numGrowthStages - 1) * numImagesPerGrowthStage;
-        drawingCtx.drawImage(x, y, imageId);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, imageId);
     }
 }

--- a/src/OpenLoco/src/Objects/LevelCrossingObject.cpp
+++ b/src/OpenLoco/src/Objects/LevelCrossingObject.cpp
@@ -71,10 +71,10 @@ namespace OpenLoco
         imageId += frameIndex;
         imageId += image;
 
-        drawingCtx.drawImage(x, y, imageId);
-        drawingCtx.drawImage(x, y, imageId + 1);
-        drawingCtx.drawImage(x, y, imageId + 2);
-        drawingCtx.drawImage(x, y, imageId + 3);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, imageId);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, imageId + 1);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, imageId + 2);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, imageId + 3);
     }
 
     // 0x004781A4

--- a/src/OpenLoco/src/Objects/RegionObject.cpp
+++ b/src/OpenLoco/src/Objects/RegionObject.cpp
@@ -10,7 +10,7 @@ namespace OpenLoco
     // 0x0043CB93
     void RegionObject::drawPreviewImage(Gfx::DrawingContext& drawingCtx, const int16_t x, const int16_t y) const
     {
-        drawingCtx.drawImage(x, y, image);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, image);
     }
 
     // 0x0043CA8C

--- a/src/OpenLoco/src/Objects/RoadExtraObject.cpp
+++ b/src/OpenLoco/src/Objects/RoadExtraObject.cpp
@@ -15,11 +15,11 @@ namespace OpenLoco
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
 
-        drawingCtx.drawImage(x, y, colourImage + 36);
-        drawingCtx.drawImage(x, y, colourImage + 37);
-        drawingCtx.drawImage(x, y, colourImage);
-        drawingCtx.drawImage(x, y, colourImage + 33);
-        drawingCtx.drawImage(x, y, colourImage + 32);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage + 36);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage + 37);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage + 33);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage + 32);
     }
 
     // 0x00477E92

--- a/src/OpenLoco/src/Objects/RoadObject.cpp
+++ b/src/OpenLoco/src/Objects/RoadObject.cpp
@@ -14,13 +14,13 @@ namespace OpenLoco
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
         if (paintStyle == 1)
         {
-            drawingCtx.drawImage(x, y, colourImage + 34);
-            drawingCtx.drawImage(x, y, colourImage + 36);
-            drawingCtx.drawImage(x, y, colourImage + 38);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage + 34);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage + 36);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage + 38);
         }
         else
         {
-            drawingCtx.drawImage(x, y, colourImage + 34);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage + 34);
         }
     }
 

--- a/src/OpenLoco/src/Objects/RoadStationObject.cpp
+++ b/src/OpenLoco/src/Objects/RoadStationObject.cpp
@@ -13,7 +13,7 @@ namespace OpenLoco
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
 
-        drawingCtx.drawImage(x - 34, y - 34, colourImage);
+        drawingCtx.drawImage(ZoomLevel::full, x - 34, y - 34, colourImage);
 
         auto colour = ExtColour::translucentMutedDarkRed1;
         if (!hasFlags(RoadStationFlags::recolourable))
@@ -23,7 +23,7 @@ namespace OpenLoco
 
         auto translucentImage = Gfx::recolourTranslucent(image + 1, colour);
 
-        drawingCtx.drawImage(x - 34, y - 34, translucentImage);
+        drawingCtx.drawImage(ZoomLevel::full, x - 34, y - 34, translucentImage);
     }
 
     // 0x00490C59

--- a/src/OpenLoco/src/Objects/ScaffoldingObject.cpp
+++ b/src/OpenLoco/src/Objects/ScaffoldingObject.cpp
@@ -15,9 +15,9 @@ namespace OpenLoco
     {
         auto colourImage = Gfx::recolour(image, Colour::yellow);
 
-        drawingCtx.drawImage(x, y + 23, colourImage + Scaffolding::ImageIds::type21x1SegmentBack);
-        drawingCtx.drawImage(x, y + 23, colourImage + Scaffolding::ImageIds::type21x1SegmentFront);
-        drawingCtx.drawImage(x, y + 23 - segmentHeights[2], colourImage + Scaffolding::ImageIds::type21x1RoofSE);
+        drawingCtx.drawImage(ZoomLevel::full, x, y + 23, colourImage + Scaffolding::ImageIds::type21x1SegmentBack);
+        drawingCtx.drawImage(ZoomLevel::full, x, y + 23, colourImage + Scaffolding::ImageIds::type21x1SegmentFront);
+        drawingCtx.drawImage(ZoomLevel::full, x, y + 23 - segmentHeights[2], colourImage + Scaffolding::ImageIds::type21x1RoofSE);
     }
 
     // 0x0042DED8

--- a/src/OpenLoco/src/Objects/SnowObject.cpp
+++ b/src/OpenLoco/src/Objects/SnowObject.cpp
@@ -10,7 +10,7 @@ namespace OpenLoco
     // 0x00469A75
     void SnowObject::drawPreviewImage(Gfx::DrawingContext& drawingCtx, const int16_t x, const int16_t y) const
     {
-        drawingCtx.drawImage(x, y, image);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, image);
     }
 
     // 0x00469A35

--- a/src/OpenLoco/src/Objects/StreetLightObject.cpp
+++ b/src/OpenLoco/src/Objects/StreetLightObject.cpp
@@ -19,8 +19,8 @@ namespace OpenLoco
         for (auto i = 0; i < 3; i++)
         {
             auto imageId = (i * 4) + image;
-            drawingCtx.drawImage(imgPosition.x - 14, imgPosition.y, imageId + 2);
-            drawingCtx.drawImage(imgPosition.x, imgPosition.y - 7, imageId);
+            drawingCtx.drawImage(ZoomLevel::full, imgPosition.x - 14, imgPosition.y, imageId + 2);
+            drawingCtx.drawImage(ZoomLevel::full, imgPosition.x, imgPosition.y - 7, imageId);
             imgPosition.x += 20;
             imgPosition.y += kDescriptionRowHeight;
         }

--- a/src/OpenLoco/src/Objects/TrackExtraObject.cpp
+++ b/src/OpenLoco/src/Objects/TrackExtraObject.cpp
@@ -17,13 +17,13 @@ namespace OpenLoco
 
         if (paintStyle == 0)
         {
-            drawingCtx.drawImage(x, y, colourImage);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage);
         }
         else
         {
-            drawingCtx.drawImage(x, y, colourImage);
-            drawingCtx.drawImage(x, y, colourImage + 97);
-            drawingCtx.drawImage(x, y, colourImage + 96);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage + 97);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage + 96);
         }
     }
 

--- a/src/OpenLoco/src/Objects/TrackObject.cpp
+++ b/src/OpenLoco/src/Objects/TrackObject.cpp
@@ -13,9 +13,9 @@ namespace OpenLoco
     {
         auto colourImage = Gfx::recolour(image + TrackObj::ImageIds::kUiPreviewImage0, Colour::mutedDarkRed);
 
-        drawingCtx.drawImage(x, y, colourImage + TrackObj::ImageIds::Style0::kStraight0BallastNE);
-        drawingCtx.drawImage(x, y, colourImage + TrackObj::ImageIds::Style0::kStraight0SleeperNE);
-        drawingCtx.drawImage(x, y, colourImage + TrackObj::ImageIds::Style0::kStraight0RailNE);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage + TrackObj::ImageIds::Style0::kStraight0BallastNE);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage + TrackObj::ImageIds::Style0::kStraight0SleeperNE);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, colourImage + TrackObj::ImageIds::Style0::kStraight0RailNE);
     }
 
     // 0x004A6C6C

--- a/src/OpenLoco/src/Objects/TrainSignalObject.cpp
+++ b/src/OpenLoco/src/Objects/TrainSignalObject.cpp
@@ -107,6 +107,6 @@ namespace OpenLoco
         frameIndex *= 8;
         auto colourImage = image + frameIndex;
 
-        drawingCtx.drawImage(x, y + 15, colourImage);
+        drawingCtx.drawImage(ZoomLevel::full, x, y + 15, colourImage);
     }
 }

--- a/src/OpenLoco/src/Objects/TrainStationObject.cpp
+++ b/src/OpenLoco/src/Objects/TrainStationObject.cpp
@@ -15,7 +15,7 @@ namespace OpenLoco
     {
         auto colourImage = Gfx::recolour(image, Colour::mutedDarkRed);
 
-        drawingCtx.drawImage(x - 34, y - 34, colourImage);
+        drawingCtx.drawImage(ZoomLevel::full, x - 34, y - 34, colourImage);
 
         auto colour = ExtColour::translucentMutedDarkRed1;
         if (!hasFlags(TrainStationFlags::recolourable))
@@ -25,7 +25,7 @@ namespace OpenLoco
 
         auto translucentImage = Gfx::recolourTranslucent(image + 1, colour);
 
-        drawingCtx.drawImage(x - 34, y - 34, translucentImage);
+        drawingCtx.drawImage(ZoomLevel::full, x - 34, y - 34, translucentImage);
     }
 
     // 0x00490A68

--- a/src/OpenLoco/src/Objects/TreeObject.cpp
+++ b/src/OpenLoco/src/Objects/TreeObject.cpp
@@ -45,10 +45,10 @@ namespace OpenLoco
                 snowImage = Gfx::recolour(snowImage, colour);
             }
             treePos.x = x + 28;
-            drawingCtx.drawImage(treePos.x, treePos.y, snowImage);
+            drawingCtx.drawImage(ZoomLevel::full, treePos.x, treePos.y, snowImage);
             treePos.x = 28;
         }
-        drawingCtx.drawImage(treePos.x, treePos.y, image);
+        drawingCtx.drawImage(ZoomLevel::full, treePos.x, treePos.y, image);
     }
 
     // 0x00500775

--- a/src/OpenLoco/src/Objects/TunnelObject.cpp
+++ b/src/OpenLoco/src/Objects/TunnelObject.cpp
@@ -12,8 +12,8 @@ namespace OpenLoco
     // 0x00469806
     void TunnelObject::drawPreviewImage(Gfx::DrawingContext& drawingCtx, const int16_t x, const int16_t y) const
     {
-        drawingCtx.drawImage(x - 16, y + 15, image);
-        drawingCtx.drawImage(x - 16, y + 15, image + 1);
+        drawingCtx.drawImage(ZoomLevel::full, x - 16, y + 15, image);
+        drawingCtx.drawImage(ZoomLevel::full, x - 16, y + 15, image + 1);
     }
 
     // 0x004697C9

--- a/src/OpenLoco/src/Objects/WallObject.cpp
+++ b/src/OpenLoco/src/Objects/WallObject.cpp
@@ -46,10 +46,10 @@ namespace OpenLoco
             image = Gfx::recolour(sprite + WallObj::ImageIds::kFlatSE, Colour::mutedDarkRed);
         }
 
-        drawingCtx.drawImage(x + 14, y + 16 + (height * 2), image);
+        drawingCtx.drawImage(ZoomLevel::full, x + 14, y + 16 + (height * 2), image);
         if ((flags & WallObjectFlags::hasGlass) != WallObjectFlags::none)
         {
-            drawingCtx.drawImage(x + 14, y + 16 + (height * 2), Gfx::recolourTranslucent(sprite + WallObj::ImageIds::kGlassFlatSE, ExtColour::unk8C));
+            drawingCtx.drawImage(ZoomLevel::full, x + 14, y + 16 + (height * 2), Gfx::recolourTranslucent(sprite + WallObj::ImageIds::kGlassFlatSE, ExtColour::unk8C));
         }
         else
         {
@@ -57,7 +57,7 @@ namespace OpenLoco
             // TODO: delete
             if ((flags & WallObjectFlags::unk4) != WallObjectFlags::none)
             {
-                drawingCtx.drawImage(x + 14, y + 16 + (height * 2), image + WallObj::ImageIds::kFlatNE);
+                drawingCtx.drawImage(ZoomLevel::full, x + 14, y + 16 + (height * 2), image + WallObj::ImageIds::kFlatNE);
             }
         }
     }

--- a/src/OpenLoco/src/Objects/WaterObject.cpp
+++ b/src/OpenLoco/src/Objects/WaterObject.cpp
@@ -55,7 +55,7 @@ namespace OpenLoco
     void WaterObject::drawPreviewImage(Gfx::DrawingContext& drawingCtx, const int16_t x, const int16_t y) const
     {
         auto colourImage = ImageId(image).withIndexOffset(35).withBlend(ExtColour::water);
-        drawingCtx.drawImage(Ui::Point{ x, y }, colourImage);
-        drawingCtx.drawImage(Ui::Point{ x, y }, ImageId(image).withIndexOffset(30));
+        drawingCtx.drawImage(ZoomLevel::full, Ui::Point{ x, y }, colourImage);
+        drawingCtx.drawImage(ZoomLevel::full, Ui::Point{ x, y }, ImageId(image).withIndexOffset(30));
     }
 }

--- a/src/OpenLoco/src/Paint/Paint.cpp
+++ b/src/OpenLoco/src/Paint/Paint.cpp
@@ -47,6 +47,17 @@ namespace OpenLoco::Paint
         _foregroundCullingHeight = options.foregroundCullHeight;
     }
 
+    // Magnifying zoom levels have several screen pixels per world unit, so the far
+    // edges have to round outwards to still cover every pixel of the render target.
+    static constexpr int32_t screenToWorldCeil(ZoomLevel zoom, int32_t value)
+    {
+        if (zoom >= ZoomLevel::full)
+        {
+            return zoom.applyTo(value);
+        }
+        return zoom.applyTo(value + zoom.applyInversedTo(1) - 1);
+    }
+
     int32_t PaintSession::getWorldX() const
     {
         return _zoom.applyTo(static_cast<int32_t>(_renderTarget->x));
@@ -59,12 +70,12 @@ namespace OpenLoco::Paint
 
     int32_t PaintSession::getWorldWidth() const
     {
-        return _zoom.applyTo(static_cast<int32_t>(_renderTarget->width));
+        return screenToWorldCeil(_zoom, _renderTarget->x + _renderTarget->width) - getWorldX();
     }
 
     int32_t PaintSession::getWorldHeight() const
     {
-        return _zoom.applyTo(static_cast<int32_t>(_renderTarget->height));
+        return screenToWorldCeil(_zoom, _renderTarget->y + _renderTarget->height) - getWorldY();
     }
 
     void PaintSession::setEntityPosition(const World::Pos2& pos)
@@ -215,8 +226,8 @@ namespace OpenLoco::Paint
 
         const auto rtWorldX = zoom.applyTo(static_cast<int32_t>(rt.x));
         const auto rtWorldY = zoom.applyTo(static_cast<int32_t>(rt.y));
-        const auto rtWorldWidth = zoom.applyTo(static_cast<int32_t>(rt.width));
-        const auto rtWorldHeight = zoom.applyTo(static_cast<int32_t>(rt.height));
+        const auto rtWorldWidth = screenToWorldCeil(zoom, rt.x + rt.width) - rtWorldX;
+        const auto rtWorldHeight = screenToWorldCeil(zoom, rt.y + rt.height) - rtWorldY;
 
         if (right <= rtWorldX)
         {
@@ -510,7 +521,7 @@ namespace OpenLoco::Paint
     {
         const auto worldX = zoom.applyTo(static_cast<int32_t>(rt->x));
         const auto worldY = zoom.applyTo(static_cast<int32_t>(rt->y));
-        const auto worldHeight = zoom.applyTo(static_cast<int32_t>(rt->height));
+        const auto worldHeight = screenToWorldCeil(zoom, rt->y + rt->height) - worldY;
 
         // TODO: Work out what these constants represent
         uint16_t numVerticalQuadrants = (worldHeight + (rotation == 0 ? 1040 : 1056)) >> 5;
@@ -1000,7 +1011,7 @@ namespace OpenLoco::Paint
         }
 
         auto imagePos = ps.vpPos;
-        if (ps.type == Ui::ViewportInteraction::InteractionItem::entity)
+        if (ps.type == Ui::ViewportInteraction::InteractionItem::entity && zoom > ZoomLevel::full)
         {
             const auto zoomAlign = zoom.applyTo(1U);
             imagePos.x = Numerics::floor2(imagePos.x, zoomAlign);
@@ -1026,7 +1037,7 @@ namespace OpenLoco::Paint
             imageId = ImageId(imageId.getIndex()).withTranslucency(ExtColour::unk30);
         }
         Ui::Point imagePos = ps.vpPos + attachPs.vpPos;
-        if (zoom != 0)
+        if (zoom > ZoomLevel::full)
         {
             imagePos.x = Numerics::floor2(imagePos.x, 2);
             imagePos.y = Numerics::floor2(imagePos.y, 2);
@@ -1112,7 +1123,7 @@ namespace OpenLoco::Paint
         const auto zoom = _zoom;
 
         auto tr = Gfx::TextRenderer(drawingCtx);
-        tr.setCurrentFont(zoom == 0 ? Gfx::Font::medium_bold : Gfx::Font::small);
+        tr.setCurrentFont(zoom <= ZoomLevel::full ? Gfx::Font::medium_bold : Gfx::Font::small);
 
         char buffer[512]{};
 

--- a/src/OpenLoco/src/Paint/Paint.cpp
+++ b/src/OpenLoco/src/Paint/Paint.cpp
@@ -24,9 +24,10 @@ using namespace OpenLoco::Ui::ViewportInteraction;
 
 namespace OpenLoco::Paint
 {
-    PaintSession::PaintSession(const Gfx::RenderTarget& rt, const SessionOptions& options)
+    PaintSession::PaintSession(const Gfx::RenderTarget& rt, ZoomLevel zoom, const SessionOptions& options)
     {
         _renderTarget = &rt;
+        _zoom = zoom;
         _lastPS = nullptr;
         for (auto& quadrant : _quadrants)
         {
@@ -44,6 +45,26 @@ namespace OpenLoco::Paint
 
         // TODO: unused
         _foregroundCullingHeight = options.foregroundCullHeight;
+    }
+
+    int32_t PaintSession::getWorldX() const
+    {
+        return _zoom.applyTo(static_cast<int32_t>(_renderTarget->x));
+    }
+
+    int32_t PaintSession::getWorldY() const
+    {
+        return _zoom.applyTo(static_cast<int32_t>(_renderTarget->y));
+    }
+
+    int32_t PaintSession::getWorldWidth() const
+    {
+        return _zoom.applyTo(static_cast<int32_t>(_renderTarget->width));
+    }
+
+    int32_t PaintSession::getWorldHeight() const
+    {
+        return _zoom.applyTo(static_cast<int32_t>(_renderTarget->height));
     }
 
     void PaintSession::setEntityPosition(const World::Pos2& pos)
@@ -184,7 +205,7 @@ namespace OpenLoco::Paint
         return addToPlotListAsParent(imageId, offset, offset, boundBoxSize);
     }
 
-    static constexpr bool imageWithinRT(const Ui::viewport_pos& imagePos, const Gfx::G1Element& g1, const Gfx::RenderTarget& rt)
+    static constexpr bool imageWithinRT(const Ui::viewport_pos& imagePos, const Gfx::G1Element& g1, const Gfx::RenderTarget& rt, ZoomLevel zoom)
     {
         int32_t left = imagePos.x + g1.xOffset;
         int32_t bottom = imagePos.y + g1.yOffset;
@@ -192,19 +213,24 @@ namespace OpenLoco::Paint
         int32_t right = left + g1.width;
         int32_t top = bottom + g1.height;
 
-        if (right <= rt.x)
+        const auto rtWorldX = zoom.applyTo(static_cast<int32_t>(rt.x));
+        const auto rtWorldY = zoom.applyTo(static_cast<int32_t>(rt.y));
+        const auto rtWorldWidth = zoom.applyTo(static_cast<int32_t>(rt.width));
+        const auto rtWorldHeight = zoom.applyTo(static_cast<int32_t>(rt.height));
+
+        if (right <= rtWorldX)
         {
             return false;
         }
-        if (top <= rt.y)
+        if (top <= rtWorldY)
         {
             return false;
         }
-        if (left >= rt.x + rt.width)
+        if (left >= rtWorldX + rtWorldWidth)
         {
             return false;
         }
-        if (bottom >= rt.y + rt.height)
+        if (bottom >= rtWorldY + rtWorldHeight)
         {
             return false;
         }
@@ -270,8 +296,8 @@ namespace OpenLoco::Paint
             return nullptr;
         }
 
-        const auto rtLeft = getRenderTarget()->x;
-        const auto rtRight = getRenderTarget()->x + getRenderTarget()->width;
+        const auto rtLeft = getWorldX();
+        const auto rtRight = getWorldX() + getWorldWidth();
 
         auto newMins = ps->bounds.mins;
         // The following uses the fact that gameToScreen calculates the
@@ -480,14 +506,18 @@ namespace OpenLoco::Paint
     };
 
     template<uint8_t rotation>
-    GenerationParameters generateParameters(const Gfx::RenderTarget* rt)
+    GenerationParameters generateParameters(const Gfx::RenderTarget* rt, ZoomLevel zoom)
     {
+        const auto worldX = zoom.applyTo(static_cast<int32_t>(rt->x));
+        const auto worldY = zoom.applyTo(static_cast<int32_t>(rt->y));
+        const auto worldHeight = zoom.applyTo(static_cast<int32_t>(rt->height));
+
         // TODO: Work out what these constants represent
-        uint16_t numVerticalQuadrants = (rt->height + (rotation == 0 ? 1040 : 1056)) >> 5;
+        uint16_t numVerticalQuadrants = (worldHeight + (rotation == 0 ? 1040 : 1056)) >> 5;
 
         auto mapLoc = Ui::viewportCoordToMapCoord(
-            Numerics::floor2(rt->x, 32),
-            Numerics::floor2(rt->y - 16, 32),
+            Numerics::floor2(worldX, 32),
+            Numerics::floor2(worldY - 16, 32),
             0,
             rotation);
         if constexpr (rotation & 1)
@@ -567,7 +597,7 @@ namespace OpenLoco::Paint
 
         const auto vpPos = World::gameToScreen(swappedRotCoord, currentRotation);
 
-        if (!imageWithinRT(vpPos, *g1, *_renderTarget))
+        if (!imageWithinRT(vpPos, *g1, *_renderTarget, _zoom))
         {
             return nullptr;
         }
@@ -607,16 +637,16 @@ namespace OpenLoco::Paint
         switch (currentRotation)
         {
             case 0:
-                generateTilesAndEntities(generateParameters<0>(getRenderTarget()));
+                generateTilesAndEntities(generateParameters<0>(getRenderTarget(), getZoom()));
                 break;
             case 1:
-                generateTilesAndEntities(generateParameters<1>(getRenderTarget()));
+                generateTilesAndEntities(generateParameters<1>(getRenderTarget(), getZoom()));
                 break;
             case 2:
-                generateTilesAndEntities(generateParameters<2>(getRenderTarget()));
+                generateTilesAndEntities(generateParameters<2>(getRenderTarget(), getZoom()));
                 break;
             case 3:
-                generateTilesAndEntities(generateParameters<3>(getRenderTarget()));
+                generateTilesAndEntities(generateParameters<3>(getRenderTarget(), getZoom()));
                 break;
         }
     }
@@ -960,7 +990,7 @@ namespace OpenLoco::Paint
         return false;
     }
 
-    static void drawStruct(const Gfx::RenderTarget& rt, Gfx::DrawingContext& drawingCtx, const PaintStruct& ps, const bool shouldCull)
+    static void drawStruct(ZoomLevel zoom, Gfx::DrawingContext& drawingCtx, const PaintStruct& ps, const bool shouldCull)
     {
         auto imageId = ps.imageId;
 
@@ -972,22 +1002,22 @@ namespace OpenLoco::Paint
         auto imagePos = ps.vpPos;
         if (ps.type == Ui::ViewportInteraction::InteractionItem::entity)
         {
-            const auto zoomAlign = 1U << rt.zoomLevel;
+            const auto zoomAlign = zoom.applyTo(1U);
             imagePos.x = Numerics::floor2(imagePos.x, zoomAlign);
             imagePos.y = Numerics::floor2(imagePos.y, zoomAlign);
         }
 
         if ((ps.flags & PaintStructFlags::hasMaskedImage) != PaintStructFlags::none)
         {
-            drawingCtx.drawImageMasked(imagePos, imageId, ps.maskedImageId);
+            drawingCtx.drawImageMasked(zoom, imagePos, imageId, ps.maskedImageId);
         }
         else
         {
-            drawingCtx.drawImage(imagePos, imageId);
+            drawingCtx.drawImage(zoom, imagePos, imageId);
         }
     }
 
-    static void drawAttachStruct(const Gfx::RenderTarget& rt, Gfx::DrawingContext& drawingCtx, const PaintStruct& ps, const AttachedPaintStruct& attachPs, const bool shouldCull)
+    static void drawAttachStruct(ZoomLevel zoom, Gfx::DrawingContext& drawingCtx, const PaintStruct& ps, const AttachedPaintStruct& attachPs, const bool shouldCull)
     {
         auto imageId = attachPs.imageId;
 
@@ -996,7 +1026,7 @@ namespace OpenLoco::Paint
             imageId = ImageId(imageId.getIndex()).withTranslucency(ExtColour::unk30);
         }
         Ui::Point imagePos = ps.vpPos + attachPs.vpPos;
-        if (rt.zoomLevel != 0)
+        if (zoom != 0)
         {
             imagePos.x = Numerics::floor2(imagePos.x, 2);
             imagePos.y = Numerics::floor2(imagePos.y, 2);
@@ -1004,15 +1034,15 @@ namespace OpenLoco::Paint
 
         if ((attachPs.flags & PaintStructFlags::hasMaskedImage) != PaintStructFlags::none)
         {
-            drawingCtx.drawImageMasked(imagePos, imageId, attachPs.maskedImageId);
+            drawingCtx.drawImageMasked(zoom, imagePos, imageId, attachPs.maskedImageId);
         }
         else
         {
-            drawingCtx.drawImage(imagePos, imageId);
+            drawingCtx.drawImage(zoom, imagePos, imageId);
         }
     }
 
-    static void drawAllAttachedStructs(const Gfx::RenderTarget& rt, Gfx::DrawingContext& drawingCtx, const PaintStruct& ps, const Ui::ViewportFlags viewFlags)
+    static void drawAllAttachedStructs(ZoomLevel zoom, Gfx::DrawingContext& drawingCtx, const PaintStruct& ps, const Ui::ViewportFlags viewFlags)
     {
         for (const auto* attachPs = ps.attachedPS; attachPs != nullptr; attachPs = attachPs->next)
         {
@@ -1024,14 +1054,14 @@ namespace OpenLoco::Paint
                     continue;
                 }
             }
-            drawAttachStruct(rt, drawingCtx, ps, *attachPs, shouldCullAttach);
+            drawAttachStruct(zoom, drawingCtx, ps, *attachPs, shouldCullAttach);
         }
     }
 
     // 0x0045EA23
     void PaintSession::drawStructs(Gfx::DrawingContext& drawingCtx)
     {
-        const Gfx::RenderTarget& rt = drawingCtx.currentRenderTarget();
+        const auto zoom = _zoom;
 
         for (const auto* ps = _paintHead; ps != nullptr; ps = ps->nextQuadrantPS)
         {
@@ -1045,7 +1075,7 @@ namespace OpenLoco::Paint
                 }
             }
 
-            drawStruct(rt, drawingCtx, *ps, shouldCull);
+            drawStruct(zoom, drawingCtx, *ps, shouldCull);
 
             // Draw any children this might have
             for (const auto* childPs = ps->children; childPs != nullptr; childPs = childPs->children)
@@ -1060,13 +1090,13 @@ namespace OpenLoco::Paint
                     }
                 }
 
-                drawStruct(rt, drawingCtx, *childPs, shouldCullChild);
+                drawStruct(zoom, drawingCtx, *childPs, shouldCullChild);
 
-                drawAllAttachedStructs(rt, drawingCtx, *childPs, _viewFlags);
+                drawAllAttachedStructs(zoom, drawingCtx, *childPs, _viewFlags);
             }
 
             // Draw any attachments to the struct
-            drawAllAttachedStructs(rt, drawingCtx, *ps, _viewFlags);
+            drawAllAttachedStructs(zoom, drawingCtx, *ps, _viewFlags);
         }
     }
 
@@ -1079,16 +1109,7 @@ namespace OpenLoco::Paint
             return;
         }
 
-        Gfx::RenderTarget unZoomedRt = drawingCtx.currentRenderTarget();
-        const auto zoom = unZoomedRt.zoomLevel;
-
-        unZoomedRt.zoomLevel = 0;
-        unZoomedRt.x >>= zoom;
-        unZoomedRt.y >>= zoom;
-        unZoomedRt.width >>= zoom;
-        unZoomedRt.height >>= zoom;
-
-        drawingCtx.pushRenderTarget(unZoomedRt);
+        const auto zoom = _zoom;
 
         auto tr = Gfx::TextRenderer(drawingCtx);
         tr.setCurrentFont(zoom == 0 ? Gfx::Font::medium_bold : Gfx::Font::small);
@@ -1097,7 +1118,7 @@ namespace OpenLoco::Paint
 
         for (; psString != nullptr; psString = psString->next)
         {
-            Ui::Point loc(psString->vpPos.x >> zoom, psString->vpPos.y >> zoom);
+            const Ui::Point loc{ _zoom.applyInversedTo(psString->vpPos.x), _zoom.applyInversedTo(psString->vpPos.y) };
             StringManager::formatString(buffer, psString->stringId, psString->argsBuf);
 
             Ui::WindowManager::setWindowColours(Ui::WindowColour::primary, AdvancedColour(static_cast<Colour>(psString->colour)));
@@ -1105,8 +1126,6 @@ namespace OpenLoco::Paint
 
             tr.drawStringYOffsets(loc, Colour::black, buffer, psString->yOffsets);
         }
-
-        drawingCtx.popRenderTarget();
     }
 
     // 0x00447C21
@@ -1154,7 +1173,7 @@ namespace OpenLoco::Paint
     }
 
     // 0x00447A5F
-    static bool isSpriteInteractedWithPaletteSet(const Gfx::RenderTarget* rt, ImageId imageId, const Ui::Point& coords, const Gfx::PaletteMap::View paletteMap)
+    static bool isSpriteInteractedWithPaletteSet(const Gfx::RenderTarget* rt, ZoomLevel zoom, ImageId imageId, const Ui::Point& coords, const Gfx::PaletteMap::View paletteMap)
     {
         const auto* g1 = Gfx::getG1Element(imageId.getIndex());
         if (g1 == nullptr)
@@ -1162,8 +1181,8 @@ namespace OpenLoco::Paint
             return false;
         }
 
-        auto zoomLevel = rt->zoomLevel;
-        Ui::Point interactionPoint{ rt->x, rt->y };
+        auto zoomLevel = zoom;
+        Ui::Point interactionPoint{ zoom.applyTo(static_cast<int32_t>(rt->x)), zoom.applyTo(static_cast<int32_t>(rt->y)) };
         Ui::Point origin = coords;
 
         if (zoomLevel > 0)
@@ -1212,7 +1231,7 @@ namespace OpenLoco::Paint
     }
 
     // 0x00447A0E
-    static bool isSpriteInteractedWith(const Gfx::RenderTarget* rt, ImageId imageId, const Ui::Point& coords)
+    static bool isSpriteInteractedWith(const Gfx::RenderTarget* rt, ZoomLevel zoom, ImageId imageId, const Ui::Point& coords)
     {
         auto paletteMap = Gfx::PaletteMap::getDefault();
         if (imageId.hasPrimary())
@@ -1223,7 +1242,7 @@ namespace OpenLoco::Paint
                 paletteMap = *pm;
             }
         }
-        return isSpriteInteractedWithPaletteSet(rt, imageId, coords, paletteMap);
+        return isSpriteInteractedWithPaletteSet(rt, zoom, imageId, coords, paletteMap);
     }
 
     // 0x0045EDFC
@@ -1270,12 +1289,12 @@ namespace OpenLoco::Paint
         return true;
     }
 
-    static std::optional<InteractionArg> getAttachedInteractionInfo(const Gfx::RenderTarget& rt, const InteractionItemFlags flags, const PaintStruct& ps)
+    static std::optional<InteractionArg> getAttachedInteractionInfo(const Gfx::RenderTarget& rt, ZoomLevel zoom, const InteractionItemFlags flags, const PaintStruct& ps)
     {
         std::optional<InteractionArg> info = std::nullopt;
         for (auto* attachedPS = ps.attachedPS; attachedPS != nullptr; attachedPS = attachedPS->next)
         {
-            if (isSpriteInteractedWith(&rt, attachedPS->imageId, attachedPS->vpPos + ps.vpPos))
+            if (isSpriteInteractedWith(&rt, zoom, attachedPS->imageId, attachedPS->vpPos + ps.vpPos))
             {
                 if (isPSSpriteTypeInFilter(ps.type, flags))
                 {
@@ -1294,7 +1313,7 @@ namespace OpenLoco::Paint
         for (auto* ps = _paintHead; ps != nullptr; ps = ps->nextQuadrantPS)
         {
             // Check main paint struct
-            if (isSpriteInteractedWith(getRenderTarget(), ps->imageId, ps->vpPos))
+            if (isSpriteInteractedWith(getRenderTarget(), getZoom(), ps->imageId, ps->vpPos))
             {
                 if (isPSSpriteTypeInFilter(ps->type, flags))
                 {
@@ -1305,7 +1324,7 @@ namespace OpenLoco::Paint
             // Check children paint structs
             for (const auto* childPs = ps->children; childPs != nullptr; childPs = childPs->children)
             {
-                if (isSpriteInteractedWith(getRenderTarget(), childPs->imageId, childPs->vpPos))
+                if (isSpriteInteractedWith(getRenderTarget(), getZoom(), childPs->imageId, childPs->vpPos))
                 {
                     if (isPSSpriteTypeInFilter(childPs->type, flags))
                     {
@@ -1313,7 +1332,7 @@ namespace OpenLoco::Paint
                     }
                 }
 
-                auto attachedInfo = getAttachedInteractionInfo(*getRenderTarget(), flags, *childPs);
+                auto attachedInfo = getAttachedInteractionInfo(*getRenderTarget(), getZoom(), flags, *childPs);
                 if (attachedInfo.has_value())
                 {
                     info = attachedInfo.value();
@@ -1321,7 +1340,7 @@ namespace OpenLoco::Paint
             }
 
             // Check attached to main paint struct
-            auto attachedInfo = getAttachedInteractionInfo(*getRenderTarget(), flags, *ps);
+            auto attachedInfo = getAttachedInteractionInfo(*getRenderTarget(), getZoom(), flags, *ps);
             if (attachedInfo.has_value())
             {
                 info = attachedInfo.value();
@@ -1340,7 +1359,7 @@ namespace OpenLoco::Paint
             return interaction;
         }
 
-        auto rect = _renderTarget->getDrawableRect();
+        auto rect = _renderTarget->getUiRect();
 
         for (auto& station : StationManager::stations())
         {
@@ -1349,7 +1368,7 @@ namespace OpenLoco::Paint
                 continue;
             }
 
-            if (!station.labelFrame.contains(rect, _renderTarget->zoomLevel))
+            if (!station.labelFrame.contains(rect, getZoom()))
             {
                 continue;
             }
@@ -1372,11 +1391,11 @@ namespace OpenLoco::Paint
             return interaction;
         }
 
-        auto rect = _renderTarget->getDrawableRect();
+        auto rect = _renderTarget->getUiRect();
 
         for (auto& town : TownManager::towns())
         {
-            if (!town.labelFrame.contains(rect, _renderTarget->zoomLevel))
+            if (!town.labelFrame.contains(rect, getZoom()))
             {
                 continue;
             }

--- a/src/OpenLoco/src/Paint/PaintAirport.cpp
+++ b/src/OpenLoco/src/Paint/PaintAirport.cpp
@@ -99,7 +99,7 @@ namespace OpenLoco::Paint
         session.resetLastPS(); // Odd...
         if (airportObj->hasFlags(AirportObjectFlags::hasShadows))
         {
-            if (session.getRenderTarget()->zoomLevel <= 1)
+            if (session.getZoom() <= 1)
             {
                 const auto shadowImageOffset = variation * 4 + airportObj->image + rotation + 1;
                 const ImageId shadowImage = ImageId(shadowImageOffset).withTranslucency(Colours::getShadow(Colour::orange));

--- a/src/OpenLoco/src/Paint/PaintBridge.cpp
+++ b/src/OpenLoco/src/Paint/PaintBridge.cpp
@@ -1396,7 +1396,7 @@ namespace OpenLoco::Paint
 
         // 0x0042BED2
         // Paint shadow
-        if (session.getRenderTarget()->zoomLevel <= 1)
+        if (session.getZoom() <= 1)
         {
             auto displaySlope = 0;
             auto height = session.getWaterHeight2();

--- a/src/OpenLoco/src/Paint/PaintBuilding.cpp
+++ b/src/OpenLoco/src/Paint/PaintBuilding.cpp
@@ -199,7 +199,7 @@ namespace OpenLoco::Paint
         session.resetLastPS(); // Odd...
         if (buildingObj->hasFlags(BuildingObjectFlags::hasShadows))
         {
-            if (session.getRenderTarget()->zoomLevel <= 1)
+            if (session.getZoom() <= 1)
             {
                 const auto shadowImageOffset = (buildingObj->numParts + buildingObj->numElevatorSequences + variation) * 4 + buildingObj->image + rotation;
                 const ImageId shadowImage = ImageId(shadowImageOffset).withTranslucency(Colours::getShadow(Colour::orange));

--- a/src/OpenLoco/src/Paint/PaintDocks.cpp
+++ b/src/OpenLoco/src/Paint/PaintDocks.cpp
@@ -84,7 +84,7 @@ namespace OpenLoco::Paint
         session.resetLastPS(); // Odd...
         if (dockObj->hasFlags(DockObjectFlags::hasShadows))
         {
-            if (session.getRenderTarget()->zoomLevel <= 1)
+            if (session.getZoom() <= 1)
             {
                 const auto shadowImageOffset = variation * 4 + dockObj->image + rotation + 1;
                 const ImageId shadowImage = ImageId(shadowImageOffset).withTranslucency(Colours::getShadow(Colour::orange));

--- a/src/OpenLoco/src/Paint/PaintEffectEntity.cpp
+++ b/src/OpenLoco/src/Paint/PaintEffectEntity.cpp
@@ -52,8 +52,7 @@ namespace OpenLoco::Paint
     // 0x00440331
     static void paintExhaustEntity(PaintSession& session, Exhaust* exhaustEntity)
     {
-        const Gfx::RenderTarget* rt = session.getRenderTarget();
-        if (rt->zoomLevel > 1)
+        if (session.getZoom() > 1)
         {
             return;
         }
@@ -75,8 +74,7 @@ namespace OpenLoco::Paint
     // 0x004403C5
     static void paintRedGreenCurrencyEntity(PaintSession& session, MoneyEffect* moneyEffect)
     {
-        const Gfx::RenderTarget* rt = session.getRenderTarget();
-        if (rt->zoomLevel > 1)
+        if (session.getZoom() > 1)
         {
             return;
         }
@@ -94,9 +92,7 @@ namespace OpenLoco::Paint
         {
             return;
         }
-
-        const Gfx::RenderTarget* rt = session.getRenderTarget();
-        if (rt->zoomLevel > 1)
+        if (session.getZoom() > 1)
         {
             return;
         }
@@ -111,8 +107,7 @@ namespace OpenLoco::Paint
     // 0x0044044E
     static void paintVehicleCrashParticleEntity(PaintSession& session, VehicleCrashParticle* particle)
     {
-        const Gfx::RenderTarget* rt = session.getRenderTarget();
-        if (rt->zoomLevel != 0)
+        if (session.getZoom() != 0)
         {
             return;
         }
@@ -137,8 +132,7 @@ namespace OpenLoco::Paint
     // 0x0044051C
     static void paintExplosionCloudEntity(PaintSession& session, ExplosionCloud* particle)
     {
-        const Gfx::RenderTarget* rt = session.getRenderTarget();
-        if (rt->zoomLevel > 2)
+        if (session.getZoom() > 2)
         {
             return;
         }
@@ -172,8 +166,7 @@ namespace OpenLoco::Paint
     // 0x00440557
     static void paintSplashEntity(PaintSession& session, Splash* particle)
     {
-        const Gfx::RenderTarget* rt = session.getRenderTarget();
-        if (rt->zoomLevel > 2)
+        if (session.getZoom() > 2)
         {
             return;
         }
@@ -217,8 +210,7 @@ namespace OpenLoco::Paint
     // 0x00440592
     static void paintFireballEntity(PaintSession& session, Fireball* particle)
     {
-        const Gfx::RenderTarget* rt = session.getRenderTarget();
-        if (rt->zoomLevel > 2)
+        if (session.getZoom() > 2)
         {
             return;
         }
@@ -265,8 +257,7 @@ namespace OpenLoco::Paint
     // 0x004404A6
     static void paintExplosionSmokeEntity(PaintSession& session, ExplosionSmoke* particle)
     {
-        const Gfx::RenderTarget* rt = session.getRenderTarget();
-        if (rt->zoomLevel > 1)
+        if (session.getZoom() > 1)
         {
             return;
         }
@@ -292,8 +283,7 @@ namespace OpenLoco::Paint
     // 0x004404E1
     static void paintSmokeEntity(PaintSession& session, Smoke* particle)
     {
-        const Gfx::RenderTarget* rt = session.getRenderTarget();
-        if (rt->zoomLevel > 1)
+        if (session.getZoom() > 1)
         {
             return;
         }

--- a/src/OpenLoco/src/Paint/PaintEntity.cpp
+++ b/src/OpenLoco/src/Paint/PaintEntity.cpp
@@ -17,8 +17,7 @@ namespace OpenLoco::Paint
     template<typename FilterType>
     static void paintEntitiesWithFilter(PaintSession& session, const World::Pos2& loc, FilterType&& filter)
     {
-        auto* rt = session.getRenderTarget();
-        if (Config::get().vehiclesMinScale < rt->zoomLevel)
+        if (Config::get().vehiclesMinScale < session.getZoom())
         {
             return;
         }
@@ -32,10 +31,10 @@ namespace OpenLoco::Paint
         for (auto* entity : entities)
         {
             // TODO: Create a rect from context dims
-            auto left = rt->x;
-            auto top = rt->y;
-            auto right = left + rt->width;
-            auto bottom = top + rt->height;
+            auto left = session.getWorldX();
+            auto top = session.getWorldY();
+            auto right = left + session.getWorldWidth();
+            auto bottom = top + session.getWorldHeight();
 
             // TODO: Create a rect from sprite dims and use a contains function
             if (entity->spriteTop > bottom)

--- a/src/OpenLoco/src/Paint/PaintIndustry.cpp
+++ b/src/OpenLoco/src/Paint/PaintIndustry.cpp
@@ -191,7 +191,7 @@ namespace OpenLoco::Paint
         session.resetLastPS(); // Odd...
         if (indObj->hasFlags(IndustryObjectFlags::hasShadows))
         {
-            if (session.getRenderTarget()->zoomLevel <= 1)
+            if (session.getZoom() <= 1)
             {
                 const auto shadowImageOffset = buildingType * 4 + indObj->shadowImageIds + rotation;
                 const ImageId shadowImage = baseColour.withIndex(shadowImageOffset).withTranslucency(Colours::getShadow(elIndustry.colour()));

--- a/src/OpenLoco/src/Paint/PaintRoad.cpp
+++ b/src/OpenLoco/src/Paint/PaintRoad.cpp
@@ -341,7 +341,7 @@ namespace OpenLoco::Paint
                 session.setMergeRoadBaseImage(roadSession.roadBaseImageId.withIndexOffset(kMergeBaseImageIndex[enumValue(rpp.isMultiTileMerge[rotation]) - 1]).toUInt32());
                 session.setMergeRoadHeight(height);
             }
-            if (session.getRenderTarget()->zoomLevel == 0 && !elRoad.hasLevelCrossing() && !elRoad.hasSignalElement() && !elRoad.hasStationElement() && elRoad.streetLightStyle() != 0)
+            if (session.getZoom() == 0 && !elRoad.hasLevelCrossing() && !elRoad.hasSignalElement() && !elRoad.hasStationElement() && elRoad.streetLightStyle() != 0)
             {
                 session.setMergeRoadStreetlight(elRoad.streetLightStyle());
             }
@@ -362,7 +362,7 @@ namespace OpenLoco::Paint
                 rpcp.boundingBoxOffsets[rotation] + heightOffset,
                 rpcp.boundingBoxSizes[rotation]);
 
-            if (session.getRenderTarget()->zoomLevel == 0 && !elRoad.hasLevelCrossing() && !elRoad.hasSignalElement() && !elRoad.hasStationElement() && elRoad.streetLightStyle() != 0)
+            if (session.getZoom() == 0 && !elRoad.hasLevelCrossing() && !elRoad.hasSignalElement() && !elRoad.hasStationElement() && elRoad.streetLightStyle() != 0)
             {
                 paintRoadStreetlights(session, elRoad, rpp.streetlightHeights[rotation]);
             }
@@ -453,7 +453,7 @@ namespace OpenLoco::Paint
         const auto height = elRoad.baseHeight();
         const auto rotation = (session.getRotation() + elRoad.rotation()) & 0x3;
         if (((session.getViewFlags() & Ui::ViewportFlags::height_marks_on_tracks_roads) != Ui::ViewportFlags::none)
-            && session.getRenderTarget()->zoomLevel == 0)
+            && session.getZoom() == 0)
         {
             const bool isLast = elRoad.isFlag6();
             const bool isFirstTile = elRoad.sequenceIndex() == 0;
@@ -471,7 +471,7 @@ namespace OpenLoco::Paint
 
         auto* roadObj = ObjectManager::get<RoadObject>(elRoad.roadObjectId());
         if (((session.getViewFlags() & Ui::ViewportFlags::one_way_direction_arrows) != Ui::ViewportFlags::none)
-            && session.getRenderTarget()->zoomLevel == 0
+            && session.getZoom() == 0
             && !elRoad.isGhost()
             && roadObj->hasFlags(RoadObjectFlags::isOneWay))
         {
@@ -541,7 +541,7 @@ namespace OpenLoco::Paint
             }
         }
 
-        if (session.getRenderTarget()->zoomLevel > 1)
+        if (session.getZoom() > 1)
         {
             return;
         }
@@ -551,7 +551,7 @@ namespace OpenLoco::Paint
             paintLevelCrossing(session, baseRoadImageColour, elRoad, rotation);
         }
 
-        if (session.getRenderTarget()->zoomLevel > 0 || roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
+        if (session.getZoom() > 0 || roadObj->hasFlags(RoadObjectFlags::anyRoadTypeCompatible))
         {
             return;
         }

--- a/src/OpenLoco/src/Paint/PaintRoad.cpp
+++ b/src/OpenLoco/src/Paint/PaintRoad.cpp
@@ -341,7 +341,7 @@ namespace OpenLoco::Paint
                 session.setMergeRoadBaseImage(roadSession.roadBaseImageId.withIndexOffset(kMergeBaseImageIndex[enumValue(rpp.isMultiTileMerge[rotation]) - 1]).toUInt32());
                 session.setMergeRoadHeight(height);
             }
-            if (session.getZoom() == 0 && !elRoad.hasLevelCrossing() && !elRoad.hasSignalElement() && !elRoad.hasStationElement() && elRoad.streetLightStyle() != 0)
+            if (session.getZoom() <= ZoomLevel::full && !elRoad.hasLevelCrossing() && !elRoad.hasSignalElement() && !elRoad.hasStationElement() && elRoad.streetLightStyle() != 0)
             {
                 session.setMergeRoadStreetlight(elRoad.streetLightStyle());
             }
@@ -362,7 +362,7 @@ namespace OpenLoco::Paint
                 rpcp.boundingBoxOffsets[rotation] + heightOffset,
                 rpcp.boundingBoxSizes[rotation]);
 
-            if (session.getZoom() == 0 && !elRoad.hasLevelCrossing() && !elRoad.hasSignalElement() && !elRoad.hasStationElement() && elRoad.streetLightStyle() != 0)
+            if (session.getZoom() <= ZoomLevel::full && !elRoad.hasLevelCrossing() && !elRoad.hasSignalElement() && !elRoad.hasStationElement() && elRoad.streetLightStyle() != 0)
             {
                 paintRoadStreetlights(session, elRoad, rpp.streetlightHeights[rotation]);
             }
@@ -453,7 +453,7 @@ namespace OpenLoco::Paint
         const auto height = elRoad.baseHeight();
         const auto rotation = (session.getRotation() + elRoad.rotation()) & 0x3;
         if (((session.getViewFlags() & Ui::ViewportFlags::height_marks_on_tracks_roads) != Ui::ViewportFlags::none)
-            && session.getZoom() == 0)
+            && session.getZoom() <= ZoomLevel::full)
         {
             const bool isLast = elRoad.isFlag6();
             const bool isFirstTile = elRoad.sequenceIndex() == 0;
@@ -471,7 +471,7 @@ namespace OpenLoco::Paint
 
         auto* roadObj = ObjectManager::get<RoadObject>(elRoad.roadObjectId());
         if (((session.getViewFlags() & Ui::ViewportFlags::one_way_direction_arrows) != Ui::ViewportFlags::none)
-            && session.getZoom() == 0
+            && session.getZoom() <= ZoomLevel::full
             && !elRoad.isGhost()
             && roadObj->hasFlags(RoadObjectFlags::isOneWay))
         {

--- a/src/OpenLoco/src/Paint/PaintSignal.cpp
+++ b/src/OpenLoco/src/Paint/PaintSignal.cpp
@@ -198,7 +198,7 @@ namespace OpenLoco::Paint
         else
         {
             if (((session.getViewFlags() & Ui::ViewportFlags::one_way_direction_arrows) != Ui::ViewportFlags::none)
-                && (session.getZoom() == 0))
+                && (session.getZoom() <= ZoomLevel::full))
             {
                 session.setItemType(InteractionItem::noInteraction);
                 const auto imageId = ImageId{ getOneWayArrowImage(!isRight, trackId, rotation), Colour::mutedAvocadoGreen };

--- a/src/OpenLoco/src/Paint/PaintSignal.cpp
+++ b/src/OpenLoco/src/Paint/PaintSignal.cpp
@@ -198,7 +198,7 @@ namespace OpenLoco::Paint
         else
         {
             if (((session.getViewFlags() & Ui::ViewportFlags::one_way_direction_arrows) != Ui::ViewportFlags::none)
-                && (session.getRenderTarget()->zoomLevel == 0))
+                && (session.getZoom() == 0))
             {
                 session.setItemType(InteractionItem::noInteraction);
                 const auto imageId = ImageId{ getOneWayArrowImage(!isRight, trackId, rotation), Colour::mutedAvocadoGreen };
@@ -231,7 +231,7 @@ namespace OpenLoco::Paint
             return;
         }
 
-        if (session.getRenderTarget()->zoomLevel > 1)
+        if (session.getZoom() > 1)
         {
             return;
         }

--- a/src/OpenLoco/src/Paint/PaintStation.cpp
+++ b/src/OpenLoco/src/Paint/PaintStation.cpp
@@ -26,7 +26,7 @@ namespace OpenLoco::Paint
         {
             return;
         }
-        if (session.getRenderTarget()->zoomLevel > 0)
+        if (session.getZoom() > 0)
         {
             return;
         }

--- a/src/OpenLoco/src/Paint/PaintSurface.cpp
+++ b/src/OpenLoco/src/Paint/PaintSurface.cpp
@@ -1489,7 +1489,7 @@ namespace OpenLoco::Paint
     void paintSurface(PaintSession& session, World::SurfaceElement& elSurface)
     {
         session.setItemType(Ui::ViewportInteraction::InteractionItem::surface);
-        const auto zoomLevel = session.getRenderTarget()->zoomLevel;
+        const auto zoomLevel = session.getZoom();
         session.setDidPassSurface(true);
 
         // 0x00F252B0 / 0x00F252B4 but if 0x00F252B0 == -2 that means industrial

--- a/src/OpenLoco/src/Paint/PaintSurface.cpp
+++ b/src/OpenLoco/src/Paint/PaintSurface.cpp
@@ -1530,7 +1530,7 @@ namespace OpenLoco::Paint
         };
 
         if (((session.getViewFlags() & Ui::ViewportFlags::height_marks_on_land) != Ui::ViewportFlags::none)
-            && zoomLevel == 0)
+            && zoomLevel <= ZoomLevel::full)
         {
             const auto markerPos = session.getUnkPosition() + World::Pos2(16, 16);
             const auto markerHeight = World::TileManager::getHeight(markerPos).landHeight + 3;
@@ -1572,7 +1572,7 @@ namespace OpenLoco::Paint
 
             session.setItemType(Ui::ViewportInteraction::InteractionItem::surface);
 
-            if ((zoomLevel == 0 && industryObj->hasFlags(IndustryObjectFlags::farmTilesDrawAboveSnow))
+            if ((zoomLevel <= ZoomLevel::full && industryObj->hasFlags(IndustryObjectFlags::farmTilesDrawAboveSnow))
                 || elSurface.snowCoverage() == 0)
             {
                 // Draw main surface image
@@ -1626,7 +1626,7 @@ namespace OpenLoco::Paint
                 const auto imageIndex = [&elSurface, zoomLevel, displaySlope, &landObj, variation]() {
                     if (!elSurface.water()
                         && elSurface.variation() != 0
-                        && zoomLevel == 0
+                        && zoomLevel <= ZoomLevel::full
                         && displaySlope == 0
                         && (landObj->numGrowthStages - 1) == elSurface.getGrowthStage())
                     {
@@ -1715,7 +1715,7 @@ namespace OpenLoco::Paint
             }
         }
 
-        if (zoomLevel == 0
+        if (zoomLevel <= ZoomLevel::full
             && (session.getViewFlags() & (Ui::ViewportFlags::underground_view | Ui::ViewportFlags::flag_7)) == Ui::ViewportFlags::none
             && Config::get().landscapeSmoothing)
         {
@@ -1736,7 +1736,7 @@ namespace OpenLoco::Paint
                 const auto variation = industryObj->numImagesPerFieldGrowthStage * elSurface.getGrowthStage() + ((industryObj->farmTileNumImageAngles - 1) & rotation) * 21;
                 const auto imageIndex = industryObj->fieldImageIds + variation + displaySlope;
 
-                if ((zoomLevel == 0 && industryObj->hasFlags(IndustryObjectFlags::farmTilesDrawAboveSnow))
+                if ((zoomLevel <= ZoomLevel::full && industryObj->hasFlags(IndustryObjectFlags::farmTilesDrawAboveSnow))
                     || selfDescriptor.snowCoverage == 0)
                 {
                     paintMainUndergroundSurface(session, imageIndex, displaySlope);
@@ -1828,7 +1828,7 @@ namespace OpenLoco::Paint
             session.attachToPrevious(attachedImage, { 0, 0 });
 
             // Draw waves
-            if (elSurface.isFlag6() && zoomLevel == 0)
+            if (elSurface.isFlag6() && zoomLevel <= ZoomLevel::full)
             {
                 const auto waveIndex = WaveManager::getWaveIndex(toTileSpace(session.getUnkPosition()));
                 const auto& wave = WaveManager::getWave(waveIndex);

--- a/src/OpenLoco/src/Paint/PaintTile.cpp
+++ b/src/OpenLoco/src/Paint/PaintTile.cpp
@@ -48,11 +48,11 @@ namespace OpenLoco::Paint
 
         const auto loc2 = loc + kUnkOffsets[session.getRotation()];
         const auto vpPos = World::gameToScreen(World::Pos3(loc2.x, loc2.y, 16), session.getRotation());
-        if (vpPos.y + 32 <= session.getRenderTarget()->y)
+        if (vpPos.y + 32 <= session.getWorldY())
         {
             return;
         }
-        if (vpPos.y - 20 >= session.getRenderTarget()->height + session.getRenderTarget()->y)
+        if (vpPos.y - 20 >= session.getWorldHeight() + session.getWorldY())
         {
             return;
         }
@@ -239,11 +239,11 @@ namespace OpenLoco::Paint
         const auto vpPos = World::gameToScreen(World::Pos3(loc2.x, loc2.y, 0), session.getRotation());
         paintConstructionArrow(session, loc2);
 
-        if (vpPos.y + 52 <= session.getRenderTarget()->y)
+        if (vpPos.y + 52 <= session.getWorldY())
         {
             return std::nullopt;
         }
-        if (vpPos.y - session.getMaxHeight() > session.getRenderTarget()->y + session.getRenderTarget()->height)
+        if (vpPos.y - session.getMaxHeight() > session.getWorldY() + session.getWorldHeight())
         {
             return std::nullopt;
         }

--- a/src/OpenLoco/src/Paint/PaintTrack.cpp
+++ b/src/OpenLoco/src/Paint/PaintTrack.cpp
@@ -251,7 +251,7 @@ namespace OpenLoco::Paint
         const auto height = elTrack.baseZ() * 4;
         const auto rotation = (session.getRotation() + elTrack.rotation()) & 0x3;
         if (((session.getViewFlags() & Ui::ViewportFlags::height_marks_on_tracks_roads) != Ui::ViewportFlags::none)
-            && session.getRenderTarget()->zoomLevel == 0)
+            && session.getZoom() == 0)
         {
             const bool isLast = elTrack.isFlag6();
             const bool isFirstTile = elTrack.sequenceIndex() == 0;
@@ -298,7 +298,7 @@ namespace OpenLoco::Paint
             }
         }
 
-        if (session.getRenderTarget()->zoomLevel > 0)
+        if (session.getZoom() > 0)
         {
             return;
         }

--- a/src/OpenLoco/src/Paint/PaintTrack.cpp
+++ b/src/OpenLoco/src/Paint/PaintTrack.cpp
@@ -251,7 +251,7 @@ namespace OpenLoco::Paint
         const auto height = elTrack.baseZ() * 4;
         const auto rotation = (session.getRotation() + elTrack.rotation()) & 0x3;
         if (((session.getViewFlags() & Ui::ViewportFlags::height_marks_on_tracks_roads) != Ui::ViewportFlags::none)
-            && session.getZoom() == 0)
+            && session.getZoom() <= ZoomLevel::full)
         {
             const bool isLast = elTrack.isFlag6();
             const bool isFirstTile = elTrack.sequenceIndex() == 0;

--- a/src/OpenLoco/src/Paint/PaintTree.cpp
+++ b/src/OpenLoco/src/Paint/PaintTree.cpp
@@ -92,7 +92,7 @@ namespace OpenLoco::Paint
 
         if (shadowImageId)
         {
-            if (session.getRenderTarget()->zoomLevel <= 1)
+            if (session.getZoom() <= 1)
             {
                 session.addToPlotListAsParent(*shadowImageId, imageOffset, imageOffset, { 18, 18, 1 });
             }

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -419,7 +419,7 @@ namespace OpenLoco::S5
         dst = *exportGameState(src);
         dst.general.savedViewX = savedView.viewX;
         dst.general.savedViewY = savedView.viewY;
-        dst.general.savedViewZoom = static_cast<uint8_t>(savedView.zoomLevel);
+        dst.general.savedViewZoom = static_cast<uint8_t>(static_cast<int8_t>(savedView.zoomLevel));
         dst.general.savedViewRotation = savedView.rotation;
 
         // Copy tile elements; remove any ghosts before saving

--- a/src/OpenLoco/src/S5/S5.cpp
+++ b/src/OpenLoco/src/S5/S5.cpp
@@ -963,7 +963,7 @@ namespace OpenLoco::S5
                 SavedViewSimple savedView;
                 savedView.viewX = file->gameState.general.savedViewX;
                 savedView.viewY = file->gameState.general.savedViewY;
-                savedView.zoomLevel = static_cast<ZoomLevel>(file->gameState.general.savedViewZoom);
+                savedView.zoomLevel = ZoomLevel{ std::clamp<int8_t>(file->gameState.general.savedViewZoom, ZoomLevel::min, ZoomLevel::max) };
                 savedView.rotation = file->gameState.general.savedViewRotation;
                 mainWindow->viewportFromSavedView(savedView);
                 mainWindow->invalidate();

--- a/src/OpenLoco/src/S5/S5LabelFrame.cpp
+++ b/src/OpenLoco/src/S5/S5LabelFrame.cpp
@@ -3,23 +3,33 @@
 
 namespace OpenLoco::S5
 {
+    static constexpr auto kNumSavedZoomLevels = std::size(S5::LabelFrame{}.left);
+
     S5::LabelFrame exportLabelFrame(const OpenLoco::LabelFrame& src)
     {
         S5::LabelFrame dst{};
-        std::ranges::copy(src.left, dst.left);
-        std::ranges::copy(src.right, dst.right);
-        std::ranges::copy(src.top, dst.top);
-        std::ranges::copy(src.bottom, dst.bottom);
+        for (auto zoom = 0U; zoom < kNumSavedZoomLevels; ++zoom)
+        {
+            const auto index = ZoomLevel(static_cast<int8_t>(zoom)).index();
+            dst.left[zoom] = static_cast<int16_t>(src.left[index]);
+            dst.right[zoom] = static_cast<int16_t>(src.right[index]);
+            dst.top[zoom] = static_cast<int16_t>(src.top[index]);
+            dst.bottom[zoom] = static_cast<int16_t>(src.bottom[index]);
+        }
         return dst;
     }
 
     OpenLoco::LabelFrame importLabelFrame(const S5::LabelFrame& src)
     {
         OpenLoco::LabelFrame dst{};
-        std::ranges::copy(src.left, dst.left);
-        std::ranges::copy(src.right, dst.right);
-        std::ranges::copy(src.top, dst.top);
-        std::ranges::copy(src.bottom, dst.bottom);
+        for (auto zoom = 0U; zoom < kNumSavedZoomLevels; ++zoom)
+        {
+            const auto index = ZoomLevel(static_cast<int8_t>(zoom)).index();
+            dst.left[index] = src.left[zoom];
+            dst.right[index] = src.right[zoom];
+            dst.top[index] = src.top[zoom];
+            dst.bottom[index] = src.bottom[zoom];
+        }
         return dst;
     }
 }

--- a/src/OpenLoco/src/S5/S5LabelFrame.cpp
+++ b/src/OpenLoco/src/S5/S5LabelFrame.cpp
@@ -1,5 +1,6 @@
 #include "S5/S5LabelFrame.h"
 #include "LabelFrame.h"
+#include <array>
 
 namespace OpenLoco::S5
 {

--- a/src/OpenLoco/src/Scenario/Scenario.cpp
+++ b/src/OpenLoco/src/Scenario/Scenario.cpp
@@ -49,6 +49,7 @@
 #include "World/TownManager.h"
 
 #include <OpenLoco/Platform/Platform.h>
+#include <algorithm>
 
 using namespace OpenLoco::World;
 using namespace OpenLoco::Ui;

--- a/src/OpenLoco/src/Scenario/Scenario.cpp
+++ b/src/OpenLoco/src/Scenario/Scenario.cpp
@@ -318,7 +318,7 @@ namespace OpenLoco::Scenario
                 SavedViewSimple savedView;
                 savedView.viewX = gameState.savedViewX;
                 savedView.viewY = gameState.savedViewY;
-                savedView.zoomLevel = static_cast<ZoomLevel>(gameState.savedViewZoom);
+                savedView.zoomLevel = ZoomLevel{ std::clamp<int8_t>(gameState.savedViewZoom, ZoomLevel::min, ZoomLevel::max) };
                 savedView.rotation = gameState.savedViewRotation;
                 mainWindow->viewportFromSavedView(savedView);
                 mainWindow->invalidate();

--- a/src/OpenLoco/src/Scenario/ScenarioPreview.cpp
+++ b/src/OpenLoco/src/Scenario/ScenarioPreview.cpp
@@ -25,8 +25,8 @@ namespace OpenLoco::Scenario
         saveVp.height = size.height;
         saveVp.flags = Ui::ViewportFlags::hideTownNames | Ui::ViewportFlags::hideStationNames;
         saveVp.zoom = ZoomLevel::half;
-        saveVp.viewWidth = size.width << saveVp.zoom;
-        saveVp.viewHeight = size.height << saveVp.zoom;
+        saveVp.viewWidth = saveVp.zoom.applyTo(size.width);
+        saveVp.viewHeight = saveVp.zoom.applyTo(size.height);
 
         const auto viewPos = saveVp.centre2dCoordinates(mapPosXYZ);
         saveVp.viewX = viewPos.x;

--- a/src/OpenLoco/src/Scenario/ScenarioPreview.cpp
+++ b/src/OpenLoco/src/Scenario/ScenarioPreview.cpp
@@ -39,7 +39,6 @@ namespace OpenLoco::Scenario
         rt.width = size.width;
         rt.height = size.height;
         rt.pitch = 0;
-        rt.zoomLevel = saveVp.zoom;
 
         auto& drawingEngine = Gfx::getDrawingEngine();
         auto& drawingCtx = drawingEngine.getDrawingContext();

--- a/src/OpenLoco/src/Ui/Dropdown.cpp
+++ b/src/OpenLoco/src/Ui/Dropdown.cpp
@@ -325,7 +325,7 @@ namespace OpenLoco::Ui::Dropdown
                         {
                             imageId++;
                         }
-                        drawingCtx.drawImage(x, y, imageId);
+                        drawingCtx.drawImage(ZoomLevel::full, x, y, imageId);
                     }
                 }
                 else

--- a/src/OpenLoco/src/Ui/Screenshot.cpp
+++ b/src/OpenLoco/src/Ui/Screenshot.cpp
@@ -189,15 +189,15 @@ namespace OpenLoco::Ui
         return prepareSaveScreenshot(rt);
     }
 
-    static Ui::Viewport createGiantViewport(const uint16_t resolutionWidth, const uint16_t resolutionHeight, const uint8_t zoomLevel)
+    static Ui::Viewport createGiantViewport(const uint16_t resolutionWidth, const uint16_t resolutionHeight, const ZoomLevel zoomLevel)
     {
         Ui::Viewport viewport{};
         viewport.width = resolutionWidth;
         viewport.height = resolutionHeight;
         viewport.x = 0;
         viewport.y = 0;
-        viewport.viewWidth = viewport.width << zoomLevel;
-        viewport.viewHeight = viewport.height << zoomLevel;
+        viewport.viewWidth = zoomLevel.applyTo<int32_t>(viewport.width);
+        viewport.viewHeight = zoomLevel.applyTo<int32_t>(viewport.height);
         viewport.zoom = zoomLevel;
         viewport.pad_11 = 0;
         viewport.flags = ViewportFlags::none;
@@ -216,10 +216,11 @@ namespace OpenLoco::Ui
     static std::string saveGiantScreenshot()
     {
         const auto& main = WindowManager::getMainWindow();
-        const auto zoomLevel = main->viewports[0]->zoom;
 
-        const uint16_t resolutionWidth = ((World::kMapColumns * 32 * 2) >> zoomLevel) + 8;
-        const uint16_t resolutionHeight = ((World::kMapRows * 32 * 1) >> zoomLevel) + 128;
+        const auto zoomLevel = ZoomLevel{ std::max<int8_t>(main->viewports[0]->zoom, ZoomLevel::full) };
+
+        const uint16_t resolutionWidth = zoomLevel.applyInversedTo(World::kMapColumns * 32 * 2) + 8;
+        const uint16_t resolutionHeight = zoomLevel.applyInversedTo(World::kMapRows * 32 * 1) + 128;
 
         Ui::Viewport viewport = createGiantViewport(resolutionWidth, resolutionHeight, zoomLevel);
 

--- a/src/OpenLoco/src/Ui/Screenshot.cpp
+++ b/src/OpenLoco/src/Ui/Screenshot.cpp
@@ -12,6 +12,7 @@
 #include "Ui/WindowManager.h"
 #include <OpenLoco/Core/Exception.hpp>
 #include <OpenLoco/Platform/Platform.h>
+#include <algorithm>
 #include <cstdint>
 #include <fstream>
 #include <png.h>

--- a/src/OpenLoco/src/Ui/Screenshot.cpp
+++ b/src/OpenLoco/src/Ui/Screenshot.cpp
@@ -238,7 +238,6 @@ namespace OpenLoco::Ui
         rt.width = resolutionWidth;
         rt.height = resolutionHeight;
         rt.pitch = 0;
-        rt.zoomLevel = 0;
 
         auto& drawingEngine = Gfx::getDrawingEngine();
         auto& drawingCtx = drawingEngine.getDrawingContext();

--- a/src/OpenLoco/src/Ui/Screenshot.cpp
+++ b/src/OpenLoco/src/Ui/Screenshot.cpp
@@ -218,7 +218,7 @@ namespace OpenLoco::Ui
     {
         const auto& main = WindowManager::getMainWindow();
 
-        const auto zoomLevel = ZoomLevel{ std::max<int8_t>(main->viewports[0]->zoom, ZoomLevel::full) };
+        const auto zoomLevel = ZoomLevel{ std::max<int8_t>(static_cast<int8_t>(main->viewports[0]->zoom), ZoomLevel::full) };
 
         const uint16_t resolutionWidth = zoomLevel.applyInversedTo(World::kMapColumns * 32 * 2) + 8;
         const uint16_t resolutionHeight = zoomLevel.applyInversedTo(World::kMapRows * 32 * 1) + 128;

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -1491,7 +1491,7 @@ namespace OpenLoco::Ui::ViewportInteraction
     std::pair<ViewportInteraction::InteractionArg, Viewport*> getMapCoordinatesFromPos(int32_t screenX, int32_t screenY, InteractionItemFlags flags)
     {
         ViewportInteraction::InteractionArg interaction{};
-        Ui::Point screenPos = { static_cast<int16_t>(screenX), static_cast<int16_t>(screenY) };
+        Ui::Point screenPos = { screenX, screenY };
         auto w = WindowManager::findAt(screenPos);
         if (w == nullptr)
         {

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -1514,7 +1514,7 @@ namespace OpenLoco::Ui::ViewportInteraction
             chosenV = vp;
             auto vpPos = vp->screenToViewport({ screenPos.x, screenPos.y });
 
-            const int32_t alignMask = vp->zoom > ZoomLevel::full ? vp->zoom.applyTo(0xFFFF) : ~0;
+            const int32_t alignMask = vp->zoom > ZoomLevel::full ? ~(vp->zoom.applyTo(1) - 1) : ~0;
 
             Gfx::RenderTarget _rt1; // 0x00E0C3E4
             _rt1.x = vp->zoom.applyInversedTo(alignMask & vpPos.x);

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -1514,7 +1514,7 @@ namespace OpenLoco::Ui::ViewportInteraction
             chosenV = vp;
             auto vpPos = vp->screenToViewport({ screenPos.x, screenPos.y });
 
-            const int32_t alignMask = vp->zoom > ZoomLevel::full ? (0xFFFF << vp->zoom) : ~0;
+            const int32_t alignMask = vp->zoom > ZoomLevel::full ? vp->zoom.applyTo(0xFFFF) : ~0;
 
             Gfx::RenderTarget _rt1; // 0x00E0C3E4
             _rt1.x = vp->zoom.applyInversedTo(alignMask & vpPos.x);

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -1514,9 +1514,11 @@ namespace OpenLoco::Ui::ViewportInteraction
             chosenV = vp;
             auto vpPos = vp->screenToViewport({ screenPos.x, screenPos.y });
 
+            const int32_t alignMask = vp->zoom > ZoomLevel::full ? (0xFFFF << vp->zoom) : ~0;
+
             Gfx::RenderTarget _rt1; // 0x00E0C3E4
-            _rt1.x = ((0xFFFF << vp->zoom) & vpPos.x) >> vp->zoom;
-            _rt1.y = ((0xFFFF << vp->zoom) & vpPos.y) >> vp->zoom;
+            _rt1.x = vp->zoom.applyInversedTo(alignMask & vpPos.x);
+            _rt1.y = vp->zoom.applyInversedTo(alignMask & vpPos.y);
 
             Gfx::RenderTarget _rt2; // 0x00E0C3F4
             _rt2.x = _rt1.x;

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -1515,16 +1515,14 @@ namespace OpenLoco::Ui::ViewportInteraction
             auto vpPos = vp->screenToViewport({ screenPos.x, screenPos.y });
 
             Gfx::RenderTarget _rt1; // 0x00E0C3E4
-            _rt1.zoomLevel = vp->zoom;
-            _rt1.x = (0xFFFF << vp->zoom) & vpPos.x;
-            _rt1.y = (0xFFFF << vp->zoom) & vpPos.y;
+            _rt1.x = ((0xFFFF << vp->zoom) & vpPos.x) >> vp->zoom;
+            _rt1.y = ((0xFFFF << vp->zoom) & vpPos.y) >> vp->zoom;
 
             Gfx::RenderTarget _rt2; // 0x00E0C3F4
             _rt2.x = _rt1.x;
             _rt2.y = _rt1.y;
             _rt2.width = 1;
             _rt2.height = 1;
-            _rt2.zoomLevel = _rt1.zoomLevel;
 
             Paint::SessionOptions options{};
             options.rotation = vp->getRotation();
@@ -1532,13 +1530,13 @@ namespace OpenLoco::Ui::ViewportInteraction
             options.isHitTest = true;
             // Todo: should this pass the cullHeight...
 
-            auto session = Paint::PaintSession(_rt2, options);
+            auto session = Paint::PaintSession(_rt2, vp->zoom, options);
             session.generate();
             session.arrangeStructs();
             interaction = session.getNormalInteractionInfo(flags);
             if (!vp->hasFlags(ViewportFlags::hideStationNames))
             {
-                if (_rt2.zoomLevel <= Config::get().stationNamesMinScale)
+                if (vp->zoom <= Config::get().stationNamesMinScale)
                 {
                     auto stationInteraction = session.getStationNameInteractionInfo(flags);
                     if (stationInteraction.type != InteractionItem::noInteraction)

--- a/src/OpenLoco/src/Ui/Widget.cpp
+++ b/src/OpenLoco/src/Ui/Widget.cpp
@@ -125,17 +125,17 @@ namespace OpenLoco::Ui
         {
             if (imageId != kContentUnk)
             {
-                drawingCtx.drawImage(pos.x, pos.y, imageId);
+                drawingCtx.drawImage(ZoomLevel::full, pos.x, pos.y, imageId);
             }
         }
         else
         {
             if (imageId != kContentUnk)
             {
-                drawingCtx.drawImage(pos.x, pos.y + 1, imageId);
+                drawingCtx.drawImage(ZoomLevel::full, pos.x, pos.y + 1, imageId);
             }
 
-            drawingCtx.drawImage(pos.x, pos.y, Gfx::recolourTranslucent(ImageIds::tab, ExtColour::unk33));
+            drawingCtx.drawImage(ZoomLevel::full, pos.x, pos.y, Gfx::recolourTranslucent(ImageIds::tab, ExtColour::unk33));
             drawingCtx.drawRect(pos.x, pos.y + 26, 31, 1, Colours::getShade(w.getColour(WindowColour::secondary).c(), 7), Gfx::RectFlags::none);
         }
     }

--- a/src/OpenLoco/src/Ui/Widgets/CaptionWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/CaptionWidget.cpp
@@ -45,8 +45,8 @@ namespace OpenLoco::Ui::Widgets
     // 0x004CF3EB
     static void drawStationNameBackground(Gfx::DrawingContext& drawingCtx, const Ui::Point& origin, AdvancedColour colour, int32_t width)
     {
-        drawingCtx.drawImage(origin - Ui::Point{ 4, 0 }, Gfx::recolour(ImageIds::curved_border_left_medium, colour.c()));
-        drawingCtx.drawImage(origin + Ui::Point(width, 0), Gfx::recolour(ImageIds::curved_border_right_medium, colour.c()));
+        drawingCtx.drawImage(ZoomLevel::full, origin - Ui::Point{ 4, 0 }, Gfx::recolour(ImageIds::curved_border_left_medium, colour.c()));
+        drawingCtx.drawImage(ZoomLevel::full, origin + Ui::Point(width, 0), Gfx::recolour(ImageIds::curved_border_right_medium, colour.c()));
         drawingCtx.fillRect(origin, Ui::Size{ width, 11 }, Colours::getShade(colour.c(), 5), Gfx::RectFlags::none);
     }
 

--- a/src/OpenLoco/src/Ui/Widgets/ColourButtonWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ColourButtonWidget.cpp
@@ -37,6 +37,6 @@ namespace OpenLoco::Ui::Widgets
         auto* window = widgetState.window;
 
         const auto pos = window->position() + widget.position();
-        drawingCtx.drawImage(pos, imageId);
+        drawingCtx.drawImage(ZoomLevel::full, pos, imageId);
     }
 }

--- a/src/OpenLoco/src/Ui/Widgets/FrameWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/FrameWidget.cpp
@@ -27,7 +27,7 @@ namespace OpenLoco::Ui::Widgets
         const auto resizeBarPos = pos + Ui::Point(size.width - kResizeHandleSize, size.height - kResizeHandleSize);
 
         uint32_t image = Gfx::recolour(ImageIds::window_resize_handle, colour.c());
-        drawingCtx.drawImage(resizeBarPos, image);
+        drawingCtx.drawImage(ZoomLevel::full, resizeBarPos, image);
     }
 
     // 0x004CAAB9
@@ -100,7 +100,7 @@ namespace OpenLoco::Ui::Widgets
             // NB: starting on the right side to counter the border on the left side of the sprite
             for (auto i = numPassesNeeded; i >= 0; i--)
             {
-                drawingCtx.drawImage(i * (backgroundImageWidth - 1), 0, imageId);
+                drawingCtx.drawImage(ZoomLevel::full, i * (backgroundImageWidth - 1), 0, imageId);
             }
 
             drawingCtx.popRenderTarget();

--- a/src/OpenLoco/src/Ui/Widgets/ImageButtonWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ImageButtonWidget.cpp
@@ -62,7 +62,7 @@ namespace OpenLoco::Ui::Widgets
             imageId = ImageId::fromUInt32(Gfx::recolour(imageId.getIndex(), colour.c()));
         }
 
-        drawingCtx.drawImage(pos, imageId);
+        drawingCtx.drawImage(ZoomLevel::full, pos, imageId);
     }
 
     static void draw_3(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)

--- a/src/OpenLoco/src/Ui/Widgets/NewsPanelWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/NewsPanelWidget.cpp
@@ -18,17 +18,17 @@ namespace OpenLoco::Ui::Widgets
         if (style == Style::old)
         {
             auto imageId = Gfx::recolour(ImageIds::news_background_old_left, ExtColour::translucentBrown1);
-            drawingCtx.drawImage(pos, imageId);
+            drawingCtx.drawImage(ZoomLevel::full, pos, imageId);
 
             imageId = Gfx::recolour(ImageIds::news_background_old_right, ExtColour::translucentBrown1);
 
-            drawingCtx.drawImage(centerPos, imageId);
+            drawingCtx.drawImage(ZoomLevel::full, centerPos, imageId);
         }
         else if (style == Style::new_)
         {
-            drawingCtx.drawImage(pos, ImageIds::news_background_new_left);
+            drawingCtx.drawImage(ZoomLevel::full, pos, ImageIds::news_background_new_left);
 
-            drawingCtx.drawImage(centerPos, ImageIds::news_background_new_right);
+            drawingCtx.drawImage(ZoomLevel::full, centerPos, ImageIds::news_background_new_right);
         }
         else
         {

--- a/src/OpenLoco/src/Ui/Widgets/PanelWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/PanelWidget.cpp
@@ -25,7 +25,7 @@ namespace OpenLoco::Ui::Widgets
         const auto resizeBarPos = pos + Ui::Point(size.width - 18, size.height - 18);
 
         uint32_t image = Gfx::recolour(ImageIds::window_resize_handle, colour.c());
-        drawingCtx.drawImage(resizeBarPos, image);
+        drawingCtx.drawImage(ZoomLevel::full, resizeBarPos, image);
     }
 
     // 0x004CAB58

--- a/src/OpenLoco/src/Ui/Widgets/TabWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/TabWidget.cpp
@@ -51,7 +51,7 @@ namespace OpenLoco::Ui::Widgets
 
         imageId = imageId.withPrimary(colour.c());
 
-        drawingCtx.drawImage(pos, imageId);
+        drawingCtx.drawImage(ZoomLevel::full, pos, imageId);
     }
 
     static void drawTabContent(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)
@@ -76,17 +76,17 @@ namespace OpenLoco::Ui::Widgets
         {
             if (widget.image != Widget::kContentNull)
             {
-                drawingCtx.drawImage(pos.x, pos.y, widget.image);
+                drawingCtx.drawImage(ZoomLevel::full, pos.x, pos.y, widget.image);
             }
         }
         else
         {
             if (widget.image != Widget::kContentUnk)
             {
-                drawingCtx.drawImage(pos.x, pos.y + 1, widget.image);
+                drawingCtx.drawImage(ZoomLevel::full, pos.x, pos.y + 1, widget.image);
             }
 
-            drawingCtx.drawImage(pos.x, pos.y, Gfx::recolourTranslucent(ImageIds::tab, ExtColour::unk33));
+            drawingCtx.drawImage(ZoomLevel::full, pos.x, pos.y, Gfx::recolourTranslucent(ImageIds::tab, ExtColour::unk33));
             drawingCtx.drawRect(pos.x, pos.y + 26, 31, 1, Colours::getShade(window->getColour(WindowColour::secondary).c(), 7), Gfx::RectFlags::none);
         }
     }

--- a/src/OpenLoco/src/Ui/Widgets/ToolbarButtonWidget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/ToolbarButtonWidget.cpp
@@ -35,6 +35,6 @@ namespace OpenLoco::Ui::Widgets
             imageId = imageId.withIndexOffset(1);
         }
 
-        drawingCtx.drawImage(pos, imageId);
+        drawingCtx.drawImage(ZoomLevel::full, pos, imageId);
     }
 }

--- a/src/OpenLoco/src/Ui/Widgets/Wt3Widget.cpp
+++ b/src/OpenLoco/src/Ui/Widgets/Wt3Widget.cpp
@@ -53,7 +53,7 @@ namespace OpenLoco::Ui::Widgets
             imageId = imageId.withPrimary(colour.c());
         }
 
-        drawingCtx.drawImage(position, imageId);
+        drawingCtx.drawImage(ZoomLevel::full, position, imageId);
     }
 
     void Wt3Widget::draw(Gfx::DrawingContext& drawingCtx, const Widget& widget, const WidgetState& widgetState)

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -226,10 +226,10 @@ namespace OpenLoco::Ui
     // 0x004C68E4
     static void viewportMove(int16_t x, int16_t y, Ui::Window* w, Ui::Viewport* vp)
     {
-        int origX = vp->viewX >> vp->zoom;
-        int origY = vp->viewY >> vp->zoom;
-        int newX = x >> vp->zoom;
-        int newY = y >> vp->zoom;
+        int origX = vp->zoom.applyInversedTo(vp->viewX);
+        int origY = vp->zoom.applyInversedTo(vp->viewY);
+        int newX = vp->zoom.applyInversedTo<int32_t>(x);
+        int newY = vp->zoom.applyInversedTo<int32_t>(y);
         int diffX = origX - newX;
         int diffY = origY - newY;
 
@@ -249,14 +249,13 @@ namespace OpenLoco::Ui
             return;
         }
 
-        uint8_t zoom = (1 << vp->zoom);
         Viewport backup = *vp;
 
         if (vp->x < 0)
         {
             vp->width += vp->x;
-            vp->viewWidth += vp->x * zoom;
-            vp->viewX -= vp->x * zoom;
+            vp->viewWidth += vp->zoom.applyTo(vp->x);
+            vp->viewX -= vp->zoom.applyTo(vp->x);
             vp->x = 0;
         }
 
@@ -264,7 +263,7 @@ namespace OpenLoco::Ui
         if (eax > 0)
         {
             vp->width -= eax;
-            vp->viewWidth -= eax * zoom;
+            vp->viewWidth -= vp->zoom.applyTo(eax);
         }
 
         if (vp->width <= 0)
@@ -276,8 +275,8 @@ namespace OpenLoco::Ui
         if (vp->y < 0)
         {
             vp->height += vp->y;
-            vp->viewHeight += vp->y * zoom;
-            vp->viewY -= vp->y * zoom;
+            vp->viewHeight += vp->zoom.applyTo(vp->y);
+            vp->viewY -= vp->zoom.applyTo(vp->y);
             vp->y = 0;
         }
 
@@ -285,7 +284,7 @@ namespace OpenLoco::Ui
         if (eax > 0)
         {
             vp->height -= eax;
-            vp->viewHeight -= eax * zoom;
+            vp->viewHeight -= vp->zoom.applyTo(eax);
         }
 
         if (vp->height <= 0)
@@ -668,7 +667,7 @@ namespace OpenLoco::Ui
         Viewport* v = this->viewports[0];
         ViewportConfig* vc = &this->viewportConfigurations[0];
 
-        zoomLevel = std::clamp<int8_t>(zoomLevel, 0, 3);
+        zoomLevel = std::clamp<int8_t>(zoomLevel, ZoomLevel::min, ZoomLevel::max);
         if (v->zoom == zoomLevel)
         {
             return;
@@ -698,18 +697,19 @@ namespace OpenLoco::Ui
 
         if (toCursor && Config::get().zoomToCursor)
         {
+            const auto newZoomLevel = ZoomLevel{ zoomLevel };
             const auto mouseCoords = Ui::getCursorPosScaled() - Point(v->x, v->y);
-            const int32_t diffX = mouseCoords.x - ((v->viewWidth >> zoomLevel) / 2);
-            const int32_t diffY = mouseCoords.y - ((v->viewHeight >> zoomLevel) / 2);
-            if (previousZoomLevel > zoomLevel)
+            const int32_t diffX = mouseCoords.x - (newZoomLevel.applyInversedTo(v->viewWidth) / 2);
+            const int32_t diffY = mouseCoords.y - (newZoomLevel.applyInversedTo(v->viewHeight) / 2);
+            if (previousZoomLevel > newZoomLevel)
             {
-                vc->savedViewX += diffX << zoomLevel;
-                vc->savedViewY += diffY << zoomLevel;
+                vc->savedViewX += newZoomLevel.applyTo(diffX);
+                vc->savedViewY += newZoomLevel.applyTo(diffY);
             }
             else
             {
-                vc->savedViewX -= diffX << previousZoomLevel;
-                vc->savedViewY -= diffY << previousZoomLevel;
+                vc->savedViewX -= previousZoomLevel.applyTo(diffX);
+                vc->savedViewY -= previousZoomLevel.applyTo(diffY);
             }
         }
 
@@ -809,22 +809,18 @@ namespace OpenLoco::Ui
             config.savedViewX = newSavedView.viewX;
             config.savedViewY = newSavedView.viewY;
 
-            auto zoom = static_cast<int32_t>(newSavedView.zoomLevel) - viewport->zoom;
-            if (zoom != 0)
+            const auto zoomDiff = static_cast<int32_t>(newSavedView.zoomLevel) - static_cast<int32_t>(viewport->zoom);
+            if (zoomDiff < 0)
             {
-                if (zoom < 0)
-                {
-                    zoom = -zoom;
-                    viewport->viewWidth >>= zoom;
-                    viewport->viewHeight >>= zoom;
-                }
-                else
-                {
-                    viewport->viewWidth <<= zoom;
-                    viewport->viewHeight <<= zoom;
-                }
+                viewport->viewWidth >>= -zoomDiff;
+                viewport->viewHeight >>= -zoomDiff;
             }
-            viewport->zoom = zoom;
+            else if (zoomDiff > 0)
+            {
+                viewport->viewWidth <<= zoomDiff;
+                viewport->viewHeight <<= zoomDiff;
+            }
+            viewport->zoom = newSavedView.zoomLevel;
             viewport->setRotation(newSavedView.rotation);
 
             config.savedViewX -= viewport->viewWidth / 2;

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -662,13 +662,13 @@ namespace OpenLoco::Ui
         }
     }
 
-    void Window::viewportZoomSet(int8_t zoomLevel, bool toCursor)
+    void Window::viewportZoomSet(ZoomLevel zoomLevel, bool toCursor)
     {
         Viewport* v = this->viewports[0];
         ViewportConfig* vc = &this->viewportConfigurations[0];
 
-        zoomLevel = std::clamp<int8_t>(zoomLevel, ZoomLevel::min, ZoomLevel::max);
-        if (v->zoom == zoomLevel)
+        const auto newZoomLevel = ZoomLevel{ std::clamp<int8_t>(static_cast<int8_t>(zoomLevel), ZoomLevel::min, ZoomLevel::max) };
+        if (v->zoom == newZoomLevel)
         {
             return;
         }
@@ -676,7 +676,7 @@ namespace OpenLoco::Ui
         const auto previousZoomLevel = v->zoom;
 
         // Zoom in
-        while (v->zoom > zoomLevel)
+        while (v->zoom > newZoomLevel)
         {
             v->zoom--;
             vc->savedViewX += v->viewWidth / 4;
@@ -686,7 +686,7 @@ namespace OpenLoco::Ui
         }
 
         // Zoom out
-        while (v->zoom < zoomLevel)
+        while (v->zoom < newZoomLevel)
         {
             v->zoom++;
             vc->savedViewX -= v->viewWidth / 2;
@@ -697,7 +697,6 @@ namespace OpenLoco::Ui
 
         if (toCursor && Config::get().zoomToCursor)
         {
-            const auto newZoomLevel = ZoomLevel{ zoomLevel };
             const auto mouseCoords = Ui::getCursorPosScaled() - Point(v->x, v->y);
             const int32_t diffX = mouseCoords.x - (newZoomLevel.applyInversedTo(v->viewWidth) / 2);
             const int32_t diffY = mouseCoords.y - (newZoomLevel.applyInversedTo(v->viewHeight) / 2);
@@ -809,7 +808,7 @@ namespace OpenLoco::Ui
             config.savedViewX = newSavedView.viewX;
             config.savedViewY = newSavedView.viewY;
 
-            const auto zoomDiff = static_cast<int32_t>(newSavedView.zoomLevel) - static_cast<int32_t>(viewport->zoom);
+            const auto zoomDiff = static_cast<int32_t>(static_cast<int8_t>(newSavedView.zoomLevel)) - static_cast<int32_t>(static_cast<int8_t>(viewport->zoom));
             if (zoomDiff < 0)
             {
                 viewport->viewWidth >>= -zoomDiff;

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -183,7 +183,7 @@ namespace OpenLoco::Ui
     // Output:
     // {x: regs.ax, y: regs.bx}
     // Note: in the original code: regs.dx: x/2 (probably not used anywhere)
-    World::Pos2 viewportCoordToMapCoord(int16_t x, int16_t y, int16_t z, int32_t rotation)
+    World::Pos2 viewportCoordToMapCoord(int32_t x, int32_t y, int32_t z, int32_t rotation)
     {
         constexpr uint8_t inverseRotationMapping[4] = { 0, 3, 2, 1 };
         const auto result = World::Pos2(y - (x >> 1) + z, y + (x >> 1) + z);
@@ -224,12 +224,12 @@ namespace OpenLoco::Ui
     }
 
     // 0x004C68E4
-    static void viewportMove(int16_t x, int16_t y, Ui::Window* w, Ui::Viewport* vp)
+    static void viewportMove(int32_t x, int32_t y, Ui::Window* w, Ui::Viewport* vp)
     {
         int origX = vp->zoom.applyInversedTo(vp->viewX);
         int origY = vp->zoom.applyInversedTo(vp->viewY);
-        int newX = vp->zoom.applyInversedTo<int32_t>(x);
-        int newY = vp->zoom.applyInversedTo<int32_t>(y);
+        int newX = vp->zoom.applyInversedTo(x);
+        int newY = vp->zoom.applyInversedTo(y);
         int diffX = origX - newX;
         int diffY = origY - newY;
 

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -46,7 +46,7 @@ namespace OpenLoco::Ui::WindowManager
 
     static std::array<AdvancedColour, enumValue(WindowColour::count)> _windowColours;
 
-    static void viewportRedrawAfterShift(Window* window, Viewport* viewport, int32_t x, int32_t y);
+    static void viewportRedrawAfterShift(Window* window, Viewport* viewport, const Ui::Rect& area, int32_t x, int32_t y);
 
     void init()
     {
@@ -1404,7 +1404,7 @@ namespace OpenLoco::Ui::WindowManager
             }
 
             auto viewport = w.viewports[0];
-            if (viewport->zoom != 0)
+            if (viewport->zoom != ZoomLevel::full)
             {
                 continue;
             }
@@ -1503,7 +1503,7 @@ namespace OpenLoco::Ui::WindowManager
             }
         }
 
-        viewportRedrawAfterShift(window, viewport, dX, dY);
+        viewportRedrawAfterShift(window, viewport, viewport->getUiRect(), dX, dY);
     }
 
     /**
@@ -1514,87 +1514,59 @@ namespace OpenLoco::Ui::WindowManager
      * @param y @<bp>
      * @param viewport @<esi>
      */
-    void viewportRedrawAfterShift(Window* window, Viewport* viewport, int32_t x, int32_t y)
+    void viewportRedrawAfterShift(Window* window, Viewport* viewport, const Ui::Rect& area, int32_t x, int32_t y)
     {
         while (window != nullptr)
         {
             // skip current window and non-intersecting windows
             if (viewport == window->viewports[0]
                 || viewport == window->viewports[1]
-                || viewport->x + viewport->width <= window->x
-                || viewport->x >= window->x + window->width
-                || viewport->y + viewport->height <= window->y
-                || viewport->y >= window->y + window->height)
+                || area.right() <= window->x
+                || area.left() >= window->x + window->width
+                || area.bottom() <= window->y
+                || area.top() >= window->y + window->height)
             {
                 size_t nextWindowIndex = WindowManager::indexOf(*window) + 1;
                 window = nextWindowIndex >= count() ? nullptr : WindowManager::get(nextWindowIndex);
                 continue;
             }
 
-            // save viewport
-            Ui::Viewport viewCopy = *viewport;
+            const auto splitVertically = [&](int32_t splitX) {
+                viewportRedrawAfterShift(window, viewport, Ui::Rect::fromLTRB(area.left(), area.top(), splitX, area.bottom()), x, y);
+                viewportRedrawAfterShift(window, viewport, Ui::Rect::fromLTRB(splitX, area.top(), area.right(), area.bottom()), x, y);
+            };
+            const auto splitHorizontally = [&](int32_t splitY) {
+                viewportRedrawAfterShift(window, viewport, Ui::Rect::fromLTRB(area.left(), area.top(), area.right(), splitY), x, y);
+                viewportRedrawAfterShift(window, viewport, Ui::Rect::fromLTRB(area.left(), splitY, area.right(), area.bottom()), x, y);
+            };
 
-            if (viewport->x < window->x)
+            if (area.left() < window->x)
             {
-                viewport->width = window->x - viewport->x;
-                viewport->viewWidth = viewport->width << viewport->zoom;
-                viewportRedrawAfterShift(window, viewport, x, y);
-
-                viewport->x += viewport->width;
-                viewport->viewX += viewport->width << viewport->zoom;
-                viewport->width = viewCopy.width - viewport->width;
-                viewport->viewWidth = viewport->width << viewport->zoom;
-                viewportRedrawAfterShift(window, viewport, x, y);
+                splitVertically(window->x);
             }
-            else if (viewport->x + viewport->width > window->x + window->width)
+            else if (area.right() > window->x + window->width)
             {
-                viewport->width = window->x + window->width - viewport->x;
-                viewport->viewWidth = viewport->width << viewport->zoom;
-                viewportRedrawAfterShift(window, viewport, x, y);
-
-                viewport->x += viewport->width;
-                viewport->viewX += viewport->width << viewport->zoom;
-                viewport->width = viewCopy.width - viewport->width;
-                viewport->viewWidth = viewport->width << viewport->zoom;
-                viewportRedrawAfterShift(window, viewport, x, y);
+                splitVertically(window->x + window->width);
             }
-            else if (viewport->y < window->y)
+            else if (area.top() < window->y)
             {
-                viewport->height = window->y - viewport->y;
-                viewport->viewHeight = viewport->height << viewport->zoom;
-                viewportRedrawAfterShift(window, viewport, x, y);
-
-                viewport->y += viewport->height;
-                viewport->viewY += viewport->height << viewport->zoom;
-                viewport->height = viewCopy.height - viewport->height;
-                viewport->viewHeight = viewport->height << viewport->zoom;
-                viewportRedrawAfterShift(window, viewport, x, y);
+                splitHorizontally(window->y);
             }
-            else if (viewport->y + viewport->height > window->y + window->height)
+            else if (area.bottom() > window->y + window->height)
             {
-                viewport->height = window->y + window->height - viewport->y;
-                viewport->viewHeight = viewport->height << viewport->zoom;
-                viewportRedrawAfterShift(window, viewport, x, y);
-
-                viewport->y += viewport->height;
-                viewport->viewY += viewport->height << viewport->zoom;
-                viewport->height = viewCopy.height - viewport->height;
-                viewport->viewHeight = viewport->height << viewport->zoom;
-                viewportRedrawAfterShift(window, viewport, x, y);
+                splitHorizontally(window->y + window->height);
             }
 
-            // restore viewport
-            *viewport = viewCopy;
             return;
         }
 
-        auto left = viewport->x;
-        auto top = viewport->y;
-        auto right = left + viewport->width;
-        auto bottom = top + viewport->height;
+        auto left = area.left();
+        auto top = area.top();
+        auto right = area.right();
+        auto bottom = area.bottom();
 
         // if moved more than the viewport size
-        if (std::abs(x) >= viewport->width || std::abs(y) >= viewport->height)
+        if (std::abs(x) >= area.width() || std::abs(y) >= area.height())
         {
             // redraw whole viewport
             Gfx::render(left, top, right, bottom);
@@ -1602,7 +1574,7 @@ namespace OpenLoco::Ui::WindowManager
         else
         {
             // update whole block
-            Gfx::movePixelsOnScreen(left, top, viewport->width, viewport->height, x, y);
+            Gfx::movePixelsOnScreen(left, top, area.width(), area.height(), x, y);
 
             if (x > 0)
             {

--- a/src/OpenLoco/src/Ui/Windows/About.cpp
+++ b/src/OpenLoco/src/Ui/Windows/About.cpp
@@ -89,7 +89,7 @@ namespace OpenLoco::Ui::Windows::About
         window.draw(drawingCtx);
 
         // Chris Sawyer logo
-        drawingCtx.drawImage(window.x + 92, window.y + 52, ImageIds::chris_sawyer_logo_small);
+        drawingCtx.drawImage(ZoomLevel::full, window.x + 92, window.y + 52, ImageIds::chris_sawyer_logo_small);
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
@@ -275,7 +275,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
 
             const CompetitorObject* competitor = reinterpret_cast<CompetitorObject*>(ObjectManager::getTemporaryObject());
             uint32_t img = Gfx::recolour(competitor->images[0] + 1, Colour::black);
-            drawingCtx.drawImage(l, t, img);
+            drawingCtx.drawImage(ZoomLevel::full, l, t, img);
         }
 
         {

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -1290,7 +1290,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
                     imageId = Gfx::recolour(imageId, company->mainColours.primary);
 
                     auto x = self.x + 4;
-                    drawingCtx.drawImage(x, y, imageId);
+                    drawingCtx.drawImage(ZoomLevel::full, x, y, imageId);
 
                     y += 7;
                     auto point = Point(self.x + 33, y);

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -427,8 +427,8 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 {
                     viewport->width = proposedDims.width;
                     viewport->height = proposedDims.height;
-                    viewport->viewWidth = proposedDims.width << viewport->zoom;
-                    viewport->viewHeight = proposedDims.height << viewport->zoom;
+                    viewport->viewWidth = viewport->zoom.applyTo(proposedDims.width);
+                    viewport->viewHeight = viewport->zoom.applyTo(proposedDims.height);
                     self.savedView.clear();
                 }
             }

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -231,7 +231,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 const uint32_t image = Gfx::recolour(competitor->images[enumValue(company->ownerEmotion)] + 1, company->mainColours.primary);
                 const uint16_t x = self.x + self.widgets[widx::face].left + 1;
                 const uint16_t y = self.y + self.widgets[widx::face].top + 1;
-                drawingCtx.drawImage(x, y, image);
+                drawingCtx.drawImage(ZoomLevel::full, x, y, image);
             }
 
             // If the owner's been naughty, draw some jail bars over them.
@@ -240,7 +240,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
                 const uint32_t image = ImageIds::owner_jailed;
                 const uint16_t x = self.x + self.widgets[widx::face].left + 1;
                 const uint16_t y = self.y + self.widgets[widx::face].top + 1;
-                drawingCtx.drawImage(x, y, image);
+                drawingCtx.drawImage(ZoomLevel::full, x, y, image);
             }
 
             // Draw owner name
@@ -2816,7 +2816,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             const uint32_t image = Gfx::recolour(competitor->images[enumValue(company->ownerEmotion)], company->mainColours.primary);
             const uint16_t x = self->x + self->widgets[Common::widx::company_select].left + 1;
             const uint16_t y = self->y + self->widgets[Common::widx::company_select].top + 1;
-            drawingCtx.drawImage(x, y, image);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, image);
         }
 
         // 0x00434413

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -948,24 +948,20 @@ namespace OpenLoco::Ui::Windows::Construction
                 auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(x, y, width, height));
                 if (clipped)
                 {
-                    clipped->zoomLevel = 1;
-                    clipped->width <<= 1;
-                    clipped->height <<= 1;
-                    clipped->x <<= 1;
-                    clipped->y <<= 1;
+                    const auto zoom = ZoomLevel{ ZoomLevel::half };
 
                     drawingCtx.pushRenderTarget(*clipped);
 
                     auto roadStationObj = ObjectManager::get<RoadStationObject>(cState.lastSelectedStationType);
                     auto imageId = Gfx::recolour(roadStationObj->image, companyColour);
-                    drawingCtx.drawImage(-4, -10, imageId);
+                    drawingCtx.drawImage(zoom, { -4, -10 }, ImageId::fromUInt32(imageId));
                     auto colour = Colours::getTranslucent(companyColour);
                     if (!roadStationObj->hasFlags(RoadStationFlags::recolourable))
                     {
                         colour = ExtColour::unk2E;
                     }
                     imageId = Gfx::recolourTranslucent(roadStationObj->image, colour) + 1;
-                    drawingCtx.drawImage(-4, -10, imageId);
+                    drawingCtx.drawImage(zoom, { -4, -10 }, ImageId::fromUInt32(imageId));
 
                     drawingCtx.popRenderTarget();
                 }
@@ -990,7 +986,7 @@ namespace OpenLoco::Ui::Windows::Construction
                         {
                             imageId += (self.frameNo / 2) % 8;
                         }
-                        drawingCtx.drawImage(x, y, imageId);
+                        drawingCtx.drawImage(ZoomLevel::full, x, y, imageId);
                     }
                 }
 
@@ -1077,17 +1073,13 @@ namespace OpenLoco::Ui::Windows::Construction
                 auto clipped = Gfx::clipRenderTarget(rt, Ui::Rect(x, y, width, height));
                 if (clipped)
                 {
-                    clipped->zoomLevel = 1;
-                    clipped->width *= 2;
-                    clipped->height *= 2;
-                    clipped->x *= 2;
-                    clipped->y *= 2;
+                    const auto zoom = ZoomLevel{ ZoomLevel::half };
 
                     drawingCtx.pushRenderTarget(*clipped);
 
                     auto trainStationObj = ObjectManager::get<TrainStationObject>(cState.lastSelectedStationType);
                     auto imageId = Gfx::recolour(trainStationObj->image + TrainStation::ImageIds::preview_image, companyColour);
-                    drawingCtx.drawImage(-4, -9, imageId);
+                    drawingCtx.drawImage(zoom, { -4, -9 }, ImageId::fromUInt32(imageId));
 
                     auto colour = Colours::getTranslucent(companyColour);
                     if (!trainStationObj->hasFlags(TrainStationFlags::recolourable))
@@ -1095,7 +1087,7 @@ namespace OpenLoco::Ui::Windows::Construction
                         colour = ExtColour::unk2E;
                     }
                     imageId = Gfx::recolourTranslucent(trainStationObj->image + TrainStation::ImageIds::preview_image_windows, colour);
-                    drawingCtx.drawImage(-4, -9, imageId);
+                    drawingCtx.drawImage(zoom, { -4, -9 }, ImageId::fromUInt32(imageId));
 
                     drawingCtx.popRenderTarget();
                 }
@@ -1133,7 +1125,7 @@ namespace OpenLoco::Ui::Windows::Construction
                         frameIndex <<= 3;
                         imageId += frameIndex;
                     }
-                    drawingCtx.drawImage(15, 31, imageId);
+                    drawingCtx.drawImage(ZoomLevel::full, 15, 31, imageId);
 
                     drawingCtx.popRenderTarget();
                 }
@@ -1157,7 +1149,7 @@ namespace OpenLoco::Ui::Windows::Construction
                         {
                             imageId += (self.frameNo / 2) % 8;
                         }
-                        drawingCtx.drawImage(x, y, imageId);
+                        drawingCtx.drawImage(ZoomLevel::full, x, y, imageId);
                     }
                 }
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -2973,7 +2973,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         options.rotation = WindowManager::getCurrentRotation();
         options.skipTrackRoadSurfaces = (flags & TrackRoadPreviewFlags::skipTrackRoadSurfaces) != TrackRoadPreviewFlags::none;
 
-        auto session = Paint::PaintSession(drawingCtx.currentRenderTarget(), options);
+        auto session = Paint::PaintSession(drawingCtx.currentRenderTarget(), ZoomLevel::full, options);
 
         for (const auto& trackPiece : trackPieces)
         {
@@ -3072,7 +3072,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
         options.rotation = WindowManager::getCurrentRotation();
         options.skipTrackRoadSurfaces = (flags & TrackRoadPreviewFlags::skipTrackRoadSurfaces) != TrackRoadPreviewFlags::none;
 
-        auto session = Paint::PaintSession(drawingCtx.currentRenderTarget(), options);
+        auto session = Paint::PaintSession(drawingCtx.currentRenderTarget(), ZoomLevel::full, options);
 
         for (const auto& roadPiece : roadPieces)
         {
@@ -3250,7 +3250,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
                     auto x = self.x + self.widgets[widx::bridge].left + 2;
                     auto y = self.y + self.widgets[widx::bridge].top + 1;
 
-                    drawingCtx.drawImage(x, y, imageId);
+                    drawingCtx.drawImage(ZoomLevel::full, x, y, imageId);
                 }
             }
         }

--- a/src/OpenLoco/src/Ui/Windows/Construction/SignalTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/SignalTab.cpp
@@ -348,14 +348,14 @@ namespace OpenLoco::Ui::Windows::Construction::Signal
         xPos = self.widgets[widx::both_directions].midX() + self.x;
         yPos = self.widgets[widx::both_directions].bottom + self.y - 4;
 
-        drawingCtx.drawImage(xPos - 8, yPos, imageId);
+        drawingCtx.drawImage(ZoomLevel::full, xPos - 8, yPos, imageId);
 
-        drawingCtx.drawImage(xPos + 8, yPos, imageId + 4);
+        drawingCtx.drawImage(ZoomLevel::full, xPos + 8, yPos, imageId + 4);
 
         xPos = self.widgets[widx::single_direction].midX() + self.x;
         yPos = self.widgets[widx::single_direction].bottom + self.y - 4;
 
-        drawingCtx.drawImage(xPos, yPos, imageId);
+        drawingCtx.drawImage(ZoomLevel::full, xPos, yPos, imageId);
 
         if (cState.signalCost != GameCommands::kFailure && cState.signalCost != 0)
         {

--- a/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/StationTab.cpp
@@ -1205,20 +1205,20 @@ namespace OpenLoco::Ui::Windows::Construction::Station
         {
             auto airportObj = ObjectManager::get<AirportObject>(cState.lastSelectedStationType);
             auto imageId = Gfx::recolour(airportObj->image, companyColour);
-            drawingCtx.drawImage(xPos, yPos, imageId);
+            drawingCtx.drawImage(ZoomLevel::full, xPos, yPos, imageId);
         }
         else if (cState.byte_1136063 & (1 << 6))
         {
             auto dockObj = ObjectManager::get<DockObject>(cState.lastSelectedStationType);
             auto imageId = Gfx::recolour(dockObj->image, companyColour);
-            drawingCtx.drawImage(xPos, yPos, imageId);
+            drawingCtx.drawImage(ZoomLevel::full, xPos, yPos, imageId);
         }
         else if (cState.trackType & (1 << 7))
         {
             auto roadStationObj = ObjectManager::get<RoadStationObject>(cState.lastSelectedStationType);
 
             auto imageId = Gfx::recolour(roadStationObj->image + RoadStation::ImageIds::preview_image, companyColour);
-            drawingCtx.drawImage(xPos, yPos, imageId);
+            drawingCtx.drawImage(ZoomLevel::full, xPos, yPos, imageId);
 
             auto colour = Colours::getTranslucent(companyColour);
             if (!roadStationObj->hasFlags(RoadStationFlags::recolourable))
@@ -1227,14 +1227,14 @@ namespace OpenLoco::Ui::Windows::Construction::Station
             }
 
             imageId = Gfx::recolourTranslucent(roadStationObj->image + RoadStation::ImageIds::preview_image_windows, colour);
-            drawingCtx.drawImage(xPos, yPos, imageId);
+            drawingCtx.drawImage(ZoomLevel::full, xPos, yPos, imageId);
         }
         else
         {
             auto trainStationObj = ObjectManager::get<TrainStationObject>(cState.lastSelectedStationType);
 
             auto imageId = Gfx::recolour(trainStationObj->image + TrainStation::ImageIds::preview_image, companyColour);
-            drawingCtx.drawImage(xPos, yPos, imageId);
+            drawingCtx.drawImage(ZoomLevel::full, xPos, yPos, imageId);
 
             auto colour = Colours::getTranslucent(companyColour);
             if (!trainStationObj->hasFlags(TrainStationFlags::recolourable))
@@ -1243,7 +1243,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
             }
 
             imageId = Gfx::recolourTranslucent(trainStationObj->image + TrainStation::ImageIds::preview_image_windows, colour);
-            drawingCtx.drawImage(xPos, yPos, imageId);
+            drawingCtx.drawImage(ZoomLevel::full, xPos, yPos, imageId);
         }
 
         if (cState.stationCost != GameCommands::kFailure && cState.stationCost != 0)
@@ -1310,7 +1310,7 @@ namespace OpenLoco::Ui::Windows::Construction::Station
                 }
 
                 auto* cargoObj = ObjectManager::get<CargoObject>(i);
-                drawingCtx.drawImage(origin.x, origin.y, cargoObj->unitInlineSprite);
+                drawingCtx.drawImage(ZoomLevel::full, origin.x, origin.y, cargoObj->unitInlineSprite);
 
                 FormatArguments args{};
                 args.push(cargoObj->name);

--- a/src/OpenLoco/src/Ui/Windows/Error.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Error.cpp
@@ -209,11 +209,11 @@ namespace OpenLoco::Ui::Windows::Error
                 imageId = Gfx::recolour(imageId, company->mainColours.primary);
                 imageId++;
 
-                drawingCtx.drawImage(xPos, yPos, imageId);
+                drawingCtx.drawImage(ZoomLevel::full, xPos, yPos, imageId);
 
                 if (company->jailStatus != 0)
                 {
-                    drawingCtx.drawImage(xPos, yPos, ImageIds::owner_jailed);
+                    drawingCtx.drawImage(ZoomLevel::full, xPos, yPos, ImageIds::owner_jailed);
                 }
 
                 auto point = Point(self.x + (self.width - kCompetitorSize) / 2 + kCompetitorSize + kPadding, self.y + 20);

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -219,8 +219,8 @@ namespace OpenLoco::Ui::Windows::Industry
                 {
                     viewport->width = newWidth;
                     viewport->height = newHeight;
-                    viewport->viewWidth = newWidth << viewport->zoom;
-                    viewport->viewHeight = newHeight << viewport->zoom;
+                    viewport->viewWidth = viewport->zoom.applyTo(newWidth);
+                    viewport->viewHeight = viewport->zoom.applyTo(newHeight);
                     self.savedView.clear();
                 }
             }

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -943,10 +943,10 @@ namespace OpenLoco::Ui::Windows::Industry
 
                 auto xPos = widget.left + self.x;
                 auto yPos = widget.top + self.y;
-                drawingCtx.drawImage(xPos, yPos, imageId);
+                drawingCtx.drawImage(ZoomLevel::full, xPos, yPos, imageId);
 
                 auto caroObj = ObjectManager::get<CargoObject>(industryObj->producedCargoType[productionTabNumber]);
-                drawingCtx.drawImage(xPos + 18, yPos + 14, caroObj->unitInlineSprite);
+                drawingCtx.drawImage(ZoomLevel::full, xPos + 18, yPos + 14, caroObj->unitInlineSprite);
 
                 Widget::drawTab(self, drawingCtx, Widget::kContentUnk, tab);
             }

--- a/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
+++ b/src/OpenLoco/src/Ui/Windows/LandscapeGeneration.cpp
@@ -661,7 +661,7 @@ namespace OpenLoco::Ui::Windows::LandscapeGeneration
 
                 // Draw tile icon.
                 const uint32_t imageId = landObject->mapPixelImage + OpenLoco::Land::ImageIds::landscape_generator_tile_icon;
-                drawingCtx.drawImage(2, yPos + 1, imageId);
+                drawingCtx.drawImage(ZoomLevel::full, 2, yPos + 1, imageId);
 
                 // Draw land description.
                 {

--- a/src/OpenLoco/src/Ui/Windows/MapToolTip.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapToolTip.cpp
@@ -141,7 +141,7 @@ namespace OpenLoco::Ui::Windows::MapToolTip
             auto* competitor = ObjectManager::get<CompetitorObject>(company->competitorId);
             auto imageId = Gfx::recolour(competitor->images[enumValue(company->ownerEmotion)], company->mainColours.primary);
 
-            drawingCtx.drawImage(left + 1, top + 1, imageId);
+            drawingCtx.drawImage(ZoomLevel::full, left + 1, top + 1, imageId);
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -2179,7 +2179,7 @@ namespace OpenLoco::Ui::Windows::MapWindow
         Gfx::getG1Element(0)->yOffset = 0;
         Gfx::getG1Element(0)->flags = Gfx::G1ElementFlags::none;
 
-        drawingCtx.drawImage(0, 0, 0);
+        drawingCtx.drawImage(ZoomLevel::full, 0, 0, 0);
 
         *element = backupElement;
 

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -477,7 +477,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             {
                 const auto itemSubject = news->itemSubjects[i];
                 const auto& viewWidget = self->widgets[Common::widx::viewport1 + i];
-                const SubjectType subjectType = SubjectType((uint8_t)_nState.savedView[i].zoomLevel);
+                const SubjectType subjectType = SubjectType(static_cast<uint8_t>(static_cast<int8_t>(_nState.savedView[i].zoomLevel)));
 
                 if (subjectType == SubjectType::companyFace && itemSubject != 0xFFFFU)
                 {

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -488,11 +488,11 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     const ImageId imageId(imageIndexBase + 1, company->mainColours.primary);
                     const auto x = self->x + viewWidget.midX() - 31;
                     const auto y = self->y + viewWidget.midY() - 31;
-                    drawingCtx.drawImage(Ui::Point(x, y), imageId);
+                    drawingCtx.drawImage(ZoomLevel::full, Ui::Point(x, y), imageId);
 
                     if (company->jailStatus != 0)
                     {
-                        drawingCtx.drawImage(Ui::Point(x, y), ImageId(ImageIds::owner_jailed));
+                        drawingCtx.drawImage(ZoomLevel::full, Ui::Point(x, y), ImageId(ImageIds::owner_jailed));
                     }
                 }
 

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -1118,9 +1118,9 @@ namespace OpenLoco::Ui::Windows::Options
         static void drawVolumeSlider(Window& self, Gfx::DrawingContext& drawingCtx, WidgetIndex_t widx, int32_t volume)
         {
             auto& widget = self.widgets[widx];
-            drawingCtx.drawImage(self.x + widget.left, self.y + widget.top, Gfx::recolour(ImageIds::volume_slider_track, self.getColour(WindowColour::secondary).c()));
+            drawingCtx.drawImage(ZoomLevel::full, self.x + widget.left, self.y + widget.top, Gfx::recolour(ImageIds::volume_slider_track, self.getColour(WindowColour::secondary).c()));
             int16_t x = kThumbHalfWidth + Audio::dbToPercent(volume) * kSliderPixelRange / 100;
-            drawingCtx.drawImage(self.x + widget.left + x, self.y + widget.top, Gfx::recolour(ImageIds::volume_slider_thumb, self.getColour(WindowColour::secondary).c()));
+            drawingCtx.drawImage(ZoomLevel::full, self.x + widget.left + x, self.y + widget.top, Gfx::recolour(ImageIds::volume_slider_thumb, self.getColour(WindowColour::secondary).c()));
         }
 
         static void draw(Window& self, Gfx::DrawingContext& drawingCtx)

--- a/src/OpenLoco/src/Ui/Windows/PlayerInfoPanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PlayerInfoPanel.cpp
@@ -196,7 +196,7 @@ namespace OpenLoco::Ui::Windows::PlayerInfoPanel
         auto playerCompany = CompanyManager::get(CompanyManager::getControllingId());
         auto competitor = ObjectManager::get<CompetitorObject>(playerCompany->competitorId);
         auto image = Gfx::recolour(competitor->images[enumValue(playerCompany->ownerEmotion)], playerCompany->mainColours.primary);
-        drawingCtx.drawImage(window.x + frame.left + 2, window.y + frame.top + 2, image);
+        drawingCtx.drawImage(ZoomLevel::full, window.x + frame.left + 2, window.y + frame.top + 2, image);
 
         auto x = window.x + frame.width() / 2 + 12;
         {

--- a/src/OpenLoco/src/Ui/Windows/ProgressBar.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ProgressBar.cpp
@@ -113,7 +113,7 @@ namespace OpenLoco::Ui::Windows::ProgressBar
         drawingCtx.pushRenderTarget(*clipped);
 
         // First, draw the train track.
-        drawingCtx.drawImage(0, 0, ImageIds::progressbar_track);
+        drawingCtx.drawImage(ZoomLevel::full, 0, 0, ImageIds::progressbar_track);
 
         // What train image to use depends on the progress bar style.
         uint32_t trainImage;
@@ -144,7 +144,7 @@ namespace OpenLoco::Ui::Windows::ProgressBar
 
         // Draw the train image from the right of the window,
         int16_t xPos = _progressBarValue - 255;
-        drawingCtx.drawImage(xPos, 0, trainImage);
+        drawingCtx.drawImage(ZoomLevel::full, xPos, 0, trainImage);
 
         drawingCtx.popRenderTarget();
     }

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -526,7 +526,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             g1->offset = (uint8_t*)saveInfo.image;
             g1->width = 250;
             g1->height = 200;
-            drawingCtx.drawImage(x + 1, y + 1, imageId);
+            drawingCtx.drawImage(ZoomLevel::full, x + 1, y + 1, imageId);
             *g1 = backupg1;
         }
         y += 207;
@@ -596,17 +596,17 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
                 g1->offset = &_previewScenarioOptions->preview[0][0];
                 g1->width = 128;
                 g1->height = 128;
-                drawingCtx.drawImage(x + 1, y + 1, imageId);
+                drawingCtx.drawImage(ZoomLevel::full, x + 1, y + 1, imageId);
                 *g1 = backupg1;
 
-                drawingCtx.drawImage(x, y + 1, ImageIds::height_map_compass);
+                drawingCtx.drawImage(ZoomLevel::full, x, y + 1, ImageIds::height_map_compass);
             }
         }
         else
         {
             // Randomly generated landscape
             auto imageId = Gfx::recolour(ImageIds::random_map_watermark, window.getColour(WindowColour::secondary).c());
-            drawingCtx.drawImage(x, y, imageId);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, imageId);
             auto origin = Ui::Point(x + 64, y + 60);
             tr.drawStringCentredWrapped(origin, 128, Colour::black, StringIds::randomly_generated_landscape);
         }
@@ -688,7 +688,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             auto x = 1;
             if (isRootPath(entry) || fs::is_directory(entry))
             {
-                drawingCtx.drawImage(x, y, ImageIds::icon_folder);
+                drawingCtx.drawImage(ZoomLevel::full, x, y, ImageIds::icon_folder);
                 x += 14;
             }
 

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -284,11 +284,11 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
                 g1->height = 128;
 
                 // Draw preview image and restore original G1 image.
-                drawingCtx.drawImage(x, y, imageId);
+                drawingCtx.drawImage(ZoomLevel::full, x, y, imageId);
                 *g1 = backupG1;
 
                 // Draw compass
-                drawingCtx.drawImage(x, y, ImageIds::height_map_compass);
+                drawingCtx.drawImage(ZoomLevel::full, x, y, ImageIds::height_map_compass);
             }
         }
         else
@@ -298,7 +298,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 
             // No preview image -- a placeholder will have to do.
             auto image = Gfx::recolour(ImageIds::random_map_watermark, self.getColour(WindowColour::secondary).c());
-            drawingCtx.drawImage(x, y, image);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, image);
 
             x += 64;
             y += 59;
@@ -427,7 +427,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             }
 
             // Draw checkmark to indicate completion
-            drawingCtx.drawImage(self.widgets[widx::list].width() - ScrollView::kScrollbarSize - 25, y + 1, ImageIds::scenario_completed_tick);
+            drawingCtx.drawImage(ZoomLevel::full, self.widgets[widx::list].width() - ScrollView::kScrollbarSize - 25, y + 1, ImageIds::scenario_completed_tick);
 
             // 'Completed by' info
             {

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -550,7 +550,7 @@ namespace OpenLoco::Ui::Windows::StationList
         uint32_t image = Gfx::recolour(competitor->images[enumValue(company->ownerEmotion)], company->mainColours.primary);
         uint16_t x = self.x + self.widgets[widx::company_select].left + 1;
         uint16_t y = self.y + self.widgets[widx::company_select].top + 1;
-        drawingCtx.drawImage(x, y, image);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, image);
     }
 
     // 0x004917BB

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -415,7 +415,7 @@ namespace OpenLoco::Ui::Windows::Station
                 }
 
                 auto* cargoObj = ObjectManager::get<CargoObject>(cargoId);
-                drawingCtx.drawImage(origin, cargoObj->unitInlineSprite);
+                drawingCtx.drawImage(ZoomLevel::full, origin, cargoObj->unitInlineSprite);
                 origin.x += 12;
 
                 cargoTypeCount++;
@@ -558,7 +558,7 @@ namespace OpenLoco::Ui::Windows::Station
                     for (; units > 0; units--)
                     {
                         {
-                            drawingCtx.drawImage(xPos, y, cargoObj->unitInlineSprite);
+                            drawingCtx.drawImage(ZoomLevel::full, xPos, y, cargoObj->unitInlineSprite);
                             xPos += 10;
                         }
                     }

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -196,8 +196,8 @@ namespace OpenLoco::Ui::Windows::Station
                 {
                     viewport->width = newWidth;
                     viewport->height = newHeight;
-                    viewport->viewWidth = newWidth << viewport->zoom;
-                    viewport->viewHeight = newHeight << viewport->zoom;
+                    viewport->viewWidth = viewport->zoom.applyTo(newWidth);
+                    viewport->viewHeight = viewport->zoom.applyTo(newHeight);
                     self.savedView.clear();
                 }
             }

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -1698,7 +1698,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
                     auto zoom = viewport->zoom;
 
-                    auto dY = -(16 >> zoom);
+                    auto dY = -zoom.applyInversedTo(16);
                     if (dY == 0)
                     {
                         dY = -1;

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -2109,7 +2109,7 @@ namespace OpenLoco::Ui::Windows::Terraform
 
             auto zoom = viewport->zoom;
 
-            auto dY = -(16 >> zoom);
+            auto dY = -zoom.applyInversedTo(16);
             if (dY == 0)
             {
                 dY = -1;

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -829,7 +829,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 }
                 image = Gfx::recolour(image, colour);
             }
-            drawingCtx.drawImage(32, 96, image);
+            drawingCtx.drawImage(ZoomLevel::full, 32, 96, image);
         }
 
         // 0x004BB982
@@ -1812,15 +1812,15 @@ namespace OpenLoco::Ui::Windows::Terraform
                         // For even sizes, we need to draw the image twice
                         // TODO: replace with proper grid images
                         placeForImage -= { 4, 0 };
-                        drawingCtx.drawImage(placeForImage, areaImage);
+                        drawingCtx.drawImage(ZoomLevel::full, placeForImage, areaImage);
 
                         placeForImage += { 8, 0 };
-                        drawingCtx.drawImage(placeForImage, areaImage);
+                        drawingCtx.drawImage(ZoomLevel::full, placeForImage, areaImage);
                     }
                     else
                     {
                         // For odd sizes, we just need the one
-                        drawingCtx.drawImage(placeForImage, areaImage);
+                        drawingCtx.drawImage(ZoomLevel::full, placeForImage, areaImage);
                     }
                 }
 
@@ -1829,7 +1829,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 {
                     auto areaImage = ImageId(ImageIds::tool_area).withIndexOffset(_adjustToolSize);
                     Ui::Point placeForImage(toolArea.left + self.x, toolArea.top + self.y);
-                    drawingCtx.drawImage(placeForImage, areaImage);
+                    drawingCtx.drawImage(ZoomLevel::full, placeForImage, areaImage);
                 }
             }
             // Or draw as a number, if we can't fit a sprite
@@ -2711,7 +2711,7 @@ namespace OpenLoco::Ui::Windows::Terraform
                 {
                     drawingCtx.pushRenderTarget(*clipped);
 
-                    drawingCtx.drawImage(kColumnWidth - 6, kRowHeight - 20, wallObj->sprite);
+                    drawingCtx.drawImage(ZoomLevel::full, kColumnWidth - 6, kRowHeight - 20, wallObj->sprite);
 
                     drawingCtx.popRenderTarget();
                 }

--- a/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
@@ -186,7 +186,7 @@ namespace OpenLoco::Ui::Windows::TimePanel
         }
 
         auto skin = ObjectManager::get<InterfaceSkinObject>();
-        drawingCtx.drawImage(self.x + _widgets[Widx::map_chat_menu].left - 2, self.y + _widgets[Widx::map_chat_menu].top - 1, skin->img + map_sprites_by_rotation[WindowManager::getCurrentRotation()]);
+        drawingCtx.drawImage(ZoomLevel::full, self.x + _widgets[Widx::map_chat_menu].left - 2, self.y + _widgets[Widx::map_chat_menu].top - 1, skin->img + map_sprites_by_rotation[WindowManager::getCurrentRotation()]);
     }
 
     // 0x004398FB

--- a/src/OpenLoco/src/Ui/Windows/TitleLogo.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleLogo.cpp
@@ -46,7 +46,7 @@ namespace OpenLoco::Ui::Windows::TitleLogo
     // 0x00439298
     static void draw(Ui::Window& window, Gfx::DrawingContext& drawingCtx)
     {
-        drawingCtx.drawImage(window.x, window.y, ImageIds::locomotion_logo);
+        drawingCtx.drawImage(ZoomLevel::full, window.x, window.y, ImageIds::locomotion_logo);
     }
 
     // 0x004392AD

--- a/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
@@ -216,8 +216,8 @@ namespace OpenLoco::Ui::Windows::TitleMenu
                 image_id = kGlobeSpin[((window.var_846 / 2) % kGlobeSpin.size())];
             }
 
-            drawingCtx.drawImage(x, y, image_id);
-            drawingCtx.drawImage(x, y, ImageIds::title_menu_sparkle);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, image_id);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, ImageIds::title_menu_sparkle);
         }
 
         if (!window.widgets[Widx::load_game_btn].hidden)
@@ -231,8 +231,8 @@ namespace OpenLoco::Ui::Windows::TitleMenu
                 image_id = kGlobeSpin[((window.var_846 / 2) % kGlobeSpin.size())];
             }
 
-            drawingCtx.drawImage(x, y, image_id);
-            drawingCtx.drawImage(x, y, ImageIds::title_menu_save);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, image_id);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, ImageIds::title_menu_save);
         }
 
         if (!window.widgets[Widx::tutorial_btn].hidden)
@@ -246,10 +246,10 @@ namespace OpenLoco::Ui::Windows::TitleMenu
                 image_id = kGlobeSpin[((window.var_846 / 2) % kGlobeSpin.size())];
             }
 
-            drawingCtx.drawImage(x, y, image_id);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, image_id);
 
             // TODO: base lesson overlay on language
-            drawingCtx.drawImage(x, y, ImageIds::title_menu_lesson_l);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, ImageIds::title_menu_lesson_l);
         }
 
         if (!window.widgets[Widx::scenario_editor_btn].hidden)
@@ -263,7 +263,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
                 image_id = kGlobeConstruct[((window.var_846 / 2) % kGlobeConstruct.size())];
             }
 
-            drawingCtx.drawImage(x, y, image_id);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, image_id);
         }
 
         if (!window.widgets[Widx::multiplayer_toggle_btn].hidden)

--- a/src/OpenLoco/src/Ui/Windows/ToolbarBottomEditor.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarBottomEditor.cpp
@@ -88,7 +88,7 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
 
         if (EditorController::canGoBack())
         {
-            drawingCtx.drawImage(self.x + previous.left + 6, self.y + previous.top + 6, ImageIds::step_back);
+            drawingCtx.drawImage(ZoomLevel::full, self.x + previous.left + 6, self.y + previous.top + 6, ImageIds::step_back);
             int x = (previous.left + 30 + previous.right) / 2;
             int y = previous.top + 6;
             auto textColour = self.getColour(WindowColour::secondary).opaque();
@@ -103,7 +103,7 @@ namespace OpenLoco::Ui::Windows::ToolbarBottom::Editor
             point = Point(self.x + x, self.y + y + 10);
             tr.drawStringCentred(point, textColour, kStepNames.at(EditorController::getPreviousStep()));
         }
-        drawingCtx.drawImage(self.x + next.right - 29, self.y + next.top + 4, ImageIds::step_forward);
+        drawingCtx.drawImage(ZoomLevel::full, self.x + next.right - 29, self.y + next.top + 4, ImageIds::step_forward);
         int x = next.left + (next.width() - 31) / 2;
         int y = next.top + 6;
         auto textColour = self.getColour(WindowColour::secondary).opaque();

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -851,10 +851,10 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                 bg_image++;
             }
 
-            drawingCtx.drawImage(x, y, fg_image);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, fg_image);
 
             y = window.widgets[Common::Widx::railroad_menu].top + window.y;
-            drawingCtx.drawImage(x, y, bg_image);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, bg_image);
         }
 
         {
@@ -881,10 +881,10 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                 bg_image++;
             }
 
-            drawingCtx.drawImage(x, y, fg_image);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, fg_image);
 
             y = window.widgets[Common::Widx::vehicles_menu].top + window.y;
-            drawingCtx.drawImage(x, y, bg_image);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, bg_image);
         }
 
         {
@@ -909,7 +909,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                 fg_image++;
             }
 
-            drawingCtx.drawImage(x, y, fg_image);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, fg_image);
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
@@ -84,10 +84,10 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
                 bgImage++;
             }
 
-            drawingCtx.drawImage(x, y, fgImage);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, fgImage);
 
             y = self.widgets[Widx::road_menu].top + self.y;
-            drawingCtx.drawImage(x, y, bgImage);
+            drawingCtx.drawImage(ZoomLevel::full, x, y, bgImage);
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
@@ -113,19 +113,19 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
         Dropdown::setHighlightedItem(0);
 
         auto mainWindow = WindowManager::getMainWindow();
-        if (mainWindow->viewports[0]->zoom == 0)
+        if (mainWindow->viewports[0]->zoom == ZoomLevel::min)
         {
             Dropdown::setItemDisabled(0);
             Dropdown::setHighlightedItem(1);
         }
 
-        if (mainWindow->viewports[0]->zoom == 3)
+        if (mainWindow->viewports[0]->zoom == ZoomLevel::max)
         {
             Dropdown::setItemDisabled(1);
             _zoomTicks = 1000;
         }
 
-        if (mainWindow->viewports[0]->zoom != 3 && _zoomTicks <= 32)
+        if (mainWindow->viewports[0]->zoom != ZoomLevel::max && _zoomTicks <= 32)
         {
             Dropdown::setHighlightedItem(1);
         }

--- a/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TownWindow.cpp
@@ -269,8 +269,8 @@ namespace OpenLoco::Ui::Windows::Town
                 {
                     viewport->width = newWidth;
                     viewport->height = newHeight;
-                    viewport->viewWidth = newWidth << viewport->zoom;
-                    viewport->viewHeight = newHeight << viewport->zoom;
+                    viewport->viewWidth = viewport->zoom.applyTo(newWidth);
+                    viewport->viewHeight = viewport->zoom.applyTo(newHeight);
                     self.savedView.clear();
                 }
             }

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -689,8 +689,8 @@ namespace OpenLoco::Ui::Windows::Vehicle
                     self.invalidate();
                     viewport->width = newWidth;
                     viewport->height = newHeight;
-                    viewport->viewWidth = newWidth << viewport->zoom;
-                    viewport->viewHeight = newHeight << viewport->zoom;
+                    viewport->viewWidth = viewport->zoom.applyTo(newWidth);
+                    viewport->viewHeight = viewport->zoom.applyTo(newHeight);
                     self.savedView.clear();
                 }
             }
@@ -1054,10 +1054,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             {
                 if ((pickupButton.image & 0x20000000) != 0 && !self.isDisabled(widx::pickup))
                 {
-                    drawingCtx.drawImage(ZoomLevel::full, 
-                        self.x + pickupButton.left,
-                        self.y + pickupButton.top,
-                        Gfx::recolour(pickupButton.image, CompanyManager::getCompanyColour(self.owner)));
+                    drawingCtx.drawImage(ZoomLevel::full, self.x + pickupButton.left, self.y + pickupButton.top, Gfx::recolour(pickupButton.image, CompanyManager::getCompanyColour(self.owner)));
                 }
             }
 
@@ -1088,10 +1085,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             Widget& speedWidget = self.widgets[widx::speedControl];
             if (!speedWidget.hidden)
             {
-                drawingCtx.drawImage(ZoomLevel::full, 
-                    self.x + speedWidget.left,
-                    self.y + speedWidget.top + 10,
-                    Gfx::recolour(ImageIds::speed_control_track, self.getColour(WindowColour::secondary).c()));
+                drawingCtx.drawImage(ZoomLevel::full, self.x + speedWidget.left, self.y + speedWidget.top + 10, Gfx::recolour(ImageIds::speed_control_track, self.getColour(WindowColour::secondary).c()));
 
                 auto point = Point(self.x + speedWidget.midX(), self.y + speedWidget.top + 4);
                 tr.drawStringCentred(point, Colour::black, StringIds::tiny_power);
@@ -1099,10 +1093,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 point = Point(self.x + speedWidget.midX(), self.y + speedWidget.bottom - 10);
                 tr.drawStringCentred(point, Colour::black, StringIds::tiny_brake);
 
-                drawingCtx.drawImage(ZoomLevel::full, 
-                    self.x + speedWidget.left + 1,
-                    self.y + speedWidget.top + 57 - veh->manualPower,
-                    Gfx::recolour(ImageIds::speed_control_thumb, self.getColour(WindowColour::secondary).c()));
+                drawingCtx.drawImage(ZoomLevel::full, self.x + speedWidget.left + 1, self.y + speedWidget.top + 57 - veh->manualPower, Gfx::recolour(ImageIds::speed_control_thumb, self.getColour(WindowColour::secondary).c()));
             }
 
             if (self.viewports[0] == nullptr && ToolManager::isToolActive(self.type, self.number))

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -1054,7 +1054,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             {
                 if ((pickupButton.image & 0x20000000) != 0 && !self.isDisabled(widx::pickup))
                 {
-                    drawingCtx.drawImage(
+                    drawingCtx.drawImage(ZoomLevel::full, 
                         self.x + pickupButton.left,
                         self.y + pickupButton.top,
                         Gfx::recolour(pickupButton.image, CompanyManager::getCompanyColour(self.owner)));
@@ -1088,7 +1088,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             Widget& speedWidget = self.widgets[widx::speedControl];
             if (!speedWidget.hidden)
             {
-                drawingCtx.drawImage(
+                drawingCtx.drawImage(ZoomLevel::full, 
                     self.x + speedWidget.left,
                     self.y + speedWidget.top + 10,
                     Gfx::recolour(ImageIds::speed_control_track, self.getColour(WindowColour::secondary).c()));
@@ -1099,7 +1099,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 point = Point(self.x + speedWidget.midX(), self.y + speedWidget.bottom - 10);
                 tr.drawStringCentred(point, Colour::black, StringIds::tiny_brake);
 
-                drawingCtx.drawImage(
+                drawingCtx.drawImage(ZoomLevel::full, 
                     self.x + speedWidget.left + 1,
                     self.y + speedWidget.top + 57 - veh->manualPower,
                     Gfx::recolour(ImageIds::speed_control_thumb, self.getColour(WindowColour::secondary).c()));
@@ -1859,7 +1859,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 if ((self.widgets[widx::pickup].image & (1 << 29)) && !self.isDisabled(widx::pickup))
                 {
                     auto image = Gfx::recolour(self.widgets[widx::pickup].image, CompanyManager::getCompanyColour(self.owner));
-                    drawingCtx.drawImage(self.widgets[widx::pickup].left + self.x, self.widgets[widx::pickup].top + self.y, image);
+                    drawingCtx.drawImage(ZoomLevel::full, self.widgets[widx::pickup].left + self.x, self.widgets[widx::pickup].top + self.y, image);
                 }
             }
             uint16_t textRightEdge = isPaintToolActive(self) ? self.width - 39 : self.width;
@@ -3981,7 +3981,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 if (ToolManager::isToolActive(self.type, self.number))
                 {
                     auto imageId = kNumberCircle[orderNumber - 1];
-                    drawingCtx.drawImage(labelWidth + 8 + 3, y, Gfx::recolour(imageId, Colour::white));
+                    drawingCtx.drawImage(ZoomLevel::full, labelWidth + 8 + 3, y, Gfx::recolour(imageId, Colour::white));
                 }
                 orderNumber++;
             }

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -572,7 +572,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         uint32_t image = Gfx::recolour(competitorObj->images[enumValue(company->ownerEmotion)], company->mainColours.primary);
         uint16_t x = self.x + self.widgets[Widx::company_select].left + 1;
         uint16_t y = self.y + self.widgets[Widx::company_select].top + 1;
-        drawingCtx.drawImage(x, y, image);
+        drawingCtx.drawImage(ZoomLevel::full, x, y, image);
     }
 
     // 0x004C21CD

--- a/src/OpenLoco/src/Vehicles/OrderManager.cpp
+++ b/src/OpenLoco/src/Vehicles/OrderManager.cpp
@@ -413,16 +413,19 @@ namespace OpenLoco::Vehicles::OrderManager
                 // The first line of the label will always be at the centre
                 // of the station/waypoint. This works out where the subsequent
                 // lines of the label will end up.
-                auto width = zoom.applyTo(stringWidth + 3);
+                const auto uiWidth = stringWidth + 3;
+                const auto uiHeight = 11;
+
+                auto width = zoom.applyTo<int32_t>(uiWidth);
                 auto numberHeight = zoom.applyTo(unk.lineNumber * 10 /* lineHeight TODO make same as Windows::Vehicle.cpp lineHeight */);
-                auto firstLineHeight = zoom.applyTo(11);
+                auto firstLineHeight = zoom.applyTo(uiHeight);
                 auto midX = width / 2;
                 auto midFirstLineY = firstLineHeight / 2;
 
                 unk.frame.left[index] = zoom.applyInversedTo(pos.x - midX);
-                unk.frame.right[index] = zoom.applyInversedTo(pos.x + midX);
+                unk.frame.right[index] = unk.frame.left[index] + uiWidth;
                 unk.frame.top[index] = zoom.applyInversedTo(pos.y - midFirstLineY + numberHeight);
-                unk.frame.bottom[index] = zoom.applyInversedTo(pos.y + midFirstLineY + numberHeight);
+                unk.frame.bottom[index] = unk.frame.top[index] + uiHeight;
             }
             i++;
         }

--- a/src/OpenLoco/src/Vehicles/OrderManager.cpp
+++ b/src/OpenLoco/src/Vehicles/OrderManager.cpp
@@ -405,21 +405,24 @@ namespace OpenLoco::Vehicles::OrderManager
             auto [loc, str] = generateOrderUiStringAndLoc(order->getOffset(), i);
             const auto pos = World::gameToScreen(loc, Ui::WindowManager::getCurrentRotation());
             auto stringWidth = Gfx::TextRenderer::getStringWidth(Gfx::Font::medium_bold, str.c_str());
-            for (auto zoom = 0; zoom < 4; ++zoom)
+            for (auto level = ZoomLevel::min; level <= ZoomLevel::max; ++level)
             {
+                const auto zoom = ZoomLevel{ level };
+                const auto index = zoom.index();
+
                 // The first line of the label will always be at the centre
                 // of the station/waypoint. This works out where the subsequent
                 // lines of the label will end up.
-                auto width = (stringWidth + 3) << zoom;
-                auto numberHeight = (unk.lineNumber * 10 /* lineHeight TODO make same as Windows::Vehicle.cpp lineHeight */) << zoom;
-                auto firstLineHeight = 11 << zoom;
+                auto width = zoom.applyTo(stringWidth + 3);
+                auto numberHeight = zoom.applyTo(unk.lineNumber * 10 /* lineHeight TODO make same as Windows::Vehicle.cpp lineHeight */);
+                auto firstLineHeight = zoom.applyTo(11);
                 auto midX = width / 2;
                 auto midFirstLineY = firstLineHeight / 2;
 
-                unk.frame.left[zoom] = (pos.x - midX) >> zoom;
-                unk.frame.right[zoom] = (pos.x + midX) >> zoom;
-                unk.frame.top[zoom] = (pos.y - midFirstLineY + numberHeight) >> zoom;
-                unk.frame.bottom[zoom] = (pos.y + midFirstLineY + numberHeight) >> zoom;
+                unk.frame.left[index] = zoom.applyInversedTo(pos.x - midX);
+                unk.frame.right[index] = zoom.applyInversedTo(pos.x + midX);
+                unk.frame.top[index] = zoom.applyInversedTo(pos.y - midFirstLineY + numberHeight);
+                unk.frame.bottom[index] = zoom.applyInversedTo(pos.y + midFirstLineY + numberHeight);
             }
             i++;
         }

--- a/src/OpenLoco/src/Vehicles/VehicleDraw.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleDraw.cpp
@@ -244,7 +244,7 @@ namespace OpenLoco
 
         const auto p1 = World::gameToScreen(World::Pos3(unk1.x, unk1.y, 0), 0);
 
-        drawingCtx.drawImage(offset + Ui::Point(p1.x, p1.y), item.image);
+        drawingCtx.drawImage(ZoomLevel::full, offset + Ui::Point(p1.x, p1.y), item.image);
     }
 
     struct DrawItems
@@ -592,7 +592,7 @@ namespace OpenLoco
             {
                 continue;
             }
-            drawingCtx.drawImage(loc + Ui::Point(item.dist, 0), item.image);
+            drawingCtx.drawImage(ZoomLevel::full, loc + Ui::Point(item.dist, 0), item.image);
         }
         // Then draw the bodies
         for (auto& item : screenDistDrawItems.items)
@@ -601,7 +601,7 @@ namespace OpenLoco
             {
                 continue;
             }
-            drawingCtx.drawImage(loc + Ui::Point(item.dist, 0), item.image);
+            drawingCtx.drawImage(ZoomLevel::full, loc + Ui::Point(item.dist, 0), item.image);
         }
         return screenDistDrawItems.totalDistance;
     }
@@ -641,7 +641,7 @@ namespace OpenLoco
             }
             else
             {
-                drawingCtx.drawImage(loc + Ui::Point(item.dist, 0), item.image);
+                drawingCtx.drawImage(ZoomLevel::full, loc + Ui::Point(item.dist, 0), item.image);
             }
         }
         return screenDistDrawItems.totalDistance;

--- a/src/OpenLoco/src/Viewport.cpp
+++ b/src/OpenLoco/src/Viewport.cpp
@@ -56,19 +56,8 @@ namespace OpenLoco::Ui
     }
 
     // 0x0048DE97
-    static void drawStationNames(Gfx::DrawingContext& drawingCtx)
+    static void drawStationNames(Gfx::DrawingContext& drawingCtx, ZoomLevel zoom)
     {
-        const auto& rt = drawingCtx.currentRenderTarget();
-
-        Gfx::RenderTarget unZoomedRt = rt;
-        unZoomedRt.zoomLevel = 0;
-        unZoomedRt.x >>= rt.zoomLevel;
-        unZoomedRt.y >>= rt.zoomLevel;
-        unZoomedRt.width >>= rt.zoomLevel;
-        unZoomedRt.height >>= rt.zoomLevel;
-
-        drawingCtx.pushRenderTarget(unZoomedRt);
-
         for (const auto& station : StationManager::stations())
         {
             if ((station.flags & StationFlags::flag_5) != StationFlags::none)
@@ -79,36 +68,21 @@ namespace OpenLoco::Ui
             bool isHovered = (World::hasMapSelectionFlag(World::MapSelectionFlags::hoveringOverStation))
                 && (station.id() == Input::getHoveredStationId());
 
-            drawStationName(drawingCtx, station, rt.zoomLevel, isHovered);
+            drawStationName(drawingCtx, station, zoom, isHovered);
         }
-
-        drawingCtx.popRenderTarget();
     }
 
     // 0x004977E5
-    static void drawTownNames(Gfx::DrawingContext& drawingCtx)
+    static void drawTownNames(Gfx::DrawingContext& drawingCtx, ZoomLevel zoom)
     {
-        const auto& rt = drawingCtx.currentRenderTarget();
-
-        Gfx::RenderTarget unZoomedRt = rt;
-        unZoomedRt.zoomLevel = 0;
-        unZoomedRt.x >>= rt.zoomLevel;
-        unZoomedRt.y >>= rt.zoomLevel;
-        unZoomedRt.width >>= rt.zoomLevel;
-        unZoomedRt.height >>= rt.zoomLevel;
-
-        drawingCtx.pushRenderTarget(unZoomedRt);
-
         for (auto& town : TownManager::towns())
         {
-            town.drawLabel(drawingCtx, rt);
+            town.drawLabel(drawingCtx, zoom);
         }
-
-        drawingCtx.popRenderTarget();
     }
 
     // 0x00470A62
-    static void drawRoutingNumbers(Gfx::DrawingContext& drawingCtx)
+    static void drawRoutingNumbers(Gfx::DrawingContext& drawingCtx, ZoomLevel zoom)
     {
         if (!World::hasMapSelectionFlag(World::MapSelectionFlags::unk_04))
         {
@@ -116,15 +90,6 @@ namespace OpenLoco::Ui
         }
 
         const auto& rt = drawingCtx.currentRenderTarget();
-
-        Gfx::RenderTarget unZoomedRt = rt;
-        unZoomedRt.zoomLevel = 0;
-        unZoomedRt.x >>= rt.zoomLevel;
-        unZoomedRt.y >>= rt.zoomLevel;
-        unZoomedRt.width >>= rt.zoomLevel;
-        unZoomedRt.height >>= rt.zoomLevel;
-
-        drawingCtx.pushRenderTarget(unZoomedRt);
 
         auto tr = Gfx::TextRenderer(drawingCtx);
 
@@ -138,7 +103,7 @@ namespace OpenLoco::Ui
                 continue;
             }
             orderNum++;
-            if (!orderFrame.frame.contains(rt.getDrawableRect(), rt.zoomLevel))
+            if (!orderFrame.frame.contains(rt.getUiRect(), zoom))
             {
                 continue;
             }
@@ -151,11 +116,9 @@ namespace OpenLoco::Ui
 
             tr.setCurrentFont(Gfx::Font::medium_normal);
 
-            auto point = Point(orderFrame.frame.left[rt.zoomLevel] + 1, orderFrame.frame.top[rt.zoomLevel]);
+            auto point = Point(orderFrame.frame.left[zoom] + 1, orderFrame.frame.top[zoom]);
             tr.drawString(point, AdvancedColour(Colour::white).outline(), const_cast<char*>(orderString.c_str()));
         }
-
-        drawingCtx.popRenderTarget();
     }
 
     // 0x0045A1A4
@@ -179,31 +142,29 @@ namespace OpenLoco::Ui
 
         const uint32_t bitmask = 0xFFFFFFFF << zoom;
 
-        // rt is in terms of the ui we need a target setup for the viewport zoom level
+        const int32_t worldLeft = rect.origin.x & bitmask;
+        const int32_t worldTop = rect.origin.y & bitmask;
+        const int32_t worldWidth = rect.width() & bitmask;
+        const int32_t worldHeight = rect.height() & bitmask;
+
         Gfx::RenderTarget zoomViewRt{};
-        zoomViewRt.width = rect.width();
-        zoomViewRt.height = rect.height();
-        zoomViewRt.x = rect.origin.x;
-        zoomViewRt.y = rect.origin.y;
+        zoomViewRt.x = worldLeft >> zoom;
+        zoomViewRt.y = worldTop >> zoom;
+        zoomViewRt.width = worldWidth >> zoom;
+        zoomViewRt.height = worldHeight >> zoom;
 
-        zoomViewRt.width &= bitmask;
-        zoomViewRt.height &= bitmask;
-        zoomViewRt.x &= bitmask;
-        zoomViewRt.y &= bitmask;
+        auto unkX = (zoomViewRt.x - (static_cast<int32_t>(viewX & bitmask) >> zoom)) + x;
 
-        auto unkX = ((zoomViewRt.x - static_cast<int32_t>(viewX & bitmask)) >> zoom) + x;
+        auto unkY = (zoomViewRt.y - (static_cast<int32_t>(viewY & bitmask) >> zoom)) + y;
 
-        auto unkY = ((zoomViewRt.y - static_cast<int32_t>(viewY & bitmask)) >> zoom) + y;
-
-        zoomViewRt.pitch = rt.width + rt.pitch - (zoomViewRt.width >> zoom);
+        zoomViewRt.pitch = rt.width + rt.pitch - zoomViewRt.width;
         zoomViewRt.bits = rt.bits + (unkX - rt.x) + ((unkY - rt.y) * (rt.width + rt.pitch));
-        zoomViewRt.zoomLevel = zoom;
 
         // make sure, the compare operation is done in int32_t to avoid the loop becoming an infinite loop.
         // this as well as the [x += 32] in the loop causes signed integer overflow -> undefined behaviour.
-        auto rightBorder = zoomViewRt.x + zoomViewRt.width;
+        auto rightBorder = worldLeft + worldWidth;
         // Floors to nearest 32
-        auto alignedX = zoomViewRt.x & ~0x1F;
+        auto alignedX = worldLeft & ~0x1F;
 
         // Drawing is performed in columns of 32 pixels (1 tile wide)
         sfl::small_vector<Gfx::RenderTarget, 512> columns;
@@ -212,21 +173,22 @@ namespace OpenLoco::Ui
         for (auto columnX = alignedX; columnX < rightBorder; columnX += 32)
         {
             Gfx::RenderTarget columnRt = zoomViewRt;
-            if (columnX >= columnRt.x)
+            const auto columnLeft = columnX >> zoom;
+            if (columnLeft >= columnRt.x)
             {
-                auto leftPitch = columnX - columnRt.x;
+                auto leftPitch = columnLeft - columnRt.x;
                 columnRt.width -= leftPitch;
-                columnRt.pitch += (leftPitch >> columnRt.zoomLevel);
-                columnRt.bits += (leftPitch >> columnRt.zoomLevel);
-                columnRt.x = columnX;
+                columnRt.pitch += leftPitch;
+                columnRt.bits += leftPitch;
+                columnRt.x = columnLeft;
             }
-            auto columnRightX = columnX + 32;
+            auto columnRightX = (columnX + 32) >> zoom;
             auto paintRight = columnRt.x + columnRt.width;
             if (paintRight >= columnRightX)
             {
-                auto rightPitch = paintRight - columnX - 32;
+                auto rightPitch = paintRight - columnRightX;
                 paintRight -= rightPitch;
-                columnRt.pitch += rightPitch >> columnRt.zoomLevel;
+                columnRt.pitch += rightPitch;
             }
 
             columnRt.width = paintRight - columnRt.x;
@@ -240,7 +202,7 @@ namespace OpenLoco::Ui
             columnDrawingCtx.pushRenderTarget(columnRt);
 
             columnDrawingCtx.clearSingle(fillColour);
-            auto sess = Paint::PaintSession(columnRt, options);
+            auto sess = Paint::PaintSession(columnRt, zoom, options);
             sess.generate();
             sess.arrangeStructs();
             sess.drawStructs(columnDrawingCtx);
@@ -250,19 +212,19 @@ namespace OpenLoco::Ui
             {
                 if (!options.hasFlags(ViewportFlags::hideStationNames))
                 {
-                    if (columnRt.zoomLevel <= Config::get().stationNamesMinScale)
+                    if (zoom <= Config::get().stationNamesMinScale)
                     {
-                        drawStationNames(columnDrawingCtx);
+                        drawStationNames(columnDrawingCtx, zoom);
                     }
                 }
                 if (!options.hasFlags(ViewportFlags::hideTownNames))
                 {
-                    drawTownNames(columnDrawingCtx);
+                    drawTownNames(columnDrawingCtx, zoom);
                 }
             }
 
             sess.drawStringStructs(columnDrawingCtx);
-            drawRoutingNumbers(columnDrawingCtx);
+            drawRoutingNumbers(columnDrawingCtx, zoom);
         });
     }
 

--- a/src/OpenLoco/src/Viewport.cpp
+++ b/src/OpenLoco/src/Viewport.cpp
@@ -115,7 +115,7 @@ namespace OpenLoco::Ui
 
             tr.setCurrentFont(Gfx::Font::medium_normal);
 
-            auto point = Point(orderFrame.frame.left[zoom] + 1, orderFrame.frame.top[zoom]);
+            auto point = Point(orderFrame.frame.left[zoom.index()] + 1, orderFrame.frame.top[zoom.index()]);
             tr.drawString(point, AdvancedColour(Colour::white).outline(), const_cast<char*>(orderString.c_str()));
         }
     }

--- a/src/OpenLoco/src/Viewport.cpp
+++ b/src/OpenLoco/src/Viewport.cpp
@@ -51,8 +51,7 @@ namespace OpenLoco::Ui
         {
             return;
         }
-        auto intersection = uiRect.intersection(viewRect);
-        paint(drawingCtx, screenToViewport(intersection));
+        paint(drawingCtx, uiRect.intersection(viewRect));
     }
 
     // 0x0048DE97
@@ -140,49 +139,38 @@ namespace OpenLoco::Ui
         options.rotation = getRotation();
         options.viewFlags = flags;
 
-        const uint32_t bitmask = 0xFFFFFFFF << zoom;
-
-        const int32_t worldLeft = rect.origin.x & bitmask;
-        const int32_t worldTop = rect.origin.y & bitmask;
-        const int32_t worldWidth = rect.width() & bitmask;
-        const int32_t worldHeight = rect.height() & bitmask;
-
         Gfx::RenderTarget zoomViewRt{};
-        zoomViewRt.x = worldLeft >> zoom;
-        zoomViewRt.y = worldTop >> zoom;
-        zoomViewRt.width = worldWidth >> zoom;
-        zoomViewRt.height = worldHeight >> zoom;
-
-        auto unkX = (zoomViewRt.x - (static_cast<int32_t>(viewX & bitmask) >> zoom)) + x;
-
-        auto unkY = (zoomViewRt.y - (static_cast<int32_t>(viewY & bitmask) >> zoom)) + y;
+        zoomViewRt.width = rect.width();
+        zoomViewRt.height = rect.height();
+        zoomViewRt.x = zoom.applyInversedTo(viewX) + (rect.left() - x);
+        zoomViewRt.y = zoom.applyInversedTo(viewY) + (rect.top() - y);
 
         zoomViewRt.pitch = rt.width + rt.pitch - zoomViewRt.width;
-        zoomViewRt.bits = rt.bits + (unkX - rt.x) + ((unkY - rt.y) * (rt.width + rt.pitch));
+        zoomViewRt.bits = rt.bits + (rect.left() - rt.x) + ((rect.top() - rt.y) * (rt.width + rt.pitch));
 
         // make sure, the compare operation is done in int32_t to avoid the loop becoming an infinite loop.
         // this as well as the [x += 32] in the loop causes signed integer overflow -> undefined behaviour.
-        auto rightBorder = worldLeft + worldWidth;
-        // Floors to nearest 32
-        auto alignedX = worldLeft & ~0x1F;
+        const auto columnWidth = zoom.applyInversedTo(32);
+        auto rightBorder = zoomViewRt.x + zoomViewRt.width;
+        // Floors to nearest column
+        auto alignedX = zoomViewRt.x & ~(columnWidth - 1);
 
         // Drawing is performed in columns of 32 pixels (1 tile wide)
         sfl::small_vector<Gfx::RenderTarget, 512> columns;
 
         // Generate and sort columns.
-        for (auto columnX = alignedX; columnX < rightBorder; columnX += 32)
+        for (auto columnX = alignedX; columnX < rightBorder; columnX += columnWidth)
         {
             Gfx::RenderTarget columnRt = zoomViewRt;
-            const auto columnLeft = columnX >> zoom;
-            if (columnLeft >= columnRt.x)
+            if (columnX >= columnRt.x)
             {
-                auto leftPitch = columnLeft - columnRt.x;
+                auto leftPitch = columnX - columnRt.x;
                 columnRt.width -= leftPitch;
                 columnRt.pitch += leftPitch;
                 columnRt.bits += leftPitch;
-                columnRt.x = columnLeft;
+                columnRt.x = columnX;
             }
-            auto columnRightX = (columnX + 32) >> zoom;
+            auto columnRightX = columnX + columnWidth;
             auto paintRight = columnRt.x + columnRt.width;
             if (paintRight >= columnRightX)
             {

--- a/src/OpenLoco/src/ViewportManager.cpp
+++ b/src/OpenLoco/src/ViewportManager.cpp
@@ -296,7 +296,7 @@ namespace OpenLoco::Ui::ViewportManager
         rect.right = t->spriteRight;
         rect.bottom = t->spriteBottom;
 
-        auto level = ZoomLevel{ std::min<int8_t>(Config::get().vehiclesMinScale, zoom) };
+        auto level = ZoomLevel{ std::min<int8_t>(Config::get().vehiclesMinScale, static_cast<int8_t>(zoom)) };
         invalidate(rect, level);
     }
 

--- a/src/OpenLoco/src/ViewportManager.cpp
+++ b/src/OpenLoco/src/ViewportManager.cpp
@@ -79,9 +79,9 @@ namespace OpenLoco::Ui::ViewportManager
         vp->width = size.width;
         vp->height = size.height;
 
-        vp->viewWidth = size.width << static_cast<uint8_t>(zoom);
-        vp->viewHeight = size.height << static_cast<uint8_t>(zoom);
-        vp->zoom = static_cast<uint8_t>(zoom);
+        vp->viewWidth = zoom.applyTo(size.width);
+        vp->viewHeight = zoom.applyTo(size.height);
+        vp->zoom = zoom;
         vp->flags = ViewportFlags::none;
 
         if (Config::get().gridlinesOnLandscape)
@@ -193,7 +193,7 @@ namespace OpenLoco::Ui::ViewportManager
             }
 
             // Skip if zoomed out further than zoom argument
-            if (viewport.zoom > (uint8_t)zoom)
+            if (viewport.zoom > zoom)
             {
                 continue;
             }
@@ -212,10 +212,10 @@ namespace OpenLoco::Ui::ViewportManager
             int16_t bottom = intersection.bottom - viewport.viewY;
 
             // apply zoom
-            left = left >> viewport.zoom;
-            right = right >> viewport.zoom;
-            top = top >> viewport.zoom;
-            bottom = bottom >> viewport.zoom;
+            left = viewport.zoom.applyInversedTo(left);
+            right = viewport.zoom.applyInversedTo(right);
+            top = viewport.zoom.applyInversedTo(top);
+            bottom = viewport.zoom.applyInversedTo(bottom);
 
             // offset calculated area by viewport offset
             left += viewport.x;
@@ -239,15 +239,11 @@ namespace OpenLoco::Ui::ViewportManager
             }
 
             ViewportRect rect;
-            rect.left = station->labelFrame.left[viewport.zoom];
-            rect.top = station->labelFrame.top[viewport.zoom];
-            rect.right = station->labelFrame.right[viewport.zoom] + 1;
-            rect.bottom = station->labelFrame.bottom[viewport.zoom] + 1;
-
-            rect.left <<= viewport.zoom;
-            rect.top <<= viewport.zoom;
-            rect.right <<= viewport.zoom;
-            rect.bottom <<= viewport.zoom;
+            const auto labelIndex = viewport.zoom.index();
+            rect.left = viewport.zoom.applyTo<int32_t>(station->labelFrame.left[labelIndex]);
+            rect.top = viewport.zoom.applyTo<int32_t>(station->labelFrame.top[labelIndex]);
+            rect.right = viewport.zoom.applyTo<int32_t>(station->labelFrame.right[labelIndex] + 1);
+            rect.bottom = viewport.zoom.applyTo<int32_t>(station->labelFrame.bottom[labelIndex] + 1);
 
             if (!viewport.intersects(rect))
             {
@@ -263,10 +259,10 @@ namespace OpenLoco::Ui::ViewportManager
             int16_t bottom = intersection.bottom - viewport.viewY;
 
             // apply zoom
-            left = left >> viewport.zoom;
-            right = right >> viewport.zoom;
-            top = top >> viewport.zoom;
-            bottom = bottom >> viewport.zoom;
+            left = viewport.zoom.applyInversedTo(left);
+            right = viewport.zoom.applyInversedTo(right);
+            top = viewport.zoom.applyInversedTo(top);
+            bottom = viewport.zoom.applyInversedTo(bottom);
 
             // offset calculated area by viewport offset
             left += viewport.x;
@@ -300,7 +296,7 @@ namespace OpenLoco::Ui::ViewportManager
         rect.right = t->spriteRight;
         rect.bottom = t->spriteBottom;
 
-        auto level = static_cast<ZoomLevel>(std::min<uint8_t>(Config::get().vehiclesMinScale, zoom));
+        auto level = ZoomLevel{ std::min<int8_t>(Config::get().vehiclesMinScale, zoom) };
         invalidate(rect, level);
     }
 

--- a/src/OpenLoco/src/World/Station.cpp
+++ b/src/OpenLoco/src/World/Station.cpp
@@ -939,7 +939,7 @@ namespace OpenLoco
         drawingCtx.drawImage(ZoomLevel::full, topLeft, ImageId(borderImages.left).withTranslucency(ExtColour::unk34));
         drawingCtx.drawImage(ZoomLevel::full, topLeft, ImageId(borderImages.left).withTranslucency(colour));
 
-        Ui::Point topRight = { static_cast<int16_t>(bottomRight.x - borderImages.width) + 1, topLeft.y };
+        Ui::Point topRight = { bottomRight.x - borderImages.width + 1, topLeft.y };
         drawingCtx.drawImage(ZoomLevel::full, topRight, ImageId(borderImages.right).withTranslucency(ExtColour::unk34));
         drawingCtx.drawImage(ZoomLevel::full, topRight, ImageId(borderImages.right).withTranslucency(colour));
 
@@ -993,17 +993,14 @@ namespace OpenLoco
             const auto [zoomWidth, zoomHeight] = ScreenToViewport::scaleTransform(Ui::Point(width, height), virtualVp);
 
             const auto left = vpPos.x - zoomWidth / 2;
-            const auto right = left + zoomWidth;
             const auto top = vpPos.y - zoomHeight / 2 - 32;
-            const auto bottom = top + zoomHeight;
 
             const auto [uiLeft, uiTop] = ViewportToScreen::scaleTransform(Ui::Point(left, top), virtualVp);
-            const auto [uiRight, uiBottom] = ViewportToScreen::scaleTransform(Ui::Point(right, bottom), virtualVp);
 
             labelFrame.left[index] = uiLeft;
-            labelFrame.right[index] = uiRight;
+            labelFrame.right[index] = uiLeft + width;
             labelFrame.top[index] = uiTop;
-            labelFrame.bottom[index] = uiBottom;
+            labelFrame.bottom[index] = uiTop + height;
         }
     }
 

--- a/src/OpenLoco/src/World/Station.cpp
+++ b/src/OpenLoco/src/World/Station.cpp
@@ -860,7 +860,19 @@ namespace OpenLoco
         uint16_t width;
         uint16_t height;
     };
-    static constexpr std::array<StationBorder, 4> kZoomToStationBorder = {
+    static constexpr std::array<StationBorder, ZoomLevel::count> kZoomToStationBorder = {
+        StationBorder{
+            ImageIds::curved_border_left_medium,
+            ImageIds::curved_border_right_medium,
+            3,
+            11,
+        },
+        StationBorder{
+            ImageIds::curved_border_left_medium,
+            ImageIds::curved_border_right_medium,
+            3,
+            11,
+        },
         StationBorder{
             ImageIds::curved_border_left_medium,
             ImageIds::curved_border_right_medium,
@@ -887,7 +899,9 @@ namespace OpenLoco
         },
     };
 
-    static constexpr std::array<Gfx::Font, 4> kZoomToStationFonts = {
+    static constexpr std::array<Gfx::Font, ZoomLevel::count> kZoomToStationFonts = {
+        Gfx::Font::medium_bold,
+        Gfx::Font::medium_bold,
         Gfx::Font::medium_bold,
         Gfx::Font::medium_bold,
         Gfx::Font::small,
@@ -895,7 +909,7 @@ namespace OpenLoco
     };
 
     // 0x0048DF4D, 0x0048E13B
-    void drawStationName(Gfx::DrawingContext& drawingCtx, const Station& station, uint8_t zoom, bool isHovered)
+    void drawStationName(Gfx::DrawingContext& drawingCtx, const Station& station, ZoomLevel zoom, bool isHovered)
     {
         const Gfx::RenderTarget& rt = drawingCtx.currentRenderTarget();
         if (!station.labelFrame.contains(rt.getUiRect(), zoom))
@@ -903,7 +917,7 @@ namespace OpenLoco
             return;
         }
 
-        auto& borderImages = kZoomToStationBorder[zoom];
+        auto& borderImages = kZoomToStationBorder[zoom.index()];
 
         const auto companyColour = [&station]() {
             if (station.owner == CompanyId::null)
@@ -917,10 +931,10 @@ namespace OpenLoco
         }();
         const auto colour = Colours::getTranslucent(companyColour, isHovered ? 0 : 1);
 
-        Ui::Point topLeft = { station.labelFrame.left[zoom],
-                              station.labelFrame.top[zoom] };
-        Ui::Point bottomRight = { station.labelFrame.right[zoom],
-                                  station.labelFrame.bottom[zoom] };
+        Ui::Point topLeft = { station.labelFrame.left[zoom.index()],
+                              station.labelFrame.top[zoom.index()] };
+        Ui::Point bottomRight = { station.labelFrame.right[zoom.index()],
+                                  station.labelFrame.bottom[zoom.index()] };
 
         drawingCtx.drawImage(ZoomLevel::full, topLeft, ImageId(borderImages.left).withTranslucency(ExtColour::unk34));
         drawingCtx.drawImage(ZoomLevel::full, topLeft, ImageId(borderImages.left).withTranslucency(colour));
@@ -943,7 +957,7 @@ namespace OpenLoco
         StringManager::formatString(str, getTransportIconsFromStationFlags(station.flags));
 
         auto tr = Gfx::TextRenderer(drawingCtx);
-        tr.setCurrentFont(kZoomToStationFonts[zoom]);
+        tr.setCurrentFont(kZoomToStationFonts[zoom.index()]);
         auto point = topLeft + Point(borderImages.width, 0);
         tr.drawString(point, Colour::black, buffer);
     }
@@ -963,17 +977,18 @@ namespace OpenLoco
         const auto remainingLength = strEnd - buffer;
         StringManager::formatString(strEnd, remainingLength, getTransportIconsFromStationFlags(flags));
 
-        for (auto zoom = 0U; zoom < 4; ++zoom)
+        for (auto level = ZoomLevel::min; level <= ZoomLevel::max; ++level)
         {
             Ui::Viewport virtualVp{};
-            virtualVp.zoom = zoom;
+            virtualVp.zoom = ZoomLevel{ level };
+            const auto index = virtualVp.zoom.index();
 
             const auto labelCenter = World::Pos3{ x, y, z };
             const auto vpPos = World::gameToScreen(labelCenter, WindowManager::getCurrentRotation());
 
-            const auto font = kZoomToStationFonts[zoom];
-            const auto width = Gfx::TextRenderer::getStringWidth(font, buffer) + kZoomToStationBorder[zoom].width * 2;
-            const auto height = kZoomToStationBorder[zoom].height;
+            const auto font = kZoomToStationFonts[index];
+            const auto width = Gfx::TextRenderer::getStringWidth(font, buffer) + kZoomToStationBorder[index].width * 2;
+            const auto height = kZoomToStationBorder[index].height;
 
             const auto [zoomWidth, zoomHeight] = ScreenToViewport::scaleTransform(Ui::Point(width, height), virtualVp);
 
@@ -985,10 +1000,10 @@ namespace OpenLoco
             const auto [uiLeft, uiTop] = ViewportToScreen::scaleTransform(Ui::Point(left, top), virtualVp);
             const auto [uiRight, uiBottom] = ViewportToScreen::scaleTransform(Ui::Point(right, bottom), virtualVp);
 
-            labelFrame.left[zoom] = uiLeft;
-            labelFrame.right[zoom] = uiRight;
-            labelFrame.top[zoom] = uiTop;
-            labelFrame.bottom[zoom] = uiBottom;
+            labelFrame.left[index] = uiLeft;
+            labelFrame.right[index] = uiRight;
+            labelFrame.top[index] = uiTop;
+            labelFrame.bottom[index] = uiBottom;
         }
     }
 

--- a/src/OpenLoco/src/World/Station.cpp
+++ b/src/OpenLoco/src/World/Station.cpp
@@ -897,8 +897,8 @@ namespace OpenLoco
     // 0x0048DF4D, 0x0048E13B
     void drawStationName(Gfx::DrawingContext& drawingCtx, const Station& station, uint8_t zoom, bool isHovered)
     {
-        const Gfx::RenderTarget& unZoomedRt = drawingCtx.currentRenderTarget();
-        if (!station.labelFrame.contains(unZoomedRt.getDrawableRect(), zoom))
+        const Gfx::RenderTarget& rt = drawingCtx.currentRenderTarget();
+        if (!station.labelFrame.contains(rt.getUiRect(), zoom))
         {
             return;
         }
@@ -922,12 +922,12 @@ namespace OpenLoco
         Ui::Point bottomRight = { station.labelFrame.right[zoom],
                                   station.labelFrame.bottom[zoom] };
 
-        drawingCtx.drawImage(topLeft, ImageId(borderImages.left).withTranslucency(ExtColour::unk34));
-        drawingCtx.drawImage(topLeft, ImageId(borderImages.left).withTranslucency(colour));
+        drawingCtx.drawImage(ZoomLevel::full, topLeft, ImageId(borderImages.left).withTranslucency(ExtColour::unk34));
+        drawingCtx.drawImage(ZoomLevel::full, topLeft, ImageId(borderImages.left).withTranslucency(colour));
 
         Ui::Point topRight = { static_cast<int16_t>(bottomRight.x - borderImages.width) + 1, topLeft.y };
-        drawingCtx.drawImage(topRight, ImageId(borderImages.right).withTranslucency(ExtColour::unk34));
-        drawingCtx.drawImage(topRight, ImageId(borderImages.right).withTranslucency(colour));
+        drawingCtx.drawImage(ZoomLevel::full, topRight, ImageId(borderImages.right).withTranslucency(ExtColour::unk34));
+        drawingCtx.drawImage(ZoomLevel::full, topRight, ImageId(borderImages.right).withTranslucency(colour));
 
         drawingCtx.drawRect(topLeft.x + borderImages.width + 1, topLeft.y, bottomRight.x - topLeft.x - 2 * borderImages.width, bottomRight.y - topLeft.y + 1, enumValue(ExtColour::unk34), Gfx::RectFlags::transparent);
         drawingCtx.drawRect(topLeft.x + borderImages.width + 1, topLeft.y, bottomRight.x - topLeft.x - 2 * borderImages.width, bottomRight.y - topLeft.y + 1, enumValue(colour), Gfx::RectFlags::transparent);

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -122,16 +122,19 @@ namespace OpenLoco
             const auto index = zoom.index();
             auto font = kZoomToTownFonts[index];
 
-            auto nameWidth = zoom.applyTo(Gfx::TextRenderer::getStringWidth(font, buffer) + 2);
-            auto nameHeight = zoom.applyTo(11); // was a lookup on 0x4FF6FC; same for all zoom levels
+            const auto uiWidth = Gfx::TextRenderer::getStringWidth(font, buffer) + 2;
+            const auto uiHeight = 11; // was a lookup on 0x4FF6FC; same for all zoom levels
+
+            auto nameWidth = zoom.applyTo(uiWidth);
+            auto nameHeight = zoom.applyTo(uiHeight);
 
             auto xOffset = rotated.x - (nameWidth / 2);
             auto yOffset = rotated.y - (nameHeight / 2);
 
             labelFrame.left[index] = zoom.applyInversedTo(xOffset);
-            labelFrame.right[index] = zoom.applyInversedTo(xOffset + nameWidth);
+            labelFrame.right[index] = labelFrame.left[index] + uiWidth;
             labelFrame.top[index] = zoom.applyInversedTo(yOffset);
-            labelFrame.bottom[index] = zoom.applyInversedTo(yOffset + nameHeight);
+            labelFrame.bottom[index] = labelFrame.top[index] + uiHeight;
         }
     }
 

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -77,7 +77,9 @@ namespace OpenLoco
     }
 
     // 0x004FF6F4
-    static constexpr std::array<Gfx::Font, 4> kZoomToTownFonts = {
+    static constexpr std::array<Gfx::Font, ZoomLevel::count> kZoomToTownFonts = {
+        Gfx::Font::medium_bold,
+        Gfx::Font::medium_bold,
         Gfx::Font::medium_bold,
         Gfx::Font::medium_bold,
         Gfx::Font::medium_normal,
@@ -96,9 +98,9 @@ namespace OpenLoco
 
         char buffer[512]{};
         StringManager::formatString(buffer, name);
-        tr.setCurrentFont(kZoomToTownFonts[zoom]);
+        tr.setCurrentFont(kZoomToTownFonts[zoom.index()]);
 
-        auto point = Ui::Point(labelFrame.left[zoom] + 1, labelFrame.top[zoom] + 1);
+        auto point = Ui::Point(labelFrame.left[zoom.index()] + 1, labelFrame.top[zoom.index()] + 1);
         tr.drawString(point, AdvancedColour(Colour::white).outline(), buffer);
     }
 
@@ -114,20 +116,22 @@ namespace OpenLoco
         auto rotated = World::gameToScreen(pos, Ui::WindowManager::getCurrentRotation());
         rotated.y -= 48;
 
-        for (auto zoomLevel = 0; zoomLevel < 4; zoomLevel++)
+        for (auto level = ZoomLevel::min; level <= ZoomLevel::max; level++)
         {
-            auto font = kZoomToTownFonts[zoomLevel];
+            const auto zoom = ZoomLevel{ level };
+            const auto index = zoom.index();
+            auto font = kZoomToTownFonts[index];
 
-            auto nameWidth = (Gfx::TextRenderer::getStringWidth(font, buffer) + 2) << zoomLevel;
-            auto nameHeight = 11 << zoomLevel; // was a lookup on 0x4FF6FC; same for all zoom levels
+            auto nameWidth = zoom.applyTo(Gfx::TextRenderer::getStringWidth(font, buffer) + 2);
+            auto nameHeight = zoom.applyTo(11); // was a lookup on 0x4FF6FC; same for all zoom levels
 
             auto xOffset = rotated.x - (nameWidth / 2);
             auto yOffset = rotated.y - (nameHeight / 2);
 
-            labelFrame.left[zoomLevel] = xOffset >> zoomLevel;
-            labelFrame.right[zoomLevel] = (xOffset + nameWidth) >> zoomLevel;
-            labelFrame.top[zoomLevel] = yOffset >> zoomLevel;
-            labelFrame.bottom[zoomLevel] = (yOffset + nameHeight) >> zoomLevel;
+            labelFrame.left[index] = zoom.applyInversedTo(xOffset);
+            labelFrame.right[index] = zoom.applyInversedTo(xOffset + nameWidth);
+            labelFrame.top[index] = zoom.applyInversedTo(yOffset);
+            labelFrame.bottom[index] = zoom.applyInversedTo(yOffset + nameHeight);
         }
     }
 

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -84,9 +84,10 @@ namespace OpenLoco
         Gfx::Font::medium_normal,
     };
 
-    void Town::drawLabel(Gfx::DrawingContext& drawingCtx, const Gfx::RenderTarget& rt)
+    void Town::drawLabel(Gfx::DrawingContext& drawingCtx, ZoomLevel zoom)
     {
-        if (!labelFrame.contains(rt.getDrawableRect(), rt.zoomLevel))
+        const auto& rt = drawingCtx.currentRenderTarget();
+        if (!labelFrame.contains(rt.getUiRect(), zoom))
         {
             return;
         }
@@ -95,9 +96,9 @@ namespace OpenLoco
 
         char buffer[512]{};
         StringManager::formatString(buffer, name);
-        tr.setCurrentFont(kZoomToTownFonts[rt.zoomLevel]);
+        tr.setCurrentFont(kZoomToTownFonts[zoom]);
 
-        auto point = Ui::Point(labelFrame.left[rt.zoomLevel] + 1, labelFrame.top[rt.zoomLevel] + 1);
+        auto point = Ui::Point(labelFrame.left[zoom] + 1, labelFrame.top[zoom] + 1);
         tr.drawString(point, AdvancedColour(Colour::white).outline(), buffer);
     }
 


### PR DESCRIPTION
Adds two more zoom levels to further zoom in, most of it was ported off from OpenRCT2 with the exception that the render target remains in screen space and doesn't carry all the pointless data, it explicitly hands down the information needed. I tried to keep commits clean but I ended up doing a lot at once since that was easier.

https://github.com/user-attachments/assets/db56ebc5-3cfc-4747-a13c-6b180ada0d58

This also incidentally fixes #3738 