### PR TITLE
Use std::source_location in Exception.hpp

### DIFF
--- a/src/Core/include/OpenLoco/Core/Exception.hpp
+++ b/src/Core/include/OpenLoco/Core/Exception.hpp
@@ -3,6 +3,7 @@
 #include "SourceLocation.h"
 #include <exception>
 #include <fmt/format.h>
+#include <source_location>
 #include <string>
 
 namespace OpenLoco::Exception
@@ -13,19 +14,19 @@ namespace OpenLoco::Exception
         class ExceptionBase : public std::exception
         {
         private:
-            SourceLocation _location;
+            std::source_location _location;
             std::string _message;
 
         public:
-            explicit ExceptionBase(const SourceLocation& location = SourceLocation{})
+            explicit ExceptionBase(const std::source_location& location = std::source_location::current())
                 : _location{ location }
             {
-                _message = fmt::format("Exception thrown at '{}' - {}:{}", _location.function(), _location.file(), _location.line());
+                _message = fmt::format("Exception thrown at '{}' - {}:{}", _location.function_name(), OpenLoco::Detail::sanitizePath(_location.file_name()), _location.line());
             }
-            explicit ExceptionBase(const std::string& message, const SourceLocation& location = SourceLocation{})
+            explicit ExceptionBase(const std::string& message, const std::source_location& location = std::source_location::current())
                 : _location{ location }
             {
-                _message = fmt::format("Exception '{}', thrown at '{}' - {}:{}", message, _location.function(), _location.file(), _location.line());
+                _message = fmt::format("Exception '{}', thrown at '{}' - {}:{}", message, _location.function_name(), OpenLoco::Detail::sanitizePath(_location.file_name()), _location.line());
             }
             const char* what() const noexcept override
             {

--- a/src/Core/include/OpenLoco/Core/SourceLocation.h
+++ b/src/Core/include/OpenLoco/Core/SourceLocation.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <string>
 #include <string_view>
 
 namespace OpenLoco
@@ -19,32 +18,4 @@ namespace OpenLoco
 #endif
         }
     }
-
-    // Something like std::source_location except it uses relative paths when possible.
-    class SourceLocation
-    {
-        std::string _function;
-        std::string _file;
-        int _line;
-
-    public:
-        explicit SourceLocation(std::string_view func = __builtin_FUNCTION(), std::string_view file = Detail::sanitizePath(__builtin_FILE()), int line = __builtin_LINE())
-            : _function(func)
-            , _file(file)
-            , _line(line)
-        {
-        }
-        const std::string& file() const noexcept
-        {
-            return _file;
-        }
-        const std::string& function() const noexcept
-        {
-            return _function;
-        }
-        int line() const noexcept
-        {
-            return _line;
-        }
-    };
 }

--- a/src/Diagnostics/include/OpenLoco/Diagnostics/Assertion.h
+++ b/src/Diagnostics/include/OpenLoco/Diagnostics/Assertion.h
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 #include <functional>
 #include <memory>
+#include <source_location>
 #include <string>
 #include <string_view>
 
@@ -35,11 +36,11 @@ namespace OpenLoco::Diagnostics::Assert
         }
 
         template<typename L, typename R>
-        inline void assertionFailure(std::string_view op, const L& lhs, const R& rhs, const SourceLocation& loc)
+        inline void assertionFailure(std::string_view op, const L& lhs, const R& rhs, const std::source_location& loc)
         {
             Logging::error(
                 "Assertion failure ({}:{}): {} {} {}",
-                loc.file(),
+                OpenLoco::Detail::sanitizePath(loc.file_name()),
                 loc.line(),
                 Detail::formatValue(lhs),
                 op,
@@ -54,7 +55,7 @@ namespace OpenLoco::Diagnostics::Assert
     }
 
     template<typename U1, typename U2>
-    inline void eq(const U1& expected, const U2& actual, const SourceLocation& loc = SourceLocation{})
+    inline void eq(const U1& expected, const U2& actual, const std::source_location& loc = std::source_location::current())
     {
         if (expected != actual)
         {
@@ -64,7 +65,7 @@ namespace OpenLoco::Diagnostics::Assert
     }
 
     template<typename U1, typename U2>
-    inline void neq(const U1& expected, const U2& actual, const SourceLocation& loc = SourceLocation{})
+    inline void neq(const U1& expected, const U2& actual, const std::source_location& loc = std::source_location::current())
     {
         if (expected == actual)
         {
@@ -74,7 +75,7 @@ namespace OpenLoco::Diagnostics::Assert
     }
 
     template<typename U1, typename U2>
-    inline void lt(const U1& lhs, const U2& rhs, const SourceLocation& loc = SourceLocation{})
+    inline void lt(const U1& lhs, const U2& rhs, const std::source_location& loc = std::source_location::current())
     {
         if (!(lhs < rhs))
         {
@@ -84,7 +85,7 @@ namespace OpenLoco::Diagnostics::Assert
     }
 
     template<typename U1, typename U2>
-    inline void le(const U1& lhs, const U2& rhs, const SourceLocation& loc = SourceLocation{})
+    inline void le(const U1& lhs, const U2& rhs, const std::source_location& loc = std::source_location::current())
     {
         if (!(lhs <= rhs))
         {
@@ -94,7 +95,7 @@ namespace OpenLoco::Diagnostics::Assert
     }
 
     template<typename U1, typename U2>
-    inline void gt(const U1& lhs, const U2& rhs, const SourceLocation& loc = SourceLocation{})
+    inline void gt(const U1& lhs, const U2& rhs, const std::source_location& loc = std::source_location::current())
     {
         if (!(lhs > rhs))
         {
@@ -104,7 +105,7 @@ namespace OpenLoco::Diagnostics::Assert
     }
 
     template<typename U1, typename U2>
-    inline void ge(const U1& lhs, const U2& rhs, const SourceLocation& loc = SourceLocation{})
+    inline void ge(const U1& lhs, const U2& rhs, const std::source_location& loc = std::source_location::current())
     {
         if (!(lhs >= rhs))
         {
@@ -113,38 +114,38 @@ namespace OpenLoco::Diagnostics::Assert
         }
     }
 
-    inline void isTrue(bool condition, const SourceLocation& loc = SourceLocation{})
+    inline void isTrue(bool condition, const std::source_location& loc = std::source_location::current())
     {
         if (!condition)
         {
             Logging::error(
                 "Assertion failure ({}:{}): expected true",
-                loc.file(),
+                OpenLoco::Detail::sanitizePath(loc.file_name()),
                 loc.line());
             OPENLOCO_DEBUG_BREAK();
         }
     }
 
-    inline void isFalse(bool condition, const SourceLocation& loc = SourceLocation{})
+    inline void isFalse(bool condition, const std::source_location& loc = std::source_location::current())
     {
         if (condition)
         {
             Logging::error(
                 "Assertion failure ({}:{}): expected false",
-                loc.file(),
+                OpenLoco::Detail::sanitizePath(loc.file_name()),
                 loc.line());
             OPENLOCO_DEBUG_BREAK();
         }
     }
 
     template<Detail::NullablePointer Ptr>
-    inline void isNull(Ptr&& ptr, const SourceLocation& loc = SourceLocation{})
+    inline void isNull(Ptr&& ptr, const std::source_location& loc = std::source_location::current())
     {
         if (ptr != nullptr)
         {
             Logging::error(
                 "Assertion failure ({}:{}): expected null pointer (got {})",
-                loc.file(),
+                OpenLoco::Detail::sanitizePath(loc.file_name()),
                 loc.line(),
                 Detail::formatValue(ptr));
             OPENLOCO_DEBUG_BREAK();
@@ -152,13 +153,13 @@ namespace OpenLoco::Diagnostics::Assert
     }
 
     template<Detail::NullablePointer Ptr>
-    inline void notNull(Ptr&& ptr, const SourceLocation& loc = SourceLocation{})
+    inline void notNull(Ptr&& ptr, const std::source_location& loc = std::source_location::current())
     {
         if (ptr == nullptr)
         {
             Logging::error(
                 "Assertion failure ({}:{}): expected non-null pointer",
-                loc.file(),
+                OpenLoco::Detail::sanitizePath(loc.file_name()),
                 loc.line());
             OPENLOCO_DEBUG_BREAK();
         }


### PR DESCRIPTION
Replaces the custom SourceLocation type in Exception.hpp with the C++20 std::source_location. sanitizePath is still applied to file_name() so exception messages keep relative paths (behaviour unchanged). Addresses the Exception.hpp item in #2140.

Note: std::source_location::function_name() reports the full function signature rather than the bare name, so the function part of exception messages is slightly more detailed.