### PR TITLE
Simplify Window::callOnResize

### DIFF
--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -347,7 +347,7 @@ namespace OpenLoco::Ui
 
         void callClose();                                                                                                 // 0
         void callOnMouseUp(WidgetIndex_t widgetIndex, WidgetId id);                                                       // 1
-        Ui::Window* callOnResize();                                                                                       // 2
+        void callOnResize();                                                                                              // 2
         void callOnMouseHover(WidgetIndex_t widgetIndex, WidgetId id);                                                    // 3
         void callOnMouseDown(WidgetIndex_t widgetIndex, WidgetId id);                                                     // 4
         void callOnDropdown(WidgetIndex_t widgetIndex, WidgetId id, int16_t itemIndex);                                   // 5

--- a/src/OpenLoco/src/Ui/Window.cpp
+++ b/src/OpenLoco/src/Ui/Window.cpp
@@ -1105,15 +1105,14 @@ namespace OpenLoco::Ui
         eventHandlers->onMouseUp(*this, widgetIndex, id);
     }
 
-    Ui::Window* Window::callOnResize()
+    void Window::callOnResize()
     {
         if (eventHandlers->onResize == nullptr)
         {
-            return this;
+            return;
         }
 
         eventHandlers->onResize(*this);
-        return this;
     }
 
     void Window::callOnMouseHover(WidgetIndex_t widgetIndex, const WidgetId id)

--- a/src/OpenLoco/src/Ui/WindowManager.cpp
+++ b/src/OpenLoco/src/Ui/WindowManager.cpp
@@ -231,11 +231,6 @@ namespace OpenLoco::Ui::WindowManager
                 }
             }
 
-            if (w.callOnResize() == nullptr)
-            {
-                return findAt(x, y);
-            }
-
             return &w;
         }
         return nullptr;
@@ -278,11 +273,6 @@ namespace OpenLoco::Ui::WindowManager
                 {
                     continue;
                 }
-            }
-
-            if (w.callOnResize() == nullptr)
-            {
-                return findAt(x, y);
             }
 
             return &w;


### PR DESCRIPTION
Callers to `Window::callOnResize` could check for it to return `nullptr`, but it never did. Presumably a leftover from the interop days.