### PR TITLE
Run CoInitialize only once with STA, fixes opening the browse prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 26.07+ (???)
 ------------------------------------------------------------------------
+- Fix: [#3842] Native browse prompt not working on Windows, preventing selecting the Locomotion path on first start.
 
 26.07 (2026-07-26)
 ------------------------------------------------------------------------

--- a/src/Platform/src/Platform.Windows.cpp
+++ b/src/Platform/src/Platform.Windows.cpp
@@ -34,7 +34,7 @@ namespace OpenLoco::Platform
         // Ensures that assert dialogs allow for ignoring them (not the default behaviour for console subsystem)
         _set_error_mode(_OUT_TO_MSGBOX);
 
-        CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+        CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
     }
 
     uint32_t getTime()
@@ -81,7 +81,7 @@ namespace OpenLoco::Platform
 
         // Initialize COM and get a pointer to the shell memory allocator
         LPMALLOC lpMalloc;
-        if (SUCCEEDED(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED)) && SUCCEEDED(SHGetMalloc(&lpMalloc)))
+        if (SUCCEEDED(SHGetMalloc(&lpMalloc)))
         {
             auto titleW = Utility::toUtf16(title);
             BROWSEINFOW bi{};
@@ -99,7 +99,6 @@ namespace OpenLoco::Platform
         {
             std::cerr << "Error opening directory browse window";
         }
-        CoUninitialize();
 
         // SHBrowseForFolderW might minimize the main window,
         // so make sure that it's visible again.


### PR DESCRIPTION
This fixes the browse prompt refusing to show up, we need to stick to STA for the whole process for any other things to not break.

Closes #3842