### PR TITLE
Fix #3846: off-by-one in company/station list scroll click handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.07+ (???)
 ------------------------------------------------------------------------
 - Fix: [#3842] Native browse prompt not working on Windows, preventing selecting the Locomotion path on first start.
+- Fix: [#3846] Can click beyond last item in station and company list windows, opening invalid windows.
 
 26.07 (2026-07-26)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyList.cpp
@@ -273,7 +273,7 @@ namespace OpenLoco::Ui::Windows::CompanyList
         static void onScrollMouseDown(Window& self, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
         {
             uint16_t currentRow = y / kRowHeight;
-            if (currentRow > self.rowCount)
+            if (currentRow >= self.rowCount)
             {
                 return;
             }

--- a/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
@@ -312,7 +312,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     static void onScrollMouseDown(Ui::Window& window, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         const uint16_t currentRow = y / kRowHeight;
-        if (currentRow > window.rowCount)
+        if (currentRow >= window.rowCount)
         {
             return;
         }
@@ -341,7 +341,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
     static void onScrollMouseOver(Ui::Window& window, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         uint16_t currentRow = y / kRowHeight;
-        if (currentRow > window.rowCount || currentRow == window.rowHover)
+        if (currentRow >= window.rowCount || currentRow == window.rowHover)
         {
             return;
         }

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -670,7 +670,7 @@ namespace OpenLoco::Ui::Windows::StationList
     static void onScrollMouseDown(Ui::Window& window, [[maybe_unused]] int16_t x, int16_t y, [[maybe_unused]] uint8_t scroll_index)
     {
         uint16_t currentRow = y / kRowHeight;
-        if (currentRow > window.rowCount)
+        if (currentRow >= window.rowCount)
         {
             return;
         }


### PR DESCRIPTION
I was sure I looked if there were others, apparently I missed them.

Closes #3846