### PR TITLE
Fix switch company cheat invalidation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.07.1+ (???)
 ------------------------------------------------------------------------
 - Fix: [#2082] Scrollbars can be overdrawn when certain windows are resized but their scrollview is not.
+- Fix: [#3855] UI invalidation issue when using switch company cheat.
 - Fix: [#3858] Save file details can overflow the file browser window at minimum height.
 
 26.07.1 (2026-07-27)

--- a/src/OpenLoco/src/Ui/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Cheats.cpp
@@ -537,6 +537,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     args.param1 = enumValue(_targetCompanyId);
 
                     GameCommands::doCommand(args, GameCommands::Flags::apply);
+                    self.invalidate();
                     WindowManager::invalidate(WindowType::playerInfoToolbar);
                     return;
                 }

--- a/src/OpenLoco/src/Ui/Windows/Cheats.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Cheats.cpp
@@ -537,8 +537,7 @@ namespace OpenLoco::Ui::Windows::Cheats
                     args.param1 = enumValue(_targetCompanyId);
 
                     GameCommands::doCommand(args, GameCommands::Flags::apply);
-                    self.invalidate();
-                    WindowManager::invalidate(WindowType::playerInfoToolbar);
+                    Gfx::invalidateScreen();
                     return;
                 }
 


### PR DESCRIPTION
Prevents this from happening when switching company that you are controlling by using the Cheats window:
<img width="492" height="222" alt="image" src="https://github.com/user-attachments/assets/bfa5d888-b5dc-4571-8738-ad78273a827f" />
