### PR TITLE
Load playNewsSounds config setting as saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#2082] Scrollbars can be overdrawn when certain windows are resized but their scrollview is not.
 - Fix: [#3858] Save file details can overflow the file browser window at minimum height.
+- Fix: [#3861] The news sound setting is not read properly from the config file.
 
 26.07.1 (2026-07-27)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -81,7 +81,7 @@ namespace OpenLoco::Config
             audioConfig.ambientVolume = audioNode["ambientVolume"].as<int32_t>(100);
             audioConfig.playJukeboxMusic = audioNode["playJukeboxMusic"].as<bool>(true);
             audioConfig.playTitleMusic = audioNode["play_title_music"].as<bool>(true);
-            audioConfig.playNewsSounds = audioNode["play_news_sounds"].as<bool>(true);
+            audioConfig.playNewsSounds = audioNode["playNewsSounds"].as<bool>(true);
             audioConfig.playlist = audioNode["playlist"].as<MusicPlaylistType>(MusicPlaylistType::currentEra);
 
             if (audioNode["customJukebox"])


### PR DESCRIPTION
The `playNewsSounds` config setting is saved as camelCase, not snake_case.