### PR TITLE
Make automatically opening toolbar menus optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.07.1+ (???)
 ------------------------------------------------------------------------
 - Change: [#3815] The keyboard shortcuts window is now separated into groups, and can now be resized.
+- Change: [#3863] The toolbar buttons can now be set to open on click instead of hover.
 - Fix: [#2082] Scrollbars can be overdrawn when certain windows are resized but their scrollview is not.
 - Fix: [#3855] UI invalidation issue when using switch company cheat.
 - Fix: [#3858] Save file details can overflow the file browser window at minimum height.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2512,3 +2512,4 @@ strings:
   2457: "{COLOUR WINDOW_2}Cargo awaiting transport:"
   2458: "{STRINGID}{STRINGID}"
   2459: "Debug window"
+  2460: "Show toolbar menus on hover instead of click"

--- a/src/OpenLoco/include/OpenLoco/Config.h
+++ b/src/OpenLoco/include/OpenLoco/Config.h
@@ -174,6 +174,8 @@ namespace OpenLoco::Config
         bool cashPopupRendering = true;
         bool edgeScrolling = true;
         int32_t edgeScrollingSpeed = 12;
+        bool invertRightMouseViewPan = false;
+        bool toolbarAutoMenu = true;
         WindowFrameStyle windowFrameStyle = WindowFrameStyle::background;
         bool zoomToCursor = true;
 
@@ -196,7 +198,6 @@ namespace OpenLoco::Config
         bool companyAIDisabled = false;
         bool disableVehicleLoadPenaltyCheat = false;
         bool displayLockedVehicles = false;
-        bool invertRightMouseViewPan = false;
         bool townGrowthDisabled = false;
         bool trainsReverseAtSignals = true;
         bool disableStationSizeLimit = false;

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -2173,6 +2173,7 @@ namespace OpenLoco::StringIds
     constexpr StringId cargo_awaiting_transport = 2457;
     constexpr StringId keyboard_shortcut_binding = 2458;
     constexpr StringId shortcut_debug_window = 2459;
+    constexpr StringId toolbar_auto_menu = 2460;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -158,6 +158,8 @@ namespace OpenLoco::Config
         _config.cashPopupRendering = config["cashPopupRendering"].as<bool>(true);
         _config.edgeScrolling = config["edgeScrolling"].as<bool>(true);
         _config.edgeScrollingSpeed = config["edgeScrollingSpeed"].as<int32_t>(12);
+        _config.invertRightMouseViewPan = config["invertRightMouseViewPan"].as<bool>(false);
+        _config.toolbarAutoMenu = config["toolbarAutoMenu"].as<bool>(true);
         _config.windowFrameStyle = config["windowFrameStyle"].as<WindowFrameStyle>(WindowFrameStyle::background);
         _config.zoomToCursor = config["zoom_to_cursor"].as<bool>(true);
 
@@ -173,7 +175,6 @@ namespace OpenLoco::Config
         _config.companyAIDisabled = config["companyAIDisabled"].as<bool>(false);
         _config.disableVehicleLoadPenaltyCheat = config["disableVehicleLoadPenaltyCheat"].as<bool>(false);
         _config.displayLockedVehicles = config["displayLockedVehicles"].as<bool>(false);
-        _config.invertRightMouseViewPan = config["invertRightMouseViewPan"].as<bool>(false);
         _config.townGrowthDisabled = config["townGrowthDisabled"].as<bool>(false);
         _config.trainsReverseAtSignals = config["trainsReverseAtSignals"].as<bool>(false);
         _config.disableStationSizeLimit = config["disableStationSizeLimit"].as<bool>(false);
@@ -297,6 +298,7 @@ namespace OpenLoco::Config
         node["cashPopupRendering"] = _config.cashPopupRendering;
         node["edgeScrolling"] = _config.edgeScrolling;
         node["edgeScrollingSpeed"] = _config.edgeScrollingSpeed;
+        node["toolbarAutoMenu"] = _config.toolbarAutoMenu;
         node["windowFrameStyle"] = _config.windowFrameStyle;
         node["zoom_to_cursor"] = _config.zoomToCursor;
 

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -1900,6 +1900,7 @@ namespace OpenLoco::Ui::Windows::Options
             edge_scrolling = Common::widx::tab_miscellaneous + 1,
             zoom_to_cursor,
             invert_right_mouse_view_pan,
+            toolbar_auto_menu,
             customize_keys
         };
 
@@ -1908,23 +1909,26 @@ namespace OpenLoco::Ui::Windows::Options
             constexpr WidgetId kEdgeScrolling{ "edge_scrolling" };
             constexpr WidgetId kZoomToCursor{ "zoom_to_cursor" };
             constexpr WidgetId kInvertRightMouseViewPan{ "invert_right_mouse_view_pan" };
+            constexpr WidgetId kToolbarMenuAuto{ "toolbar_auto_menu" };
             constexpr WidgetId kCustomizeKeys{ "customize_keys" };
         }
 
-        static constexpr Ui::Size kWindowSize = { 366, 114 };
+        static constexpr Ui::Size kWindowSize = { 366, 129 };
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_controls),
             Widgets::Checkbox(Widx::kEdgeScrolling, { 10, 49 }, { 346, 12 }, WindowColour::secondary, StringIds::scroll_screen_edge, StringIds::scroll_screen_edge_tip),
             Widgets::Checkbox(Widx::kZoomToCursor, { 10, 64 }, { 346, 12 }, WindowColour::secondary, StringIds::zoom_to_cursor, StringIds::zoom_to_cursor_tip),
             Widgets::Checkbox(Widx::kInvertRightMouseViewPan, { 10, 79 }, { 346, 12 }, WindowColour::secondary, StringIds::invert_right_mouse_dragging, StringIds::tooltip_invert_right_mouse_dragging),
-            Widgets::Button(Widx::kCustomizeKeys, { 26, 94 }, { 160, 12 }, WindowColour::secondary, StringIds::customise_keys, StringIds::customise_keys_tip)
+            Widgets::Checkbox(Widx::kToolbarMenuAuto, { 10, 94 }, { 346, 12 }, WindowColour::secondary, StringIds::toolbar_auto_menu),
+            Widgets::Button(Widx::kCustomizeKeys, { 26, 109 }, { 160, 12 }, WindowColour::secondary, StringIds::customise_keys, StringIds::customise_keys_tip)
 
         );
 
         static void edgeScrollingMouseUp(Window& self);
         static void zoomToCursorMouseUp(Window& self);
         static void invertRightMouseViewPan(Window& self);
+        static void toolbarAutoMenuMouseUp(Window& self);
         static void openKeyboardShortcuts();
 
         static void prepareDraw(Window& self)
@@ -1933,7 +1937,7 @@ namespace OpenLoco::Ui::Windows::Options
 
             Common::prepareDraw(self);
 
-            self.activatedWidgets &= ~(1ULL << widx::edge_scrolling | 1ULL << widx::zoom_to_cursor | 1ULL << widx::invert_right_mouse_view_pan);
+            self.activatedWidgets &= ~(1ULL << widx::edge_scrolling | 1ULL << widx::zoom_to_cursor | 1ULL << widx::invert_right_mouse_view_pan | 1ULL << widx::toolbar_auto_menu);
             if (Config::get().edgeScrolling)
             {
                 self.activatedWidgets |= (1ULL << widx::edge_scrolling);
@@ -1945,6 +1949,10 @@ namespace OpenLoco::Ui::Windows::Options
             if (Config::get().invertRightMouseViewPan)
             {
                 self.activatedWidgets |= (1ULL << widx::invert_right_mouse_view_pan);
+            }
+            if (Config::get().toolbarAutoMenu)
+            {
+                self.activatedWidgets |= (1ULL << widx::toolbar_auto_menu);
             }
         }
 
@@ -1979,6 +1987,10 @@ namespace OpenLoco::Ui::Windows::Options
                 case Widx::kInvertRightMouseViewPan:
                     invertRightMouseViewPan(self);
                     break;
+
+                case Widx::kToolbarMenuAuto:
+                    toolbarAutoMenuMouseUp(self);
+                    break;
             }
         }
 
@@ -2005,6 +2017,15 @@ namespace OpenLoco::Ui::Windows::Options
         {
             auto& cfg = OpenLoco::Config::get();
             cfg.invertRightMouseViewPan = !cfg.invertRightMouseViewPan;
+            Config::write();
+
+            self.invalidate();
+        }
+
+        static void toolbarAutoMenuMouseUp(Window& self)
+        {
+            auto& cfg = OpenLoco::Config::get();
+            cfg.toolbarAutoMenu = !cfg.toolbarAutoMenu;
             Config::write();
 
             self.invalidate();

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -774,6 +774,14 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         }
     }
 
+    static void onMouseHover(Window& window, WidgetIndex_t widgetIndex, const WidgetId id)
+    {
+        if (Config::get().toolbarAutoMenu)
+        {
+            onMouseDown(window, widgetIndex, id);
+        }
+    }
+
     static void onDropdown(Window& window, WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
         switch (id)
@@ -1007,7 +1015,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
 
     static constexpr WindowEventList kEvents = {
         .onResize = Common::onResize,
-        .onMouseHover = onMouseDown,
+        .onMouseHover = onMouseHover,
         .onMouseDown = onMouseDown,
         .onDropdown = onDropdown,
         .onUpdate = Common::onUpdate,

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
@@ -279,6 +279,14 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
         }
     }
 
+    static void onMouseHover(Window& window, WidgetIndex_t widgetIndex, const WidgetId id)
+    {
+        if (Config::get().toolbarAutoMenu)
+        {
+            onMouseDown(window, widgetIndex, id);
+        }
+    }
+
     // 0x0043D5A6
     static void onDropdown(Window& window, WidgetIndex_t widgetIndex, const WidgetId id, int16_t itemIndex)
     {
@@ -347,7 +355,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
 
     static constexpr WindowEventList kEvents = {
         .onResize = Common::onResize,
-        .onMouseHover = onMouseDown,
+        .onMouseHover = onMouseHover,
         .onMouseDown = onMouseDown,
         .onDropdown = onDropdown,
         .onUpdate = Common::onUpdate,


### PR DESCRIPTION
Locomotion automatically opens the toolbar menus on _hover_, rather than on click. This PR introduces a setting to make this optional, letting menus open on click instead.

By default, the setting is enabled, meaning menus still expand on hover rather than click.

<img width="366" height="129" alt="North America (Mid) 1970" src="https://github.com/user-attachments/assets/22d7304f-1a40-4ec3-a013-ea1e4052dc43" />

@ZehMatt This one's for you