### PR TITLE
Pass the correct widget id for the manual event calls

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -692,7 +692,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
         // Allow setting company owner name if no preferred owner name has been set.
         if (!Config::get().usePreferredOwnerName)
         {
-            Status::onMouseUp(*self, Status::widx::change_owner_name, WidgetId::none);
+            Status::onMouseUp(*self, Status::widx::change_owner_name, Status::Widx::kChangeOwnerName);
         }
 
         return self;

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -2135,7 +2135,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
             // Attempt to place track piece -- in silence
             GameCommands::setErrorSound(false);
-            onMouseUp(*window, widx::construct, WidgetId::none);
+            onMouseUp(*window, widx::construct, Widx::kConstruct);
             GameCommands::setErrorSound(true);
 
             if (cState.trackCost != GameCommands::kFailure || cState.roadCost != GameCommands::kFailure)
@@ -2163,7 +2163,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
             }
 
             // Failed to place track piece -- rotate and make error sound
-            onMouseUp(*window, widx::rotate_90, WidgetId::none);
+            onMouseUp(*window, widx::rotate_90, Widx::kRotate90);
             Audio::playSound(Audio::SoundId::error, Audio::ChannelId::ui, int32_t(Input::getMouseLocation().x));
             return;
         }


### PR DESCRIPTION
That fixes being unable to place roads and tracks and found another one for company rename.