### PR TITLE
Remove callOnResize from setWidgets, that causes stack overflow

### DIFF
--- a/src/OpenLoco/include/OpenLoco/Ui/Window.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Window.h
@@ -246,9 +246,7 @@ namespace OpenLoco::Ui
             widgets.clear();
             widgets.insert(widgets.end(), newWidgets.begin(), newWidgets.end());
 
-            // Ensure initial widget positions are assigned through event function
             invalidate();
-            callOnResize();
         }
 
         constexpr bool setSize(Ui::Size size)


### PR DESCRIPTION
I haven't seen anything else break so that part isn't even needed anymore. Currently opening the company window crashes due to a stack overflow.

```
Status::prepareDraw -> Common::switchTabWidgets(&self) 
Common::switchTabWidgets -> self->setWidgets(newWidgets)
Window::setWidgets ->  invalidate(); callOnResize(); 
Window::callOnResize  -> Status::onResize
Status::onResize -> self.callViewportRotate();            // CompanyWindow.cpp:460
Window::callViewportRotate -> Status::viewportRotate
Status::viewportRotate -> self.callPrepareDraw();         // currentTab==0, no early-out (line 522)
Window::callPrepareDraw -> Status::prepareDraw            // back to the top, stack overflow
```