### PR TITLE
Cycle track types and road types with build road and track keyboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 26.08+ (???)
 ------------------------------------------------------------------------
+- Change: [#3867] Repeated presses of the build tracks and build roads keyboard shortcuts now cycles track/road types.
 - Fix: [#3943] Unable to place or remove signals on multi tile track elements.
 - Fix: [#3955] Terraform window can break dimensions of construction window.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Feature: [#3872] Added an option to align the top toolbar buttons horizontally centred (off by default).
 - Change: [#3815] The keyboard shortcuts window is now separated into groups, and can now be resized.
 - Change: [#3863] The toolbar buttons can now be set to open on click instead of hover.
+- Change: [#3867] Repeated presses of the build tracks and build roads keyboard shortcuts now cycles track/road types.
 - Fix: [#2082] Scrollbars can be overdrawn when certain windows are resized but their scrollview is not.
 - Fix: [#2983] Can no longer scroll to adjust terraform tool size widgets.
 - Fix: [#3676] Fix bug where last land variation sprite went unused (original bug).

--- a/src/OpenLoco/include/OpenLoco/Ui/WindowManager.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/WindowManager.h
@@ -186,6 +186,7 @@ namespace OpenLoco::Ui::Windows
         void removeConstructionGhosts();
         void resetGhostVisibilityFlags();
         uint16_t getLastSelectedMods();
+        uint8_t getCurrentTrackType();
         World::Track::ModSection getLastSelectedTrackModSection();
     }
 

--- a/src/OpenLoco/include/OpenLoco/Ui/WindowManager.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/WindowManager.h
@@ -181,6 +181,7 @@ namespace OpenLoco::Ui::Windows
         void removeConstructionGhosts();
         void resetGhostVisibilityFlags();
         uint16_t getLastSelectedMods();
+        uint8_t getCurrentTrackType();
         World::Track::ModSection getLastSelectedTrackModSection();
     }
 

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -19,6 +19,7 @@
 #include "World/TownManager.h"
 #include <OpenLoco/Engine/Input/ShortcutManager.h>
 #include <SDL3/SDL_keyboard.h>
+#include <algorithm>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -344,12 +345,30 @@ namespace OpenLoco::Input::Shortcuts
             return;
         }
 
-        if (getGameState().defaultRailroadObjectId == 0xFF)
+        auto track = getGameState().defaultRailroadObjectId;
+
+        if (track == 0xFF)
         {
             return;
         }
 
-        Windows::Construction::openWithFlags(getGameState().defaultRailroadObjectId);
+        // Is construction for it already open?
+        if (WindowManager::find(WindowType::construction) != nullptr && Windows::Construction::getCurrentTrackType() == track)
+        {
+            // Find next available track
+            const auto available = companyGetAvailableRailTracks(GameCommands::getUpdatingCompanyId());
+            auto it = std::find(available.begin(), available.end(), track);
+            if (it != available.end() && it + 1 != available.end())
+            {
+                track = *(it + 1);
+            }
+            else
+            {
+                track = available[0];
+            }
+        }
+
+        Windows::Construction::openWithFlags(track);
     }
 
     // 0x004BF24F
@@ -360,12 +379,30 @@ namespace OpenLoco::Input::Shortcuts
             return;
         }
 
-        if (getGameState().defaultRoadObjectId == 0xFF)
+        auto road = getGameState().defaultRoadObjectId;
+
+        if (road == 0xFF)
         {
             return;
         }
 
-        Windows::Construction::openWithFlags(getGameState().defaultRoadObjectId);
+        // Is construction for it already open?
+        if (WindowManager::find(WindowType::construction) != nullptr && Windows::Construction::getCurrentTrackType() == road)
+        {
+            // Find next available road
+            const auto available = companyGetAvailableRoads(GameCommands::getUpdatingCompanyId());
+            auto it = std::find(available.begin(), available.end(), road);
+            if (it != available.end() && it + 1 != available.end())
+            {
+                road = *(it + 1);
+            }
+            else
+            {
+                road = available[0];
+            }
+        }
+
+        Windows::Construction::openWithFlags(road);
     }
 
     // 0x004BF276

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -337,6 +337,37 @@ namespace OpenLoco::Input::Shortcuts
         Windows::Terraform::openClearArea();
     }
 
+    static void buildTracksBuildRoadsCommon(uint8_t roadOrTrackId, const AvailableTracksAndRoads available)
+    {
+        if (roadOrTrackId == 0xFF)
+        {
+            return;
+        }
+
+        if (available.empty())
+        {
+            assert(false); // If there are none avaiable, why is the default not 0xFF ?
+            return;
+        }
+
+        // Is construction with this road/track type already open?
+        if (WindowManager::find(WindowType::construction) != nullptr && Windows::Construction::getCurrentTrackType() == roadOrTrackId)
+        {
+            // Find next available with wrapping
+            auto it = std::find(available.begin(), available.end(), roadOrTrackId);
+            if (it != available.end() && it + 1 != available.end())
+            {
+                roadOrTrackId = *(it + 1);
+            }
+            else
+            {
+                roadOrTrackId = available[0];
+            }
+        }
+
+        Windows::Construction::openWithFlags(roadOrTrackId);
+    }
+
     // 0x004BF232
     static void buildTracks()
     {
@@ -345,36 +376,7 @@ namespace OpenLoco::Input::Shortcuts
             return;
         }
 
-        // Could be either a track object or a road object
-        auto track = getGameState().defaultRailroadObjectId;
-
-        if (track == 0xFF)
-        {
-            return;
-        }
-
-        // Is construction for it already open?
-        if (WindowManager::find(WindowType::construction) != nullptr && Windows::Construction::getCurrentTrackType() == track)
-        {
-            // Find next available track
-            const auto available = companyGetAvailableRailTracks(GameCommands::getUpdatingCompanyId());
-            if (available.empty())
-            {
-                assert(false); // getGameState().defaultRailroadObjectId != 0xFF, but there are no available rail tracks?
-                return;
-            }
-            auto it = std::find(available.begin(), available.end(), track);
-            if (it != available.end() && it + 1 != available.end())
-            {
-                track = *(it + 1);
-            }
-            else
-            {
-                track = available[0];
-            }
-        }
-
-        Windows::Construction::openWithFlags(track);
+        buildTracksBuildRoadsCommon(getGameState().defaultRailroadObjectId, companyGetAvailableRailTracks(GameCommands::getUpdatingCompanyId()));
     }
 
     // 0x004BF24F
@@ -385,36 +387,7 @@ namespace OpenLoco::Input::Shortcuts
             return;
         }
 
-        // Could be either a track object or a road object
-        auto road = getGameState().defaultRoadObjectId;
-
-        if (road == 0xFF)
-        {
-            return;
-        }
-
-        // Is construction for it already open?
-        if (WindowManager::find(WindowType::construction) != nullptr && Windows::Construction::getCurrentTrackType() == road)
-        {
-            // Find next available road
-            const auto available = companyGetAvailableRoads(GameCommands::getUpdatingCompanyId());
-            if (available.empty())
-            {
-                assert(false); // getGameState().defaultRoadObjectId != 0xFF, but there are no available roads?
-                return;
-            }
-            auto it = std::find(available.begin(), available.end(), road);
-            if (it != available.end() && it + 1 != available.end())
-            {
-                road = *(it + 1);
-            }
-            else
-            {
-                road = available[0];
-            }
-        }
-
-        Windows::Construction::openWithFlags(road);
+        buildTracksBuildRoadsCommon(getGameState().defaultRoadObjectId, companyGetAvailableRoads(GameCommands::getUpdatingCompanyId()));
     }
 
     // 0x004BF276

--- a/src/OpenLoco/src/Input/Shortcuts.cpp
+++ b/src/OpenLoco/src/Input/Shortcuts.cpp
@@ -345,6 +345,7 @@ namespace OpenLoco::Input::Shortcuts
             return;
         }
 
+        // Could be either a track object or a road object
         auto track = getGameState().defaultRailroadObjectId;
 
         if (track == 0xFF)
@@ -357,6 +358,11 @@ namespace OpenLoco::Input::Shortcuts
         {
             // Find next available track
             const auto available = companyGetAvailableRailTracks(GameCommands::getUpdatingCompanyId());
+            if (available.empty())
+            {
+                assert(false); // getGameState().defaultRailroadObjectId != 0xFF, but there are no available rail tracks?
+                return;
+            }
             auto it = std::find(available.begin(), available.end(), track);
             if (it != available.end() && it + 1 != available.end())
             {
@@ -379,6 +385,7 @@ namespace OpenLoco::Input::Shortcuts
             return;
         }
 
+        // Could be either a track object or a road object
         auto road = getGameState().defaultRoadObjectId;
 
         if (road == 0xFF)
@@ -391,6 +398,11 @@ namespace OpenLoco::Input::Shortcuts
         {
             // Find next available road
             const auto available = companyGetAvailableRoads(GameCommands::getUpdatingCompanyId());
+            if (available.empty())
+            {
+                assert(false); // getGameState().defaultRoadObjectId != 0xFF, but there are no available roads?
+                return;
+            }
             auto it = std::find(available.begin(), available.end(), road);
             if (it != available.end() && it + 1 != available.end())
             {

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -729,6 +729,12 @@ namespace OpenLoco::Ui::Windows::Construction
         return getConstructionState().lastSelectedMods;
     }
 
+    uint8_t getCurrentTrackType()
+    {
+        auto& cState = getConstructionState();
+        return cState.trackType;
+    }
+
     Track::ModSection getLastSelectedTrackModSection()
     {
         auto& cState = getConstructionState();

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -725,6 +725,12 @@ namespace OpenLoco::Ui::Windows::Construction
         return getConstructionState().lastSelectedMods;
     }
 
+    uint8_t getCurrentTrackType()
+    {
+        auto& cState = getConstructionState();
+        return cState.trackType;
+    }
+
     Track::ModSection getLastSelectedTrackModSection()
     {
         auto& cState = getConstructionState();


### PR DESCRIPTION
Repeated presses of R or T (default) will now cycle their road and track types.

https://github.com/user-attachments/assets/00ca7953-6840-4076-8a5b-1f49065be82c

- [x] Changelog
- [ ] Consider other shortcuts
    - Build airports, docks, and new vehicles have widgets you can click to switch which type you are building, so it isn't really needed for them as much?


**Additional context**
- I also considered cycling on repeated clicks of the road/track icon on the top toolbar ([Discord message link](https://discord.com/channels/689445672390361176/701513924545085530/1531829009586065499)), but have not included this change in this pull as it was determined to feel confusing and/or more controversial.
- An alternate suggestion might to be to add a track type switcher as a widget in the construction window (perhaps like how airports and docks have a drop-down list).