### PR TITLE
Add option to centre the top toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 26.07.1+ (???)
 ------------------------------------------------------------------------
+- Feature: [#3872] Added an option to align the top toolbar buttons horizontally centred (off by default).
 - Change: [#3815] The keyboard shortcuts window is now separated into groups, and can now be resized.
 - Change: [#3863] The toolbar buttons can now be set to open on click instead of hover.
 - Fix: [#2082] Scrollbars can be overdrawn when certain windows are resized but their scrollview is not.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2513,3 +2513,4 @@ strings:
   2458: "{STRINGID}{STRINGID}"
   2459: "Debug window"
   2460: "Show toolbar menus on hover instead of click"
+  2461: "Align toolbar buttons horizontally centred"

--- a/src/OpenLoco/include/OpenLoco/Config.h
+++ b/src/OpenLoco/include/OpenLoco/Config.h
@@ -176,6 +176,7 @@ namespace OpenLoco::Config
         int32_t edgeScrollingSpeed = 12;
         bool invertRightMouseViewPan = false;
         bool toolbarAutoMenu = true;
+        bool toolbarButtonsCentred = false;
         WindowFrameStyle windowFrameStyle = WindowFrameStyle::background;
         bool zoomToCursor = true;
 

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -2174,6 +2174,7 @@ namespace OpenLoco::StringIds
     constexpr StringId keyboard_shortcut_binding = 2458;
     constexpr StringId shortcut_debug_window = 2459;
     constexpr StringId toolbar_auto_menu = 2460;
+    constexpr StringId toolbar_buttons_centred = 2461;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/include/OpenLoco/Ui/Windows/ToolbarTopCommon.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Windows/ToolbarTopCommon.h
@@ -66,5 +66,6 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     void onMouseDown(Window* window, WidgetIndex_t widgetIndex);
     void onDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex);
 
-    void rightAlignTabs(Window* window, uint32_t& x, const std::initializer_list<uint32_t> widxs);
+    [[nodiscard]] uint32_t leftAlignTabs(Window& window, uint32_t x, const std::initializer_list<uint32_t> widxs);
+    [[nodiscard]] uint32_t rightAlignTabs(Window& window, uint32_t x, const std::initializer_list<uint32_t> widxs);
 }

--- a/src/OpenLoco/include/OpenLoco/Ui/Windows/ToolbarTopCommon.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/Windows/ToolbarTopCommon.h
@@ -66,6 +66,6 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     void onMouseDown(Window* window, WidgetIndex_t widgetIndex);
     void onDropdown(Window* window, WidgetIndex_t widgetIndex, int16_t itemIndex);
 
-    [[nodiscard]] uint32_t leftAlignTabs(Window& window, uint32_t x, const std::initializer_list<uint32_t> widxs);
-    [[nodiscard]] uint32_t rightAlignTabs(Window& window, uint32_t x, const std::initializer_list<uint32_t> widxs);
+    void centreToolbar(Window& self);
+    void justifyToolbar(Window& self);
 }

--- a/src/OpenLoco/src/Config.cpp
+++ b/src/OpenLoco/src/Config.cpp
@@ -160,6 +160,7 @@ namespace OpenLoco::Config
         _config.edgeScrollingSpeed = config["edgeScrollingSpeed"].as<int32_t>(12);
         _config.invertRightMouseViewPan = config["invertRightMouseViewPan"].as<bool>(false);
         _config.toolbarAutoMenu = config["toolbarAutoMenu"].as<bool>(true);
+        _config.toolbarButtonsCentred = config["toolbarButtonsCentred"].as<bool>(false);
         _config.windowFrameStyle = config["windowFrameStyle"].as<WindowFrameStyle>(WindowFrameStyle::background);
         _config.zoomToCursor = config["zoom_to_cursor"].as<bool>(true);
 
@@ -299,6 +300,7 @@ namespace OpenLoco::Config
         node["edgeScrolling"] = _config.edgeScrolling;
         node["edgeScrollingSpeed"] = _config.edgeScrollingSpeed;
         node["toolbarAutoMenu"] = _config.toolbarAutoMenu;
+        node["toolbarButtonsCentred"] = _config.toolbarButtonsCentred;
         node["windowFrameStyle"] = _config.windowFrameStyle;
         node["zoom_to_cursor"] = _config.zoomToCursor;
 

--- a/src/OpenLoco/src/Graphics/FPSCounter.cpp
+++ b/src/OpenLoco/src/Graphics/FPSCounter.cpp
@@ -1,4 +1,5 @@
 #include "Graphics/FPSCounter.h"
+#include "Config.h"
 #include "Graphics/Colour.h"
 #include "Graphics/Gfx.h"
 #include "Graphics/TextRenderer.h"
@@ -52,7 +53,8 @@ namespace OpenLoco::Gfx
 
         // Draw text
         const int stringWidth = tr.getStringWidth(buffer);
-        auto point = Ui::Point(Ui::width() / 2 - (stringWidth / 2), 2);
+        const bool inCentre = !Config::get().toolbarButtonsCentred;
+        auto point = Ui::Point{ (inCentre ? (Ui::width() - stringWidth) / 2 : 4), 4 };
         tr.drawString(point, Colour::black, buffer);
 
         // Make area dirty so the text doesn't get drawn over the last

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -1901,6 +1901,7 @@ namespace OpenLoco::Ui::Windows::Options
             zoom_to_cursor,
             invert_right_mouse_view_pan,
             toolbar_auto_menu,
+            toolbar_buttons_centred,
             customize_keys
         };
 
@@ -1910,10 +1911,11 @@ namespace OpenLoco::Ui::Windows::Options
             constexpr WidgetId kZoomToCursor{ "zoom_to_cursor" };
             constexpr WidgetId kInvertRightMouseViewPan{ "invert_right_mouse_view_pan" };
             constexpr WidgetId kToolbarMenuAuto{ "toolbar_auto_menu" };
+            constexpr WidgetId kToolbarButtonsCentred{ "toolbar_buttons_centred" };
             constexpr WidgetId kCustomizeKeys{ "customize_keys" };
         }
 
-        static constexpr Ui::Size kWindowSize = { 366, 129 };
+        static constexpr Ui::Size kWindowSize = { 366, 144 };
 
         static constexpr auto _widgets = makeWidgets(
             Common::makeCommonWidgets(kWindowSize, StringIds::options_title_controls),
@@ -1921,7 +1923,8 @@ namespace OpenLoco::Ui::Windows::Options
             Widgets::Checkbox(Widx::kZoomToCursor, { 10, 64 }, { 346, 12 }, WindowColour::secondary, StringIds::zoom_to_cursor, StringIds::zoom_to_cursor_tip),
             Widgets::Checkbox(Widx::kInvertRightMouseViewPan, { 10, 79 }, { 346, 12 }, WindowColour::secondary, StringIds::invert_right_mouse_dragging, StringIds::tooltip_invert_right_mouse_dragging),
             Widgets::Checkbox(Widx::kToolbarMenuAuto, { 10, 94 }, { 346, 12 }, WindowColour::secondary, StringIds::toolbar_auto_menu),
-            Widgets::Button(Widx::kCustomizeKeys, { 26, 109 }, { 160, 12 }, WindowColour::secondary, StringIds::customise_keys, StringIds::customise_keys_tip)
+            Widgets::Checkbox(Widx::kToolbarButtonsCentred, { 10, 109 }, { 346, 12 }, WindowColour::secondary, StringIds::toolbar_buttons_centred),
+            Widgets::Button(Widx::kCustomizeKeys, { 26, 124 }, { 160, 12 }, WindowColour::secondary, StringIds::customise_keys, StringIds::customise_keys_tip)
 
         );
 
@@ -1929,6 +1932,7 @@ namespace OpenLoco::Ui::Windows::Options
         static void zoomToCursorMouseUp(Window& self);
         static void invertRightMouseViewPan(Window& self);
         static void toolbarAutoMenuMouseUp(Window& self);
+        static void toolbarButtonsCentredMouseUp(Window& self);
         static void openKeyboardShortcuts();
 
         static void prepareDraw(Window& self)
@@ -1953,6 +1957,10 @@ namespace OpenLoco::Ui::Windows::Options
             if (Config::get().toolbarAutoMenu)
             {
                 self.activatedWidgets |= (1ULL << widx::toolbar_auto_menu);
+            }
+            if (Config::get().toolbarButtonsCentred)
+            {
+                self.activatedWidgets |= (1ULL << widx::toolbar_buttons_centred);
             }
         }
 
@@ -1991,6 +1999,10 @@ namespace OpenLoco::Ui::Windows::Options
                 case Widx::kToolbarMenuAuto:
                     toolbarAutoMenuMouseUp(self);
                     break;
+
+                case Widx::kToolbarButtonsCentred:
+                    toolbarButtonsCentredMouseUp(self);
+                    break;
             }
         }
 
@@ -2028,6 +2040,16 @@ namespace OpenLoco::Ui::Windows::Options
             cfg.toolbarAutoMenu = !cfg.toolbarAutoMenu;
             Config::write();
 
+            self.invalidate();
+        }
+
+        static void toolbarButtonsCentredMouseUp(Window& self)
+        {
+            auto& cfg = OpenLoco::Config::get();
+            cfg.toolbarButtonsCentred = !cfg.toolbarButtonsCentred;
+            Config::write();
+
+            WindowManager::invalidate(WindowType::topToolbar);
             self.invalidate();
         }
 

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -56,6 +56,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     }
 
     static constexpr auto _widgets = makeWidgets(
+        // Left-hand side
         Widgets::ToolbarButton(Common::Widx::kLoadsaveMenu, { 0, 0 }, { 30, 28 }, WindowColour::primary),
         Widgets::ToolbarButton(Common::Widx::kAudioMenu, { 30, 0 }, { 30, 28 }, WindowColour::primary),
         Widgets::ToolbarButton(Widx::kCheatsMenu, { 60, 0 }, { 30, 28 }, WindowColour::primary),
@@ -64,6 +65,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         Widgets::ToolbarButton(Common::Widx::kRotateMenu, { 134, 0 }, { 30, 28 }, WindowColour::secondary),
         Widgets::ToolbarButton(Common::Widx::kViewMenu, { 164, 0 }, { 30, 28 }, WindowColour::secondary),
 
+        // Right-hand side
         Widgets::ToolbarButton(Common::Widx::kTerraformMenu, { 267, 0 }, { 30, 28 }, WindowColour::tertiary),
         Widgets::ToolbarButton(Common::Widx::kRailroadMenu, { 387, 0 }, { 30, 28 }, WindowColour::tertiary),
         Widgets::ToolbarButton(Common::Widx::kRoadMenu, { 357, 0 }, { 30, 28 }, WindowColour::tertiary),
@@ -923,6 +925,8 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         }
     }
 
+    static void justifyTabs(Window& self);
+
     // 0x00439BCB
     static void prepareDraw(Window& window)
     {
@@ -990,27 +994,43 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         window.widgets[Common::widx::railroad_menu].hidden = !(getGameState().defaultRailroadObjectId != 0xFF);
         window.widgets[Common::widx::port_menu].hidden = !(getGameState().lastAirport != 0xFF || getGameState().lastShipPort != 0xFF);
 
-        uint32_t x = std::max(640, Ui::width()) - 1;
-        Common::rightAlignTabs(&window, x, { Common::widx::towns_menu, Common::widx::stations_menu, Common::widx::vehicles_menu });
+        justifyTabs(window);
+    }
+
+    static void justifyTabs(Window& self)
+    {
+        // Left-hand side
+        uint32_t x = 0;
+        x = Common::leftAlignTabs(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu });
+        if (!self.widgets[widx::cheats_menu].hidden)
+        {
+            x = Common::leftAlignTabs(self, x, { widx::cheats_menu });
+        }
+        x += 11;
+        x = Common::leftAlignTabs(self, x, { Common::widx::zoom_menu, Common::widx::rotate_menu, Common::widx::view_menu });
+
+        // Right-hand side
+        x = std::max(640, Ui::width()) - 1;
+        x = Common::rightAlignTabs(self, x, { Common::widx::towns_menu, Common::widx::stations_menu, Common::widx::vehicles_menu });
         x -= 11;
-        Common::rightAlignTabs(&window, x, { Common::widx::build_vehicles_menu });
+        x = Common::rightAlignTabs(self, x, { Common::widx::build_vehicles_menu });
 
-        if (!window.widgets[Common::widx::port_menu].hidden)
+        if (!self.widgets[Common::widx::port_menu].hidden)
         {
-            Common::rightAlignTabs(&window, x, { Common::widx::port_menu });
+            x = Common::rightAlignTabs(self, x, { Common::widx::port_menu });
         }
 
-        if (!window.widgets[Common::widx::road_menu].hidden)
+        if (!self.widgets[Common::widx::road_menu].hidden)
         {
-            Common::rightAlignTabs(&window, x, { Common::widx::road_menu });
+            x = Common::rightAlignTabs(self, x, { Common::widx::road_menu });
         }
 
-        if (!window.widgets[Common::widx::railroad_menu].hidden)
+        if (!self.widgets[Common::widx::railroad_menu].hidden)
         {
-            Common::rightAlignTabs(&window, x, { Common::widx::railroad_menu });
+            x = Common::rightAlignTabs(self, x, { Common::widx::railroad_menu });
         }
 
-        Common::rightAlignTabs(&window, x, { Common::widx::terraform_menu });
+        x = Common::rightAlignTabs(self, x, { Common::widx::terraform_menu });
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -995,11 +995,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         window.widgets[Common::widx::railroad_menu].hidden = !(getGameState().defaultRailroadObjectId != 0xFF);
         window.widgets[Common::widx::port_menu].hidden = !(getGameState().lastAirport != 0xFF || getGameState().lastShipPort != 0xFF);
 
-        // if (false)
+        if (!Config::get().toolbarButtonsCentred)
         {
             justifyTabs(window);
         }
-        // else
+        else
         {
             centreTabs(window);
         }

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -926,6 +926,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
     }
 
     static void justifyTabs(Window& self);
+    static void centreTabs(Window& self);
 
     // 0x00439BCB
     static void prepareDraw(Window& window)
@@ -994,7 +995,61 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         window.widgets[Common::widx::railroad_menu].hidden = !(getGameState().defaultRailroadObjectId != 0xFF);
         window.widgets[Common::widx::port_menu].hidden = !(getGameState().lastAirport != 0xFF || getGameState().lastShipPort != 0xFF);
 
-        justifyTabs(window);
+        // if (false)
+        {
+            justifyTabs(window);
+        }
+        // else
+        {
+            centreTabs(window);
+        }
+    }
+
+    static void centreTabs(Window& self)
+    {
+        auto numVisibleWidgets = 0;
+        for (auto& widget : self.widgets)
+        {
+            if (!widget.hidden)
+            {
+                numVisibleWidgets++;
+            }
+        }
+
+        auto totalWidth = numVisibleWidgets * 30 + (4 * 11);
+
+        // Left-hand side
+        uint32_t x = std::max(0, (Ui::width() - totalWidth) / 2);
+        x = Common::leftAlignTabs(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu });
+        if (!self.widgets[widx::cheats_menu].hidden)
+        {
+            x = Common::leftAlignTabs(self, x, { widx::cheats_menu });
+        }
+        x += 11;
+        x = Common::leftAlignTabs(self, x, { Common::widx::zoom_menu, Common::widx::rotate_menu, Common::widx::view_menu });
+
+        // Right-hand side
+        x += 11;
+        x = Common::leftAlignTabs(self, x, { Common::widx::terraform_menu });
+
+        if (!self.widgets[Common::widx::railroad_menu].hidden)
+        {
+            x = Common::leftAlignTabs(self, x, { Common::widx::railroad_menu });
+        }
+
+        if (!self.widgets[Common::widx::road_menu].hidden)
+        {
+            x = Common::leftAlignTabs(self, x, { Common::widx::road_menu });
+        }
+
+        if (!self.widgets[Common::widx::port_menu].hidden)
+        {
+            x = Common::leftAlignTabs(self, x, { Common::widx::port_menu });
+        }
+
+        x = Common::leftAlignTabs(self, x, { Common::widx::build_vehicles_menu });
+        x += 11;
+        x = Common::leftAlignTabs(self, x, { Common::widx::vehicles_menu, Common::widx::stations_menu, Common::widx::towns_menu });
     }
 
     static void justifyTabs(Window& self)

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -925,9 +925,6 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         }
     }
 
-    static void justifyTabs(Window& self);
-    static void centreTabs(Window& self);
-
     // 0x00439BCB
     static void prepareDraw(Window& window)
     {
@@ -995,97 +992,14 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
         window.widgets[Common::widx::railroad_menu].hidden = !(getGameState().defaultRailroadObjectId != 0xFF);
         window.widgets[Common::widx::port_menu].hidden = !(getGameState().lastAirport != 0xFF || getGameState().lastShipPort != 0xFF);
 
-        if (!Config::get().toolbarButtonsCentred)
+        if (Config::get().toolbarButtonsCentred)
         {
-            justifyTabs(window);
+            Common::centreToolbar(window);
         }
         else
         {
-            centreTabs(window);
+            Common::justifyToolbar(window);
         }
-    }
-
-    static void centreTabs(Window& self)
-    {
-        auto numVisibleWidgets = 0;
-        for (auto& widget : self.widgets)
-        {
-            if (!widget.hidden)
-            {
-                numVisibleWidgets++;
-            }
-        }
-
-        auto totalWidth = numVisibleWidgets * 30 + (4 * 11);
-
-        // Left-hand side
-        uint32_t x = std::max(0, (Ui::width() - totalWidth) / 2);
-        x = Common::leftAlignTabs(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu });
-        if (!self.widgets[widx::cheats_menu].hidden)
-        {
-            x = Common::leftAlignTabs(self, x, { widx::cheats_menu });
-        }
-        x += 11;
-        x = Common::leftAlignTabs(self, x, { Common::widx::zoom_menu, Common::widx::rotate_menu, Common::widx::view_menu });
-
-        // Right-hand side
-        x += 11;
-        x = Common::leftAlignTabs(self, x, { Common::widx::terraform_menu });
-
-        if (!self.widgets[Common::widx::railroad_menu].hidden)
-        {
-            x = Common::leftAlignTabs(self, x, { Common::widx::railroad_menu });
-        }
-
-        if (!self.widgets[Common::widx::road_menu].hidden)
-        {
-            x = Common::leftAlignTabs(self, x, { Common::widx::road_menu });
-        }
-
-        if (!self.widgets[Common::widx::port_menu].hidden)
-        {
-            x = Common::leftAlignTabs(self, x, { Common::widx::port_menu });
-        }
-
-        x = Common::leftAlignTabs(self, x, { Common::widx::build_vehicles_menu });
-        x += 11;
-        x = Common::leftAlignTabs(self, x, { Common::widx::vehicles_menu, Common::widx::stations_menu, Common::widx::towns_menu });
-    }
-
-    static void justifyTabs(Window& self)
-    {
-        // Left-hand side
-        uint32_t x = 0;
-        x = Common::leftAlignTabs(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu });
-        if (!self.widgets[widx::cheats_menu].hidden)
-        {
-            x = Common::leftAlignTabs(self, x, { widx::cheats_menu });
-        }
-        x += 11;
-        x = Common::leftAlignTabs(self, x, { Common::widx::zoom_menu, Common::widx::rotate_menu, Common::widx::view_menu });
-
-        // Right-hand side
-        x = std::max(640, Ui::width()) - 1;
-        x = Common::rightAlignTabs(self, x, { Common::widx::towns_menu, Common::widx::stations_menu, Common::widx::vehicles_menu });
-        x -= 11;
-        x = Common::rightAlignTabs(self, x, { Common::widx::build_vehicles_menu });
-
-        if (!self.widgets[Common::widx::port_menu].hidden)
-        {
-            x = Common::rightAlignTabs(self, x, { Common::widx::port_menu });
-        }
-
-        if (!self.widgets[Common::widx::road_menu].hidden)
-        {
-            x = Common::rightAlignTabs(self, x, { Common::widx::road_menu });
-        }
-
-        if (!self.widgets[Common::widx::railroad_menu].hidden)
-        {
-            x = Common::rightAlignTabs(self, x, { Common::widx::railroad_menu });
-        }
-
-        x = Common::rightAlignTabs(self, x, { Common::widx::terraform_menu });
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
@@ -356,11 +356,11 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
 
         Common::prepareTownWidget(window);
 
-        // if (false)
+        if (!Config::get().toolbarButtonsCentred)
         {
             justifyTabs(window);
         }
-        // else
+        else
         {
             centreTabs(window);
         }

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
@@ -326,6 +326,8 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
         window.widgets[Common::widx::railroad_menu].hidden = true;
         window.widgets[Common::widx::road_menu].hidden = !(isLandscapeEditor && getGameState().defaultRoadObjectId != 0xFF);
         window.widgets[Common::widx::port_menu].hidden = true;
+        window.widgets[Common::widx::build_vehicles_menu].hidden = true;
+
         window.widgets[Common::widx::vehicles_menu].hidden = true;
         window.widgets[Common::widx::stations_menu].hidden = true;
         window.widgets[Common::widx::towns_menu].hidden = !isLandscapeEditor;

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
@@ -310,9 +310,6 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
         }
     }
 
-    static void justifyTabs(Window& self);
-    static void centreTabs(Window& self);
-
     // 0x0043D2F3
     static void prepareDraw(Window& window)
     {
@@ -356,67 +353,14 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
 
         Common::prepareTownWidget(window);
 
-        if (!Config::get().toolbarButtonsCentred)
+        if (Config::get().toolbarButtonsCentred)
         {
-            justifyTabs(window);
+            Common::centreToolbar(window);
         }
         else
         {
-            centreTabs(window);
+            Common::justifyToolbar(window);
         }
-    }
-
-    static void centreTabs(Window& self)
-    {
-        auto numVisibleWidgets = 0;
-        for (auto& widget : self.widgets)
-        {
-            if (!widget.hidden)
-            {
-                numVisibleWidgets++;
-            }
-        }
-
-        auto totalWidth = numVisibleWidgets * 30 + (3 * 11);
-
-        // Left-hand side
-        uint32_t x = std::max(0, (Ui::width() - totalWidth) / 2);
-        x = Common::leftAlignTabs(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu });
-        if (!self.widgets[widx::map_generation_menu].hidden)
-        {
-            x = Common::leftAlignTabs(self, x, { widx::map_generation_menu });
-        }
-        x += 11;
-        x = Common::leftAlignTabs(self, x, { Common::widx::zoom_menu, Common::widx::rotate_menu, Common::widx::view_menu });
-
-        // Right-hand side
-        x += 11;
-        x = Common::leftAlignTabs(self, x, { Common::widx::terraform_menu });
-        if (!self.widgets[Common::widx::road_menu].hidden)
-        {
-            x = Common::leftAlignTabs(self, x, { Common::widx::road_menu });
-        }
-        x = Common::leftAlignTabs(self, x, { Common::widx::towns_menu });
-    }
-
-    static void justifyTabs(Window& self)
-    {
-        // Left-hand side
-        uint32_t x = 0;
-
-        x = Common::leftAlignTabs(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu });
-        if (!self.widgets[widx::map_generation_menu].hidden)
-        {
-            x = Common::leftAlignTabs(self, x, { widx::map_generation_menu });
-        }
-        x += 11;
-        x = Common::leftAlignTabs(self, x, { Common::widx::zoom_menu, Common::widx::rotate_menu, Common::widx::view_menu });
-
-        // Right-hand side
-        x = std::max(640, Ui::width()) - 1;
-        x = Common::rightAlignTabs(self, x, { Common::widx::towns_menu });
-        x -= 11;
-        x = Common::rightAlignTabs(self, x, { Common::widx::road_menu, Common::widx::terraform_menu });
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
@@ -310,23 +310,28 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
         }
     }
 
+    static void justifyTabs(Window& self);
+    static void centreTabs(Window& self);
+
     // 0x0043D2F3
     static void prepareDraw(Window& window)
     {
-        uint32_t x = std::max(640, Ui::width()) - 1;
-        x = Common::rightAlignTabs(window, x, { Common::widx::towns_menu });
-        x -= 11;
-        x = Common::rightAlignTabs(window, x, { Common::widx::road_menu, Common::widx::terraform_menu });
-
         const bool isLandscapeEditor = EditorController::getCurrentStep() == EditorController::Step::landscapeEditor;
 
+        // Left-hand side
+        window.widgets[widx::map_generation_menu].hidden = !isLandscapeEditor;
         window.widgets[Common::widx::zoom_menu].hidden = !isLandscapeEditor;
         window.widgets[Common::widx::rotate_menu].hidden = !isLandscapeEditor;
         window.widgets[Common::widx::view_menu].hidden = !isLandscapeEditor;
+
+        // Right-hand side
         window.widgets[Common::widx::terraform_menu].hidden = !isLandscapeEditor;
-        window.widgets[widx::map_generation_menu].hidden = !isLandscapeEditor;
-        window.widgets[Common::widx::towns_menu].hidden = !isLandscapeEditor;
+        window.widgets[Common::widx::railroad_menu].hidden = true;
         window.widgets[Common::widx::road_menu].hidden = !(isLandscapeEditor && getGameState().defaultRoadObjectId != 0xFF);
+        window.widgets[Common::widx::port_menu].hidden = true;
+        window.widgets[Common::widx::vehicles_menu].hidden = true;
+        window.widgets[Common::widx::stations_menu].hidden = true;
+        window.widgets[Common::widx::towns_menu].hidden = !isLandscapeEditor;
 
         auto interface = ObjectManager::get<InterfaceSkinObject>();
         if (!Audio::isAudioEnabled())
@@ -350,6 +355,68 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
         window.widgets[Common::widx::road_menu].image = Gfx::recolour(interface->img + InterfaceSkin::ImageIds::toolbar_empty_opaque);
 
         Common::prepareTownWidget(window);
+
+        // if (false)
+        {
+            justifyTabs(window);
+        }
+        // else
+        {
+            centreTabs(window);
+        }
+    }
+
+    static void centreTabs(Window& self)
+    {
+        auto numVisibleWidgets = 0;
+        for (auto& widget : self.widgets)
+        {
+            if (!widget.hidden)
+            {
+                numVisibleWidgets++;
+            }
+        }
+
+        auto totalWidth = numVisibleWidgets * 30 + (3 * 11);
+
+        // Left-hand side
+        uint32_t x = std::max(0, (Ui::width() - totalWidth) / 2);
+        x = Common::leftAlignTabs(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu });
+        if (!self.widgets[widx::map_generation_menu].hidden)
+        {
+            x = Common::leftAlignTabs(self, x, { widx::map_generation_menu });
+        }
+        x += 11;
+        x = Common::leftAlignTabs(self, x, { Common::widx::zoom_menu, Common::widx::rotate_menu, Common::widx::view_menu });
+
+        // Right-hand side
+        x += 11;
+        x = Common::leftAlignTabs(self, x, { Common::widx::terraform_menu });
+        if (!self.widgets[Common::widx::road_menu].hidden)
+        {
+            x = Common::leftAlignTabs(self, x, { Common::widx::road_menu });
+        }
+        x = Common::leftAlignTabs(self, x, { Common::widx::towns_menu });
+    }
+
+    static void justifyTabs(Window& self)
+    {
+        // Left-hand side
+        uint32_t x = 0;
+
+        x = Common::leftAlignTabs(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu });
+        if (!self.widgets[widx::map_generation_menu].hidden)
+        {
+            x = Common::leftAlignTabs(self, x, { widx::map_generation_menu });
+        }
+        x += 11;
+        x = Common::leftAlignTabs(self, x, { Common::widx::zoom_menu, Common::widx::rotate_menu, Common::widx::view_menu });
+
+        // Right-hand side
+        x = std::max(640, Ui::width()) - 1;
+        x = Common::rightAlignTabs(self, x, { Common::widx::towns_menu });
+        x -= 11;
+        x = Common::rightAlignTabs(self, x, { Common::widx::road_menu, Common::widx::terraform_menu });
     }
 
     static constexpr WindowEventList kEvents = {

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopAlt.cpp
@@ -314,10 +314,9 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Editor
     static void prepareDraw(Window& window)
     {
         uint32_t x = std::max(640, Ui::width()) - 1;
-
-        Common::rightAlignTabs(&window, x, { Common::widx::towns_menu });
+        x = Common::rightAlignTabs(window, x, { Common::widx::towns_menu });
         x -= 11;
-        Common::rightAlignTabs(&window, x, { Common::widx::road_menu, Common::widx::terraform_menu });
+        x = Common::rightAlignTabs(window, x, { Common::widx::road_menu, Common::widx::terraform_menu });
 
         const bool isLandscapeEditor = EditorController::getCurrentStep() == EditorController::Step::landscapeEditor;
 

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
@@ -621,34 +621,13 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
 
         // Left-hand side
         uint32_t x = std::max(0, (Ui::width() - totalWidth) / 2);
-        x = Common::leftAlignButtons(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu });
-        if (!self.widgets[widx::w2].hidden)
-        {
-            x = Common::leftAlignButtons(self, x, { widx::w2 });
-        }
+        x = Common::leftAlignButtons(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu, widx::w2 });
         x += 11;
         x = Common::leftAlignButtons(self, x, { Common::widx::zoom_menu, Common::widx::rotate_menu, Common::widx::view_menu });
 
         // Right-hand side
         x += 11;
-        x = Common::leftAlignButtons(self, x, { Common::widx::terraform_menu });
-
-        if (!self.widgets[Common::widx::railroad_menu].hidden)
-        {
-            x = Common::leftAlignButtons(self, x, { Common::widx::railroad_menu });
-        }
-
-        if (!self.widgets[Common::widx::road_menu].hidden)
-        {
-            x = Common::leftAlignButtons(self, x, { Common::widx::road_menu });
-        }
-
-        if (!self.widgets[Common::widx::port_menu].hidden)
-        {
-            x = Common::leftAlignButtons(self, x, { Common::widx::port_menu });
-        }
-
-        x = Common::leftAlignButtons(self, x, { Common::widx::build_vehicles_menu });
+        x = Common::leftAlignButtons(self, x, { Common::widx::terraform_menu, Common::widx::railroad_menu, Common::widx::road_menu, Common::widx::port_menu, Common::widx::build_vehicles_menu });
         x += 11;
         x = Common::leftAlignButtons(self, x, { Common::widx::vehicles_menu, Common::widx::stations_menu, Common::widx::towns_menu });
     }
@@ -657,11 +636,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
     {
         // Left-hand side
         uint32_t x = 0;
-        x = Common::leftAlignButtons(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu });
-        if (!self.widgets[widx::w2].hidden)
-        {
-            x = Common::leftAlignButtons(self, x, { widx::w2 });
-        }
+        x = Common::leftAlignButtons(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu, widx::w2 });
         x += 11;
         x = Common::leftAlignButtons(self, x, { Common::widx::zoom_menu, Common::widx::rotate_menu, Common::widx::view_menu });
 
@@ -669,24 +644,6 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
         x = std::max(640, Ui::width()) - 1;
         x = Common::rightAlignButtons(self, x, { Common::widx::towns_menu, Common::widx::stations_menu, Common::widx::vehicles_menu });
         x -= 11;
-        x = Common::rightAlignButtons(self, x, { Common::widx::build_vehicles_menu });
-
-        if (!self.widgets[Common::widx::port_menu].hidden)
-        {
-            x = Common::rightAlignButtons(self, x, { Common::widx::port_menu });
-        }
-
-        if (!self.widgets[Common::widx::road_menu].hidden)
-        {
-            x = Common::rightAlignButtons(self, x, { Common::widx::road_menu });
-        }
-
-        if (!self.widgets[Common::widx::railroad_menu].hidden)
-        {
-            x = Common::rightAlignButtons(self, x, { Common::widx::railroad_menu });
-        }
-
-        x = Common::rightAlignButtons(self, x, { Common::widx::terraform_menu });
+        x = Common::rightAlignButtons(self, x, { Common::widx::build_vehicles_menu, Common::widx::port_menu, Common::widx::road_menu, Common::widx::railroad_menu, Common::widx::terraform_menu });
     }
-
 }

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
@@ -572,25 +572,121 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
         }
     }
 
-    [[nodiscard]] uint32_t leftAlignTabs(Window& self, uint32_t x, const std::initializer_list<uint32_t> widxs)
+    [[nodiscard]] static uint32_t leftAlignButtons(Window& self, uint32_t x, const std::initializer_list<uint32_t> widxs)
     {
         for (const auto& widx : widxs)
         {
-            self.widgets[widx].left = x;
-            self.widgets[widx].right = x + 29;
+            auto& widget = self.widgets[widx];
+            if (widget.hidden)
+            {
+                continue;
+            }
+
+            widget.left = x;
+            widget.right = x + 29;
             x += 30;
         }
         return x;
     }
 
-    [[nodiscard]] uint32_t rightAlignTabs(Window& self, uint32_t x, const std::initializer_list<uint32_t> widxs)
+    [[nodiscard]] static uint32_t rightAlignButtons(Window& self, uint32_t x, const std::initializer_list<uint32_t> widxs)
     {
         for (const auto& widx : widxs)
         {
-            self.widgets[widx].right = x;
-            self.widgets[widx].left = x - 29;
+            auto& widget = self.widgets[widx];
+            if (widget.hidden)
+            {
+                continue;
+            }
+
+            widget.right = x;
+            widget.left = x - 29;
             x -= 30;
         }
         return x;
     }
+
+    void centreToolbar(Window& self)
+    {
+        auto numVisibleWidgets = 0;
+        for (auto& widget : self.widgets)
+        {
+            if (!widget.hidden)
+            {
+                numVisibleWidgets++;
+            }
+        }
+
+        auto totalWidth = numVisibleWidgets * 30 + (4 * 11);
+
+        // Left-hand side
+        uint32_t x = std::max(0, (Ui::width() - totalWidth) / 2);
+        x = Common::leftAlignButtons(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu });
+        if (!self.widgets[widx::w2].hidden)
+        {
+            x = Common::leftAlignButtons(self, x, { widx::w2 });
+        }
+        x += 11;
+        x = Common::leftAlignButtons(self, x, { Common::widx::zoom_menu, Common::widx::rotate_menu, Common::widx::view_menu });
+
+        // Right-hand side
+        x += 11;
+        x = Common::leftAlignButtons(self, x, { Common::widx::terraform_menu });
+
+        if (!self.widgets[Common::widx::railroad_menu].hidden)
+        {
+            x = Common::leftAlignButtons(self, x, { Common::widx::railroad_menu });
+        }
+
+        if (!self.widgets[Common::widx::road_menu].hidden)
+        {
+            x = Common::leftAlignButtons(self, x, { Common::widx::road_menu });
+        }
+
+        if (!self.widgets[Common::widx::port_menu].hidden)
+        {
+            x = Common::leftAlignButtons(self, x, { Common::widx::port_menu });
+        }
+
+        x = Common::leftAlignButtons(self, x, { Common::widx::build_vehicles_menu });
+        x += 11;
+        x = Common::leftAlignButtons(self, x, { Common::widx::vehicles_menu, Common::widx::stations_menu, Common::widx::towns_menu });
+    }
+
+    void justifyToolbar(Window& self)
+    {
+        // Left-hand side
+        uint32_t x = 0;
+        x = Common::leftAlignButtons(self, x, { Common::widx::loadsave_menu, Common::widx::audio_menu });
+        if (!self.widgets[widx::w2].hidden)
+        {
+            x = Common::leftAlignButtons(self, x, { widx::w2 });
+        }
+        x += 11;
+        x = Common::leftAlignButtons(self, x, { Common::widx::zoom_menu, Common::widx::rotate_menu, Common::widx::view_menu });
+
+        // Right-hand side
+        x = std::max(640, Ui::width()) - 1;
+        x = Common::rightAlignButtons(self, x, { Common::widx::towns_menu, Common::widx::stations_menu, Common::widx::vehicles_menu });
+        x -= 11;
+        x = Common::rightAlignButtons(self, x, { Common::widx::build_vehicles_menu });
+
+        if (!self.widgets[Common::widx::port_menu].hidden)
+        {
+            x = Common::rightAlignButtons(self, x, { Common::widx::port_menu });
+        }
+
+        if (!self.widgets[Common::widx::road_menu].hidden)
+        {
+            x = Common::rightAlignButtons(self, x, { Common::widx::road_menu });
+        }
+
+        if (!self.widgets[Common::widx::railroad_menu].hidden)
+        {
+            x = Common::rightAlignButtons(self, x, { Common::widx::railroad_menu });
+        }
+
+        x = Common::rightAlignButtons(self, x, { Common::widx::terraform_menu });
+    }
+
 }

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTopCommon.cpp
@@ -572,13 +572,25 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Common
         }
     }
 
-    void rightAlignTabs(Window* window, uint32_t& x, const std::initializer_list<uint32_t> widxs)
+    [[nodiscard]] uint32_t leftAlignTabs(Window& self, uint32_t x, const std::initializer_list<uint32_t> widxs)
     {
         for (const auto& widx : widxs)
         {
-            window->widgets[widx].right = x;
-            window->widgets[widx].left = x - 29;
+            self.widgets[widx].left = x;
+            self.widgets[widx].right = x + 29;
+            x += 30;
+        }
+        return x;
+    }
+
+    [[nodiscard]] uint32_t rightAlignTabs(Window& self, uint32_t x, const std::initializer_list<uint32_t> widxs)
+    {
+        for (const auto& widx : widxs)
+        {
+            self.widgets[widx].right = x;
+            self.widgets[widx].left = x - 29;
             x -= 30;
         }
+        return x;
     }
 }


### PR DESCRIPTION
To do:
- [x] Add UI option
- [x] Share alignment code between ToolbarTop and ToolbarTopAlt?
- [x] Move frame counter to corner?

Justified (default):
<img width="756" height="458" alt="Boulder Breakers (1)" src="https://github.com/user-attachments/assets/d706941a-85a5-4541-8ad4-3981a70285d6" />

Centred (new):
<img width="756" height="458" alt="Boulder Breakers (2)" src="https://github.com/user-attachments/assets/9113c21d-8775-4ecb-9924-76f390debc41" />
