### PR TITLE
Fix inital state of keyboard shortcuts and music selection windows

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -43,7 +43,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
         Widgets::ImageButton(Widx::kCloseButton, { kWindowSize.width - 15, 2 }, { 13, 13 }, WindowColour::primary, ImageIds::close_button, StringIds::tooltip_close_window),
         Widgets::Panel({ 0, 15 }, { kWindowSize.width, kWindowSize.height - 15 }, WindowColour::secondary),
         Widgets::ScrollView({ 4, 19 }, { kWindowSize.width - 8, 202 }, WindowColour::secondary, Scrollbars::vertical, StringIds::keyboard_shortcut_list_tip),
-        Widgets::Button(Widx::kResetKeysBtn, { 4, 223 }, { 150, 12 }, WindowColour::secondary, StringIds::reset_keys, StringIds::reset_keys_tip)
+        Widgets::Button(Widx::kResetKeysBtn, { kWindowSize.width - 150 - 4 - 12, 223 }, { 150, 12 }, WindowColour::secondary, StringIds::reset_keys, StringIds::reset_keys_tip)
 
     );
 

--- a/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
+++ b/src/OpenLoco/src/Ui/Windows/KeyboardShortcuts.cpp
@@ -109,10 +109,7 @@ namespace OpenLoco::Ui::Windows::KeyboardShortcuts
         window->rowCount = static_cast<int16_t>(_shortcutList.size());
         window->rowHover = -1;
 
-        window->minWidth = kWindowSize.width;
-        window->minHeight = kWindowSize.height;
-        window->maxWidth = kMaxWindowSize.width;
-        window->maxHeight = kMaxWindowSize.height;
+        window->setSizeBounds(kWindowSize, kMaxWindowSize);
 
         return window;
     }

--- a/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
@@ -142,6 +142,7 @@ namespace OpenLoco::Ui::Windows::MusicSelection
             WindowFlags::resizable,
             getEvents());
 
+        window->setSizeBounds(kWindowSizeMin, kWindowSizeMax);
         window->setWidgets(_widgets);
         window->initScrollWidgets();
 
@@ -151,11 +152,6 @@ namespace OpenLoco::Ui::Windows::MusicSelection
 
         window->rowCount = Jukebox::kNumMusicTracks;
         window->rowHover = -1;
-
-        window->minWidth = kWindowSizeMin.width;
-        window->minHeight = kWindowSizeMin.height;
-        window->maxWidth = kWindowSizeMax.width;
-        window->maxHeight = kWindowSizeMax.height;
 
         setSortMode(*window, Jukebox::MusicSortMode::original);
 

--- a/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MusicSelection.cpp
@@ -152,6 +152,11 @@ namespace OpenLoco::Ui::Windows::MusicSelection
         window->rowCount = Jukebox::kNumMusicTracks;
         window->rowHover = -1;
 
+        window->minWidth = kWindowSizeMin.width;
+        window->minHeight = kWindowSizeMin.height;
+        window->maxWidth = kWindowSizeMax.width;
+        window->maxHeight = kWindowSizeMax.height;
+
         setSortMode(*window, Jukebox::MusicSortMode::original);
 
         // Set status bar text


### PR DESCRIPTION
Fixes mistakes in #3384 and #3815 that were previously hidden by onResize being automatically called, until #3865.