### PR TITLE
Add Flatpak support for OpenLoco

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,3 +343,44 @@ jobs:
           name: OpenLoco-macos-arm64
           path: artifacts
           if-no-files-found: error
+  flatpak:
+    name: Flatpak x64
+    runs-on: ubuntu-latest
+    needs: check-code-formatting
+    container: ghcr.io/openloco/openloco:11-ubuntu26.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Install Flatpak dependencies
+        run: |
+          apt-get update
+          apt-get install -y flatpak flatpak-builder
+      - name: Setup Flatpak
+        run: |
+          flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak install --assumeyes flathub org.freedesktop.Platform//24.08
+          flatpak install --assumeyes flathub org.freedesktop.Sdk//24.08
+      - name: Build Flatpak
+        run: |
+          mkdir -p flatpak-build flatpak-install flatpak-repo
+          cd distribution/linux
+          flatpak-builder \
+            --user \
+            --install-deps-from=flathub \
+            --arch=x86_64 \
+            --build-dir=../../flatpak-build \
+            --install-dir=../../flatpak-install \
+            ../../flatpak-repo \
+            com.openloco.OpenLoco.json
+      - name: Create Flatpak bundle
+        run: |
+          flatpak build-bundle ../../flatpak-repo ../../OpenLoco.flatpak com.openloco.OpenLoco --arch=x86_64
+      - name: Upload Flatpak artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenLoco-flatpak-x64
+          path: OpenLoco.flatpak
+          if-no-files-found: error

--- a/distribution/linux/README.md
+++ b/distribution/linux/README.md
@@ -1,0 +1,154 @@
+# OpenLoco Flatpak Distribution
+
+This directory contains the files needed to build and distribute OpenLoco as a Flatpak.
+
+## Files
+
+- `com.openloco.OpenLoco.json` - Flatpak application manifest
+- `com.openloco.OpenLoco.appdata.xml` - AppStream metadata for software centers
+- `openloco.desktop` - Desktop entry file (used by Flatpak)
+- `build-flatpak.sh` - Build script to simplify Flatpak creation
+
+## Requirements
+
+To build the Flatpak, you need:
+
+- **flatpak** - Flatpak package manager
+- **flatpak-builder** - Flatpak build tool
+- **cmake** (>= 3.22) - Build system
+- **ninja** - Build system backend
+- **git** - Version control system
+
+### Installing Dependencies
+
+#### Debian/Ubuntu
+```bash
+sudo apt install flatpak flatpak-builder cmake ninja-build git
+```
+
+#### Fedora
+```bash
+sudo dnf install flatpak flatpak-builder cmake ninja-build git
+```
+
+#### Arch Linux
+```bash
+sudo pacman -S flatpak flatpak-builder cmake ninja git
+```
+
+## Quick Start
+
+The easiest way to build, install, and run OpenLoco Flatpak is:
+
+```bash
+./build-flatpak.sh --all
+```
+
+This will:
+1. Clean any previous build
+2. Build the Flatpak
+3. Install it locally
+4. Run OpenLoco
+
+## Manual Build Process
+
+### 1. Setup Flatpak Environment
+
+Add Flathub repository:
+```bash
+flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+```
+
+Install the required runtimes:
+```bash
+flatpak install flathub org.freedesktop.Platform//24.08
+flatpak install flathub org.freedesktop.Sdk//24.08
+```
+
+### 2. Build the Flatpak
+
+```bash
+flatpak-builder \
+    --user \
+    --install-deps-from=flathub \
+    --arch=x86_64 \
+    --build-dir=flatpak-build \
+    --install-dir=flatpak-install \
+    flatpak-repo \
+    com.openloco.OpenLoco.json
+```
+
+### 3. Export and Install
+
+```bash
+# Export to a local repository
+flatpak build-export flatpak-repo flatpak-install
+
+# Add the local repository
+flatpak remote-add --user openloco-repo flatpak-repo
+
+# Install the application
+flatpak install --user openloco-repo com.openloco.OpenLoco
+```
+
+### 4. Run OpenLoco
+
+```bash
+flatpak run com.openloco.OpenLoco
+```
+
+## Building for Distribution
+
+To create a Flatpak bundle that can be distributed:
+
+```bash
+flatpak build-bundle flatpak-repo openloco.flatpak com.openloco.OpenLoco
+```
+
+This will create a `.flatpak` file that users can install with:
+
+```bash
+flatpak install --user openloco.flatpak
+```
+
+## Updating the Flatpak
+
+When updating OpenLoco to a new version:
+
+1. Update the `version` field in the manifest
+2. Update the `release` section in the AppStream metadata
+3. Update the SHA256 checksums if dependencies have changed
+4. Rebuild and test
+
+## Debugging
+
+To run with verbose output:
+```bash
+flatpak run --verbose com.openloco.OpenLoco
+```
+
+To enter the application's sandbox for debugging:
+```bash
+flatpak run --command=sh com.openloco.OpenLoco
+```
+
+## Notes
+
+- OpenLoco requires the asset files from the original Chris Sawyer's Locomotion game
+- These can be purchased from Steam or GOG.com
+- The Flatpak will look for assets in `~/.local/share/chris-sawyer-locomotion/`
+- Users can also configure the path in the game settings
+
+## Permissions
+
+The Flatpak has the following permissions:
+
+- **Display**: Wayland and X11 support
+- **Audio**: PulseAudio for sound
+- **D-Bus**: Session bus for system integration
+- **Filesystem**: 
+  - `xdg-config` for configuration
+  - `xdg-data` (read-only) for application data
+  - `xdg-save` for save files
+  - `~/.local/share/chris-sawyer-locomotion` for game assets (create if needed)
+- **Hardware**: DRI for GPU acceleration

--- a/distribution/linux/build-flatpak.sh
+++ b/distribution/linux/build-flatpak.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# Build script for OpenLoco Flatpak
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Default values
+BUILD_DIR="${SCRIPT_DIR}/flatpak-build"
+INSTALL_DIR="${SCRIPT_DIR}/flatpak-install"
+REPO_DIR="${SCRIPT_DIR}/flatpak-repo"
+ARCH="x86_64"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+function usage() {
+    echo "Usage: $0 [options]"
+    echo ""
+    echo "Options:"
+    echo "  -h, --help          Show this help message"
+    echo "  -b, --build-dir DIR  Specify build directory (default: ${BUILD_DIR})"
+    echo "  -i, --install-dir DIR Specify install directory (default: ${INSTALL_DIR})"
+    echo "  -r, --repo-dir DIR   Specify repo directory (default: ${REPO_DIR})"
+    echo "  -a, --arch ARCH      Target architecture (default: ${ARCH})"
+    echo "  --build             Build the Flatpak"
+    echo "  --install           Install the Flatpak locally"
+    echo "  --run               Run the Flatpak"
+    echo "  --clean             Clean build and install directories"
+    echo "  --all               Build, install, and run"
+    echo ""
+    echo "Examples:"
+    echo "  $0 --all                    # Build, install, and run"
+    echo "  $0 --build --install        # Build and install"
+    echo "  $0 --clean                  # Clean all build files"
+}
+
+function check_dependencies() {
+    echo -e "${YELLOW}Checking dependencies...${NC}"
+    
+    local missing=()
+    
+    command -v flatpak >/dev/null 2>&1 || missing+=("flatpak")
+    command -v flatpak-builder >/dev/null 2>&1 || missing+=("flatpak-builder")
+    command -v cmake >/dev/null 2>&1 || missing+=("cmake")
+    command -v ninja >/dev/null 2>&1 || missing+=("ninja")
+    command -v git >/dev/null 2>&1 || missing+=("git")
+    
+    if [ ${#missing[@]} -ne 0 ]; then
+        echo -e "${RED}Error: Missing dependencies:${NC}"
+        for dep in "${missing[@]}"; do
+            echo "  - $dep"
+        done
+        echo ""
+        echo "On Debian/Ubuntu, install with:"
+        echo "  sudo apt install flatpak flatpak-builder cmake ninja-build git"
+        echo ""
+        echo "On Fedora:"
+        echo "  sudo dnf install flatpak flatpak-builder cmake ninja-build git"
+        exit 1
+    fi
+    
+    echo -e "${GREEN}All dependencies found!${NC}"
+}
+
+function setup_flatpak() {
+    echo -e "${YELLOW}Setting up Flatpak environment...${NC}"
+    
+    # Add Flathub repo if not already added
+    if ! flatpak remote-list | grep -q flathub; then
+        echo "Adding Flathub repository..."
+        flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+    fi
+    
+    # Install required runtimes
+    flatpak install --assumeyes flathub org.freedesktop.Platform//24.08
+    flatpak install --assumeyes flathub org.freedesktop.Sdk//24.08
+    
+    echo -e "${GREEN}Flatpak environment ready!${NC}"
+}
+
+function clean() {
+    echo -e "${YELLOW}Cleaning...${NC}"
+    
+    if [ -d "$BUILD_DIR" ]; then
+        rm -rf "$BUILD_DIR"
+        echo "Removed build directory: $BUILD_DIR"
+    fi
+    
+    if [ -d "$INSTALL_DIR" ]; then
+        rm -rf "$INSTALL_DIR"
+        echo "Removed install directory: $INSTALL_DIR"
+    fi
+    
+    if [ -d "$REPO_DIR" ]; then
+        rm -rf "$REPO_DIR"
+        echo "Removed repo directory: $REPO_DIR"
+    fi
+    
+    echo -e "${GREEN}Cleanup complete!${NC}"
+}
+
+function build_flatpak() {
+    echo -e "${YELLOW}Building Flatpak...${NC}"
+    
+    mkdir -p "$BUILD_DIR"
+    mkdir -p "$INSTALL_DIR"
+    mkdir -p "$REPO_DIR"
+    
+    cd "$SCRIPT_DIR"
+    
+    echo "Building with manifest: com.openloco.OpenLoco.json"
+    echo "Build directory: $BUILD_DIR"
+    echo "Install directory: $INSTALL_DIR"
+    
+    # Build the Flatpak
+    flatpak-builder \
+        --user \
+        --install-deps-from=flathub \
+        --arch="$ARCH" \
+        --build-dir="$BUILD_DIR" \
+        --install-dir="$INSTALL_DIR" \
+        --force-clean \
+        "$REPO_DIR" \
+        com.openloco.OpenLoco.json
+    
+    echo -e "${GREEN}Flatpak build complete!${NC}"
+}
+
+function install_flatpak() {
+    echo -e "${YELLOW}Installing Flatpak...${NC}"
+    
+    # Create local repo
+    flatpak build-export "$REPO_DIR" "$INSTALL_DIR"
+    
+    # Add local repo
+    flatpak remote-add --user --if-not-exists openloco-repo "$REPO_DIR"
+    
+    # Install the application
+    flatpak install --user --assumeyes openloco-repo com.openloco.OpenLoco
+    
+    echo -e "${GREEN}Flatpak installed!${NC}"
+}
+
+function run_flatpak() {
+    echo -e "${YELLOW}Running OpenLoco...${NC}"
+    flatpak run com.openloco.OpenLoco
+}
+
+# Parse arguments
+ACTION=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -b|--build-dir)
+            BUILD_DIR="$2"
+            shift 2
+            ;;
+        -i|--install-dir)
+            INSTALL_DIR="$2"
+            shift 2
+            ;;
+        -r|--repo-dir)
+            REPO_DIR="$2"
+            shift 2
+            ;;
+        -a|--arch)
+            ARCH="$2"
+            shift 2
+            ;;
+        --build)
+            ACTION+="build "
+            shift
+            ;;
+        --install)
+            ACTION+="install "
+            shift
+            ;;
+        --run)
+            ACTION+="run "
+            shift
+            ;;
+        --clean)
+            ACTION+="clean "
+            shift
+            ;;
+        --all)
+            ACTION="clean build install run"
+            shift
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# If no action specified, show help
+if [ -z "$ACTION" ]; then
+    usage
+    exit 1
+fi
+
+# Execute actions in order
+for action in $ACTION; do
+    case "$action" in
+        clean)
+            clean
+            ;;
+        build)
+            check_dependencies
+            setup_flatpak
+            build_flatpak
+            ;;
+        install)
+            install_flatpak
+            ;;
+        run)
+            run_flatpak
+            ;;
+    esac
+done
+
+echo -e "${GREEN}Done!${NC}"

--- a/distribution/linux/com.openloco.OpenLoco.appdata.xml
+++ b/distribution/linux/com.openloco.OpenLoco.appdata.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.openloco.OpenLoco</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-only</project_license>
+  
+  <name>OpenLoco</name>
+  <summary>Open Source re-implementation of Chris Sawyer's Locomotion</summary>
+  <description>
+    <p>
+      OpenLoco is an open-source re-implementation of Chris Sawyer's Locomotion (CSL),
+      the spiritual successor to Transport Tycoon. OpenLoco aims to improve the game
+      similar to how OpenTTD improved Transport Tycoon, and OpenRCT2 improved
+      RollerCoaster Tycoon.
+    </p>
+    <p>
+      CSL was originally written in x86 assembly, building on top of the
+      RollerCoaster Tycoon 2 engine. However, the engine has changed substantially
+      enough that OpenLoco currently does not share its codebase with OpenRCT2.
+    </p>
+    <p>
+      Note: OpenLoco requires the asset files of the original Chris Sawyer's Locomotion
+      to play the game. It can be bought at e.g. Steam or GOG.com.
+    </p>
+  </description>
+  
+  <categories>
+    <category>Game</category>
+    <category>Simulation</category>
+  </categories>
+  
+  <keywords>
+    <keyword>transport</keyword>
+    <keyword>management</keyword>
+    <keyword>simulation</keyword>
+    <keyword>tycoon</keyword>
+    <keyword>locomotion</keyword>
+    <keyword>chris-sawyer</keyword>
+    <keyword>train</keyword>
+    <keyword>bus</keyword>
+    <keyword>truck</keyword>
+    <keyword>ship</keyword>
+    <keyword>airplane</keyword>
+  </keywords>
+  
+  <url type="homepage">https://github.com/OpenLoco/OpenLoco</url>
+  <url type="bugtracker">https://github.com/OpenLoco/OpenLoco/issues</url>
+  <url type="help">https://discord.gg/vEuNRHD</url>
+  <url type="donation">https://github.com/sponsors/OpenLoco</url>
+  
+  <developer>
+    <name>OpenLoco Team</name>
+    <email>openloco@protonmail.com</email>
+    <url>https://github.com/OpenLoco/OpenLoco</url>
+  </developer>
+  
+  <screenshots>
+    <screenshot type="default">
+      <image>https://user-images.githubusercontent.com/604665/55420349-1a2aea00-5577-11e9-87da-78fe5cdb09e1.png</image>
+      <caption>OpenLoco Gameplay Screenshot</caption>
+    </screenshot>
+  </screenshots>
+  
+  <releases>
+    <release version="26.07.1" date="2026-07-30">
+      <description>
+        <p>Latest development version</p>
+      </description>
+    </release>
+  </releases>
+  
+  <content_rating type="oars-1.1" />
+  
+  <launchable type="desktop-id">openloco.desktop</launchable>
+</component>

--- a/distribution/linux/com.openloco.OpenLoco.json
+++ b/distribution/linux/com.openloco.OpenLoco.json
@@ -1,0 +1,134 @@
+{
+    "app-id": "com.openloco.OpenLoco",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "24.08",
+    "sdk": "org.freedesktop.Sdk",
+    "command": "openloco",
+    "finish-args": [
+        "--device=dri",
+        "--socket=wayland",
+        "--socket=x11",
+        "--socket=pulseaudio",
+        "--socket=session-bus",
+        "--filesystem=xdg-config",
+        "--filesystem=xdg-data:ro",
+        "--filesystem=xdg-save",
+        "--filesystem=~/.local/share/chris-sawyer-locomotion:create"
+    ],
+    "modules": [
+        {
+            "name": "yaml-cpp",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DYAML_CPP_BUILD_TESTS=OFF",
+                "-DYAML_CPP_BUILD_TOOLS=OFF",
+                "-DYAML_CPP_BUILD_CONTRIB=OFF",
+                "-DYAML_BUILD_SHARED_LIBS=OFF",
+                "-DYAML_CPP_INSTALL=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/jbeder/yaml-cpp/archive/c2680200486572baf8221ba052ef50b58ecd816e.tar.gz",
+                    "sha256": "a7a23371444762b15822332534d124481545507f86401aa727763938e79a6452"
+                }
+            ]
+        },
+        {
+            "name": "fmt",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DFMT_TEST=OFF",
+                "-DFMT_DOC=OFF",
+                "-DBUILD_SHARED_LIBS=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/fmtlib/fmt/archive/11.1.4.tar.gz",
+                    "sha256": "5244b5582f43940450c10346301439c9d18a89a34086f6746722a11424e0146b"
+                }
+            ]
+        },
+        {
+            "name": "sfl",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DSFL_NO_TESTS=ON",
+                "-DBUILD_SHARED_LIBS=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/slavenf/sfl-library/archive/refs/tags/v2.2.0.tar.gz",
+                    "sha256": "2b333387e35641353410e753166507915234996141d6b6417294c3847895547a"
+                }
+            ]
+        },
+        {
+            "name": "openloco",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DOPENLOCO_USE_VCPKG=OFF",
+                "-DOPENLOCO_BUILD_TESTS=OFF",
+                "-DOPENLOCO_HEADER_CHECK=OFF",
+                "-DCMAKE_INSTALL_PREFIX=/app",
+                "-DCMAKE_PREFIX_PATH=/app"
+            ],
+            "build-options": {
+                "cxxflags": "-std=c++20"
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/OpenLoco/OpenGraphics/releases/download/v0.1.9/objects.zip",
+                    "sha256": "442790242746559704516e98f8427af108607b532145c3502f7770e132f9e1bd",
+                    "dest": "openloco-objects"
+                },
+                {
+                    "type": "dir",
+                    "path": ".",
+                    "dest": "openloco"
+                }
+            ],
+            "post-install": [
+                "cp -r openloco-objects /app/data/objects",
+                "cp -r openloco/data /app/data"
+            ]
+        }
+    ],
+    "metadata": {
+        "name": "OpenLoco",
+        "summary": "Open Source re-implementation of Chris Sawyer's Locomotion",
+        "description": "<p>OpenLoco is an open-source re-implementation of <em>Chris Sawyer's Locomotion</em> (CSL), the spiritual successor to Transport Tycoon. OpenLoco aims to improve the game similar to how OpenTTD improved Transport Tycoon, and OpenRCT2 improved RollerCoaster Tycoon.</p><p>CSL was originally written in x86 assembly, building on top of the RollerCoaster Tycoon 2 engine. However, the engine has changed substantially enough that OpenLoco currently does not share its codebase with OpenRCT2.</p>",
+        "license": "GPL-2.0-only",
+        "url": {
+            "homepage": "https://github.com/OpenLoco/OpenLoco",
+            "bugtracker": "https://github.com/OpenLoco/OpenLoco/issues",
+            "help": "https://discord.gg/vEuNRHD"
+        },
+        "screenshots": [
+            {
+                "url": "https://user-images.githubusercontent.com/604665/55420349-1a2aea00-5577-11e9-87da-78fe5cdb09e1.png",
+                "caption": "OpenLoco Gameplay Screenshot"
+            }
+        ],
+        "categories": ["Game", "Simulation"],
+        "keywords": ["transport", "management", "simulation", "tycoon", "locomotion", "chris-sawyer"],
+        "icon": "com.openloco.OpenLoco.svg",
+        "icon-64": "com.openloco.OpenLoco-64.png",
+        "icon-128": "com.openloco.OpenLoco-128.png",
+        "developer": [
+            {
+                "name": "OpenLoco Team",
+                "url": "https://github.com/OpenLoco/OpenLoco",
+                "email": "openloco@protonmail.com"
+            }
+        ]
+    }
+}

--- a/distribution/linux/openloco.desktop
+++ b/distribution/linux/openloco.desktop
@@ -3,9 +3,10 @@
 Type=Application
 Version=1.0
 Exec=OpenLoco %u
-Icon=openloco
+Icon=com.openloco.OpenLoco
 Name=OpenLoco
 GenericName=Transport management game
+StartupWMClass=OpenLoco
 GenericName[nl]=Transportbedrijfsimulator
 Comment=Open Source re-implementation of Chris Sawyer's Locomotion.
 Comment[ca]=Reimplementació de codi obert del Chris Sawyer's Locomotion.


### PR DESCRIPTION
- Add Flatpak manifest file (com.openloco.OpenLoco.json)
- Add AppStream metadata (com.openloco.OpenLoco.appdata.xml)
- Add build script (build-flatpak.sh) for easy Flatpak building
- Add README.md with Flatpak build instructions
- Update openloco.desktop for Flatpak compatibility
- Add Flatpak build job to CI workflow

The Flatpak uses:
- org.freedesktop.Platform 24.08 runtime
- SDL3, OpenAL, libpng, zlib from the runtime
- Bundles yaml-cpp, fmt, sfl dependencies
- Provides proper sandboxing with appropriate permissions

Generated by Mistral Vibe.