### PR TITLE
Fixes #3889 - use std::getline() for reading path instead of std::cin >> in Posix platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix: [#3855] UI invalidation issue when using switch company cheat.
 - Fix: [#3858] Save file details can overflow the file browser window at minimum height.
 - Fix: [#3861] The news sound setting is not read properly from the config file.
+- Fix: [#3890] On Linux/POSIX, setting the game path does not work correctly if it contains spaces.
 
 26.07.1 (2026-07-27)
 ------------------------------------------------------------------------

--- a/src/Platform/src/Platform.Posix.cpp
+++ b/src/Platform/src/Platform.Posix.cpp
@@ -110,7 +110,7 @@ namespace OpenLoco::Platform
     {
         std::string input;
         std::cout << "Type your Locomotion path: ";
-        std::cin >> input;
+        std::getline(std::cin, input);
 
         auto path = fs::canonical(input);
         return path;


### PR DESCRIPTION
Currently, entering a path containing a space cuts off the path before the space because that's how `std::cin >>` works. By using `std::getline(...)`, the full path is read.