### PR TITLE
Fix #3888: Remove vanilla 128 clamp on paint bounding box height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix: [#3856] News ticker uses double the line height.
 - Fix: [#3858] Save file details can overflow the file browser window at minimum height.
 - Fix: [#3861] The news sound setting is not read properly from the config file.
+- Fix: [#3888] Bridges can be drawn over tall buildings, industries and stations (original bug).
 - Fix: [#3890] On Linux/POSIX, setting the game path does not work correctly if it contains spaces.
 
 26.07.1 (2026-07-27)

--- a/src/OpenLoco/src/Paint/PaintAirport.cpp
+++ b/src/OpenLoco/src/Paint/PaintAirport.cpp
@@ -85,7 +85,7 @@ namespace OpenLoco::Paint
         // ceil to 4
         clearHeight += 3;
         clearHeight &= ~3;
-        const int16_t bbLengthZ = std::min(clearHeight, 128) - 2;
+        const int16_t bbLengthZ = clearHeight - 2;
 
         const auto baseHeight = elStation.baseHeight();
 

--- a/src/OpenLoco/src/Paint/PaintBuilding.cpp
+++ b/src/OpenLoco/src/Paint/PaintBuilding.cpp
@@ -182,7 +182,7 @@ namespace OpenLoco::Paint
         const uint8_t rotation = (session.getRotation() + elBuilding.rotation()) & 0x3;
 
         // 0x00525D4E
-        const int16_t bbLengthZ = std::min(elBuilding.clearHeight() - elBuilding.baseHeight(), 128) - 2;
+        const int16_t bbLengthZ = elBuilding.clearHeight() - elBuilding.baseHeight() - 2;
 
         // 0x00525D18
         const auto variation = elBuilding.variation();

--- a/src/OpenLoco/src/Paint/PaintDocks.cpp
+++ b/src/OpenLoco/src/Paint/PaintDocks.cpp
@@ -70,7 +70,7 @@ namespace OpenLoco::Paint
         // Combine this with any imageId
         const auto rotation = (session.getRotation() + elStation.rotation()) & 0x3;
 
-        const int16_t bbLengthZ = std::min(elStation.clearHeight() - elStation.baseHeight(), 128) - 2;
+        const int16_t bbLengthZ = elStation.clearHeight() - elStation.baseHeight() - 2;
 
         const auto baseHeight = elStation.baseHeight();
 

--- a/src/OpenLoco/src/Paint/PaintIndustry.cpp
+++ b/src/OpenLoco/src/Paint/PaintIndustry.cpp
@@ -175,7 +175,7 @@ namespace OpenLoco::Paint
         const uint8_t rotation = (session.getRotation() + elIndustry.rotation()) & 0x3;
 
         // 0x00525D4E
-        const int16_t bbLengthZ = std::min(elIndustry.clearHeight() - elIndustry.baseHeight(), 128) - 2;
+        const int16_t bbLengthZ = elIndustry.clearHeight() - elIndustry.baseHeight() - 2;
 
         // 0x00E0C3A4
         uint32_t buildingType = elIndustry.buildingType();


### PR DESCRIPTION
I briefly discussed this with @duncanspumpkin and checked the assembly, it did have the clamp but that seems to be working against us with tall constructions, the sort after the fix is now correct.

Closes #3888