### PR TITLE
Deduplicate news viewport layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Change: [#3863] The toolbar buttons can now be set to open on click instead of hover.
 - Fix: [#2082] Scrollbars can be overdrawn when certain windows are resized but their scrollview is not.
 - Fix: [#2983] Can no longer scroll to adjust terraform tool size widgets.
+- Fix: [#3597] News messages don't update viewport/image position correctly between messages.
 - Fix: [#3676] Fix bug where last land variation sprite went unused (original bug).
 - Fix: [#3855] UI invalidation issue when using switch company cheat.
 - Fix: [#3856] News ticker uses double the line height.

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -748,29 +748,25 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 drawStationNews(self, drawingCtx, news);
             }
 
-            if (mtd.hasFlag(MessageTypeFlags::hasFirstItem))
+            if (mtd.hasFlag(MessageTypeFlags::hasFirstItem) && news->itemSubjects[0] != 0xFFFF)
             {
-                if (news->itemSubjects[0] != 0xFFFF)
-                {
-                    auto x = (self.widgets[Common::widx::viewport1Button].left + self.widgets[Common::widx::viewport1Button].right) / 2;
-                    auto y = self.widgets[Common::widx::viewport1Button].bottom - 7;
-                    auto width = self.widgets[Common::widx::viewport1Button].width() - 1;
-                    auto point = Point(x, y);
+                auto& widget = self.widgets[Common::widx::viewport1Button];
+                auto x = widget.midX();
+                auto y = widget.bottom - 7;
+                auto width = widget.width() - 1;
+                auto point = Point(x, y);
 
-                    drawViewportString(drawingCtx, point, width, mtd.argumentTypes[0], news->itemSubjects[0]);
-                }
+                drawViewportString(drawingCtx, point, width, mtd.argumentTypes[0], news->itemSubjects[0]);
             }
-            if (mtd.hasFlag(MessageTypeFlags::hasSecondItem))
+            if (mtd.hasFlag(MessageTypeFlags::hasSecondItem) && news->itemSubjects[1] != 0xFFFF)
             {
-                if (news->itemSubjects[1] != 0xFFFF)
-                {
-                    auto x = (self.widgets[Common::widx::viewport2Button].left + self.widgets[Common::widx::viewport2Button].right) / 2;
-                    auto y = self.widgets[Common::widx::viewport2Button].bottom - 7;
-                    auto width = self.widgets[Common::widx::viewport2Button].width() - 1;
-                    auto point = Point(x, y);
+                auto& widget = self.widgets[Common::widx::viewport2Button];
+                auto x = widget.midX();
+                auto y = widget.bottom - 7;
+                auto width = widget.width() - 1;
+                auto point = Point(x, y);
 
-                    drawViewportString(drawingCtx, point, width, mtd.argumentTypes[1], news->itemSubjects[1]);
-                }
+                drawViewportString(drawingCtx, point, width, mtd.argumentTypes[1], news->itemSubjects[1]);
             }
         }
 

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -174,7 +174,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             }
         }
 
-        static SavedView getView(Window* self, Message* news, uint16_t itemId, MessageItemArgumentType itemType, bool* selectable)
+        static SavedView getView(Window* self, const Message* news, uint16_t itemId, MessageItemArgumentType itemType, bool* selectable)
         {
             SavedView view;
             view.mapX = -1;
@@ -303,8 +303,6 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
         static void initViewport(Window& self, const uint8_t subjectIndex)
         {
-            auto& layout = kViewportLayouts[subjectIndex];
-
             SavedView view;
             view.mapX = -1;
             view.mapY = -1;
@@ -313,11 +311,11 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             view.zoomLevel = (ZoomLevel)0xFFU;
             view.entityId = EntityId::null;
 
-            auto news = MessageManager::get(MessageManager::getActiveIndex());
+            const auto* news = MessageManager::get(MessageManager::getActiveIndex());
             const auto& mtd = getMessageTypeDescriptor(news->type);
+            const auto& layout = kViewportLayouts[subjectIndex];
 
             bool selectable = false;
-
             if (MessageManager::getActiveIndex() != MessageId::null)
             {
                 if (mtd.hasFlag(layout.subjectFlag))
@@ -331,45 +329,40 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 }
             }
 
-            self.widgets[layout.viewportWidgetId].hidden = true;
-            self.widgets[layout.buttonWidgetId].hidden = true;
+            auto& viewportWidget = self.widgets[layout.viewportWidgetId];
+            auto& buttonWidget = self.widgets[layout.buttonWidgetId];
 
-            if (!view.isEmpty())
-            {
-                self.widgets[layout.viewportWidgetId].hidden = false;
-            }
+            viewportWidget.hidden = view.isEmpty();
+            buttonWidget.hidden = !selectable;
 
-            if (selectable)
-            {
-                self.widgets[layout.buttonWidgetId].hidden = false;
-            }
-
+            // Update viewport focus
             if (_nState.savedView[0] != view)
             {
                 _nState.savedView[0] = view;
                 self.viewportRemove(0);
                 self.invalidate();
 
+                // Update viewport layout
                 const bool juxtapose = subjectIndex == 0 && mtd.hasFlag(MessageTypeFlags::hasSecondItem);
                 const auto& size = juxtapose ? layout.halfSize : layout.fullSize;
 
-                self.widgets[layout.viewportWidgetId].left = layout.position.x + 2;
-                self.widgets[layout.viewportWidgetId].right = layout.position.x + size.width - 4;
-                self.widgets[layout.buttonWidgetId].left = layout.position.x + size.width;
-                self.widgets[layout.buttonWidgetId].right = layout.position.x + size.width;
+                viewportWidget.left = layout.position.x + 2;
+                viewportWidget.right = layout.position.x + size.width - 4;
+                buttonWidget.left = layout.position.x + size.width;
+                buttonWidget.right = layout.position.x + size.width;
 
                 if (!view.isEmpty())
                 {
-                    auto origin = self.widgets[layout.viewportWidgetId].position() + Point{ 1, 1 };
+                    auto origin = viewportWidget.position() + Point{ 1, 1 };
 
-                    uint16_t viewportWidth = self.widgets[layout.viewportWidgetId].width();
+                    uint16_t viewportWidth = viewportWidget.width();
                     uint16_t viewportHeight = 62;
                     Ui::Size viewportSize = { viewportWidth, viewportHeight };
 
                     if (mtd.hasFlag(MessageTypeFlags::isGeneralNews))
                     {
-                        origin = self.widgets[layout.viewportWidgetId].position();
-                        viewportWidth = self.widgets[layout.viewportWidgetId].width() + 2;
+                        origin = viewportWidget.position();
+                        viewportWidth = viewportWidget.width() + 2;
                         viewportHeight = 64;
                         viewportSize = { viewportWidth, viewportHeight };
                     }

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -283,9 +283,28 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             return view;
         }
 
-        // TODO: deduplicate with initViewport1
-        static void initViewport0(Window& self)
+        struct ViewportLayout
         {
+            MessageTypeFlags subjectFlag;
+            WidgetIndex_t viewportWidgetId;
+            WidgetIndex_t buttonWidgetId;
+            Point position;
+            Size fullSize;
+            Size halfSize;
+        };
+
+        static constexpr Size kFullSizeNews = { 351, 42 };
+        static constexpr Size kHalfSizeNews = { 174, 42 };
+
+        static constexpr std::array kViewportLayouts = std::to_array<ViewportLayout>({
+            { MessageTypeFlags::hasFirstItem, Common::widx::viewport1, Common::widx::viewport1Button, Point{ 4, 42 }, kFullSizeNews, kHalfSizeNews },
+            { MessageTypeFlags::hasSecondItem, Common::widx::viewport2, Common::widx::viewport2Button, Point{ 186, 42 }, kHalfSizeNews, kHalfSizeNews },
+        });
+
+        static void initViewport(Window& self, const uint8_t subjectIndex)
+        {
+            auto& layout = kViewportLayouts[subjectIndex];
+
             SavedView view;
             view.mapX = -1;
             view.mapY = -1;
@@ -301,28 +320,28 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
             if (MessageManager::getActiveIndex() != MessageId::null)
             {
-                if (mtd.hasFlag(MessageTypeFlags::hasFirstItem))
+                if (mtd.hasFlag(layout.subjectFlag))
                 {
-                    auto itemType = mtd.argumentTypes[0];
+                    auto itemType = mtd.argumentTypes[subjectIndex];
 
-                    if (news->itemSubjects[0] != 0xFFFF)
+                    if (news->itemSubjects[subjectIndex] != 0xFFFF)
                     {
-                        view = getView(&self, news, news->itemSubjects[0], itemType, &selectable);
+                        view = getView(&self, news, news->itemSubjects[subjectIndex], itemType, &selectable);
                     }
                 }
             }
 
-            self.widgets[Common::widx::viewport1].hidden = true;
-            self.widgets[Common::widx::viewport1Button].hidden = true;
+            self.widgets[layout.viewportWidgetId].hidden = true;
+            self.widgets[layout.buttonWidgetId].hidden = true;
 
             if (!view.isEmpty())
             {
-                self.widgets[Common::widx::viewport1].hidden = false;
+                self.widgets[layout.viewportWidgetId].hidden = false;
             }
 
             if (selectable)
             {
-                self.widgets[Common::widx::viewport1Button].hidden = false;
+                self.widgets[layout.buttonWidgetId].hidden = false;
             }
 
             if (_nState.savedView[0] != view)
@@ -331,36 +350,26 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                 self.viewportRemove(0);
                 self.invalidate();
 
-                self.widgets[Common::widx::viewport1].left = 6;
-                self.widgets[Common::widx::viewport1].right = 353;
-                self.widgets[Common::widx::viewport1Button].left = 4;
-                self.widgets[Common::widx::viewport1Button].right = 355;
+                const bool juxtapose = subjectIndex == 0 && mtd.hasFlag(MessageTypeFlags::hasSecondItem);
+                const auto& size = juxtapose ? layout.halfSize : layout.fullSize;
 
-                if (mtd.hasFlag(MessageTypeFlags::hasSecondItem))
-                {
-                    self.widgets[Common::widx::viewport1].left = 6;
-                    self.widgets[Common::widx::viewport1].right = 173;
-                    self.widgets[Common::widx::viewport1Button].left = 4;
-                    self.widgets[Common::widx::viewport1Button].right = 175;
-                }
+                self.widgets[layout.viewportWidgetId].left = layout.position.x + 2;
+                self.widgets[layout.viewportWidgetId].right = layout.position.x + size.width - 4;
+                self.widgets[layout.buttonWidgetId].left = layout.position.x + size.width;
+                self.widgets[layout.buttonWidgetId].right = layout.position.x + size.width;
 
                 if (!view.isEmpty())
                 {
-                    int16_t x = self.widgets[Common::widx::viewport1].left + 1;
-                    int16_t y = self.widgets[Common::widx::viewport1].top + 1;
-                    Ui::Point origin = { x, y };
+                    auto origin = self.widgets[layout.viewportWidgetId].position() + Point{ 1, 1 };
 
-                    uint16_t viewportWidth = self.widgets[Common::widx::viewport1].width();
+                    uint16_t viewportWidth = self.widgets[layout.viewportWidgetId].width();
                     uint16_t viewportHeight = 62;
                     Ui::Size viewportSize = { viewportWidth, viewportHeight };
 
                     if (mtd.hasFlag(MessageTypeFlags::isGeneralNews))
                     {
-                        x = self.widgets[Common::widx::viewport1].left;
-                        y = self.widgets[Common::widx::viewport1].top;
-                        origin = { x, y };
-
-                        viewportWidth = self.widgets[Common::widx::viewport1].width() + 2;
+                        origin = self.widgets[layout.viewportWidgetId].position();
+                        viewportWidth = self.widgets[layout.viewportWidgetId].width() + 2;
                         viewportHeight = 64;
                         viewportSize = { viewportWidth, viewportHeight };
                     }
@@ -378,92 +387,11 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             }
         }
 
-        // TODO: deduplicate with initViewport0
-        static void initViewport1(Window& self)
-        {
-            SavedView view;
-            view.mapX = -1;
-            view.mapY = -1;
-            view.surfaceZ = -1;
-            view.rotation = -1;
-            view.zoomLevel = (ZoomLevel)0xFFU;
-            view.entityId = EntityId::null;
-
-            auto news = MessageManager::get(MessageManager::getActiveIndex());
-            const auto& mtd = getMessageTypeDescriptor(news->type);
-
-            bool selectable = false;
-
-            if (MessageManager::getActiveIndex() != MessageId::null)
-            {
-                if (mtd.hasFlag(MessageTypeFlags::hasSecondItem))
-                {
-                    auto itemType = mtd.argumentTypes[1];
-
-                    if (news->itemSubjects[1] != 0xFFFF)
-                    {
-                        view = getView(&self, news, news->itemSubjects[1], itemType, &selectable);
-                    }
-                }
-            }
-
-            self.widgets[Common::widx::viewport2].hidden = true;
-            self.widgets[Common::widx::viewport2Button].hidden = true;
-
-            if (!view.isEmpty())
-            {
-                self.widgets[Common::widx::viewport2].hidden = false;
-            }
-
-            if (selectable)
-            {
-                self.widgets[Common::widx::viewport2Button].hidden = false;
-            }
-
-            if (_nState.savedView[1] != view)
-            {
-                _nState.savedView[1] = view;
-                self.viewportRemove(1);
-                self.invalidate();
-
-                self.widgets[Common::widx::viewport2].left = 186;
-                self.widgets[Common::widx::viewport2].right = 353;
-                self.widgets[Common::widx::viewport2Button].left = 184;
-                self.widgets[Common::widx::viewport2Button].right = 355;
-
-                if (!view.isEmpty())
-                {
-                    int16_t x = self.widgets[Common::widx::viewport2].left + 1;
-                    int16_t y = self.widgets[Common::widx::viewport2].top + 1;
-                    Ui::Point origin = { x, y };
-
-                    uint16_t viewportWidth = self.widgets[Common::widx::viewport2].width();
-                    uint16_t viewportHeight = 62;
-                    Ui::Size viewportSize = { viewportWidth, viewportHeight };
-
-                    if (mtd.hasFlag(MessageTypeFlags::isGeneralNews))
-                    {
-                        x = self.widgets[Common::widx::viewport2].left;
-                        y = self.widgets[Common::widx::viewport2].top;
-                        origin = { x, y };
-
-                        viewportWidth = self.widgets[Common::widx::viewport2].width() + 2;
-                        viewportHeight = 64;
-                        viewportSize = { viewportWidth, viewportHeight };
-                    }
-
-                    ViewportManager::create(&self, 1, origin, viewportSize, view.zoomLevel, view.getPos());
-
-                    self.invalidate();
-                }
-            }
-        }
-
         // 0x00429209
         void initViewports(Window& self)
         {
-            initViewport0(self);
-            initViewport1(self);
+            initViewport(self, 0);
+            initViewport(self, 1);
         }
 
         // 0x0042A136

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -174,7 +174,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             }
         }
 
-        static SavedView getView(Window* self, const Message* news, uint16_t itemId, MessageItemArgumentType itemType, bool* selectable)
+        static SavedView getView(Window* self, const Message* news, uint16_t itemId, MessageItemArgumentType itemType, bool& selectable)
         {
             SavedView view;
             view.mapX = -1;
@@ -194,7 +194,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     view.surfaceZ = World::TileManager::getHeight({ view.mapX, view.mapY }).landHeight;
                     view.rotation = WindowManager::getCurrentRotation();
                     view.zoomLevel = ZoomLevel::half;
-                    *selectable = true;
+                    selectable = true;
                     break;
                 }
 
@@ -207,7 +207,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     view.surfaceZ = station->z;
                     view.rotation = WindowManager::getCurrentRotation();
                     view.zoomLevel = ZoomLevel::full;
-                    *selectable = true;
+                    selectable = true;
                     break;
                 }
 
@@ -220,7 +220,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     view.surfaceZ = World::TileManager::getHeight({ view.mapX, view.mapY }).landHeight;
                     view.rotation = WindowManager::getCurrentRotation();
                     view.zoomLevel = ZoomLevel::half;
-                    *selectable = true;
+                    selectable = true;
                     break;
                 }
 
@@ -247,7 +247,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     view.flags = (1 << 15);
                     view.zoomLevel = ZoomLevel::full;
                     view.rotation = WindowManager::getCurrentRotation();
-                    *selectable = true;
+                    selectable = true;
                     break;
                 }
 
@@ -256,7 +256,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     // TODO: Do this better
                     view.zoomLevel = enumValue(SubjectType::companyFace);
                     self->invalidate();
-                    *selectable = true;
+                    selectable = true;
                     break;
 
                 case MessageItemArgumentType::location:
@@ -265,7 +265,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     view.surfaceZ = World::TileManager::getHeight({ view.mapX, view.mapY }).landHeight;
                     view.zoomLevel = ZoomLevel::full;
                     view.rotation = WindowManager::getCurrentRotation();
-                    *selectable = true;
+                    selectable = true;
                     break;
 
                 case MessageItemArgumentType::unk6:
@@ -277,7 +277,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     // TODO: Do this better
                     view.zoomLevel = enumValue(SubjectType::vehicleImage);
                     self->invalidate();
-                    *selectable = true;
+                    selectable = true;
                     break;
             }
             return view;
@@ -324,7 +324,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
                     if (news->itemSubjects[subjectIndex] != 0xFFFF)
                     {
-                        view = getView(&self, news, news->itemSubjects[subjectIndex], itemType, &selectable);
+                        view = getView(&self, news, news->itemSubjects[subjectIndex], itemType, selectable);
                     }
                 }
             }

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -345,10 +345,10 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             buttonWidget.right = layout.position.x + size.width;
 
             // Update viewport focus
-            if (_nState.savedView[0] != view)
+            if (_nState.savedView[subjectIndex] != view)
             {
-                _nState.savedView[0] = view;
-                self.viewportRemove(0);
+                _nState.savedView[subjectIndex] = view;
+                self.viewportRemove(subjectIndex);
                 self.invalidate();
 
                 if (!view.isEmpty())
@@ -375,6 +375,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
                     {
                         ViewportManager::create(&self, 0, origin, viewportSize, view.zoomLevel, view.getPos());
                     }
+
                     self.invalidate();
                 }
             }

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -341,7 +341,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
 
             viewportWidget.left = layout.position.x + 2;
             viewportWidget.right = layout.position.x + size.width - 4;
-            buttonWidget.left = layout.position.x + size.width;
+            buttonWidget.left = layout.position.x;
             buttonWidget.right = layout.position.x + size.width;
 
             // Update viewport focus

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -335,21 +335,21 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             viewportWidget.hidden = view.isEmpty();
             buttonWidget.hidden = !selectable;
 
+            // Update viewport layout
+            const bool juxtapose = subjectIndex == 0 && mtd.hasFlag(MessageTypeFlags::hasSecondItem);
+            const auto& size = juxtapose ? layout.halfSize : layout.fullSize;
+
+            viewportWidget.left = layout.position.x + 2;
+            viewportWidget.right = layout.position.x + size.width - 4;
+            buttonWidget.left = layout.position.x + size.width;
+            buttonWidget.right = layout.position.x + size.width;
+
             // Update viewport focus
             if (_nState.savedView[0] != view)
             {
                 _nState.savedView[0] = view;
                 self.viewportRemove(0);
                 self.invalidate();
-
-                // Update viewport layout
-                const bool juxtapose = subjectIndex == 0 && mtd.hasFlag(MessageTypeFlags::hasSecondItem);
-                const auto& size = juxtapose ? layout.halfSize : layout.fullSize;
-
-                viewportWidget.left = layout.position.x + 2;
-                viewportWidget.right = layout.position.x + size.width - 4;
-                buttonWidget.left = layout.position.x + size.width;
-                buttonWidget.right = layout.position.x + size.width;
 
                 if (!view.isEmpty())
                 {


### PR DESCRIPTION
This deduplicates the news viewport layout routines. To this end, an intermediary `ViewportLayout` struct is introduced that captures the properties for both news viewport 'images' in a constant array `kViewportLayouts`. Both 'full size' viewports (centred) and 'half size' viewports (juxtaposed) are accounted for. Refactored a bit for legibility while at it.

Fixes #3597