### PR TITLE
Update docker images to fix linux vcpkg sdl3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,11 +337,15 @@ jobs:
       - name: Install to artifacts
         run: |
           cmake --build --preset linux-vcpkg-static --target install
+      - name: Tar artifacts
+        run: |
+          cd artifacts
+          tar zcvf ../OpenLoco-linux-x64-glibc2.43.tar.gz *
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: OpenLoco-linux-x64-glibc2.43
-          path: artifacts
+          path: artifacts/OpenLoco-linux-x64-glibc2.43.tar.gz
+          archive: false
           if-no-files-found: error
   macos:
     name: macOS Sequoia ARM64 vcpkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           Copy-Item CHANGELOG.md,CONTRIBUTORS.md,LICENSE artifacts
           Copy-Item build\${{ matrix.build_dir }}\Release\* artifacts -Recurse
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: OpenLoco-${{ matrix.os }}-x64
           path: |
@@ -94,7 +94,7 @@ jobs:
             !artifacts/*.pdb
           if-no-files-found: error
       - name: Upload symbols artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: OpenLoco-${{ matrix.os }}-x64-symbols
           path: |
@@ -175,7 +175,7 @@ jobs:
           Copy-Item CHANGELOG.md,CONTRIBUTORS.md,LICENSE artifacts
           Copy-Item build\windows-x86-32-ci\Release\* artifacts -Recurse
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: OpenLoco-${{ runner.os }}-Win32
           path: |
@@ -183,7 +183,7 @@ jobs:
             !artifacts/*.pdb
           if-no-files-found: error
       - name: Upload symbols artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: OpenLoco-${{ runner.os }}-Win32-symbols
           path: |
@@ -342,7 +342,7 @@ jobs:
           cd artifacts
           tar zcvf OpenLoco-linux-x64-glibc2.43.tar.gz *
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: artifacts/OpenLoco-linux-x64-glibc2.43.tar.gz
           archive: false
@@ -392,7 +392,7 @@ jobs:
         run: |
           cmake --build --preset macos-vcpkg-static --target install
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: OpenLoco-macos-arm64
           path: artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
       - name: Tar artifacts
         run: |
           cd artifacts
-          tar zcvf ../OpenLoco-linux-x64-glibc2.43.tar.gz *
+          tar zcvf OpenLoco-linux-x64-glibc2.43.tar.gz *
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
     name: Ubuntu ${{ matrix.distro }} ${{ matrix.compiler }} i686
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: ghcr.io/openloco/openloco:11-ubuntu${{ matrix.distro }}.32
+    container: ghcr.io/openloco/openloco:12-ubuntu${{ matrix.distro }}.32
     strategy:
       fail-fast: false
       matrix:
@@ -223,7 +223,7 @@ jobs:
     name: Ubuntu ${{ matrix.distro }} ${{ matrix.compiler }} x64
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: ghcr.io/openloco/openloco:11-ubuntu${{ matrix.distro }}
+    container: ghcr.io/openloco/openloco:12-ubuntu${{ matrix.distro }}
     strategy:
       fail-fast: false
       matrix:
@@ -249,7 +249,7 @@ jobs:
     name: Header checks ${{ matrix.distro }} ${{ matrix.compiler }}
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: ghcr.io/openloco/openloco:11-ubuntu${{ matrix.distro }}
+    container: ghcr.io/openloco/openloco:12-ubuntu${{ matrix.distro }}
     strategy:
       fail-fast: false
       matrix:
@@ -270,7 +270,7 @@ jobs:
     name: Fedora shared=${{ matrix.build_shared_libs }} i686 MinGW32
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: ghcr.io/openloco/openloco:11-mingw32
+    container: ghcr.io/openloco/openloco:12-mingw32
     strategy:
       fail-fast: false
       matrix:
@@ -292,7 +292,7 @@ jobs:
     name: Ubuntu 26.04 g++ x64 vcpkg static linkage
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: ghcr.io/openloco/openloco:11-ubuntu26.04.vcpkg
+    container: ghcr.io/openloco/openloco:12-ubuntu26.04.vcpkg
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -340,7 +340,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: OpenLoco-linux-x64-glibc2.42
+          name: OpenLoco-linux-x64-glibc2.43
           path: artifacts
           if-no-files-found: error
   macos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,8 @@ jobs:
           # Cache currently broken as docker image does not include unzip
       - name: Build OpenLoco
         run: |
-          cmake --preset linux-vcpkg-static
+          mkdir -p artifacts
+          cmake --preset linux-vcpkg-static -DCMAKE_INSTALL_PREFIX=./artifacts
           cmake --build --preset linux-vcpkg-static
       - name: Save binary cache
         if: always()
@@ -335,8 +336,7 @@ jobs:
       # Static linkage means the binary should be fairly portable / distributable across distros!
       - name: Install to artifacts
         run: |
-          mkdir -p artifacts
-          cmake --install build/linux-vcpkg-static --prefix ./artifacts
+          cmake --build --preset linux-vcpkg-static --target install
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Bumping the docker image to 12 as that now has the corrected libs to build sdl3 correctly.