### PR TITLE
Fix issues with terrain generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Fix: [#3861] The news sound setting is not read properly from the config file.
 - Fix: [#3888] Bridges can be drawn over tall buildings, industries and stations (original bug).
 - Fix: [#3890] On Linux/POSIX, setting the game path does not work correctly if it contains spaces.
-- Fix: [#3906] Random landscapes have the wrong terrain applied due to inverted 'terrain near water' condition.
+- Fix: [#3906] Random landscapes have their land types applied incorrectly due to incorrect 'near water' and 'around cliffs' conditions.
 
 26.07.1 (2026-07-27)
 ------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix: [#3861] The news sound setting is not read properly from the config file.
 - Fix: [#3888] Bridges can be drawn over tall buildings, industries and stations (original bug).
 - Fix: [#3890] On Linux/POSIX, setting the game path does not work correctly if it contains spaces.
+- Fix: [#3906] Random landscapes have the wrong terrain applied due to inverted 'terrain near water' condition.
 
 26.07.1 (2026-07-27)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -341,7 +341,7 @@ namespace OpenLoco::World::MapGenerator
         for (auto pos : getWorldRange())
         {
             auto height = heightMap.getHeight({ pos.x, pos.y });
-            if (height < seaLevel)
+            if (height > seaLevel)
             {
                 continue;
             }

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -467,13 +467,13 @@ namespace OpenLoco::World::MapGenerator
         // Mark tiles with sudden height changes in the next row
         for (auto pos : getDrawableTileRange())
         {
-            auto heightA = heightMap.getHeight({ pos + TilePos2{ 0, 1 } });
+            auto heightA = heightMap.getHeight({ pos + TilePos2{ 0, 0 } });
             auto heightB = heightMap.getHeight({ pos + TilePos2{ 0, 1 } });
 
             // Find no cliff between A and B?
             if (std::abs(heightB - heightA) < kCliffTerrainHeightDiff)
             {
-                auto heightC = heightMap.getHeight({ pos + TilePos2{ 0, 1 } });
+                auto heightC = heightMap.getHeight({ pos + TilePos2{ 0, 0 } });
                 auto heightD = heightMap.getHeight({ pos + TilePos2{ 0, 1 } });
 
                 // Find no cliff between C and D?

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -548,6 +548,7 @@ namespace OpenLoco::World::MapGenerator
 
         for (auto i = 0U; i < landDistributionPatterns.size(); i++)
         {
+            const auto distPattern = landDistributionPatterns[i];
             updateProgress(55 + 12 * i);
 
             for (uint8_t landObjectIdx = 0; landObjectIdx < ObjectManager::getMaxObjects(ObjectType::land); ++landObjectIdx)
@@ -559,7 +560,6 @@ namespace OpenLoco::World::MapGenerator
                 }
 
                 const auto typePattern = Scenario::getOptions().landDistributionPatterns[landObjectIdx];
-                const auto distPattern = landDistributionPatterns[i];
                 if (typePattern != distPattern)
                 {
                     continue;

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -546,8 +546,8 @@ namespace OpenLoco::World::MapGenerator
             Scenario::LandDistributionPattern::aroundCliffs,
         };
 
-        constexpr auto kProgressStart = 55;
-        constexpr auto kProgressEnd = 175;
+        constexpr auto kProgressStart = 52;
+        constexpr auto kProgressEnd = 178;
         constexpr auto kProgressRange = kProgressEnd - kProgressStart;
         constexpr auto kProgressStep = kProgressRange / ObjectManager::getMaxObjects(ObjectType::land);
 
@@ -1114,11 +1114,11 @@ namespace OpenLoco::World::MapGenerator
             updateProgress(45);
 
             generateTerrain(heightMap);
-            updateProgress(55);
+            updateProgress(52);
         }
 
         generateSurfaceVariation();
-        updateProgress(175);
+        updateProgress(178);
 
         generateTrees();
         updateProgress(200);

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -497,7 +497,7 @@ namespace OpenLoco::World::MapGenerator
     static void generateTerrainNull([[maybe_unused]] HeightMap& heightMap, [[maybe_unused]] uint8_t surfaceStyle) {}
 
     using GenerateTerrainFunc = void (*)(HeightMap&, uint8_t);
-    static constexpr GenerateTerrainFunc kGenerateFuncs[] = {
+    static const GenerateTerrainFunc _generateFuncs[] = {
         generateTerrainNull,               // LandDistributionPattern::everywhere This is null as it is a special function performed separately
         generateTerrainNull,               // LandDistributionPattern::nowhere
         generateTerrainFarFromWater,       // LandDistributionPattern::farFromWater
@@ -536,23 +536,37 @@ namespace OpenLoco::World::MapGenerator
             }
         }
 
-        constexpr auto kProgressStart = 52;
-        constexpr auto kProgressEnd = 178;
-        constexpr auto kProgressRange = kProgressEnd - kProgressStart;
-        constexpr auto kProgressStep = kProgressRange / ObjectManager::getMaxObjects(ObjectType::land);
+        constexpr std::array landDistributionPatterns = {
+            Scenario::LandDistributionPattern::farFromWater,
+            Scenario::LandDistributionPattern::nearWater,
+            Scenario::LandDistributionPattern::onMountains,
+            Scenario::LandDistributionPattern::farFromMountains,
+            Scenario::LandDistributionPattern::inSmallRandomAreas,
+            Scenario::LandDistributionPattern::inLargeRandomAreas,
+            Scenario::LandDistributionPattern::aroundCliffs,
+        };
 
-        for (uint8_t landObjectIdx = 0; landObjectIdx < ObjectManager::getMaxObjects(ObjectType::land); ++landObjectIdx)
+        for (auto i = 0U; i < landDistributionPatterns.size(); i++)
         {
-            updateProgress(kProgressStart + landObjectIdx * kProgressStep);
+            updateProgress(55 + 12 * i);
 
-            const auto* landObj = ObjectManager::get<LandObject>(landObjectIdx);
-            if (landObj == nullptr)
+            for (uint8_t landObjectIdx = 0; landObjectIdx < ObjectManager::getMaxObjects(ObjectType::land); ++landObjectIdx)
             {
-                continue;
-            }
+                const auto* landObj = ObjectManager::get<LandObject>(landObjectIdx);
+                if (landObj == nullptr)
+                {
+                    continue;
+                }
 
-            const auto typePattern = Scenario::getOptions().landDistributionPatterns[landObjectIdx];
-            kGenerateFuncs[enumValue(typePattern)](heightMap, landObjectIdx);
+                const auto typePattern = Scenario::getOptions().landDistributionPatterns[landObjectIdx];
+                const auto distPattern = landDistributionPatterns[i];
+                if (typePattern != distPattern)
+                {
+                    continue;
+                }
+
+                _generateFuncs[enumValue(distPattern)](heightMap, landObjectIdx);
+            }
         }
     }
 
@@ -1095,11 +1109,11 @@ namespace OpenLoco::World::MapGenerator
             updateProgress(45);
 
             generateTerrain(heightMap);
-            updateProgress(52);
+            updateProgress(55);
         }
 
         generateSurfaceVariation();
-        updateProgress(178);
+        updateProgress(175);
 
         generateTrees();
         updateProgress(200);

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -546,19 +546,24 @@ namespace OpenLoco::World::MapGenerator
             Scenario::LandDistributionPattern::aroundCliffs,
         };
 
-        for (auto i = 0U; i < landDistributionPatterns.size(); i++)
+        constexpr auto kProgressStart = 55;
+        constexpr auto kProgressEnd = 175;
+        constexpr auto kProgressRange = kProgressEnd - kProgressStart;
+        constexpr auto kProgressStep = kProgressRange / ObjectManager::getMaxObjects(ObjectType::land);
+
+        for (uint8_t landObjectIdx = 0; landObjectIdx < ObjectManager::getMaxObjects(ObjectType::land); ++landObjectIdx)
         {
-            updateProgress(55 + 12 * i);
+            updateProgress(kProgressStart + landObjectIdx * kProgressStep);
 
-            for (uint8_t landObjectIdx = 0; landObjectIdx < ObjectManager::getMaxObjects(ObjectType::land); ++landObjectIdx)
+            const auto* landObj = ObjectManager::get<LandObject>(landObjectIdx);
+            if (landObj == nullptr)
             {
-                const auto* landObj = ObjectManager::get<LandObject>(landObjectIdx);
-                if (landObj == nullptr)
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                const auto typePattern = Scenario::getOptions().landDistributionPatterns[landObjectIdx];
+            const auto typePattern = Scenario::getOptions().landDistributionPatterns[landObjectIdx];
+            for (auto i = 0U; i < landDistributionPatterns.size(); i++)
+            {
                 const auto distPattern = landDistributionPatterns[i];
                 if (typePattern != distPattern)
                 {

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -497,7 +497,7 @@ namespace OpenLoco::World::MapGenerator
     static void generateTerrainNull([[maybe_unused]] HeightMap& heightMap, [[maybe_unused]] uint8_t surfaceStyle) {}
 
     using GenerateTerrainFunc = void (*)(HeightMap&, uint8_t);
-    static const GenerateTerrainFunc _generateFuncs[] = {
+    static constexpr GenerateTerrainFunc kGenerateFuncs[] = {
         generateTerrainNull,               // LandDistributionPattern::everywhere This is null as it is a special function performed separately
         generateTerrainNull,               // LandDistributionPattern::nowhere
         generateTerrainFarFromWater,       // LandDistributionPattern::farFromWater
@@ -536,16 +536,6 @@ namespace OpenLoco::World::MapGenerator
             }
         }
 
-        constexpr std::array landDistributionPatterns = {
-            Scenario::LandDistributionPattern::farFromWater,
-            Scenario::LandDistributionPattern::nearWater,
-            Scenario::LandDistributionPattern::onMountains,
-            Scenario::LandDistributionPattern::farFromMountains,
-            Scenario::LandDistributionPattern::inSmallRandomAreas,
-            Scenario::LandDistributionPattern::inLargeRandomAreas,
-            Scenario::LandDistributionPattern::aroundCliffs,
-        };
-
         constexpr auto kProgressStart = 52;
         constexpr auto kProgressEnd = 178;
         constexpr auto kProgressRange = kProgressEnd - kProgressStart;
@@ -562,16 +552,7 @@ namespace OpenLoco::World::MapGenerator
             }
 
             const auto typePattern = Scenario::getOptions().landDistributionPatterns[landObjectIdx];
-            for (auto i = 0U; i < landDistributionPatterns.size(); i++)
-            {
-                const auto distPattern = landDistributionPatterns[i];
-                if (typePattern != distPattern)
-                {
-                    continue;
-                }
-
-                _generateFuncs[enumValue(distPattern)](heightMap, landObjectIdx);
-            }
+            kGenerateFuncs[enumValue(typePattern)](heightMap, landObjectIdx);
         }
     }
 

--- a/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
+++ b/src/OpenLoco/src/Map/MapGenerator/MapGenerator.cpp
@@ -474,7 +474,7 @@ namespace OpenLoco::World::MapGenerator
             if (std::abs(heightB - heightA) < kCliffTerrainHeightDiff)
             {
                 auto heightC = heightMap.getHeight({ pos + TilePos2{ 0, 0 } });
-                auto heightD = heightMap.getHeight({ pos + TilePos2{ 0, 1 } });
+                auto heightD = heightMap.getHeight({ pos + TilePos2{ 1, 0 } });
 
                 // Find no cliff between C and D?
                 if (std::abs(heightD - heightC) < kCliffTerrainHeightDiff)


### PR DESCRIPTION
~~Basically stops terrain generation from continuously repeating itself. Should be much faster to boot.~~

~~Progress is now reported by terrain type (max 32 objects) instead of distribution pattern (max 10 patterns). I've changed the progress step accordingly (128/32 instead of 120/10).~~

Found a mistake in `generateTerrainNearWater` and `generateTerrainAroundCliffs`, which fixes #3906.