### PR TITLE
Increment kMinBaseLandHeight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Change: [#3863] The toolbar buttons can now be set to open on click instead of hover.
 - Fix: [#2082] Scrollbars can be overdrawn when certain windows are resized but their scrollview is not.
 - Fix: [#2983] Can no longer scroll to adjust terraform tool size widgets.
+- Fix: [#3534] The minimum landscape height can be set to 0 in the landscape generator, while 1 is expected.
 - Fix: [#3597] News messages don't update viewport/image position correctly between messages.
 - Fix: [#3676] Fix bug where last land variation sprite went unused (original bug).
 - Fix: [#3855] UI invalidation issue when using switch company cheat.

--- a/src/OpenLoco/include/OpenLoco/Scenario/Scenario.h
+++ b/src/OpenLoco/include/OpenLoco/Scenario/Scenario.h
@@ -82,7 +82,7 @@ namespace OpenLoco::Scenario
     constexpr uint8_t kMinRiverMeanderRate = 0;
     constexpr uint8_t kMaxRiverMeanderRate = 20;
 
-    constexpr uint8_t kMinBaseLandHeight = 0;
+    constexpr uint8_t kMinBaseLandHeight = 1;
     constexpr uint8_t kMaxBaseLandHeight = 15;
 
     constexpr uint8_t kMinHillDensity = 0;


### PR DESCRIPTION
This constant is only used by the `LandscapeGeneration` window. Fixes #3534.