### PR TITLE
Add tutorial standby state and fix viewport panning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix: [#3855] UI invalidation issue when using switch company cheat.
 - Fix: [#3856] News ticker uses double the line height.
 - Fix: [#3858] Save file details can overflow the file browser window at minimum height.
+- Fix: [#3860] Viewport panning is broken during tutorial playback.
 - Fix: [#3861] The news sound setting is not read properly from the config file.
 - Fix: [#3888] Bridges can be drawn over tall buildings, industries and stations (original bug).
 - Fix: [#3890] On Linux/POSIX, setting the game path does not work correctly if it contains spaces.

--- a/src/OpenLoco/include/OpenLoco/Tutorial.h
+++ b/src/OpenLoco/include/OpenLoco/Tutorial.h
@@ -8,13 +8,15 @@ namespace OpenLoco::Tutorial
     {
         none,
         initialising,
+        standby,
         playing,
         recording,
     };
 
     State state();
 
-    void start(int16_t tutorialNumber);
+    void initialise(int16_t tutorialNumber);
+    void start();
     void stop();
 
     int32_t nextInput();

--- a/src/OpenLoco/src/Input/Keyboard.cpp
+++ b/src/OpenLoco/src/Input/Keyboard.cpp
@@ -130,6 +130,7 @@ namespace OpenLoco::Input
         {
             case Tutorial::State::none:
             case Tutorial::State::initialising:
+            case Tutorial::State::standby:
                 break;
 
             case Tutorial::State::playing:

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -288,6 +288,7 @@ namespace OpenLoco::Input
         {
             case Tutorial::State::none:
             case Tutorial::State::initialising:
+            case Tutorial::State::standby:
             {
                 _cursor2 = _cursor;
                 break;

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -583,7 +583,13 @@ namespace OpenLoco::Input
                 }
 
                 Ui::Point dragOffset = { x, y };
-                if (Tutorial::state() != Tutorial::State::playing)
+                if (Tutorial::state() == Tutorial::State::playing)
+                {
+                    // Tutorial has negative coords stored as int16_t when dragging.
+                    // OpenLoco uses int32_t, which makes them be interpreted as positive!
+                    dragOffset = { static_cast<int16_t>(x), static_cast<int16_t>(y) };
+                }
+                else
                 {
                     // Fix #151: use relative drag from one frame to the next rather than
                     //           using the relative position from the message loop

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -291,6 +291,11 @@ namespace OpenLoco
             _time_since_last_tick = 31;
         }
 
+        if (Tutorial::state() == Tutorial::State::standby && SceneManager::isPlayMode())
+        {
+            Tutorial::start();
+        }
+
         GameCommands::resetCommandNestLevel();
         Ui::tick();
 

--- a/src/OpenLoco/src/Tutorial.cpp
+++ b/src/OpenLoco/src/Tutorial.cpp
@@ -103,6 +103,8 @@ namespace OpenLoco::Tutorial
         // Disable options that interfere with tutorial operations.
         config.cheatsMenuEnabled = false;
         config.invertRightMouseViewPan = false;
+        config.toolbarAutoMenu = true;
+        config.toolbarButtonsCentred = false;
 
         // Get the environment file for this tutorial.
         static constexpr Environment::PathId tutorialFileIds[] = {

--- a/src/OpenLoco/src/Tutorial.cpp
+++ b/src/OpenLoco/src/Tutorial.cpp
@@ -61,7 +61,7 @@ namespace OpenLoco::Tutorial
     }
 
     // 0x0043C590
-    void start(int16_t tutorialNumber)
+    void initialise(int16_t tutorialNumber)
     {
         if (tutorialNumber < 0 || tutorialNumber > 3)
         {
@@ -124,7 +124,7 @@ namespace OpenLoco::Tutorial
             StringIds::tutorial_3_string_1,
         };
 
-        _state = State::playing;
+        _state = State::standby;
         _tutorialString = openingStringIds[_tutorialNumber];
 
         // Load the scenario
@@ -137,6 +137,12 @@ namespace OpenLoco::Tutorial
 
         // Start the scenario
         Scenario::start();
+    }
+
+    void start()
+    {
+        assert(_state == State::standby);
+        _state = State::playing;
     }
 
     // 0x0043C70E

--- a/src/OpenLoco/src/Tutorial.cpp
+++ b/src/OpenLoco/src/Tutorial.cpp
@@ -101,7 +101,9 @@ namespace OpenLoco::Tutorial
         }
 
         // Disable options that interfere with tutorial operations.
+        config.buildLockedVehicles = false;
         config.cheatsMenuEnabled = false;
+        config.displayLockedVehicles = false;
         config.invertRightMouseViewPan = false;
         config.toolbarAutoMenu = true;
         config.toolbarButtonsCentred = false;

--- a/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
@@ -433,7 +433,7 @@ namespace OpenLoco::Ui::Windows::TitleMenu
             return;
         }
 
-        OpenLoco::Tutorial::start(itemIndex);
+        OpenLoco::Tutorial::initialise(itemIndex);
     }
 
     static void sub_4391DA()


### PR DESCRIPTION
In #3851, we changed how the game transitions from one scene to the other. Rather than interrupting the current tick, we finish it, then transition the scene after. This works fine for normal transitions, but evidently the tutorial does not like it.

I've added a standby state, which the tutorial now transitions into just after initialising. The game scene then kicks off the tutorial if it notices one is standing by.

Further, there was an issue with viewport panning. Until #3836, this could lead to a crash when playing back the tutorial. However, the issue was caused by #3540, which changed the internal mouse coordinates from int16_t to int32_t. This led to the tutorial dragging coordinates to be interpreted as some wild mouse coordinates indeed.

Fixes #3860 (viewport panning)
Fixes #3921 (scene regression)