### PR TITLE
Fix incorrect namespace comment in InvalidationGrid.h

### DIFF
--- a/src/OpenLoco/include/OpenLoco/Graphics/InvalidationGrid.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/InvalidationGrid.h
@@ -82,5 +82,4 @@ namespace OpenLoco::Gfx
             }
         }
     };
-
-} // namespace OpenRCT2
+} // namespace OpenLoco::Gfx


### PR DESCRIPTION
Came across this by accident while lookup something up. Figured I’d just fix it.