### PR TITLE
Move close button in signal tab when tutorial is running

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -435,6 +435,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
             resetTrackTypeTabSelection(window);
             sub_4B92A5(window);
 
+            // TODO: REMOVE WHEN REWORKING TUTORIALS (and tutorial.h include above)
             if (OpenLoco::Tutorial::state() != OpenLoco::Tutorial::State::none)
             {
                 // Restore vanilla window layout

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -27,6 +27,7 @@
 #include "Objects/TrainStationObject.h"
 #include "Objects/VehicleObject.h"
 #include "SceneManager.h"
+#include "Tutorial.h"
 #include "Ui/ToolManager.h"
 #include "Ui/Widget.h"
 #include "Ui/Windows/Construction/Construction.h"
@@ -900,6 +901,14 @@ namespace OpenLoco::Ui::Windows::Construction
             self.holdableWidgets = 0;
 
             setDisabledWidgets(&self);
+
+            if (widgetIndex == widx::tab_signal && OpenLoco::Tutorial::state() != OpenLoco::Tutorial::State::none)
+            {
+                // Restore original window size/layout from before signal auto placement was added
+                // ...Or actually just the close button because I'm lazy and that is all is needed for the original tutorial 3 to play correctly
+                self.widgets[widx::close_button].left = 138 - 15;
+                self.widgets[widx::close_button].right = 138 - 15 + 13 - 1;
+            }
 
             self.invalidate();
 

--- a/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/Common.cpp
@@ -902,6 +902,7 @@ namespace OpenLoco::Ui::Windows::Construction
 
             setDisabledWidgets(&self);
 
+            // TODO: REMOVE WHEN REWORKING TUTORIALS (and tutorial.h include above)
             if (widgetIndex == widx::tab_signal && OpenLoco::Tutorial::state() != OpenLoco::Tutorial::State::none)
             {
                 // Restore original window size/layout from before signal auto placement was added

--- a/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Construction/ConstructionTab.cpp
@@ -1135,7 +1135,7 @@ namespace OpenLoco::Ui::Windows::Construction::Construction
 
         setDisabledWidgets(*window);
 
-        // TODO: rework when tutorial is reworked
+        // TODO: REMOVE WHEN REWORKING TUTORIALS (and tutorial.h include above)
         if (OpenLoco::Tutorial::state() != OpenLoco::Tutorial::State::none)
         {
             // Restore original window layout from before copy and paste buttons were added

--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -131,6 +131,7 @@ namespace OpenLoco::Ui::Windows::ToolbarTop::Game
                      .item(LoadSaveDropdownId::options, StringIds::options)
                      .item(LoadSaveDropdownId::screenshot, StringIds::menu_screenshot);
 
+        // TODO: REMOVE WHEN REWORKING TUTORIALS (the if statement - keep the item) (and tutorial.h include above)
         if (OpenLoco::Tutorial::state() == OpenLoco::Tutorial::State::none)
         {
             d.item(LoadSaveDropdownId::giantScreenshot, StringIds::menu_giant_screenshot);


### PR DESCRIPTION
Essentially a continuation of #3837

Makes Tutorial 3 work better

Note There is still a remaining issue where the tutorial messes up after or when setting the orders of the second vehicle. (I however do not care.)