### PR TITLE
Replace panel DIY invalidation with window invalidation

### DIFF
--- a/src/OpenLoco/include/OpenLoco/Ui/WindowManager.h
+++ b/src/OpenLoco/include/OpenLoco/Ui/WindowManager.h
@@ -153,7 +153,6 @@ namespace OpenLoco::Ui::Windows
     namespace CompanyInfoPanel
     {
         Window* open();
-        void invalidateFrame();
     }
 
     namespace CompanyList
@@ -398,7 +397,6 @@ namespace OpenLoco::Ui::Windows
     namespace TimePanel
     {
         Window* open();
-        void invalidateFrame();
         void beginSendChatMessage(Window& self);
     }
 

--- a/src/OpenLoco/src/GameCommands/Company/ChangeLoan.cpp
+++ b/src/OpenLoco/src/GameCommands/Company/ChangeLoan.cpp
@@ -45,7 +45,7 @@ namespace OpenLoco::GameCommands
             Ui::WindowManager::invalidate(Ui::WindowType::company, static_cast<uint16_t>(GameCommands::getUpdatingCompanyId()));
             if (CompanyManager::getControllingId() == GameCommands::getUpdatingCompanyId())
             {
-                Ui::Windows::CompanyInfoPanel::invalidateFrame();
+                Ui::WindowManager::invalidate(Ui::WindowType::companyInfoToolbar);
             }
         }
         return 0;

--- a/src/OpenLoco/src/GameCommands/GameCommands.cpp
+++ b/src/OpenLoco/src/GameCommands/GameCommands.cpp
@@ -299,7 +299,7 @@ namespace OpenLoco::GameCommands
             if ((SceneManager::getPauseFlags() & PauseFlags::player) != PauseFlags::none)
             {
                 SceneManager::unsetPauseFlag(PauseFlags::player);
-                Ui::Windows::CompanyInfoPanel::invalidateFrame();
+                WindowManager::invalidate(WindowType::companyInfoToolbar);
             }
 
             if (SceneManager::getGameSpeed() != GameSpeed::Normal)

--- a/src/OpenLoco/src/SceneManager.cpp
+++ b/src/OpenLoco/src/SceneManager.cpp
@@ -333,13 +333,13 @@ namespace OpenLoco::SceneManager
     static void onPause()
     {
         Audio::pauseSound();
-        Ui::Windows::TimePanel::invalidateFrame();
+        Ui::WindowManager::invalidate(Ui::WindowType::timeToolbar);
     }
 
     static void onUnpause()
     {
         Audio::unpauseSound();
-        Ui::Windows::TimePanel::invalidateFrame();
+        Ui::WindowManager::invalidate(Ui::WindowType::timeToolbar);
     }
 
     void setPauseFlag(PauseFlags value)

--- a/src/OpenLoco/src/Scenes/GameScene.cpp
+++ b/src/OpenLoco/src/Scenes/GameScene.cpp
@@ -164,7 +164,7 @@ namespace OpenLoco::Scenes::GameScene
                 auto today = calcDate(getCurrentDay());
                 setDate(today);
                 Scenario::updateSnowLine(today.dayOfYear);
-                Ui::Windows::TimePanel::invalidateFrame();
+                WindowManager::invalidate(WindowType::timeToolbar);
 
                 if (today.month != yesterday.month)
                 {

--- a/src/OpenLoco/src/Ui/Windows/CompanyInfoPanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyInfoPanel.cpp
@@ -62,8 +62,6 @@ namespace OpenLoco::Ui::Windows::CompanyInfoPanel
 
     std::vector<const Company*> _sortedCompanies;
 
-    static bool _redrawScheduled = false; // _50A004 (first bit)
-
     // 0x43AA4C
     static void competitorMouseDown(Ui::Window* self, WidgetIndex_t widgetIndex)
     {
@@ -351,11 +349,6 @@ namespace OpenLoco::Ui::Windows::CompanyInfoPanel
         formatPerformanceIndex(playerCompany->performanceIndex, args);
     }
 
-    void invalidateFrame()
-    {
-        _redrawScheduled = true;
-    }
-
     // 0x00439670
     static void onUpdate(Window& w)
     {
@@ -363,12 +356,6 @@ namespace OpenLoco::Ui::Windows::CompanyInfoPanel
         if (w.var_854 >= 24)
         {
             w.var_854 = 0;
-        }
-
-        if (_redrawScheduled)
-        {
-            _redrawScheduled = false;
-            WindowManager::invalidateWidget(WindowType::companyInfoToolbar, 0, widx::inner_frame);
         }
     }
 

--- a/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TimePanel.cpp
@@ -69,8 +69,6 @@ namespace OpenLoco::Ui::Windows::TimePanel
         Widgets::ImageButton(Widx::kFastForwardBtn, { 58, 15 }, { 20, 12 }, WindowColour::primary, ImageIds::speed_fast_forward, StringIds::tooltip_speed_fast_forward),
         Widgets::ImageButton(Widx::kExtraFastForwardBtn, { 78, 15 }, { 20, 12 }, WindowColour::primary, ImageIds::speed_extra_fast_forward, StringIds::tooltip_speed_extra_fast_forward));
 
-    static bool redrawScheduled = false; // 0x0050A004 (2nd bit)
-
     static const WindowEventList& getEvents();
 
     Window* open()
@@ -386,11 +384,6 @@ namespace OpenLoco::Ui::Windows::TimePanel
         Network::sendChatMessage(string);
     }
 
-    void invalidateFrame()
-    {
-        redrawScheduled = true;
-    }
-
     // 0x00439AD9
     static void onUpdate(Window& w)
     {
@@ -411,16 +404,8 @@ namespace OpenLoco::Ui::Windows::TimePanel
         {
             if (w.numTicksVisible == 0 || w.numTicksVisible == kPausedStatusTextDuration)
             {
-                redrawScheduled = true;
+                WindowManager::invalidate(WindowType::timeToolbar);
             }
-        }
-
-        if (redrawScheduled)
-        {
-            redrawScheduled = false;
-
-            // Invalidating the inner frame widget effectively causes the entire time panel to be redrawn.
-            WindowManager::invalidateWidget(WindowType::timeToolbar, 0, widx::inner_frame);
         }
     }
 

--- a/src/OpenLoco/src/World/CompanyManager.cpp
+++ b/src/OpenLoco/src/World/CompanyManager.cpp
@@ -1133,7 +1133,7 @@ namespace OpenLoco::CompanyManager
         // Invalidate the company balance if this is the player company
         if (getControllingId() == id)
         {
-            Ui::Windows::CompanyInfoPanel::invalidateFrame();
+            WindowManager::invalidate(WindowType::companyInfoToolbar);
         }
         auto cost = currency48_t{ payment };
         company->cash -= cost;


### PR DESCRIPTION
This replaces the partial invalidation of the company and time info panels with actual window invalidation. I think this 'DIY' invalidation was more relevant when they were part of one wide window, like in RCT. However, as it is, we can simplify it quite a bit.