### PR TITLE
Shrink and reposition top toolbar

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolbarTop.cpp
@@ -1611,10 +1611,19 @@ namespace OpenLoco::Ui::Windows::ToolbarTop
             }
         }
 
-        auto totalWidth = numVisibleWidgets * 30 + (4 * 11);
+        auto totalWidth = numVisibleWidgets * 30 + (3 * 11);
 
         // Left-hand side
-        uint32_t x = std::max(0, (Ui::width() - totalWidth) / 2);
+        int32_t x = std::max(0, (Ui::width() - totalWidth) / 2);
+        if (self.x != x)
+        {
+            self.invalidate();
+            self.x = x;
+            self.width = totalWidth;
+            self.invalidate();
+        }
+
+        x = 0;
         x = leftAlignButtons(self, x, { widx::loadsave_menu, widx::audio_menu, widx::cheats_menu, widx::map_generation_menu });
         x += 11;
         x = leftAlignButtons(self, x, { widx::zoom_menu, widx::rotate_menu, widx::view_menu });
@@ -1629,7 +1638,15 @@ namespace OpenLoco::Ui::Windows::ToolbarTop
     static void justifyToolbar(Window& self)
     {
         // Left-hand side
-        uint32_t x = 0;
+        int32_t x = 0;
+        if (self.x != x)
+        {
+            self.invalidate();
+            self.width = Ui::width();
+            self.x = x;
+            self.invalidate();
+        }
+
         x = leftAlignButtons(self, x, { widx::loadsave_menu, widx::audio_menu, widx::cheats_menu, widx::map_generation_menu });
         x += 11;
         x = leftAlignButtons(self, x, { widx::zoom_menu, widx::rotate_menu, widx::view_menu });


### PR DESCRIPTION
This resizes the top toolbar to just the size needed, and only when centred.

Before:
<img width="1111" height="714" alt="Boulder Breakers (3)" src="https://github.com/user-attachments/assets/67c14721-9bbc-4160-a5aa-7c6a2f9c409e" />

After:
<img width="1111" height="714" alt="Boulder Breakers (1)" src="https://github.com/user-attachments/assets/7efc8060-2629-440a-9585-ce16691e4c87" />

I've also backported this change to OpenRCT2: https://github.com/OpenRCT2/OpenRCT2/pull/26936.