### PR TITLE
Feature #3942. Add drag dimensions tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 26.08+ (???)
 ------------------------------------------------------------------------
+- Feature: [#3949] Added a tooltip to show the drag dimensions when using the map area selection tool.
 - Feature: [#3978] Improved automatic detection of Locomotion installs on Linux.
 - Change: [#3867] Repeated presses of the build tracks and build roads keyboard shortcuts now cycles track/road types.
 - Change: [#3967] English localisations now use typographically correct curved single quotes.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2520,4 +2520,4 @@ strings:
   2465: "Signals block"
   2466: "Has cargo order"
   2467: "Transports cargo"
-
+  2468: "{INT16} x {INT16}"

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -2177,6 +2177,7 @@ namespace OpenLoco::StringIds
     constexpr StringId capt_signals_block = 2465;
     constexpr StringId has_cargo_order = 2466;
     constexpr StringId transports_cargo = 2467;
+    constexpr StringId map_tooltip_int_x_int = 2468;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -1638,6 +1638,16 @@ namespace OpenLoco::Input
 
         if (!skipItem)
         {
+            if (World::hasMapSelectionFlag(World::MapSelectionFlags::enable))
+            {
+                const auto area = World::getMapSelectionArea();
+                const auto length = std::abs(area.first.x - area.second.x) / 32 + 1;
+                const auto depth = std::abs(area.first.y - area.second.y) / 32 + 1;
+                auto args = FormatArguments::mapToolTip();
+                args.push<StringId>(StringIds::map_tooltip_int_x_int);
+                args.push<int16_t>(length);
+                args.push<int16_t>(depth);
+            }
             ViewportInteraction::rightOver(x, y);
         }
 

--- a/src/OpenLoco/src/Input/MouseInput.cpp
+++ b/src/OpenLoco/src/Input/MouseInput.cpp
@@ -1643,6 +1643,7 @@ namespace OpenLoco::Input
                 const auto area = World::getMapSelectionArea();
                 const auto length = std::abs(area.first.x - area.second.x) / 32 + 1;
                 const auto depth = std::abs(area.first.y - area.second.y) / 32 + 1;
+
                 auto args = FormatArguments::mapToolTip();
                 args.push<StringId>(StringIds::map_tooltip_int_x_int);
                 args.push<int16_t>(length);

--- a/src/OpenLoco/src/Ui/Windows/MapToolTip.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapToolTip.cpp
@@ -2,6 +2,7 @@
 #include "Graphics/TextRenderer.h"
 #include "Input.h"
 #include "Localisation/FormatArguments.hpp"
+#include "Map/MapSelection.h"
 #include "Objects/CompetitorObject.h"
 #include "Objects/InterfaceSkinObject.h"
 #include "Objects/ObjectManager.h"
@@ -35,22 +36,25 @@ namespace OpenLoco::Ui::Windows::MapToolTip
         _mapTooltipTimeout++;
         auto cursor = Input::getMouseLocation();
 
-        static Ui::Point tooltipLocation = {};
-        if ((std::abs(tooltipLocation.x - cursor.x) > 5)
-            || (std::abs(tooltipLocation.y - cursor.y) > 5)
-            || Input::hasFlag(Input::Flags::rightMousePressed))
+        if (!World::hasMapSelectionFlag(World::MapSelectionFlags::enable))
         {
-            _mapTooltipTimeout = 0;
-        }
+            static Ui::Point tooltipLocation = {};
+            if ((std::abs(tooltipLocation.x - cursor.x) > 5)
+                || (std::abs(tooltipLocation.y - cursor.y) > 5)
+                || Input::hasFlag(Input::Flags::rightMousePressed))
+            {
+                _mapTooltipTimeout = 0;
+            }
 
-        tooltipLocation = cursor;
-        auto args = FormatArguments::mapToolTip();
-        FormatArgumentsView argsWrap(args);
-        auto firstArg = argsWrap.pop<StringId>();
-        if (_mapTooltipTimeout < 25 || firstArg == StringIds::null || Input::hasFlag(Input::Flags::rightMousePressed) || Input::hasKeyModifier(Input::KeyModifier::control) || Input::hasKeyModifier(Input::KeyModifier::shift) || WindowManager::find(WindowType::error) != nullptr)
-        {
-            WindowManager::close(WindowType::mapTooltip);
-            return;
+            tooltipLocation = cursor;
+            auto args = FormatArguments::mapToolTip();
+            FormatArgumentsView argsWrap(args);
+            auto firstArg = argsWrap.pop<StringId>();
+            if (_mapTooltipTimeout < 25 || firstArg == StringIds::null || Input::hasFlag(Input::Flags::rightMousePressed) || Input::hasKeyModifier(Input::KeyModifier::control) || Input::hasKeyModifier(Input::KeyModifier::shift) || WindowManager::find(WindowType::error) != nullptr)
+            {
+                WindowManager::close(WindowType::mapTooltip);
+                return;
+            }
         }
 
         const auto height = 55;


### PR DESCRIPTION
This adds it for all cases where you use the MapSelectionFlags::enable which is the rectangular map selection. I'm not too sure if that is how we want to do it though.