### PR TITLE
Fix terraform windows lashing out at other windows during close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.08+ (???)
 ------------------------------------------------------------------------
 - Fix: [#3943] Unable to place or remove signals on multi tile track elements.
+- Fix: [#3955] Terraform window can break dimensions of construction window.
 
 26.08 (2026-08-13)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TerraForm.cpp
@@ -384,11 +384,13 @@ namespace OpenLoco::Ui::Windows::Terraform
             if (!Input::hasFlag(Input::Flags::toolActive))
             {
                 WindowManager::close(&self);
+                return;
             }
 
             if (ToolManager::getToolWindowType() != WindowType::terraform)
             {
                 WindowManager::close(&self);
+                return;
             }
 
             if (!Input::hasFlag(Input::Flags::rightMousePressed))
@@ -2371,11 +2373,13 @@ namespace OpenLoco::Ui::Windows::Terraform
             if (!Input::hasFlag(Input::Flags::toolActive))
             {
                 WindowManager::close(&self);
+                return;
             }
 
             if (ToolManager::getToolWindowType() != WindowType::terraform)
             {
                 WindowManager::close(&self);
+                return;
             }
 
             if (!Input::hasFlag(Input::Flags::rightMousePressed))
@@ -2764,11 +2768,13 @@ namespace OpenLoco::Ui::Windows::Terraform
             if (!Input::hasFlag(Input::Flags::toolActive))
             {
                 WindowManager::close(&self);
+                return;
             }
 
             if (ToolManager::getToolWindowType() != WindowType::terraform)
             {
                 WindowManager::close(&self);
+                return;
             }
 
             self.frameNo++;


### PR DESCRIPTION
Looks like this has been here for a long time but now we've changed how often the resize event is triggered its flushed this mistake out.