### PR TITLE
Added Appimage build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,8 +392,6 @@ jobs:
         with:
           path: vcpkg-cache
           key: ${{ runner.os }}-vcpkg-ubuntu26.04.vcpkg-${{ steps.vcpkg_baseline.outputs.sha }}-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('vcpkg-cache/**') }}
-      - name: Smoke test
-        run: ./build/linux-vcpkg-static/dist/OpenLoco-*-linux-x64.AppImage --appimage-extract-and-run --version
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,6 @@ jobs:
     needs: check-code-formatting
     container:
       image: ghcr.io/openloco/openloco:12-ubuntu26.04.vcpkg
-      options: --device /dev/fuse
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -365,10 +364,6 @@ jobs:
         uses: ammaraskar/gcc-problem-matcher@master
       - name: Workaround git permissions issue
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - name: Install FUSE
-        run: |
-          apt-get update -qq
-          apt-get install -y -qq --no-install-recommends fuse
       - name: Setup cache env vars
         run: |
           echo "VCPKG_DEFAULT_BINARY_CACHE=$GITHUB_WORKSPACE/vcpkg-cache" >> "$GITHUB_ENV"
@@ -398,7 +393,7 @@ jobs:
           path: vcpkg-cache
           key: ${{ runner.os }}-vcpkg-ubuntu26.04.vcpkg-${{ steps.vcpkg_baseline.outputs.sha }}-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('vcpkg-cache/**') }}
       - name: Smoke test
-        run: ./build/linux-vcpkg-static/dist/OpenLoco-*-linux-x64.AppImage --version
+        run: ./build/linux-vcpkg-static/dist/OpenLoco-*-linux-x64.AppImage --appimage-extract-and-run --version
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,66 @@ jobs:
           path: artifacts/OpenLoco-linux-x64-glibc2.43.tar.gz
           archive: false
           if-no-files-found: error
+
+  appimage:
+    name: Linux x64 AppImage
+    runs-on: ubuntu-latest
+    needs: check-code-formatting
+    container:
+      image: ghcr.io/openloco/openloco:12-ubuntu26.04.vcpkg
+      options: --device /dev/fuse
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Install GCC problem matcher
+        uses: ammaraskar/gcc-problem-matcher@master
+      - name: Workaround git permissions issue
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Install FUSE
+        run: |
+          apt-get update -qq
+          apt-get install -y -qq --no-install-recommends fuse
+      - name: Setup cache env vars
+        run: |
+          echo "VCPKG_DEFAULT_BINARY_CACHE=$GITHUB_WORKSPACE/vcpkg-cache" >> "$GITHUB_ENV"
+      - name: Setup cache directories
+        run: mkdir -p "$GITHUB_WORKSPACE/vcpkg-cache"
+      - name: Get vcpkg baseline
+        id: vcpkg_baseline
+        run: |
+          sha=$(sed -n 's/^set(VCPKG_GIT_TAG[[:space:]]*\([0-9a-f]*\)).*/\1/p' CMakeLists.txt)
+          test -n "$sha" || { echo "VCPKG_GIT_TAG not found in CMakeLists.txt" >&2; exit 1; }
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+      - name: Restore binary cache
+        uses: actions/cache/restore@v6
+        with:
+          path: vcpkg-cache
+          key: ${{ runner.os }}-vcpkg-ubuntu26.04.vcpkg-${{ steps.vcpkg_baseline.outputs.sha }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-ubuntu26.04.vcpkg-${{ steps.vcpkg_baseline.outputs.sha }}-
+      - name: Build AppImage
+        run: |
+          cmake --preset linux-vcpkg-static -DOPENLOCO_BUILD_TESTS=OFF -DOPENLOCO_BUILD_APPIMAGE=ON
+          cmake --build --preset linux-vcpkg-static --target appimage
+      - name: Save binary cache
+        if: always()
+        uses: actions/cache/save@v6
+        with:
+          path: vcpkg-cache
+          key: ${{ runner.os }}-vcpkg-ubuntu26.04.vcpkg-${{ steps.vcpkg_baseline.outputs.sha }}-${{ hashFiles('vcpkg.json') }}-${{ hashFiles('vcpkg-cache/**') }}
+      - name: Smoke test
+        run: ./build/linux-vcpkg-static/dist/OpenLoco-*-linux-x64.AppImage --version
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: OpenLoco-linux-x64-AppImage
+          path: build/linux-vcpkg-static/dist/OpenLoco-*-linux-x64.AppImage
+          archive: false
+          if-no-files-found: error
+
   macos:
     name: macOS Sequoia ARM64 vcpkg
     runs-on: macos-15

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ include(OpenLocoUtility)
 option(STRICT "Build with warnings as errors" YES)
 option(OPENLOCO_BUILD_TESTS "Build tests" YES)
 option(OPENLOCO_HEADER_CHECK "Verify all public interfaces are standalone" NO)
+option(OPENLOCO_BUILD_APPIMAGE "Build a Linux x86_64 AppImage (custom target 'appimage')" OFF)
 
 if (APPLE)
     # Enable the use of e.g. std::execution::par
@@ -169,4 +170,8 @@ endif()
 if (NOT APPLE)
     install(DIRECTORY "data/" DESTINATION "${CMAKE_INSTALL_BINDIR}/data")
     install(DIRECTORY "${openloco_objects_SOURCE_DIR}" DESTINATION "${CMAKE_INSTALL_BINDIR}/data/objects")
+endif()
+
+if (OPENLOCO_BUILD_APPIMAGE)
+    include(OpenLocoAppImage)
 endif()

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,6 +20,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * luciditee
 * killerdevildog
 * ravsmedstrom
+* ben-leone
 
 ## Bugfixes
 * seifer7

--- a/cmake/OpenLocoAppImage.cmake
+++ b/cmake/OpenLocoAppImage.cmake
@@ -1,0 +1,75 @@
+# Linux x86_64 AppImage packaging (custom target: appimage).
+
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    message(FATAL_ERROR "OPENLOCO_BUILD_APPIMAGE is only supported on Linux")
+endif()
+
+if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
+    message(FATAL_ERROR "OPENLOCO_BUILD_APPIMAGE is only supported on x86_64, not ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+set(APPIMAGE_DIR "${CMAKE_BINARY_DIR}/appimage")
+set(APPIMAGE_APPDIR "${APPIMAGE_DIR}/AppDir")
+set(APPIMAGE_OUTPUT "${CMAKE_BINARY_DIR}/dist/OpenLoco-${OPENLOCO_VERSION_TAG}-linux-x64.AppImage")
+
+# Without --config, cmake --install would install every configuration of a multi-config build.
+set(APPIMAGE_INSTALL_ARGS)
+if (CMAKE_CONFIGURATION_TYPES)
+    set(APPIMAGE_INSTALL_ARGS --config Release)
+endif()
+
+set(APPIMAGETOOL "${APPIMAGE_DIR}/appimagetool-x86_64.AppImage")
+if (NOT EXISTS "${APPIMAGETOOL}")
+    file(DOWNLOAD
+        "https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage"
+        "${APPIMAGETOOL}"
+        STATUS APPIMAGETOOL_DOWNLOAD_STATUS
+        LOG APPIMAGETOOL_DOWNLOAD_LOG)
+    list(GET APPIMAGETOOL_DOWNLOAD_STATUS 0 APPIMAGETOOL_DOWNLOAD_CODE)
+    if (NOT APPIMAGETOOL_DOWNLOAD_CODE EQUAL 0)
+        file(REMOVE "${APPIMAGETOOL}")
+        message(FATAL_ERROR "Failed to download appimagetool: ${APPIMAGETOOL_DOWNLOAD_STATUS}\n${APPIMAGETOOL_DOWNLOAD_LOG}")
+    endif()
+    file(SHA256 "${APPIMAGETOOL}" APPIMAGETOOL_HASH)
+    if (NOT APPIMAGETOOL_HASH STREQUAL "ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0")
+        file(REMOVE "${APPIMAGETOOL}")
+        message(FATAL_ERROR "appimagetool hash mismatch: expected ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0, got ${APPIMAGETOOL_HASH}")
+    endif()
+    file(CHMOD "${APPIMAGETOOL}" PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+endif()
+
+# Running appimagetool (an AppImage itself) requires /dev/fuse. Without it, extract and run the unpacked binary.
+if (EXISTS /dev/fuse)
+    set(APPIMAGETOOL_EXECUTABLE "${APPIMAGETOOL}")
+else()
+    set(APPIMAGETOOL_EXECUTABLE "${APPIMAGE_DIR}/appimagetool-extracted/squashfs-root/AppRun")
+    add_custom_command(
+        OUTPUT "${APPIMAGETOOL_EXECUTABLE}"
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${APPIMAGE_DIR}/appimagetool-extracted"
+        COMMAND "${APPIMAGETOOL}" --appimage-extract
+        WORKING_DIRECTORY "${APPIMAGE_DIR}/appimagetool-extracted"
+        DEPENDS "${APPIMAGETOOL}"
+        COMMENT "Extracting appimagetool (no /dev/fuse)"
+        VERBATIM)
+endif()
+
+# Reuse the install rules for the AppDir payload, then add AppRun plus the root desktop file/icon that appimagetool embeds.
+add_custom_command(
+    OUTPUT "${APPIMAGE_OUTPUT}"
+    COMMAND "${CMAKE_COMMAND}" -E rm -rf "${APPIMAGE_APPDIR}"
+    COMMAND "${CMAKE_COMMAND}" --install "${CMAKE_BINARY_DIR}" --prefix "${APPIMAGE_APPDIR}/usr" ${APPIMAGE_INSTALL_ARGS}
+    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/distribution/linux/appimage/AppRun" "${APPIMAGE_APPDIR}/AppRun"
+    COMMAND chmod 755 "${APPIMAGE_APPDIR}/AppRun"
+    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/distribution/linux/openloco.desktop" "${APPIMAGE_APPDIR}/openloco.desktop"
+    COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_CURRENT_SOURCE_DIR}/src/Resources/src/logo/icon_x256.png" "${APPIMAGE_APPDIR}/openloco.png"
+    COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/dist"
+    COMMAND "${APPIMAGETOOL_EXECUTABLE}" "${APPIMAGE_APPDIR}" "${APPIMAGE_OUTPUT}"
+    DEPENDS App
+        "${CMAKE_CURRENT_SOURCE_DIR}/distribution/linux/appimage/AppRun"
+        "${CMAKE_CURRENT_SOURCE_DIR}/distribution/linux/openloco.desktop"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/Resources/src/logo/icon_x256.png"
+        "${APPIMAGETOOL_EXECUTABLE}"
+    COMMENT "Building ${APPIMAGE_OUTPUT}"
+    VERBATIM)
+
+add_custom_target(appimage DEPENDS "${APPIMAGE_OUTPUT}")

--- a/distribution/linux/appimage/AppRun
+++ b/distribution/linux/appimage/AppRun
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Bundled data is located relative to the executable, so no path manipulation is needed.
+DIR="$(dirname "$(readlink -f "$0")")"
+exec -a OpenLoco "$DIR/usr/bin/OpenLoco" "$@"


### PR DESCRIPTION
Added an appimage build as an additional linux portable artifact. Tested artifact output of ci, working on cachyos. 

Local Qwen3.6 instance was used to help build this. 