### PR TITLE
Fix clipRenderTarget for non-overlapping rects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.08+ (???)
 ------------------------------------------------------------------------
 - Change: [#3867] Repeated presses of the build tracks and build roads keyboard shortcuts now cycles track/road types.
+- Fix: [#3966] Clipping a render target that does not overlap no longer produces a negative-size rectangle.
 - Fix: [#3943] Unable to place or remove signals on multi tile track elements.
 - Fix: [#3955] Terraform window can break dimensions of construction window.
 

--- a/src/OpenLoco/src/Graphics/RenderTarget.cpp
+++ b/src/OpenLoco/src/Graphics/RenderTarget.cpp
@@ -11,6 +11,11 @@ namespace OpenLoco::Gfx
     std::optional<RenderTarget> clipRenderTarget(const RenderTarget& src, const Ui::Rect& newRect)
     {
         const Ui::Rect oldRect = src.getUiRect();
+        if (!oldRect.intersects(newRect))
+        {
+            return {};
+        }
+
         Ui::Rect intersect = oldRect.intersection(newRect);
         const auto stride = oldRect.size.width + src.pitch;
         const auto newPitch = stride - intersect.size.width;


### PR DESCRIPTION
## Summary
- `clipRenderTarget` computed an intersection even when the rectangles did not overlap, which produced a negative-size `Rect` and pointer arithmetic on that result.
- Return `nullopt` first via the existing `Rect::intersects` check.

Fixes #3966

## Test plan
- [ ] Game still draws the title screen and windows.
- [ ] Debug/assert builds no longer trip if `Rect::intersection` asserts non-negative size.