### PR TITLE
Fix 2753: Unable to remove walls and trees above 127 in height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.08+ (???)
 ------------------------------------------------------------------------
 - Change: [#3867] Repeated presses of the build tracks and build roads keyboard shortcuts now cycles track/road types.
+- Fix: [#2753] Unable to remove walls and trees at heights above 127.
 - Fix: [#3943] Unable to place or remove signals on multi tile track elements.
 - Fix: [#3955] Terraform window can break dimensions of construction window.
 

--- a/src/OpenLoco/include/OpenLoco/GameCommands/Terraform/RemoveTree.h
+++ b/src/OpenLoco/include/OpenLoco/GameCommands/Terraform/RemoveTree.h
@@ -10,7 +10,7 @@ namespace OpenLoco::GameCommands
 
         TreeRemovalArgs() = default;
         explicit TreeRemovalArgs(const registers& regs)
-            : pos(regs.ax, regs.cx, regs.dl * World::kSmallZStep)
+            : pos(regs.ax, regs.cx, static_cast<uint8_t>(regs.dl) * World::kSmallZStep)
             , type(regs.dh)
             , quadrant(regs.di & 0b11)
             , rotation(regs.bh & 0b11)

--- a/src/OpenLoco/include/OpenLoco/GameCommands/Terraform/RemoveWall.h
+++ b/src/OpenLoco/include/OpenLoco/GameCommands/Terraform/RemoveWall.h
@@ -10,7 +10,7 @@ namespace OpenLoco::GameCommands
 
         WallRemovalArgs() = default;
         explicit WallRemovalArgs(const registers& regs)
-            : pos(regs.ax, regs.cx, regs.dh * World::kSmallZStep)
+            : pos(regs.ax, regs.cx, static_cast<uint8_t>(regs.dh) * World::kSmallZStep)
             , rotation(regs.dl)
         {
         }


### PR DESCRIPTION
Mistake in serialisation. (Would have also been fixed during the serialisation work)