### PR TITLE
Allow filtering vehicle list by actual cargo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 26.08+ (???)
 ------------------------------------------------------------------------
 - Change: [#3867] Repeated presses of the build tracks and build roads keyboard shortcuts now cycles track/road types.
+- Change: [#3974] The vehicle list can now be filtered by vehicles that transport cargo, rather than just 'wait for' orders.
 - Fix: [#2753] Unable to remove walls and trees at heights above 127.
 - Fix: [#3943] Unable to place or remove signals on multi tile track elements.
 - Fix: [#3955] Terraform window can break dimensions of construction window.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2519,4 +2519,5 @@ strings:
   2464: "Step size:"
   2465: "Signals block"
   2466: "Has cargo order"
+  2467: "Transports cargo"
 

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2518,4 +2518,5 @@ strings:
   2463: "{SMALLFONT}{COLOUR BLACK}Place signals repeatedly at every ‘step size’ track elements"
   2464: "Step size:"
   2465: "Signals block"
+  2466: "Has cargo order"
 

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -2179,6 +2179,7 @@ namespace OpenLoco::StringIds
     constexpr StringId signal_placement_repeat_tooltip = 2463;
     constexpr StringId signal_placement_step_size = 2464;
     constexpr StringId capt_signals_block = 2465;
+    constexpr StringId has_cargo_order = 2466;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -2180,6 +2180,7 @@ namespace OpenLoco::StringIds
     constexpr StringId signal_placement_step_size = 2464;
     constexpr StringId capt_signals_block = 2465;
     constexpr StringId has_cargo_order = 2466;
+    constexpr StringId transports_cargo = 2467;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -581,8 +581,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
         static constexpr std::array<StringId, 3> kTypeToFilterStringIds{
             StringIds::all_vehicles,
-            StringIds::has_cargo_order,
             StringIds::transports_cargo,
+            StringIds::has_cargo_order,
         };
 
         {

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -157,14 +157,14 @@ namespace OpenLoco::Ui::Windows::VehicleList
         return self.var_850 == static_cast<uint16_t>(FilterMode::hasCargoOrder) && (!checkSelection || self.var_852 != 0xFFFF);
     }
 
-    constexpr bool isTransportingCargoFilterActive(const Window& self, bool checkSelection = true)
+    constexpr bool isTransportsCargoFilterActive(const Window& self, bool checkSelection = true)
     {
         return self.var_850 == static_cast<uint16_t>(FilterMode::transportingCargo) && (!checkSelection || self.var_852 != 0xFFFF);
     }
 
     constexpr bool isCargoFilterActive(const Window& self, bool checkSelection = true)
     {
-        return isCargoOrderFilterActive(self, checkSelection) || isTransportingCargoFilterActive(self, checkSelection);
+        return isCargoOrderFilterActive(self, checkSelection) || isTransportsCargoFilterActive(self, checkSelection);
     }
 
     using Vehicles::VehicleHead;
@@ -193,7 +193,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         return false;
     }
 
-    static bool vehicleIsTransportingCargo(const VehicleHead* head, int16_t filterCargoId)
+    static bool vehicleTransportsCargo(const VehicleHead* head, int16_t filterCargoId)
     {
         auto train = Vehicles::Vehicle(*head);
         for (auto& car : train.cars)
@@ -231,7 +231,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
                 continue;
             }
 
-            if (isTransportingCargoFilterActive(self) && !vehicleIsTransportingCargo(vehicle, self.var_852))
+            if (isTransportsCargoFilterActive(self) && !vehicleTransportsCargo(vehicle, self.var_852))
             {
                 continue;
             }
@@ -582,7 +582,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         static constexpr std::array<StringId, 3> kTypeToFilterStringIds{
             StringIds::all_vehicles,
             StringIds::has_cargo_order,
-            StringIds::transporting_cargo,
+            StringIds::transports_cargo,
         };
 
         {
@@ -835,7 +835,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
             Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 3, 0x80);
 
             Dropdown::add(0, StringIds::dropdown_stringid, StringIds::all_vehicles);
-            Dropdown::add(1, StringIds::dropdown_stringid, StringIds::transporting_cargo);
+            Dropdown::add(1, StringIds::dropdown_stringid, StringIds::transports_cargo);
             Dropdown::add(2, StringIds::dropdown_stringid, StringIds::has_cargo_order);
             Dropdown::setItemSelected(self.var_850);
         }

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -33,6 +33,8 @@
 #include "Vehicles/Vehicle.h"
 #include "Vehicles/Vehicle1.h"
 #include "Vehicles/Vehicle2.h"
+#include "Vehicles/VehicleBody.h"
+#include "Vehicles/VehicleBogie.h"
 #include "Vehicles/VehicleDraw.h"
 #include "Vehicles/VehicleHead.h"
 #include "Vehicles/VehicleManager.h"
@@ -135,6 +137,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     enum FilterMode : uint8_t
     {
         allVehicles,
+        hasCargoOrder,
         transportingCargo,
     };
 
@@ -149,14 +152,24 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
     static widx getTabFromType(VehicleType type);
 
-    constexpr bool isCargoFilterActive(const Window& self, bool checkSelection = true)
+    constexpr bool isCargoOrderFilterActive(const Window& self, bool checkSelection = true)
+    {
+        return self.var_850 == static_cast<uint16_t>(FilterMode::hasCargoOrder) && (!checkSelection || self.var_852 != 0xFFFF);
+    }
+
+    constexpr bool isTransportingCargoFilterActive(const Window& self, bool checkSelection = true)
     {
         return self.var_850 == static_cast<uint16_t>(FilterMode::transportingCargo) && (!checkSelection || self.var_852 != 0xFFFF);
     }
 
+    constexpr bool isCargoFilterActive(const Window& self, bool checkSelection = true)
+    {
+        return isCargoOrderFilterActive(self, checkSelection) || isTransportingCargoFilterActive(self, checkSelection);
+    }
+
     using Vehicles::VehicleHead;
 
-    static bool vehicleIsTransportingCargo(const VehicleHead* head, int16_t filterCargoId)
+    static bool vehicleHasCargoOrder(const VehicleHead* head, int16_t filterCargoId)
     {
         auto orders = Vehicles::OrderRingView(head->orderTableOffset);
         for (auto& order : orders)
@@ -173,6 +186,19 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
             const auto cargoId = cargoOrder->getCargo();
             if (cargoId == filterCargoId)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static bool vehicleIsTransportingCargo(const VehicleHead* head, int16_t filterCargoId)
+    {
+        auto train = Vehicles::Vehicle(*head);
+        for (auto& car : train.cars)
+        {
+            if (car.body->primaryCargo.type == filterCargoId || car.front->secondaryCargo.type == filterCargoId || car.back->secondaryCargo.type == filterCargoId)
             {
                 return true;
             }
@@ -200,7 +226,12 @@ namespace OpenLoco::Ui::Windows::VehicleList
                 continue;
             }
 
-            if (isCargoFilterActive(self) && !vehicleIsTransportingCargo(vehicle, self.var_852))
+            if (isCargoOrderFilterActive(self) && !vehicleHasCargoOrder(vehicle, self.var_852))
+            {
+                continue;
+            }
+
+            if (isTransportingCargoFilterActive(self) && !vehicleIsTransportingCargo(vehicle, self.var_852))
             {
                 continue;
             }
@@ -511,7 +542,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
         self.widgets[widx::sort_reliability].text = self.sortMode == SortMode::Reliability ? StringIds::table_header_reliability_desc : StringIds::table_header_reliability;
 
         // Disable cargo dropdown if not applicable
-        if (self.var_850 != FilterMode::transportingCargo)
+        if (self.var_850 == FilterMode::allVehicles)
         {
             self.disabledWidgets |= (1 << widx::cargo_type) | (1 << widx::cargo_type_btn);
         }
@@ -548,8 +579,9 @@ namespace OpenLoco::Ui::Windows::VehicleList
             args.push(self.rowCount);
         }
 
-        static constexpr std::array<StringId, 2> kTypeToFilterStringIds{
+        static constexpr std::array<StringId, 3> kTypeToFilterStringIds{
             StringIds::all_vehicles,
+            StringIds::has_cargo_order,
             StringIds::transporting_cargo,
         };
 
@@ -800,10 +832,11 @@ namespace OpenLoco::Ui::Windows::VehicleList
         else if (id == Widx::kFilterTypeBtn)
         {
             Widget dropdown = self.widgets[widx::filter_type];
-            Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 2, 0x80);
+            Dropdown::show(self.x + dropdown.left, self.y + dropdown.top, dropdown.width() - 4, dropdown.height(), self.getColour(WindowColour::secondary), 3, 0x80);
 
             Dropdown::add(0, StringIds::dropdown_stringid, StringIds::all_vehicles);
             Dropdown::add(1, StringIds::dropdown_stringid, StringIds::transporting_cargo);
+            Dropdown::add(2, StringIds::dropdown_stringid, StringIds::has_cargo_order);
             Dropdown::setItemSelected(self.var_850);
         }
         else if (id == Widx::kCargoTypeBtn)

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -137,8 +137,8 @@ namespace OpenLoco::Ui::Windows::VehicleList
     enum FilterMode : uint8_t
     {
         allVehicles,
-        hasCargoOrder,
         transportingCargo,
+        hasCargoOrder,
     };
 
     static constexpr uint8_t row_heights[] = {

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -137,7 +137,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
     enum FilterMode : uint8_t
     {
         allVehicles,
-        transportingCargo,
+        transportsCargo,
         hasCargoOrder,
     };
 
@@ -159,7 +159,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
 
     constexpr bool isTransportsCargoFilterActive(const Window& self, bool checkSelection = true)
     {
-        return self.var_850 == static_cast<uint16_t>(FilterMode::transportingCargo) && (!checkSelection || self.var_852 != 0xFFFF);
+        return self.var_850 == static_cast<uint16_t>(FilterMode::transportsCargo) && (!checkSelection || self.var_852 != 0xFFFF);
     }
 
     constexpr bool isCargoFilterActive(const Window& self, bool checkSelection = true)


### PR DESCRIPTION
This PR allows filtering the vehicle list by actual cargo contained by vehicles, in addition to filtering what cargo _orders_ a vehicle has. I believe this resolves #3957.

I have renamed the existing filter to 'Has cargo order' to better reflect its actual purpose, while using 'Transports cargo' for the new filter.