### PR TITLE
Town/growth formula product testing

### DIFF
--- a/src/OpenLoco/include/OpenLoco/World/Town.h
+++ b/src/OpenLoco/include/OpenLoco/World/Town.h
@@ -13,6 +13,7 @@ namespace OpenLoco
     constexpr int32_t kMinCompanyRating = -1000;
     constexpr int32_t kMaxCompanyRating = 1000;
     constexpr uint8_t kNumTownGrowthBrackets = 16;
+    constexpr uint8_t kNumGrowthCargos = 4;
 
     enum class TownFlags : uint16_t
     {
@@ -55,10 +56,11 @@ namespace OpenLoco
 
     struct TownGrowthInputCargo
     {
-        uint16_t pointsMultiplier;
-        uint16_t pointsCap;
-        TownSize necessaryAtThisSize;
-        uint8_t cargoType;
+        int32_t pointsMultiplier = 1;
+        int32_t pointsCap = std::numeric_limits<int32_t>::max();
+        int32_t pointsFloor = 0;
+        TownSize minimumTownSize = TownSize::hamlet;
+        uint8_t cargoType = 255;
     };
 
     using GrowthSpeed = uint8_t;
@@ -78,13 +80,13 @@ namespace OpenLoco
 
     struct TownGrowthSpeedBracket
     {
-        uint16_t minimumCargo;
-        GrowthSpeed speed;
+        int32_t maximumPoints = 0;
+        GrowthSpeed speed = TownGrowthSpeed::zero;
     };
 
     struct TownGrowthConfiguration
     {
-        std::array<TownGrowthInputCargo, 8> cargos;
+        std::array<TownGrowthInputCargo, kNumGrowthCargos> cargos;
         std::array<TownGrowthSpeedBracket, kNumTownGrowthBrackets> brackets;
     };
 
@@ -113,6 +115,7 @@ namespace OpenLoco
         uint8_t numberOfAirports; // 0x1A5
         uint16_t numStations;     // 0x1A6
         uint32_t var_1A8;
+        TownGrowthConfiguration growthConfiguration;
 
         bool empty() const;
         TownId id() const;
@@ -127,4 +130,5 @@ namespace OpenLoco
     };
 
     GrowthSpeed getTownGrowthSpeed(uint8_t bracket);
+    TownGrowthConfiguration getDefaultTownGrowthConfiguration();
 }

--- a/src/OpenLoco/include/OpenLoco/World/Town.h
+++ b/src/OpenLoco/include/OpenLoco/World/Town.h
@@ -59,6 +59,7 @@ namespace OpenLoco
         int32_t pointsMultiplier = 1;
         int32_t pointsCap = std::numeric_limits<int32_t>::max();
         int32_t pointsFloor = 0;
+        TownSize maximumTownSize = TownSize::metropolis;
         TownSize minimumTownSize = TownSize::hamlet;
         uint8_t cargoType = 255;
     };

--- a/src/OpenLoco/include/OpenLoco/World/Town.h
+++ b/src/OpenLoco/include/OpenLoco/World/Town.h
@@ -13,7 +13,7 @@ namespace OpenLoco
     constexpr int32_t kMinCompanyRating = -1000;
     constexpr int32_t kMaxCompanyRating = 1000;
     constexpr uint8_t kNumTownGrowthBrackets = 16;
-    constexpr uint8_t kNumGrowthCargos = 4;
+    constexpr uint8_t kNumGrowthCargos = 8;
 
     enum class TownFlags : uint16_t
     {
@@ -59,8 +59,8 @@ namespace OpenLoco
         int32_t pointsMultiplier = 1;
         int32_t pointsCap = std::numeric_limits<int32_t>::max();
         int32_t pointsFloor = 0;
-        TownSize maximumTownSize = TownSize::metropolis;
         TownSize minimumTownSize = TownSize::hamlet;
+        TownSize maximumTownSize = TownSize::metropolis;
         uint8_t cargoType = 255;
     };
 

--- a/src/OpenLoco/include/OpenLoco/World/Town.h
+++ b/src/OpenLoco/include/OpenLoco/World/Town.h
@@ -61,33 +61,32 @@ namespace OpenLoco
         uint8_t cargoType;
     };
 
-    enum class TownGrowthSpeed
+    using GrowthSpeed = uint8_t;
+    namespace TownGrowthSpeed
     {
-        zero,
-        oneEighth,
-        oneQuarter,
-        threeEighth,
-        oneHalf,
-        fiveEighth,
-        threeQuarter,
-        sevenEighth,
-        one,
-        two,
-        three,
-        four,
-        five,
-        six,
-        seven,
-        eight,
-        nine,
-    };
+        constexpr GrowthSpeed zero = 0;
+        constexpr GrowthSpeed oneEighth = 1;
+        constexpr GrowthSpeed oneQuarter = 2;
+        constexpr GrowthSpeed threeEighth = 3;
+        constexpr GrowthSpeed oneHalf = 4;
+        constexpr GrowthSpeed fiveEighth = 5;
+        constexpr GrowthSpeed threeQuarter = 6;
+        constexpr GrowthSpeed sevenEighth = 7;
+        constexpr GrowthSpeed intZero = 7;
+        constexpr GrowthSpeed one = 8;
+    }
 
     struct TownGrowthSpeedBracket
     {
         uint16_t minimumCargo;
-        TownGrowthSpeed speed;
+        GrowthSpeed speed;
     };
-    using TownGrowthSpeedBrackets = std::array<TownGrowthSpeedBracket, kNumTownGrowthBrackets>;
+
+    struct TownGrowthConfiguration
+    {
+        std::array<TownGrowthInputCargo, 8> cargos;
+        std::array<TownGrowthSpeedBracket, kNumTownGrowthBrackets> brackets;
+    };
 
     struct Town
     {
@@ -110,7 +109,7 @@ namespace OpenLoco
         uint16_t monthlyCargoDelivered[32]; // 0x158
         uint32_t cargoInfluenceFlags;       // 0x198
         uint16_t var_19C[2][2];
-        uint8_t buildSpeed;       // 0x1A4, 1=slow build speed, 4=fast build speed
+        GrowthSpeed buildSpeed;   // 0x1A4
         uint8_t numberOfAirports; // 0x1A5
         uint16_t numStations;     // 0x1A6
         uint32_t var_1A8;
@@ -126,4 +125,6 @@ namespace OpenLoco
         void grow(TownGrowFlags growFlags);
         StringId getTownSizeString() const;
     };
+
+    GrowthSpeed getTownGrowthSpeed(uint8_t bracket);
 }

--- a/src/OpenLoco/include/OpenLoco/World/Town.h
+++ b/src/OpenLoco/include/OpenLoco/World/Town.h
@@ -12,6 +12,7 @@ namespace OpenLoco
 {
     constexpr int32_t kMinCompanyRating = -1000;
     constexpr int32_t kMaxCompanyRating = 1000;
+    constexpr uint8_t kNumTownGrowthBrackets = 16;
 
     enum class TownFlags : uint16_t
     {
@@ -52,6 +53,42 @@ namespace OpenLoco
         struct RenderTarget;
     }
 
+    struct TownGrowthInputCargo
+    {
+        uint16_t pointsMultiplier;
+        uint16_t pointsCap;
+        TownSize necessaryAtThisSize;
+        uint8_t cargoType;
+    };
+
+    enum class TownGrowthSpeed
+    {
+        zero,
+        oneEighth,
+        oneQuarter,
+        threeEighth,
+        oneHalf,
+        fiveEighth,
+        threeQuarter,
+        sevenEighth,
+        one,
+        two,
+        three,
+        four,
+        five,
+        six,
+        seven,
+        eight,
+        nine,
+    };
+
+    struct TownGrowthSpeedBracket
+    {
+        uint16_t minimumCargo;
+        TownGrowthSpeed speed;
+    };
+    using TownGrowthSpeedBrackets = std::array<TownGrowthSpeedBracket, kNumTownGrowthBrackets>;
+
     struct Town
     {
         StringId name;                      // 0x00
@@ -80,7 +117,7 @@ namespace OpenLoco
 
         bool empty() const;
         TownId id() const;
-        void tick();
+        void tick(uint8_t tickNum);
         void drawLabel(Gfx::DrawingContext& drawingCtx, ZoomLevel zoom);
         void updateLabel();
         void updateMonthly();

--- a/src/OpenLoco/include/OpenLoco/World/Town.h
+++ b/src/OpenLoco/include/OpenLoco/World/Town.h
@@ -80,7 +80,7 @@ namespace OpenLoco
 
     struct TownGrowthSpeedBracket
     {
-        int32_t maximumPoints = 0;
+        int32_t startThreshold = 0;
         GrowthSpeed speed = TownGrowthSpeed::zero;
     };
 

--- a/src/OpenLoco/include/OpenLoco/World/Town.h
+++ b/src/OpenLoco/include/OpenLoco/World/Town.h
@@ -131,5 +131,6 @@ namespace OpenLoco
     };
 
     GrowthSpeed getTownGrowthSpeed(uint8_t bracket);
+    uint8_t getLegacyTownGrowthSpeed(GrowthSpeed speed);
     TownGrowthConfiguration getDefaultTownGrowthConfiguration();
 }

--- a/src/OpenLoco/src/S5/S5Town.cpp
+++ b/src/OpenLoco/src/S5/S5Town.cpp
@@ -61,6 +61,7 @@ namespace OpenLoco::S5
         dst.numberOfAirports = src.numberOfAirports;
         dst.numStations = src.numStations;
         dst.var_1A8 = src.var_1A8;
+        dst.growthConfiguration = getDefaultTownGrowthConfiguration();
         return dst;
     }
 }

--- a/src/OpenLoco/src/S5/S5Town.cpp
+++ b/src/OpenLoco/src/S5/S5Town.cpp
@@ -27,8 +27,7 @@ namespace OpenLoco::S5
         std::ranges::copy(src.monthlyCargoDelivered, dst.monthlyCargoDelivered);
         dst.cargoInfluenceFlags = src.cargoInfluenceFlags;
         std::memcpy(dst.var_19C, src.var_19C, sizeof(dst.var_19C));
-        // not implemented
-        dst.buildSpeed = 1;
+        dst.buildSpeed = getLegacyTownGrowthSpeed(src.buildSpeed);
         dst.numberOfAirports = src.numberOfAirports;
         dst.numStations = src.numStations;
         dst.var_1A8 = src.var_1A8;

--- a/src/OpenLoco/src/S5/S5Town.cpp
+++ b/src/OpenLoco/src/S5/S5Town.cpp
@@ -27,7 +27,8 @@ namespace OpenLoco::S5
         std::ranges::copy(src.monthlyCargoDelivered, dst.monthlyCargoDelivered);
         dst.cargoInfluenceFlags = src.cargoInfluenceFlags;
         std::memcpy(dst.var_19C, src.var_19C, sizeof(dst.var_19C));
-        dst.buildSpeed = src.buildSpeed;
+        // not implemented
+        dst.buildSpeed = 1;
         dst.numberOfAirports = src.numberOfAirports;
         dst.numStations = src.numStations;
         dst.var_1A8 = src.var_1A8;
@@ -56,7 +57,7 @@ namespace OpenLoco::S5
         std::ranges::copy(src.monthlyCargoDelivered, dst.monthlyCargoDelivered);
         dst.cargoInfluenceFlags = src.cargoInfluenceFlags;
         std::memcpy(dst.var_19C, src.var_19C, sizeof(dst.var_19C));
-        dst.buildSpeed = src.buildSpeed;
+        dst.buildSpeed = getTownGrowthSpeed(src.buildSpeed);
         dst.numberOfAirports = src.numberOfAirports;
         dst.numStations = src.numStations;
         dst.var_1A8 = src.var_1A8;

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -356,22 +356,26 @@ namespace OpenLoco
             }
             if (size < cargo.minimumTownSize)
             {
+                printf("Town %d was smaller than minimum for cargo %d (%d < %d)\n", enumValue(id()), cargo.cargoType, enumValue(cargo.minimumTownSize), enumValue(size));
                 continue;
             }
             if (size > cargo.maximumTownSize)
             {
+                printf("Town %d was larger than maximum for cargo %d (%d > %d)\n", enumValue(id()), cargo.cargoType, enumValue(cargo.maximumTownSize), enumValue(size));
                 continue;
             }
             auto cargoPoints = std::clamp<int32_t>(monthlyCargoDelivered[cargo.cargoType] * cargo.pointsMultiplier, cargo.pointsFloor, cargo.pointsCap);
             points += cargoPoints;
         }
         GrowthSpeed speed = TownGrowthSpeed::zero;
+        int32_t previousBracket = std::numeric_limits<int32_t>::min();
         for (auto bracket : growthConfiguration.brackets)
         {
-            if (bracket.startThreshold >= points)
+            if ((bracket.startThreshold > points) || (previousBracket > bracket.startThreshold))
             {
                 break;
             }
+            previousBracket = bracket.startThreshold;
             speed = bracket.speed;
         }
         printf("Town %d scored %d points this month. Growth speed is %s\n", enumValue(id()), points, getTownGrowthSpeedName(speed).c_str());

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -51,8 +51,9 @@ namespace OpenLoco
      * Update town
      *
      * @param this @<esi>
+     * @param tickNum
      */
-    void Town::tick()
+    void Town::tick(uint8_t tickNum)
     {
         recalculateSize();
 
@@ -60,7 +61,7 @@ namespace OpenLoco
         {
             return;
         }
-
+        assert(buildSpeed < 6);
         static constexpr std::array<uint8_t, 12> kBuildSpeedToGrowthPerTick = { 0, 1, 3, 5, 7, 9, 12, 16, 22, 0, 0, 0 };
         auto growthPerTick = kBuildSpeedToGrowthPerTick[this->buildSpeed];
         if (growthPerTick == 0 || (growthPerTick == 1 && (gPrng1().randNext() & 7)))

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -23,6 +23,7 @@
 #include "Objects/BuildingObject.h"
 #include "Objects/ObjectManager.h"
 #include "Objects/ObjectUtils.h"
+#include "Objects/RegionObject.h"
 #include "Objects/RoadObject.h"
 #include "Objects/RoadStationObject.h"
 #include "Objects/StreetLightObject.h"
@@ -156,6 +157,48 @@ namespace OpenLoco
         return kBuildSpeedToGrowthPerTick[bracket];
     }
 
+    TownGrowthConfiguration getDefaultTownGrowthConfiguration()
+    {
+        // this is specifically designed to work with the vanilla region objects. Custom region objects may not work.
+        uint8_t paxCargoId = 255;
+        const auto* regionObj = ObjectManager::get<RegionObject>();
+        for (auto i = 0U; i < regionObj->numCargoInflunceObjects; ++i)
+        {
+            auto a = regionObj->cargoInfluenceObjectIds[i];
+            if (a != 255 && regionObj->cargoInfluenceTownFilter[i] == CargoInfluenceTownFilterType::allTowns)
+            {
+                paxCargoId = i;
+                break;
+            }
+        }
+        assert(paxCargoId != 255);
+        TownGrowthConfiguration config = {
+            {
+                TownGrowthInputCargo(
+                    1,
+                    300,
+                    0,
+                    TownSize::hamlet,
+                    paxCargoId),
+            },
+            {
+                TownGrowthSpeedBracket(
+                    100,
+                    TownGrowthSpeed::oneEighth),
+                TownGrowthSpeedBracket(
+                    200,
+                    TownGrowthSpeed::intZero + 3),
+                TownGrowthSpeedBracket(
+                    300,
+                    TownGrowthSpeed::intZero + 5),
+                TownGrowthSpeedBracket(
+                    65535,
+                    TownGrowthSpeed::intZero + 5),
+            },
+        };
+        return config;
+    }
+
     // 0x0049749B
     void Town::updateMonthly()
     {
@@ -225,22 +268,26 @@ namespace OpenLoco
             }
         }
 
-        // Work towards computing new build speed.
-        // will be the smallest of the influence cargo delivered to the town
-        // i.e. to get maximum growth max of the influence cargo must be delivered
-        // every update. If no influence cargo the town grows at max rate
-        uint16_t minCargoDelivered = std::numeric_limits<uint16_t>::max();
-        uint32_t cargoFlags = cargoInfluenceFlags;
-        while (cargoFlags != 0)
+        int32_t points = 0;
+        for (auto cargo: growthConfiguration.cargos)
         {
-            uint32_t cargoId = Numerics::bitScanForward(cargoFlags);
-            cargoFlags &= ~(1 << cargoId);
-
-            minCargoDelivered = std::min(minCargoDelivered, monthlyCargoDelivered[cargoId]);
+            if (cargo.cargoType == 255)
+                continue;
+            if (size < cargo.minimumTownSize)
+                continue;
+            auto cargoPoints = std::clamp<int32_t>(monthlyCargoDelivered[cargo.cargoType] * cargo.pointsMultiplier, cargo.pointsFloor, cargo.pointsCap);
+            points += cargoPoints;
         }
-        // Compute build speed (1=slow build speed, 4=fast build speed)
-        buildSpeed = getTownGrowthSpeed(std::clamp((minCargoDelivered / 100) + 1, 1, 4));
-
+        GrowthSpeed speed = TownGrowthSpeed::zero;
+        for (auto bracket: growthConfiguration.brackets)
+        {
+            if (bracket.maximumPoints > points)
+            {
+                speed = bracket.speed;
+                break;
+            }
+        }
+        buildSpeed = speed;
         // Reset all monthlyCargoDelivered intermediaries to zero.
         memset(&monthlyCargoDelivered, 0, sizeof(monthlyCargoDelivered));
     }

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -71,7 +71,7 @@ namespace OpenLoco
                 break;
         }
         char buff[4];
-        sprintf(buff,"%d",speed - TownGrowthSpeed::intZero);
+        sprintf(buff, "%d", speed - TownGrowthSpeed::intZero);
         return buff;
     }
 
@@ -191,7 +191,7 @@ namespace OpenLoco
     {
         auto objHeader = ObjectHeader();
         objHeader.flags = enumValue(ObjectType::cargo);
-        memcpy(objHeader.name, name.c_str(),8);
+        memcpy(objHeader.name, name.c_str(), 8);
         return ObjectManager::findObjectHandle(objHeader);
     }
 
@@ -366,7 +366,7 @@ namespace OpenLoco
             }
             speed = bracket.speed;
         }
-        printf("Town %d scored %d points this month. Growth speed is %s\n",enumValue(id()),points,getTownGrowthSpeedName(speed).c_str());
+        printf("Town %d scored %d points this month. Growth speed is %s\n", enumValue(id()), points, getTownGrowthSpeedName(speed).c_str());
         buildSpeed = speed;
         // Reset all monthlyCargoDelivered intermediaries to zero.
         memset(&monthlyCargoDelivered, 0, sizeof(monthlyCargoDelivered));

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -187,6 +187,43 @@ namespace OpenLoco
         return kBuildSpeedToGrowthPerTick[bracket];
     }
 
+    uint8_t getLegacyTownGrowthSpeed(GrowthSpeed speed)
+    {
+        if (speed == TownGrowthSpeed::zero)
+        {
+            return 0;
+        }
+        if (speed < TownGrowthSpeed::intZero + 3)
+        {
+            return 1;
+        }
+        if (speed < TownGrowthSpeed::intZero + 5)
+        {
+            return 2;
+        }
+        if (speed < TownGrowthSpeed::intZero + 7)
+        {
+            return 3;
+        }
+        if (speed < TownGrowthSpeed::intZero + 9)
+        {
+            return 4;
+        }
+        if (speed < TownGrowthSpeed::intZero + 12)
+        {
+            return 5;
+        }
+        if (speed < TownGrowthSpeed::intZero + 16)
+        {
+            return 6;
+        }
+        if (speed < TownGrowthSpeed::intZero + 22)
+        {
+            return 7;
+        }
+        return 8;
+    }
+
     static std::optional<LoadedObjectHandle> getCargoObject(std::string name)
     {
         auto objHeader = ObjectHeader();

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -187,20 +187,23 @@ namespace OpenLoco
         return kBuildSpeedToGrowthPerTick[bracket];
     }
 
+    static std::optional<LoadedObjectHandle> getCargoObject(std::string name)
+    {
+        auto objHeader = ObjectHeader();
+        objHeader.flags = enumValue(ObjectType::cargo);
+        memcpy(objHeader.name, name.c_str(),8);
+        return ObjectManager::findObjectHandle(objHeader);
+    }
+
     TownGrowthConfiguration getDefaultTownGrowthConfiguration()
     {
-        // this is specifically designed to work with the vanilla region objects. Custom region objects may not work.
         uint8_t paxCargoId = 255;
-        const auto* regionObj = ObjectManager::get<RegionObject>();
-        for (auto i = 0U; i < regionObj->numCargoInflunceObjects; ++i)
+        auto res = getCargoObject("PASS    ");
+        if (res.has_value())
         {
-            auto a = regionObj->cargoInfluenceObjectIds[i];
-            if (a != 255 && regionObj->cargoInfluenceTownFilter[i] == CargoInfluenceTownFilterType::allTowns)
-            {
-                paxCargoId = a;
-                break;
-            }
+            paxCargoId = res->id;
         }
+
         assert(paxCargoId != 255);
         TownGrowthConfiguration config = {
             {

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -61,15 +61,13 @@ namespace OpenLoco
         {
             return;
         }
-        assert(buildSpeed < 6);
-        static constexpr std::array<uint8_t, 12> kBuildSpeedToGrowthPerTick = { 0, 1, 3, 5, 7, 9, 12, 16, 22, 0, 0, 0 };
-        auto growthPerTick = kBuildSpeedToGrowthPerTick[this->buildSpeed];
-        if (growthPerTick == 0 || (growthPerTick == 1 && (gPrng1().randNext() & 7)))
+        if (buildSpeed < TownGrowthSpeed::one && tickNum >= buildSpeed)
         {
             grow(TownGrowFlags::buildInitialRoad | TownGrowFlags::roadUpdate | TownGrowFlags::neutralRoadTakeover);
         }
-        else
+        else if (buildSpeed > TownGrowthSpeed::zero)
         {
+            auto growthPerTick = buildSpeed >= TownGrowthSpeed::one ? buildSpeed - TownGrowthSpeed::intZero : 1;
             for (int32_t counter = 0; counter < growthPerTick; ++counter)
             {
                 grow(TownGrowFlags::buildInitialRoad | TownGrowFlags::roadUpdate | TownGrowFlags::neutralRoadTakeover | TownGrowFlags::allowRoadExpansion | TownGrowFlags::allowRoadBranching | TownGrowFlags::constructBuildings);
@@ -137,6 +135,25 @@ namespace OpenLoco
             labelFrame.top[index] = zoom.applyInversedTo(yOffset);
             labelFrame.bottom[index] = labelFrame.top[index] + uiHeight;
         }
+    }
+
+    GrowthSpeed getTownGrowthSpeed(uint8_t bracket)
+    {
+        static constexpr std::array<GrowthSpeed, 12> kBuildSpeedToGrowthPerTick = {
+            TownGrowthSpeed::zero,
+            TownGrowthSpeed::oneEighth,
+            TownGrowthSpeed::intZero + 3,
+            TownGrowthSpeed::intZero + 5,
+            TownGrowthSpeed::intZero + 7,
+            TownGrowthSpeed::intZero + 9,
+            TownGrowthSpeed::intZero + 12,
+            TownGrowthSpeed::intZero + 16,
+            TownGrowthSpeed::intZero + 22,
+            TownGrowthSpeed::zero,
+            TownGrowthSpeed::zero,
+            TownGrowthSpeed::zero,
+        };
+        return kBuildSpeedToGrowthPerTick[bracket];
     }
 
     // 0x0049749B
@@ -221,9 +238,8 @@ namespace OpenLoco
 
             minCargoDelivered = std::min(minCargoDelivered, monthlyCargoDelivered[cargoId]);
         }
-
         // Compute build speed (1=slow build speed, 4=fast build speed)
-        buildSpeed = std::clamp((minCargoDelivered / 100) + 1, 1, 4);
+        buildSpeed = getTownGrowthSpeed(std::clamp((minCargoDelivered / 100) + 1, 1, 4));
 
         // Reset all monthlyCargoDelivered intermediaries to zero.
         memset(&monthlyCargoDelivered, 0, sizeof(monthlyCargoDelivered));

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -198,35 +198,77 @@ namespace OpenLoco
     TownGrowthConfiguration getDefaultTownGrowthConfiguration()
     {
         uint8_t paxCargoId = 255;
+        uint8_t mailCargoId = 255;
+        uint8_t goodsCargoId = 255;
+        uint8_t foodCargoId = 255;
         auto res = getCargoObject("PASS    ");
         if (res.has_value())
         {
             paxCargoId = res->id;
         }
+        res = getCargoObject("GOODS   ");
+        if (res.has_value())
+        {
+            goodsCargoId = res->id;
+        }
+        res = getCargoObject("FOOD    ");
+        if (res.has_value())
+        {
+            foodCargoId = res->id;
+        }
+        res = getCargoObject("MAIL    ");
+        if (res.has_value())
+        {
+            mailCargoId = res->id;
+        }
 
         assert(paxCargoId != 255);
+        assert(goodsCargoId != 255);
+        assert(foodCargoId != 255);
+        assert(mailCargoId != 255);
         TownGrowthConfiguration config = {
             {
                 TownGrowthInputCargo(
                     1,
-                    300,
+                    65535,
                     0,
                     TownSize::hamlet,
                     paxCargoId),
+                TownGrowthInputCargo(
+                    2,
+                    65535,
+                    0,
+                    TownSize::hamlet,
+                    mailCargoId),
+                TownGrowthInputCargo(
+                    10,
+                    65535,
+                    0,
+                    TownSize::hamlet,
+                    foodCargoId),
+                TownGrowthInputCargo(
+                    10,
+                    65535,
+                    0,
+                    TownSize::hamlet,
+                    goodsCargoId),
             },
             {
                 TownGrowthSpeedBracket(
-                    100,
+                    50,
                     TownGrowthSpeed::oneEighth),
                 TownGrowthSpeedBracket(
-                    200,
+                    400,
+                    TownGrowthSpeed::one),
+                TownGrowthSpeedBracket(
+                    800,
                     TownGrowthSpeed::intZero + 3),
                 TownGrowthSpeedBracket(
-                    300,
+                    1250,
                     TownGrowthSpeed::intZero + 5),
                 TownGrowthSpeedBracket(
                     65535,
-                    TownGrowthSpeed::intZero + 5),
+                    TownGrowthSpeed::intZero + 7),
             },
         };
         return config;

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -47,6 +47,34 @@ namespace OpenLoco
         return name == StringIds::null;
     }
 
+    static std::string getTownGrowthSpeedName(GrowthSpeed speed)
+    {
+        switch (speed)
+        {
+            case TownGrowthSpeed::zero:
+                return "0";
+            case TownGrowthSpeed::oneEighth:
+                return "1/8";
+            case TownGrowthSpeed::oneQuarter:
+                return "1/4";
+            case TownGrowthSpeed::threeEighth:
+                return "3/8";
+            case TownGrowthSpeed::oneHalf:
+                return "1/2";
+            case TownGrowthSpeed::fiveEighth:
+                return "5/8";
+            case TownGrowthSpeed::threeQuarter:
+                return "3/4";
+            case TownGrowthSpeed::sevenEighth:
+                return "7/8";
+            default:
+                break;
+        }
+        char buff[4];
+        sprintf(buff,"%d",speed - TownGrowthSpeed::intZero);
+        return buff;
+    }
+
     /**
      * 0x0049742F
      * Update town
@@ -62,7 +90,9 @@ namespace OpenLoco
         {
             return;
         }
-        if (buildSpeed < TownGrowthSpeed::one && tickNum >= buildSpeed)
+        printf("Ticking town %d with growth speed %s\n", enumValue(id()), getTownGrowthSpeedName(buildSpeed).c_str());
+        auto rng = gPrng1().randNext() & 7;
+        if (buildSpeed < TownGrowthSpeed::one && buildSpeed > rng)
         {
             grow(TownGrowFlags::buildInitialRoad | TownGrowFlags::roadUpdate | TownGrowFlags::neutralRoadTakeover);
         }
@@ -167,7 +197,7 @@ namespace OpenLoco
             auto a = regionObj->cargoInfluenceObjectIds[i];
             if (a != 255 && regionObj->cargoInfluenceTownFilter[i] == CargoInfluenceTownFilterType::allTowns)
             {
-                paxCargoId = i;
+                paxCargoId = a;
                 break;
             }
         }
@@ -269,17 +299,21 @@ namespace OpenLoco
         }
 
         int32_t points = 0;
-        for (auto cargo: growthConfiguration.cargos)
+        for (auto cargo : growthConfiguration.cargos)
         {
             if (cargo.cargoType == 255)
+            {
                 continue;
+            }
             if (size < cargo.minimumTownSize)
+            {
                 continue;
+            }
             auto cargoPoints = std::clamp<int32_t>(monthlyCargoDelivered[cargo.cargoType] * cargo.pointsMultiplier, cargo.pointsFloor, cargo.pointsCap);
             points += cargoPoints;
         }
         GrowthSpeed speed = TownGrowthSpeed::zero;
-        for (auto bracket: growthConfiguration.brackets)
+        for (auto bracket : growthConfiguration.brackets)
         {
             if (bracket.maximumPoints > points)
             {
@@ -287,6 +321,7 @@ namespace OpenLoco
                 break;
             }
         }
+        printf("Town %d scored %d points this month. Growth speed is %s\n",enumValue(id()),points,getTownGrowthSpeedName(speed).c_str());
         buildSpeed = speed;
         // Reset all monthlyCargoDelivered intermediaries to zero.
         memset(&monthlyCargoDelivered, 0, sizeof(monthlyCargoDelivered));

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -233,24 +233,28 @@ namespace OpenLoco
                     65535,
                     0,
                     TownSize::hamlet,
+                    TownSize::metropolis,
                     paxCargoId),
                 TownGrowthInputCargo(
                     2,
                     65535,
                     0,
                     TownSize::hamlet,
+                    TownSize::metropolis,
                     mailCargoId),
                 TownGrowthInputCargo(
                     10,
                     65535,
                     0,
                     TownSize::hamlet,
+                    TownSize::metropolis,
                     foodCargoId),
                 TownGrowthInputCargo(
                     10,
                     65535,
                     0,
                     TownSize::hamlet,
+                    TownSize::metropolis,
                     goodsCargoId),
             },
             {
@@ -351,6 +355,10 @@ namespace OpenLoco
                 continue;
             }
             if (size < cargo.minimumTownSize)
+            {
+                continue;
+            }
+            if (size > cargo.maximumTownSize)
             {
                 continue;
             }

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -360,12 +360,11 @@ namespace OpenLoco
         GrowthSpeed speed = TownGrowthSpeed::zero;
         for (auto bracket : growthConfiguration.brackets)
         {
-            if (bracket.startThreshold < points)
+            if (bracket.startThreshold >= points)
             {
-                speed = bracket.speed;
-                continue;
+                break;
             }
-            break;
+            speed = bracket.speed;
         }
         printf("Town %d scored %d points this month. Growth speed is %s\n",enumValue(id()),points,getTownGrowthSpeedName(speed).c_str());
         buildSpeed = speed;

--- a/src/OpenLoco/src/World/Town.cpp
+++ b/src/OpenLoco/src/World/Town.cpp
@@ -255,19 +255,19 @@ namespace OpenLoco
             },
             {
                 TownGrowthSpeedBracket(
-                    50,
+                    0,
                     TownGrowthSpeed::oneEighth),
                 TownGrowthSpeedBracket(
-                    400,
+                    50,
                     TownGrowthSpeed::one),
                 TownGrowthSpeedBracket(
-                    800,
+                    400,
                     TownGrowthSpeed::intZero + 3),
                 TownGrowthSpeedBracket(
-                    1250,
+                    800,
                     TownGrowthSpeed::intZero + 5),
                 TownGrowthSpeedBracket(
-                    65535,
+                    1250,
                     TownGrowthSpeed::intZero + 7),
             },
         };
@@ -360,11 +360,12 @@ namespace OpenLoco
         GrowthSpeed speed = TownGrowthSpeed::zero;
         for (auto bracket : growthConfiguration.brackets)
         {
-            if (bracket.maximumPoints > points)
+            if (bracket.startThreshold < points)
             {
                 speed = bracket.speed;
-                break;
+                continue;
             }
+            break;
         }
         printf("Town %d scored %d points this month. Growth speed is %s\n",enumValue(id()),points,getTownGrowthSpeedName(speed).c_str());
         buildSpeed = speed;

--- a/src/OpenLoco/src/World/TownManager.cpp
+++ b/src/OpenLoco/src/World/TownManager.cpp
@@ -282,8 +282,8 @@ namespace OpenLoco::TownManager
 
         std::fill_n(&town->monthlyCargoDelivered[0], std::size(town->monthlyCargoDelivered), 0);
 
-        town->cargoInfluenceFlags = calcCargoInfluenceFlags(*town);
-        town->buildSpeed = 1;
+        getDefaultTownGrowthConfiguration();
+        town->buildSpeed = town->growthConfiguration.brackets[0].speed;
 
         // Figure out a name for this town?
         if (!generateTownName(town))
@@ -454,7 +454,7 @@ namespace OpenLoco::TownManager
                 if (town != nullptr && !town->empty())
                 {
                     GameCommands::setUpdatingCompanyId(CompanyId::neutral);
-                    auto ticknum = (ticks / 8 / 256) % 8;
+                    auto ticknum = (ticks / 8 / 127) % 8;
                     town->tick(ticknum);
                 }
             }

--- a/src/OpenLoco/src/World/TownManager.cpp
+++ b/src/OpenLoco/src/World/TownManager.cpp
@@ -454,7 +454,8 @@ namespace OpenLoco::TownManager
                 if (town != nullptr && !town->empty())
                 {
                     GameCommands::setUpdatingCompanyId(CompanyId::neutral);
-                    town->tick();
+                    auto ticknum = (ticks & 0x38)>>3;
+                    town->tick(ticknum);
                 }
             }
         }

--- a/src/OpenLoco/src/World/TownManager.cpp
+++ b/src/OpenLoco/src/World/TownManager.cpp
@@ -454,7 +454,7 @@ namespace OpenLoco::TownManager
                 if (town != nullptr && !town->empty())
                 {
                     GameCommands::setUpdatingCompanyId(CompanyId::neutral);
-                    auto ticknum = (ticks & 0x38)>>3;
+                    auto ticknum = (ticks / 8 / 256) % 8;
                     town->tick(ticknum);
                 }
             }


### PR DESCRIPTION
This branch is a proof of concept to improve the flexibility of the game by introducing new conditions for town growth. In particular, towns can grow faster when more types of necessary cargoes are delivered. This makes the gameplay match the expected mechanics as described in the manual, when it says that town growth can be accelerated with mail, goods, and food.

This feature relies on NSF and NOF before it can be merged.

This PR is made so that users may download the artifacts.

2026-08-23: the hard-coded town growth formula is provided by Banskia Slayer on Discord.