### PR TITLE
Rework Buffer Strings

### DIFF
--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -342,8 +342,7 @@ namespace OpenLoco::StringIds
     constexpr StringId click_on_view_select_string_id_start = 334;
     constexpr StringId incompatible_vehicle = 335;
     constexpr StringId too_many_vehicles = 336;
-    constexpr StringId buffer_337 = 337;
-    constexpr StringId buffer_338 = 338;
+    // UNUSED 337, 338 (was buffer string)
     constexpr StringId tooltip_stringid = 339;
     constexpr StringId vehicle_details_tooltip_built = 340;
     constexpr StringId vehicle_details_tooltip_value = 341;
@@ -985,7 +984,7 @@ namespace OpenLoco::StringIds
     constexpr StringId road = 1247;
     constexpr StringId no_vehicles_available = 1248;
     constexpr StringId no_compatible_vehicles_available = 1249;
-    constexpr StringId buffer_1250 = 1250;
+    // UNUSED was buffer string 1250
     constexpr StringId stats_cost = 1251;
     constexpr StringId stats_requires = 1252;
     constexpr StringId stats_power = 1253;
@@ -1225,7 +1224,7 @@ namespace OpenLoco::StringIds
     constexpr StringId new_game_currency_tip = 1503;
     constexpr StringId current_game_currency = 1504;
     constexpr StringId new_game_currency = 1505;
-    constexpr StringId preferred_currency_buffer = 1506;
+    // UNUSED was buffer string 1506
     constexpr StringId company_major_news = 1507;
     constexpr StringId competitor_major_news = 1508;
     constexpr StringId company_minor_news = 1509;
@@ -1435,8 +1434,7 @@ namespace OpenLoco::StringIds
     constexpr StringId chat_send_message = 1716;
     constexpr StringId chat_title = 1717;
     constexpr StringId chat_instructions = 1718;
-    constexpr StringId buffer_1719 = 1719;
-
+    // UNUSED was buffer string 1719
     constexpr StringId object_selection_designed = 1723;
     constexpr StringId object_selection_obsolete = 1724;
     constexpr StringId object_selection_power = 1725;
@@ -1752,9 +1750,7 @@ namespace OpenLoco::StringIds
     constexpr StringId position_14th = 2036;
     constexpr StringId position_15th = 2037;
     constexpr StringId num_selected_num_max = 2038;
-    constexpr StringId buffer_2039 = 2039;
-    constexpr StringId buffer_2040 = 2040;
-
+    // UNUSED was buffer string 2039, 2040
     constexpr StringId data_for_following_object_not_found = 2042;
     constexpr StringId not_enough_space_for_graphics = 2043;
     constexpr StringId too_many_objects_of_this_type_selected = 2044;
@@ -2197,4 +2193,12 @@ namespace OpenLoco::StringIds
     constexpr StringId temporary_object_load_str_14 = 8206;
     constexpr StringId temporary_object_load_str_15 = 8207;
     constexpr StringId object_strings_begin = 8208;
+
+    constexpr StringId buffer_337 = StringManager::kBufferStringsStart + 0;
+    constexpr StringId buffer_338 = StringManager::kBufferStringsStart + 1;
+    constexpr StringId buffer_1250 = StringManager::kBufferStringsStart + 2;
+    constexpr StringId buffer_1719 = StringManager::kBufferStringsStart + 3;
+    constexpr StringId buffer_2039 = StringManager::kBufferStringsStart + 4;
+    constexpr StringId buffer_2040 = StringManager::kBufferStringsStart + 5;
+    constexpr StringId preferred_currency_buffer = StringManager::kBufferStringsStart + 6;
 }

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringManager.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringManager.h
@@ -25,6 +25,9 @@ namespace OpenLoco::StringManager
     constexpr uint16_t kUserStringsStart = 0x8000;
     constexpr uint16_t kUserStringsEnd = kUserStringsStart + Limits::kMaxUserStrings;
 
+    constexpr uint16_t kBufferStringsStart = kUserStringsEnd;
+    constexpr uint16_t kBufferStringsEnd = kBufferStringsStart + 7;
+
     constexpr uint16_t kMaxTownNames = 345;
     constexpr uint16_t kTownNamesStart = 0x9EE7;
     constexpr uint16_t kTownNamesEnd = kTownNamesStart + kMaxTownNames;
@@ -33,6 +36,7 @@ namespace OpenLoco::StringManager
     void setString(StringId id, std::string_view value);
     const char* swapString(StringId id, const char* src);
     const char* getString(StringId id);
+    char* getBufferString(StringId id);
 
     StringId userStringAllocate(char* str, bool mustBeUnique);
     const char* getUserString(StringId id);

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringManager.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringManager.h
@@ -33,7 +33,6 @@ namespace OpenLoco::StringManager
     constexpr uint16_t kTownNamesEnd = kTownNamesStart + kMaxTownNames;
 
     void reset();
-    void setString(StringId id, std::string_view value);
     const char* swapString(StringId id, const char* src);
     const char* getString(StringId id);
     char* getBufferString(StringId id);

--- a/src/OpenLoco/include/OpenLoco/Objects/IndustryObject.h
+++ b/src/OpenLoco/include/OpenLoco/Objects/IndustryObject.h
@@ -124,8 +124,8 @@ namespace OpenLoco
 
         bool requiresCargo() const;
         bool producesCargo() const;
-        char* getProducedCargoString(const char* buffer) const;
-        char* getRequiredCargoString(const char* buffer) const;
+        char* getProducedCargoString(char* buffer) const;
+        char* getRequiredCargoString(char* buffer) const;
         void drawPreviewImage(Gfx::DrawingContext& drawingCtx, const int16_t x, const int16_t y) const;
         void drawIndustry(Gfx::DrawingContext& drawingCtx, int16_t x, int16_t y) const;
         bool validate() const;

--- a/src/OpenLoco/include/OpenLoco/World/Industry.h
+++ b/src/OpenLoco/include/OpenLoco/World/Industry.h
@@ -76,7 +76,7 @@ namespace OpenLoco
         bool empty() const;
         bool canReceiveCargo() const;
         bool canProduceCargo() const;
-        void getStatusString(const char* buffer);
+        void getStatusString(char* buffer);
 
         void tick();
         void updateDaily();

--- a/src/OpenLoco/src/Graphics/TextRenderer.cpp
+++ b/src/OpenLoco/src/Graphics/TextRenderer.cpp
@@ -464,7 +464,7 @@ namespace OpenLoco::Gfx
             const char* ptr = buffer;
             for (auto i = 0; ptr != nullptr && i < breakCount; i++)
             {
-                drawString(drawState, ctx, rt, point, AdvancedColour::FE(), const_cast<char*>(ptr));
+                drawString(drawState, ctx, rt, point, AdvancedColour::FE(), ptr);
                 ptr = advanceToNextLineWrapped(ptr);
                 point.y += lineHeight;
             }
@@ -726,7 +726,7 @@ namespace OpenLoco::Gfx
                 auto point = basePoint;
                 point.x -= lineWidth / 2;
 
-                drawString(drawState, ctx, rt, point, AdvancedColour::FE(), const_cast<char*>(ptr));
+                drawString(drawState, ctx, rt, point, AdvancedColour::FE(), ptr);
                 ptr = advanceToNextLineWrapped(ptr);
 
                 basePoint.y += lineHeight;
@@ -768,7 +768,7 @@ namespace OpenLoco::Gfx
                 auto point = basePoint;
                 point.x -= lineWidth / 2;
 
-                drawString(drawState, ctx, rt, point, AdvancedColour::FE(), const_cast<char*>(ptr));
+                drawString(drawState, ctx, rt, point, AdvancedColour::FE(), ptr);
 
                 ptr = advanceToNextLineWrapped(ptr);
                 basePoint.y += getLineHeight(drawState.font);

--- a/src/OpenLoco/src/Localisation/Formatting.cpp
+++ b/src/OpenLoco/src/Localisation/Formatting.cpp
@@ -607,6 +607,11 @@ namespace OpenLoco::StringManager
 
             buffer.append(sourceStr, kUserStringSize);
         }
+        else if (id < kBufferStringsEnd)
+        {
+            const char* sourceStr = getBufferString(id);
+            formatStringPart(buffer, sourceStr, args);
+        }
         else if (id < kTownNamesEnd)
         {
             id -= kTownNamesStart;

--- a/src/OpenLoco/src/Localisation/LanguageFiles.cpp
+++ b/src/OpenLoco/src/Localisation/LanguageFiles.cpp
@@ -3,7 +3,6 @@
 #include "Environment.h"
 #include "Localisation/Conversion.h"
 #include "Localisation/Formatting.h"
-#include "Localisation/StringIds.h"
 #include "Localisation/StringManager.h"
 #include "Localisation/Unicode.h"
 #include "Logging.h"
@@ -230,23 +229,6 @@ namespace OpenLoco::Localisation
         return str;
     }
 
-    static bool stringIsBuffer(int id)
-    {
-        switch (id)
-        {
-            case StringIds::buffer_337:
-            case StringIds::buffer_338:
-            case StringIds::buffer_1250:
-            case StringIds::preferred_currency_buffer:
-            case StringIds::buffer_1719:
-            case StringIds::buffer_2039:
-            case StringIds::buffer_2040:
-                return true;
-            default:
-                return false;
-        }
-    }
-
     static bool loadLanguageStringTable(fs::path languageFile)
     {
         try
@@ -257,11 +239,6 @@ namespace OpenLoco::Localisation
             for (YAML::const_iterator it = node.begin(); it != node.end(); ++it)
             {
                 int id = it->first.as<int>();
-                if (stringIsBuffer(id))
-                {
-                    continue;
-                }
-
                 std::string new_string = it->second.as<std::string>();
                 _stringsOwner.emplace_back(readString(new_string.data(), new_string.length()));
                 char* processedString = _stringsOwner.back().get();

--- a/src/OpenLoco/src/Localisation/StringManager.cpp
+++ b/src/OpenLoco/src/Localisation/StringManager.cpp
@@ -48,13 +48,6 @@ namespace OpenLoco::StringManager
         return str;
     }
 
-    void setString(StringId id, std::string_view value)
-    {
-        auto* dst = _strings[id];
-        std::memcpy(dst, value.data(), value.size());
-        dst[value.size()] = '\0';
-    }
-
     const char* swapString(StringId id, const char* src)
     {
         auto* dst = _strings[id];

--- a/src/OpenLoco/src/Localisation/StringManager.cpp
+++ b/src/OpenLoco/src/Localisation/StringManager.cpp
@@ -3,6 +3,7 @@
 #include "GameState.h"
 #include "Localisation/StringIds.h"
 #include <OpenLoco/Diagnostics/Logging.h>
+#include <array>
 #include <cassert>
 #include <cstring>
 
@@ -14,32 +15,18 @@ namespace OpenLoco::StringManager
     // Size for buffer strings that are used for temporary text storage
     static constexpr size_t kBufferStringSize = 512;
 
-    static char _buffer_337[kBufferStringSize];
-    static char _buffer_338[kBufferStringSize];
-    static char _buffer_1250[kBufferStringSize];
-    static char _preferred_currency_buffer[kBufferStringSize];
-    static char _buffer_1719[kBufferStringSize];
-    static char _buffer_2039[kBufferStringSize];
-    static char _buffer_2040[kBufferStringSize];
+    static std::array<std::array<char, kBufferStringSize>, 7> _bufferStrings = {};
 
     // 0x005183FC
-    // Initialize string pointer array with buffers for specific IDs
-    static std::array<char*, kNumStringPointers> _strings = []() {
-        std::array<char*, kNumStringPointers> strings = {};
-
-        // Assign pre-allocated buffers to specific string IDs
-        strings[StringIds::buffer_337] = _buffer_337;
-        strings[StringIds::buffer_338] = _buffer_338;
-        strings[StringIds::buffer_1250] = _buffer_1250;
-        strings[StringIds::preferred_currency_buffer] = _preferred_currency_buffer;
-        strings[StringIds::buffer_1719] = _buffer_1719;
-        strings[StringIds::buffer_2039] = _buffer_2039;
-        strings[StringIds::buffer_2040] = _buffer_2040;
-
-        return strings;
-    }();
+    static std::array<char*, kNumStringPointers> _strings = {};
 
     static auto& rawUserStrings() { return getGameState().userStrings; }
+
+    char* getBufferString(StringId id)
+    {
+        const auto index = id - StringManager::kBufferStringsStart;
+        return _bufferStrings[index].data();
+    }
 
     // 0x0049650E
     void reset()

--- a/src/OpenLoco/src/Objects/IndustryObject.cpp
+++ b/src/OpenLoco/src/Objects/IndustryObject.cpp
@@ -41,9 +41,9 @@ namespace OpenLoco
         return produceCargoState;
     }
 
-    char* IndustryObject::getProducedCargoString(const char* buffer) const
+    char* IndustryObject::getProducedCargoString(char* buffer) const
     {
-        char* ptr = (char*)buffer;
+        char* ptr = buffer;
         auto producedCargoCount = 0;
 
         for (const auto& producedCargo : producedCargoType)
@@ -64,9 +64,9 @@ namespace OpenLoco
         return ptr;
     }
 
-    char* IndustryObject::getRequiredCargoString(const char* buffer) const
+    char* IndustryObject::getRequiredCargoString(char* buffer) const
     {
-        char* ptr = (char*)buffer;
+        char* ptr = buffer;
         auto requiredCargoCount = 0;
 
         for (const auto& requiredCargo : requiredCargoType)

--- a/src/OpenLoco/src/Objects/ObjectIndex.cpp
+++ b/src/OpenLoco/src/Objects/ObjectIndex.cpp
@@ -747,7 +747,7 @@ namespace OpenLoco::ObjectManager
         // Note: This mode is never used in vanilla!
         if (isRecursed && (mode & SelectObjectModes::selectDependents) == SelectObjectModes::none)
         {
-            auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2040));
+            auto buffer = StringManager::getBufferString(StringIds::buffer_2040);
             buffer = StringManager::formatString(buffer, 512, StringIds::the_following_object_must_be_selected_first);
             objectCreateIdentifierName(buffer, objHeader);
             GameCommands::setErrorText(StringIds::buffer_2040);
@@ -824,7 +824,7 @@ namespace OpenLoco::ObjectManager
         auto objIndexEntry = internalFindObjectInIndex(objHeader);
         if (!objIndexEntry.has_value())
         {
-            auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2040));
+            auto buffer = StringManager::getBufferString(StringIds::buffer_2040);
             buffer = StringManager::formatString(buffer, 512, StringIds::data_for_following_object_not_found);
             objectCreateIdentifierName(buffer, objHeader);
             GameCommands::setErrorText(StringIds::buffer_2040);

--- a/src/OpenLoco/src/Objects/VehicleObject.cpp
+++ b/src/OpenLoco/src/Objects/VehicleObject.cpp
@@ -63,7 +63,7 @@ namespace OpenLoco
             args.push(speed);
             tr.drawStringLeft(rowPosition, Colour::black, StringIds::object_selection_max_speed, args);
         }
-        auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
+        auto buffer = StringManager::getBufferString(StringIds::buffer_1250);
         // Clear buffer
         *buffer = '\0';
 

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -196,7 +196,7 @@ namespace OpenLoco::Ui::ViewportInteraction
         args.push(station->name);
         args.push(station->town);
         args.push(getTransportIconsFromStationFlags(station->flags));
-        char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_338));
+        char* buffer = StringManager::getBufferString(StringIds::buffer_338);
         buffer = station->getStatusString(buffer);
 
         buffer = StringManager::formatString(buffer, StringIds::station_accepts);
@@ -254,7 +254,7 @@ namespace OpenLoco::Ui::ViewportInteraction
         interaction.value = enumValue(industryTile->industryId());
         auto industry = industryTile->industry();
 
-        char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_338));
+        char* buffer = StringManager::getBufferString(StringIds::buffer_338);
         *buffer = 0;
         industry->getStatusString(buffer);
         auto args = FormatArguments::mapToolTip();
@@ -885,7 +885,7 @@ namespace OpenLoco::Ui::ViewportInteraction
         }
 
         const auto* buildingObj = building->getObject();
-        auto* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_338));
+        auto* buffer = StringManager::getBufferString(StringIds::buffer_338);
         buffer = StringManager::formatString(buffer, buildingObj->name);
         if (!building->isConstructed())
         {

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -1498,7 +1498,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
         }
 
         auto vehicleObj = ObjectManager::get<VehicleObject>(self.rowHover);
-        auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
+        auto buffer = StringManager::getBufferString(StringIds::buffer_1250);
 
         {
             auto cost = Economy::getInflationAdjustedCost(vehicleObj->costFactor, vehicleObj->costIndex, 6);
@@ -1731,7 +1731,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
                 drawVehicleOverview(drawingCtx, { 90, 37 }, window.rowHover, yaw, roll, CompanyManager::getControllingId());
 
                 auto vehicleObj = ObjectManager::get<VehicleObject>(window.rowHover);
-                auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
+                auto buffer = StringManager::getBufferString(StringIds::buffer_1250);
                 buffer = StringManager::formatString(buffer, vehicleObj->name);
                 auto usableCargoTypes = vehicleObj->compatibleCargoCategories[0] | vehicleObj->compatibleCargoCategories[1];
 

--- a/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/BuildVehicle.cpp
@@ -1418,7 +1418,7 @@ namespace OpenLoco::Ui::Windows::BuildVehicle
 
     static void drawSearchBox(Window& self, Gfx::DrawingContext& drawingCtx)
     {
-        char* textBuffer = (char*)StringManager::getString(StringIds::buffer_2039);
+        char* textBuffer = StringManager::getBufferString(StringIds::buffer_2039);
         strncpy(textBuffer, inputSession.buffer.c_str(), 256);
 
         auto& widget = _widgets[widx::searchBox];

--- a/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyFaceSelection.cpp
@@ -290,7 +290,7 @@ namespace OpenLoco::Ui::Windows::CompanyFaceSelection
             const auto x = self.widgets[widx::face_frame].midX();
             const auto y = self.widgets[widx::face_frame].bottom + 3;
             const auto width = self.width - self.widgets[widx::scrollview].right - 6;
-            auto str = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+            auto str = StringManager::getBufferString(StringIds::buffer_2039);
             *str++ = ControlCodes::windowColour2;
             strcpy(str, ObjectManager::getObjectInIndex(self.rowHover)._name.c_str());
 

--- a/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/CompanyWindow.cpp
@@ -394,7 +394,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
 
             // Temporarily store the new name in buffer string 2039.
             // TODO: replace with a fixed length!
-            char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+            char* buffer = StringManager::getBufferString(StringIds::buffer_2039);
             strcpy(buffer, input);
 
             FormatArguments args{};
@@ -2405,7 +2405,7 @@ namespace OpenLoco::Ui::Windows::CompanyWindow
             self.draw(drawingCtx);
             Common::drawTabs(self, drawingCtx);
 
-            char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+            char* buffer_2039 = StringManager::getBufferString(StringIds::buffer_2039);
             *buffer_2039++ = static_cast<char>(ControlCodes::Colour::black);
             char* scenarioDetailsString = getGameState().scenarioDetails;
             StringManager::locoStrcpy(buffer_2039, scenarioDetailsString);

--- a/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryList.cpp
@@ -463,8 +463,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 }
                 // Industry Status
                 {
-                    const char* buffer = StringManager::getString(StringIds::buffer_1250);
-                    industry->getStatusString((char*)buffer);
+                    char* buffer = StringManager::getBufferString(StringIds::buffer_1250);
+                    industry->getStatusString(buffer);
 
                     FormatArguments args{};
                     args.push(StringIds::buffer_1250);
@@ -828,7 +828,7 @@ namespace OpenLoco::Ui::Windows::IndustryList
                 string = StringIds::null;
             }
 
-            if (StringManager::getString(StringIds::buffer_337)[0] != '\0')
+            if (StringManager::getBufferString(StringIds::buffer_337)[0] != '\0')
             {
                 if (string == self.widgets[widx::scrollview].tooltip)
                 {
@@ -848,8 +848,8 @@ namespace OpenLoco::Ui::Windows::IndustryList
             }
 
             auto industryObj = ObjectManager::get<IndustryObject>(rowInfo);
-            auto buffer = const_cast<char*>(StringManager::getString(string));
-            char* ptr = (char*)buffer;
+            auto* buffer = StringManager::getBufferString(StringIds::buffer_337);
+            char* ptr = buffer;
 
             *ptr = '\0';
             *ptr++ = ControlCodes::Font::regular;

--- a/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/IndustryWindow.cpp
@@ -159,9 +159,9 @@ namespace OpenLoco::Ui::Windows::Industry
             self.draw(drawingCtx);
             Common::drawTabs(self, drawingCtx);
 
-            const char* buffer = StringManager::getString(StringIds::buffer_1250);
+            char* buffer = StringManager::getBufferString(StringIds::buffer_1250);
             auto industry = IndustryManager::get(IndustryId(self.number));
-            industry->getStatusString(const_cast<char*>(buffer));
+            industry->getStatusString(buffer);
 
             FormatArguments args{};
             args.push(StringIds::buffer_1250);

--- a/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MapWindow.cpp
@@ -1645,8 +1645,8 @@ namespace OpenLoco::Ui::Windows::MapWindow
                 stringId = industryObj->nameSingular;
             }
 
-            auto buffer = StringManager::getString(StringIds::buffer_1250);
-            char* ptr = const_cast<char*>(buffer);
+            auto buffer = StringManager::getBufferString(StringIds::buffer_1250);
+            char* ptr = buffer;
 
             auto argsBuf = FormatArgumentsBuffer{};
             auto argsTmp = FormatArguments{ argsBuf };

--- a/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/MessageWindow.cpp
@@ -240,7 +240,7 @@ namespace OpenLoco::Ui::Windows::MessageWindow
 
                 auto message = MessageManager::get(MessageId(i));
                 char* buffer = message->messageString;
-                auto str = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+                auto str = StringManager::getBufferString(StringIds::buffer_2039);
 
                 const size_t bufferLength = 512;
                 strncpy(str, buffer, bufferLength);

--- a/src/OpenLoco/src/Ui/Windows/NetworkStatus.cpp
+++ b/src/OpenLoco/src/Ui/Windows/NetworkStatus.cpp
@@ -103,7 +103,8 @@ namespace OpenLoco::Ui::Windows::NetworkStatus
 
     static void prepareDraw([[maybe_unused]] Window& self)
     {
-        StringManager::setString(StringIds::buffer_1250, _text.c_str());
+        char* buffer = StringManager::getBufferString(StringIds::buffer_2039);
+        strcpy(buffer, _text.c_str());
     }
 
     static void draw(Window& self, Gfx::DrawingContext& drawingCtx)

--- a/src/OpenLoco/src/Ui/Windows/News/News.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/News.cpp
@@ -541,7 +541,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             auto tr = Gfx::TextRenderer(drawingCtx);
 
             char* newsString = news->messageString;
-            auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+            auto buffer = StringManager::getBufferString(StringIds::buffer_2039);
             const auto& mtd = getMessageTypeDescriptor(news->type);
 
             if (!mtd.hasFlag(MessageTypeFlags::smallerFont))
@@ -621,7 +621,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             auto tr = Gfx::TextRenderer(drawingCtx);
 
             char* newsString = news->messageString;
-            auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+            auto buffer = StringManager::getBufferString(StringIds::buffer_2039);
             const auto& mtd = getMessageTypeDescriptor(news->type);
 
             if (!mtd.hasFlag(MessageTypeFlags::smallerFont))
@@ -674,7 +674,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow
             auto tr = Gfx::TextRenderer(drawingCtx);
 
             char* newsString = news->messageString;
-            auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+            auto buffer = StringManager::getBufferString(StringIds::buffer_2039);
 
             *buffer = ControlCodes::Colour::black;
             buffer++;

--- a/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
+++ b/src/OpenLoco/src/Ui/Windows/News/Ticker.cpp
@@ -188,7 +188,7 @@ namespace OpenLoco::Ui::Windows::NewsWindow::Ticker
         drawingCtx.clearSingle(colour);
 
         char* newsString = news->messageString;
-        auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+        auto buffer = StringManager::getBufferString(StringIds::buffer_2039);
 
         *buffer = ControlCodes::Colour::black;
         buffer++;

--- a/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectLoadError.cpp
@@ -187,7 +187,7 @@ namespace OpenLoco::Ui::Windows::ObjectLoadError
         drawingCtx.clearSingle(shade);
 
         // Acquire string buffer
-        auto* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+        auto* buffer = StringManager::getBufferString(StringIds::buffer_2039);
 
         uint16_t y = 0;
         auto namePos = Point(1, y);

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -997,7 +997,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
 
     static void drawSearchBox(Window& self, Gfx::DrawingContext& drawingCtx)
     {
-        char* textBuffer = (char*)StringManager::getString(StringIds::buffer_2039);
+        char* textBuffer = StringManager::getBufferString(StringIds::buffer_2039);
         strncpy(textBuffer, inputSession.buffer.c_str(), 256);
 
         auto& widget = widgets[widx::textInput];

--- a/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ObjectSelectionWindow.cpp
@@ -982,7 +982,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         // Draw object filename
         {
             auto filename = fs::u8path(indexEntry._filepath).filename().u8string();
-            auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
+            auto buffer = StringManager::getBufferString(StringIds::buffer_1250);
             strncpy(buffer, filename.c_str(), filename.length() + 1);
 
             FormatArguments args{};
@@ -1117,7 +1117,7 @@ namespace OpenLoco::Ui::Windows::ObjectSelectionWindow
         auto width = self.width - self.widgets[widx::scrollview].right - 6;
 
         {
-            auto buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+            auto buffer = StringManager::getBufferString(StringIds::buffer_2039);
 
             *buffer++ = ControlCodes::windowColour2;
 

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -2228,7 +2228,7 @@ namespace OpenLoco::Ui::Windows::Options
             // Set preferred owner name.
             {
                 // TODO: Do not share this buffer, also unsafe, we should change the localisation to use a string pointer.
-                auto buffer = (char*)StringManager::getString(StringIds::buffer_2039);
+                auto buffer = StringManager::getBufferString(StringIds::buffer_2039);
                 const char* playerName = Config::get().preferredOwnerName.c_str();
                 strcpy(buffer, playerName);
                 buffer[strlen(playerName)] = '\0';
@@ -2255,7 +2255,7 @@ namespace OpenLoco::Ui::Windows::Options
             // Set preferred company nam
             {
                 // TODO: Do not share this buffer, also unsafe, we should change the localisation to use a string pointer.
-                auto buffer = (char*)StringManager::getString(StringIds::buffer_2040);
+                auto buffer = StringManager::getBufferString(StringIds::buffer_2040);
                 const char* companyName = Config::get().preferredCompanyName.c_str();
                 strcpy(buffer, companyName);
                 buffer[strlen(companyName)] = '\0';
@@ -2273,7 +2273,7 @@ namespace OpenLoco::Ui::Windows::Options
         // 0x004C1319
         static void changePreferredName(Window& self)
         {
-            auto buffer = (char*)StringManager::getString(StringIds::buffer_2039);
+            auto buffer = StringManager::getBufferString(StringIds::buffer_2039);
             const char* playerName = Config::get().preferredOwnerName.c_str();
             strcpy(buffer, playerName);
             buffer[strlen(playerName)] = '\0';
@@ -2317,7 +2317,7 @@ namespace OpenLoco::Ui::Windows::Options
 
         static void changePreferredCompany(Window& self)
         {
-            auto buffer = (char*)StringManager::getString(StringIds::buffer_2040);
+            auto buffer = StringManager::getBufferString(StringIds::buffer_2040);
             const char* companyName = Config::get().preferredCompanyName.c_str();
             strcpy(buffer, companyName);
             buffer[strlen(companyName)] = '\0';

--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -2865,7 +2865,7 @@ namespace OpenLoco::Ui::Windows::Options
         const auto res = ObjectManager::findObjectInIndex(Config::get().preferredCurrency);
         if (res.has_value())
         {
-            auto buffer = const_cast<char*>(StringManager::getString(StringIds::preferred_currency_buffer));
+            auto buffer = StringManager::getBufferString(StringIds::preferred_currency_buffer);
             strcpy(buffer, res->_name.c_str());
         }
     }

--- a/src/OpenLoco/src/Ui/Windows/ProgressBar.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ProgressBar.cpp
@@ -93,7 +93,7 @@ namespace OpenLoco::Ui::Windows::ProgressBar
         self.x = (Ui::width() / 2) - (self.width / 2);
         self.y = std::max(28, (Ui::height() / 2) - (self.height / 2));
 
-        char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
+        char* buffer = StringManager::getBufferString(StringIds::buffer_1250);
         strncpy(buffer, _captionString.c_str(), 256);
     }
 

--- a/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptBrowseWindow.cpp
@@ -965,7 +965,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
             if (fs::exists(path))
             {
                 // Copy directory and filename to buffer.
-                char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+                char* buffer_2039 = StringManager::getBufferString(StringIds::buffer_2039);
                 auto filenameUtf8 = path.stem().make_preferred().u8string();
                 auto filenameLoco = Localisation::convertUnicodeToLoco(filenameUtf8);
                 strncpy(&buffer_2039[0], filenameLoco.c_str(), 512);
@@ -1027,7 +1027,7 @@ namespace OpenLoco::Ui::Windows::PromptBrowse
         path += getExtensionFromFileType(_fileType);
 
         // Copy directory and filename to buffer.
-        char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+        char* buffer_2039 = StringManager::getBufferString(StringIds::buffer_2039);
         auto filenameUtf8 = path.stem().make_preferred().u8string();
         auto filenameLoco = Localisation::convertUnicodeToLoco(filenameUtf8);
         strncpy(&buffer_2039[0], filenameLoco.c_str(), 512);

--- a/src/OpenLoco/src/Ui/Windows/PromptOkCancelWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/PromptOkCancelWindow.cpp
@@ -121,7 +121,7 @@ namespace OpenLoco::Ui::Windows::PromptOkCancel
     static void prepareDraw([[maybe_unused]] Window& self)
     {
         // Prepare description string for drawing.
-        char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+        char* buffer_2039 = StringManager::getBufferString(StringIds::buffer_2039);
         strncpy(&buffer_2039[0], _descriptionBuffer, 512);
     }
 

--- a/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioOptions.cpp
@@ -1107,7 +1107,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
             {
                 // Prepare scenario name text.
-                char* buffer = (char*)StringManager::getString(StringIds::buffer_2039);
+                char* buffer = StringManager::getBufferString(StringIds::buffer_2039);
                 strncpy(buffer, Scenario::getOptions().scenarioName, 512);
 
                 FormatArguments args{};
@@ -1146,7 +1146,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
             {
                 // Prepare scenario details text.
-                char* buffer = (char*)StringManager::getString(StringIds::buffer_2039);
+                char* buffer = StringManager::getBufferString(StringIds::buffer_2039);
                 strncpy(buffer, Scenario::getOptions().scenarioDetails, 512);
 
                 FormatArguments args{};
@@ -1218,7 +1218,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
                 case Widx::kChangeNameBtn:
                 {
-                    char* buffer = (char*)StringManager::getString(StringIds::buffer_2039);
+                    char* buffer = StringManager::getBufferString(StringIds::buffer_2039);
                     strncpy(buffer, Scenario::getOptions().scenarioName, 512);
                     auto inputSize = std::size(Scenario::getOptions().scenarioName) - 1;
 
@@ -1228,7 +1228,7 @@ namespace OpenLoco::Ui::Windows::ScenarioOptions
 
                 case Widx::kChangeDetailsBtn:
                 {
-                    char* buffer = (char*)StringManager::getString(StringIds::buffer_2039);
+                    char* buffer = StringManager::getBufferString(StringIds::buffer_2039);
                     strncpy(buffer, Scenario::getOptions().scenarioDetails, 512);
                     auto inputSize = std::size(Scenario::getOptions().scenarioDetails) - 1;
 

--- a/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ScenarioSelect.cpp
@@ -256,7 +256,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 
         // Scenario name
         {
-            auto str = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+            auto str = StringManager::getBufferString(StringIds::buffer_2039);
             strncpy(str, scenarioInfo->scenarioName, std::size(scenarioInfo->scenarioName));
 
             FormatArguments args{};
@@ -324,7 +324,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             y = baseY + 150;
 
             // Description
-            auto str = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+            auto str = StringManager::getBufferString(StringIds::buffer_2039);
             strncpy(str, scenarioInfo->description, std::size(scenarioInfo->description));
 
             FormatArguments args{};
@@ -338,7 +338,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
             tr.drawStringLeft(Point(x, y), Colour::black, StringIds::challenge_label);
 
             // Challenge text
-            str = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
+            str = StringManager::getBufferString(StringIds::buffer_1250);
             strncpy(str, scenarioInfo->objective, std::size(scenarioInfo->objective));
 
             y += 10;
@@ -418,7 +418,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 
             // Scenario name
             {
-                auto str = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+                auto str = StringManager::getBufferString(StringIds::buffer_2039);
                 strncpy(str, scenarioInfo->scenarioName, std::size(scenarioInfo->scenarioName));
 
                 FormatArguments args{};
@@ -440,7 +440,7 @@ namespace OpenLoco::Ui::Windows::ScenarioSelect
 
             // 'Completed by' info
             {
-                auto str = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+                auto str = StringManager::getBufferString(StringIds::buffer_2039);
                 strncpy(str, scenarioInfo->highscoreName, std::size(scenarioInfo->highscoreName));
 
                 FormatArguments args{};

--- a/src/OpenLoco/src/Ui/Windows/StationList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationList.cpp
@@ -480,7 +480,7 @@ namespace OpenLoco::Ui::Windows::StationList
                 tr.drawStringLeftClipped(point, 198, Colour::black, text_colour_id, args);
             }
 
-            char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
+            char* buffer = StringManager::getBufferString(StringIds::buffer_1250);
             station->getStatusString(buffer);
 
             // Then the station's current status.

--- a/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/StationWindow.cpp
@@ -167,8 +167,8 @@ namespace OpenLoco::Ui::Windows::Station
 
             // Set station status
             auto station = StationManager::get(StationId(self.number));
-            const char* buffer = StringManager::getString(StringIds::buffer_1250);
-            station->getStatusString((char*)buffer);
+            char* buffer = StringManager::getBufferString(StringIds::buffer_1250);
+            station->getStatusString(buffer);
             FormatArguments args{ self.widgets[widx::status_bar].textArgs };
             args.push(StringIds::buffer_1250);
 

--- a/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TextInputWindow.cpp
@@ -226,7 +226,7 @@ namespace OpenLoco::Ui::Windows::TextInput
         auto& inputWidget = window.widgets[widx::input];
         if (drawingCtx.pushClip(Ui::Rect(inputWidget.left + 1, inputWidget.top + 1, inputWidget.width() - 2, inputWidget.height() - 2)))
         {
-            char* drawnBuffer = (char*)StringManager::getString(StringIds::buffer_2039);
+            char* drawnBuffer = StringManager::getBufferString(StringIds::buffer_2039);
             strcpy(drawnBuffer, inputSession.buffer.c_str());
 
             {

--- a/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
+++ b/src/OpenLoco/src/Ui/Windows/TitleMenu.cpp
@@ -372,7 +372,8 @@ namespace OpenLoco::Ui::Windows::TitleMenu
 
     static void showMultiplayer(Window* window)
     {
-        StringManager::setString(StringIds::buffer_2039, "");
+        char* buffer = StringManager::getBufferString(StringIds::buffer_2039);
+        buffer[0] = '\0';
         TextInput::openTextInput(window, StringIds::enter_host_address, StringIds::enter_host_address_description, StringIds::buffer_2039, widx::multiplayer_toggle_btn, {});
     }
 

--- a/src/OpenLoco/src/Ui/Windows/ToolTip.cpp
+++ b/src/OpenLoco/src/Ui/Windows/ToolTip.cpp
@@ -257,7 +257,7 @@ namespace OpenLoco::Ui::Windows::ToolTip
     // 0x004C94F7
     static void onClose([[maybe_unused]] Ui::Window& window)
     {
-        auto str337 = const_cast<char*>(StringManager::getString(StringIds::buffer_337));
+        auto str337 = StringManager::getBufferString(StringIds::buffer_337);
         str337[0] = '\0';
     }
 

--- a/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Vehicle.cpp
@@ -1522,7 +1522,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 self.invalidate();
             }
 
-            char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_337));
+            char* buffer = StringManager::getBufferString(StringIds::buffer_337);
             if (StringManager::locoStrlen(buffer) != 0)
             {
                 if (self.widgets[widx::carList].tooltip == tooltipFormat && self.var_85C == enumValue(tooltipContent))
@@ -2323,7 +2323,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
             Common::drawTabs(self, drawingCtx);
 
             // draw total cargo
-            char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
+            char* buffer = StringManager::getBufferString(StringIds::buffer_1250);
             auto head = Common::getVehicle(self);
             if (head == nullptr)
             {
@@ -2341,7 +2341,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
 
             // draw cargo capacity
             {
-                buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_1250));
+                buffer = StringManager::getBufferString(StringIds::buffer_1250);
                 head->generateCargoCapacityString(buffer);
 
                 FormatArguments args = {};
@@ -2631,7 +2631,7 @@ namespace OpenLoco::Ui::Windows::Vehicle
                 }
             }
 
-            char* buffer = const_cast<char*>(StringManager::getString(StringIds::buffer_337));
+            char* buffer = StringManager::getBufferString(StringIds::buffer_337);
             if (*buffer != '\0')
             {
                 if (self.widgets[widx::cargoList].tooltip == tooltipFormat && EntityId(self.var_85C) == tooltipContent)

--- a/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
+++ b/src/OpenLoco/src/Ui/Windows/VehicleList.cpp
@@ -975,7 +975,7 @@ namespace OpenLoco::Ui::Windows::VehicleList
             tooltipId = StringIds::null;
         }
 
-        char* tooltipBuffer = const_cast<char*>(StringManager::getString(StringIds::buffer_337));
+        char* tooltipBuffer = StringManager::getBufferString(StringIds::buffer_337);
 
         // Have we already got the right tooltip?
         if (tooltipBuffer[0] != '\0' && self.widgets[widx::scrollview].tooltip == tooltipId && self.rowHover == self.var_85C)

--- a/src/OpenLoco/src/World/CompanyManager.cpp
+++ b/src/OpenLoco/src/World/CompanyManager.cpp
@@ -1262,7 +1262,7 @@ namespace OpenLoco::CompanyManager
         }
 
         // Temporarily store the preferred name in buffer string 2039.
-        char* buffer_2039 = const_cast<char*>(StringManager::getString(StringIds::buffer_2039));
+        char* buffer_2039 = StringManager::getBufferString(StringIds::buffer_2039);
         strncpy(buffer_2039, Config::get().preferredOwnerName.c_str(), 256);
 
         // Prepare '{NAME} Transport' in a buffer.

--- a/src/OpenLoco/src/World/Industry.cpp
+++ b/src/OpenLoco/src/World/Industry.cpp
@@ -95,9 +95,9 @@ namespace OpenLoco
     }
 
     // 0x0045935F
-    void Industry::getStatusString(const char* buffer)
+    void Industry::getStatusString(char* buffer)
     {
-        char* ptr = (char*)buffer;
+        char* ptr = buffer;
         *ptr = '\0';
         const auto* industryObj = getObject();
 

--- a/src/OpenLoco/src/World/TownManager.cpp
+++ b/src/OpenLoco/src/World/TownManager.cpp
@@ -98,7 +98,7 @@ namespace OpenLoco::TownManager
     }
 
     // 0x00497A6A
-    static LocationFlags townNameFromNamesObject(uint32_t rand, const char* buffer)
+    static LocationFlags townNameFromNamesObject(uint32_t rand, char* buffer)
     {
         auto* namesObj = ObjectManager::get<TownNamesObject>();
         LocationFlags locationFlags = LocationFlags::none;
@@ -122,7 +122,7 @@ namespace OpenLoco::TownManager
 
             if (index >= 0)
             {
-                char* strEnd = const_cast<char*>(buffer + strlen(buffer));
+                char* strEnd = buffer + strlen(buffer);
                 locationFlags |= copyTownNameToBuffer(namesObj, category.offset, index, strEnd);
             }
 


### PR DESCRIPTION
Move the buffer strings out of the general string pool and into their own dedicated area. This means we don't need const cast's all over the place and it means a future rework I have doesn't have to deal with this nonsense.