### PR TITLE
Fix unable to remove stations when stations are on different rotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix: [#2753] Unable to remove walls and trees at heights above 127.
 - Fix: [#3943] Unable to place or remove signals on multi tile track elements.
 - Fix: [#3955] Terraform window can break dimensions of construction window.
+- Fix: [#3987] Unable to remove multi tile stations if one of the stations is for trams.
 
 26.08 (2026-08-13)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/GameCommands/Road/CreateRoadStation.cpp
+++ b/src/OpenLoco/src/GameCommands/Road/CreateRoadStation.cpp
@@ -354,7 +354,10 @@ namespace OpenLoco::GameCommands
         }
 
         currency32_t totalCost = 0;
-
+        // It is possible that this might not == args.rotation but
+        // we need it later on for the stations tile list to exactly match
+        // what we place so hence why we are tracking it.
+        uint8_t stationPiece0Rotation = args.rotation;
         for (auto& piece : roadPieces)
         {
             const auto roadLoc = roadStart + World::Pos3{ Math::Vector::rotate(World::Pos2{ piece.x, piece.y }, args.rotation), piece.z };
@@ -648,6 +651,10 @@ namespace OpenLoco::GameCommands
                         elRoadEntries[0] = &el;
                     }
                 }
+                if (piece.index == 0)
+                {
+                    stationPiece0Rotation = elRoads[1]->rotation();
+                }
                 newStationElement->setRotation(elRoads[1]->rotation());
                 newStationElement->setGhost(hasFlags(flags, Flags::ghost));
                 newStationElement->setAiAllocated(hasFlags(flags, Flags::aiAllocated));
@@ -688,7 +695,7 @@ namespace OpenLoco::GameCommands
         {
             if (isNewStationTile)
             {
-                addTileToStation(returnState.lastPlacedTrackRoadStationId, roadStart, args.rotation);
+                addTileToStation(returnState.lastPlacedTrackRoadStationId, roadStart, stationPiece0Rotation);
             }
             auto* station = StationManager::get(returnState.lastPlacedTrackRoadStationId);
             station->invalidate();


### PR DESCRIPTION
This was a fun one :). Tram stations rotations are not always the same as args.rotation. I checked all the other game commands and it is only tram/road that is affected by this issue.