### PR TITLE
Fix setting the wrong name when changing ai company owner face

### DIFF
--- a/src/OpenLoco/src/GameCommands/Company/ChangeCompanyFace.cpp
+++ b/src/OpenLoco/src/GameCommands/Company/ChangeCompanyFace.cpp
@@ -98,8 +98,8 @@ namespace OpenLoco::GameCommands
         if (!CompanyManager::isPlayerCompany(targetCompanyId))
         {
             auto* competitor = ObjectManager::get<CompetitorObject>(foundCompetitor->id);
-            auto oldName = targetCompany->name;
-            targetCompany->name = competitor->firstName;
+            auto oldName = targetCompany->ownerName;
+            targetCompany->ownerName = competitor->firstName;
             StringManager::emptyUserString(oldName);
         }
 


### PR DESCRIPTION
I came across this. I don't think you can actually reach this code at present but if it does ever get reached this was setting the wrong name (don't think it deserves a changelog entry). (checked against assembly) 