### PR TITLE
Add GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Description of changes
+
+<!-- Briefly describe what was changed in the PR -->
+
+### Rationale behind changes
+
+<!-- Why were these changes made? What problem does it solve, or what does it improve? -->
+
+### Suggested testing steps
+
+<!-- Any particular areas of the game we need to look at? You can include example save games if needed. -->
+
+### Did you use AI to help find, test, or implement this issue or feature?
+
+<!-- Please answer honestly. If you answer yes, please provide a brief explanation as to how you used it. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 ### Suggested testing steps
 
-<!-- Any particular areas of the game we need to look at? You can include example save games if needed. -->
+<!-- Any particular areas of the game we need to look at? If needed, you can include example save games, compressed to zip. -->
 
 ### Did you use AI to help find, test, or implement this issue or feature?
 


### PR DESCRIPTION
This PR adds a pull request template, in the same vein as the issue templates we previously introduced (#156, #716). I believe this will be helpful in general, but it also forces AI disclosure.

Also filed as https://github.com/OpenRCT2/OpenRCT2/pull/27007