### PR TITLE
Fix #2992. Track/road additions may incorrectly draw on some curves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Change: [#3973] Game already running error message now says "OpenLoco" instead of "Chris Sawyer's Locomotion".
 - Change: [#3974] The vehicle list can now be filtered by vehicles that transport cargo, rather than just 'wait for' orders.
 - Fix: [#2753] Unable to remove walls and trees at heights above 127.
+- Fix: [#2992] Track and Road additions may incorrectly draw on some curves.
 - Fix: [#3676] Roads added using object selection window could not be used by vehicles.
 - Fix: [#3943] Unable to place or remove signals on multi tile track elements.
 - Fix: [#3955] Terraform window can break dimensions of construction window.

--- a/src/OpenLoco/include/OpenLoco/Paint/PaintRoadAdditionsData.h
+++ b/src/OpenLoco/include/OpenLoco/Paint/PaintRoadAdditionsData.h
@@ -63,7 +63,7 @@ namespace OpenLoco::Paint::AdditionStyle1
     constexpr std::array<uint8_t, 4> kRotationTable2301 = { 2, 3, 0, 1 };
     constexpr std::array<uint8_t, 4> kRotationTable3012 = { 3, 0, 1, 2 };
 
-    constexpr RoadPaintAdditionPiece kNullRoadPaintAdditionPiece = {};
+    constexpr RoadPaintAdditionPiece kNullRoadPaintAdditionPiece = { { std::numeric_limits<uint32_t>::max() } };
     constexpr auto kNoSupports = std::nullopt;
 
     consteval std::optional<RoadAdditionSupport> rotateRoadPPASupport(const std::optional<RoadAdditionSupport>& reference, const std::array<uint8_t, 4>& rotationTable)

--- a/src/OpenLoco/include/OpenLoco/Paint/PaintTrackAdditionsData.h
+++ b/src/OpenLoco/include/OpenLoco/Paint/PaintTrackAdditionsData.h
@@ -1577,7 +1577,7 @@ namespace OpenLoco::Paint
         constexpr std::array<uint8_t, 4> kRotationTable2301 = { 2, 3, 0, 1 };
         constexpr std::array<uint8_t, 4> kRotationTable3012 = { 3, 0, 1, 2 };
 
-        constexpr TrackPaintAdditionPiece kNullTrackPaintAdditionPiece = {};
+        constexpr TrackPaintAdditionPiece kNullTrackPaintAdditionPiece = { { std::numeric_limits<uint32_t>::max() } };
         constexpr auto kNoSupports = std::nullopt;
 
         consteval std::optional<TrackAdditionSupport> rotateTrackPPASupport(const std::optional<TrackAdditionSupport>& reference, const std::array<uint8_t, 4>& rotationTable)

--- a/src/OpenLoco/src/Paint/PaintRoad.cpp
+++ b/src/OpenLoco/src/Paint/PaintRoad.cpp
@@ -297,8 +297,7 @@ namespace OpenLoco::Paint
 
         static void paintRoadAdditionPP(PaintSession& session, const World::RoadElement& elRoad, const uint8_t rotation, const ImageId baseImageId, const RoadPaintAdditionPiece& tppa)
         {
-            // TODO: Better way to detect kNullTrackPaintAdditionPiece
-            if (tppa.imageIds[3] != 0)
+            if (tppa.imageIds[0] != kNullRoadPaintAdditionPiece.imageIds[0])
             {
                 if (tppa.isIsMergeable)
                 {

--- a/src/OpenLoco/src/Paint/PaintTrack.cpp
+++ b/src/OpenLoco/src/Paint/PaintTrack.cpp
@@ -120,8 +120,7 @@ namespace OpenLoco::Paint
 
         static void paintTrackAdditionPP(PaintSession& session, const World::TrackElement& elTrack, const uint8_t rotation, const ImageId baseImageId, const TrackPaintAdditionPiece& tppa)
         {
-            // TODO: Better way to detect kNullTrackPaintAdditionPiece
-            if (tppa.imageIds[3] != 0)
+            if (tppa.imageIds[0] != kNullTrackPaintAdditionPiece.imageIds[0])
             {
                 if (tppa.isIsMergeable)
                 {


### PR DESCRIPTION
So turns out just assuming that 0 wasn't used was a bad idea since 0 is a perfectly valid image id.