### PR TITLE
Fix scenario challenge not failed when exceeding its time limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Change: [#3974] The vehicle list can now be filtered by vehicles that transport cargo, rather than just 'wait for' orders.
 - Fix: [#2753] Unable to remove walls and trees at heights above 127.
 - Fix: [#2992] Track and Road additions may incorrectly draw on some curves.
+- Fix: [#3112] Scenario challenge is not failed when exceeding its time limit.
 - Fix: [#3676] Roads added using object selection window could not be used by vehicles.
 - Fix: [#3943] Unable to place or remove signals on multi tile track elements.
 - Fix: [#3955] Terraform window can break dimensions of construction window.

--- a/src/OpenLoco/include/OpenLoco/Date.h
+++ b/src/OpenLoco/include/OpenLoco/Date.h
@@ -53,7 +53,7 @@ namespace OpenLoco
     uint16_t getDayProgression();
     void setDayProgression(const uint16_t progression);
 
-    int8_t getCurrentDayOfMonth();
+    int8_t getCurrentDayOfMonth(); // returns 0 on the 1st, 1 on the 2nd, etc.
 
     /**
      * Updates the current day counter.

--- a/src/OpenLoco/include/OpenLoco/World/Company.h
+++ b/src/OpenLoco/include/OpenLoco/World/Company.h
@@ -21,7 +21,7 @@ namespace OpenLoco
         none = 0U,
         aiHasStarted = (1U << 0),              // 0x01 Set when an AI starts converting its first ai allocated to real assets
         unk1 = (1U << 1),                      // 0x02
-        unk2 = (1U << 2),                      // 0x04
+        unk2 = (1U << 2),                      // 0x04 Set when converting aiAllocated items into real items
         sorted = (1U << 3),                    // 0x08; unused; previously used by the compnay list
         increasedPerformance = (1U << 4),      // 0x10
         decreasedPerformance = (1U << 5),      // 0x20

--- a/src/OpenLoco/src/World/Company.cpp
+++ b/src/OpenLoco/src/World/Company.cpp
@@ -1071,8 +1071,8 @@ namespace OpenLoco
         auto& objective = Scenario::getObjective();
         if ((objective.flags & Scenario::ObjectiveFlags::withinTimeLimit) != Scenario::ObjectiveFlags::none)
         {
-            // Vanilla behaviour, for whatever reason: the scenario fails on Jan 2nd
-            if (objectiveProgress.timeLimitUntilYear < getCurrentYear() && (getCurrentMonth() == MonthId::january && getCurrentDayOfMonth() == 1))
+            // Vanilla behaviour, for whatever reason: the scenario fails on Jan 2nd (0 as the currentDayOfMonth means the 1st)
+            if (objectiveProgress.timeLimitUntilYear < getCurrentYear() && !(getCurrentMonth() == MonthId::january && getCurrentDayOfMonth() == 0))
             {
                 return 255;
             }

--- a/src/OpenLoco/src/World/Company.cpp
+++ b/src/OpenLoco/src/World/Company.cpp
@@ -163,6 +163,7 @@ namespace OpenLoco
             Ui::WindowManager::invalidate(Ui::WindowType::company, enumValue(id()));
         }
 
+        // Do not evaluate challenge progress if the challenge is already over
         constexpr auto requiredFlags = CompanyFlags::challengeBeatenByOpponent | CompanyFlags::challengeCompleted | CompanyFlags::challengeFailed;
         if ((challengeFlags & requiredFlags) != CompanyFlags::none)
         {

--- a/src/OpenLoco/src/World/Company.cpp
+++ b/src/OpenLoco/src/World/Company.cpp
@@ -1071,8 +1071,8 @@ namespace OpenLoco
         auto& objective = Scenario::getObjective();
         if ((objective.flags & Scenario::ObjectiveFlags::withinTimeLimit) != Scenario::ObjectiveFlags::none)
         {
-            // Vanilla behaviour, for whatever reason: the scenario fails on Jan 2nd (0 as the currentDayOfMonth means the 1st)
-            if (objectiveProgress.timeLimitUntilYear < getCurrentYear() && !(getCurrentMonth() == MonthId::january && getCurrentDayOfMonth() == 0))
+            // The time limit does not kick in until the 2nd (currentDayOfMonth uses 0 for the 1st)
+            if (objectiveProgress.timeLimitUntilYear < getCurrentYear() && getCurrentDayOfMonth() != 0)
             {
                 return 255;
             }

--- a/src/OpenLoco/src/World/Company.cpp
+++ b/src/OpenLoco/src/World/Company.cpp
@@ -1068,9 +1068,10 @@ namespace OpenLoco
 
         auto& objectiveProgress = Scenario::getObjectiveProgress();
         auto& objective = Scenario::getObjective();
-        if ((challengeFlags & CompanyFlags::unk2) != CompanyFlags::none)
+        if ((objective.flags & Scenario::ObjectiveFlags::withinTimeLimit) != Scenario::ObjectiveFlags::none)
         {
-            if (objectiveProgress.timeLimitUntilYear < getCurrentYear() && getCurrentMonth() != MonthId::january)
+            // Vanilla behaviour, for whatever reason: the scenario fails on Jan 2nd
+            if (objectiveProgress.timeLimitUntilYear < getCurrentYear() && (getCurrentMonth() == MonthId::january && getCurrentDayOfMonth() == 1))
             {
                 return 255;
             }


### PR DESCRIPTION
### Description of changes

<!-- Briefly describe what was changed in the PR -->
Corrects check for scenario challenge time limit in `Company::getNewChallengeProgress()`.

Also added a couple code comments in tangentially-related areas that I believe helpful.

### Rationale behind changes

<!-- Why were these changes made? What problem does it solve, or what does it improve? -->
- Fixes #3112
- Check for January changed to check for January 1st so behaviour matches behaviour observed in vanilla (Steam version) of the scenario failing on Jan 2nd (date on newspaper; date shown by mouse hover tooltip of time panel).
  - Would be appreciated if someone wanted to compare my changes to the original assembly code (as I am not able to do that).

#### Extra detail of main fix
It was not checking if the scenario had the time limit checkbox checked. Instead, it was checking.... if the challengeFlags was thinking about building AI allocated track/road 'for real'....?
Note that `CompanyFlags::unk2` and `Scenario::ObjectiveFlags::withinTimeLimit` both have a value of 4, which satisfies me as an explanation of how this mistake was made.

### Suggested testing steps

<!-- Any particular areas of the game we need to look at? If needed, you can include example save games, compressed to zip. -->
- Test exceeding the deadline of a scenario with a time limit.
   - Expected result: Compare with doing the same in the original game: a newspaper style message should pop up on Jan 2nd saying you have failed your challenge.
- Test exceeding the deadline after editing the scenario settings to disable the time limit (e.g. via cheats/debug toolbar).
   - Expected result: scenario should challenge should **not** be failed.

Helpful save file: "[Failure Imminent.zip](https://github.com/user-attachments/files/20512656/Failure.Imminent.zip)" (same link as I posted in the issue's discussion)

(I have already done these tests myself).

### Did you use AI to help find, test, or implement this issue or feature?

<!-- Please answer honestly. If you answer yes, please provide a brief explanation as to how you used it. -->
No. I also completely ignored knoxio/OpenLoco/pull/9.