### PR TITLE
Fix Zig install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,7 +399,7 @@ jobs:
       - name: Build OpenLoco
         env:
           ZIG_TARGET: x86_64-linux-gnu.${{ env.GLIBC_FLOOR }}
-          ADDITIONAL_CMAKE_ARGS: -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/artifacts
+          ADDITIONAL_CMAKE_ARGS: -DCMAKE_INSTALL_PREFIX=./artifacts
         run: |
           mkdir -p artifacts
           bash scripts/build-linux-zig.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,7 +399,10 @@ jobs:
       - name: Build OpenLoco
         env:
           ZIG_TARGET: x86_64-linux-gnu.${{ env.GLIBC_FLOOR }}
-        run: bash scripts/build-linux-zig.sh
+          ADDITIONAL_CMAKE_ARGS: -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/artifacts
+        run: |
+          mkdir -p artifacts
+          bash scripts/build-linux-zig.sh
       - name: Save binary cache
         if: always()
         uses: actions/cache/save@v6
@@ -448,9 +451,7 @@ jobs:
           archive: false
           if-no-files-found: error
       - name: Install to artifacts
-        run: |
-          mkdir -p artifacts
-          cmake --install build/linux-zig-static --prefix ./artifacts
+        run: cmake --build --preset linux-zig-static --target install
       - name: Tar artifacts
         run: |
           cd artifacts

--- a/scripts/build-linux-zig.sh
+++ b/scripts/build-linux-zig.sh
@@ -31,5 +31,5 @@ write_shim zig-ranlib ranlib
 
 export OPENLOCO_ZIG_SHIM_DIR="$SHIM_DIR"
 
-cmake --preset "$PRESET"
+cmake --preset "$PRESET" ${ADDITIONAL_CMAKE_ARGS}
 cmake --build --preset "$PRESET"


### PR DESCRIPTION
Removes the use of --install which is a super unhelpful cmake command line option that only works some of the time.