### PR TITLE
Fix crash on corrupted saves when showing map tooltips of buildings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix: [#3943] Unable to place or remove signals on multi tile track elements.
 - Fix: [#3955] Terraform window can break dimensions of construction window.
 - Fix: [#3987] Unable to remove multi tile stations if one of the stations is for trams.
+- Fix: [#4006] Crash when generating mouse over tooltip of a building on a corrupted save.
 
 26.08 (2026-08-13)
 ------------------------------------------------------------------------

--- a/src/OpenLoco/src/Map/BuildingElement.cpp
+++ b/src/OpenLoco/src/Map/BuildingElement.cpp
@@ -172,6 +172,10 @@ namespace OpenLoco::World
             const uint8_t randArr[2] = { static_cast<uint8_t>(randVal), static_cast<uint8_t>(randVal >> 8) };
             for (auto i = 0; i < 2; ++i)
             {
+                if (buildingObj->producedCargoType[i] == 0xFFU)
+                {
+                    continue;
+                }
                 if (randArr[i] >= buildingObj->producedQuantity[i])
                 {
                     continue;

--- a/src/OpenLoco/src/Ui/ViewportInteraction.cpp
+++ b/src/OpenLoco/src/Ui/ViewportInteraction.cpp
@@ -899,7 +899,7 @@ namespace OpenLoco::Ui::ViewportInteraction
                 bool requiresComma = false;
                 for (auto i = 0; i < 2; ++i)
                 {
-                    if (buildingObj->producedQuantity[i] != 0)
+                    if (buildingObj->producedCargoType[i] != 0xFFU && buildingObj->producedQuantity[i] != 0)
                     {
                         if (requiresComma)
                         {
@@ -917,7 +917,7 @@ namespace OpenLoco::Ui::ViewportInteraction
                 bool requiresComma = false;
                 for (auto i = 0; i < 2; ++i)
                 {
-                    if (buildingObj->producedCargoQty[i] != 0)
+                    if (buildingObj->producedCargoType[i] != 0xFFU && buildingObj->producedCargoQty[i] != 0)
                     {
                         if (requiresComma)
                         {
@@ -934,7 +934,7 @@ namespace OpenLoco::Ui::ViewportInteraction
                 }
                 for (auto i = 0; i < 2; ++i)
                 {
-                    if (buildingObj->consumedCargoQty[i] != 0)
+                    if (buildingObj->consumedCargoType[i] != 0xFF && buildingObj->consumedCargoQty[i] != 0)
                     {
                         if (requiresComma)
                         {

--- a/src/OpenLoco/src/World/IndustryManager.cpp
+++ b/src/OpenLoco/src/World/IndustryManager.cpp
@@ -121,6 +121,7 @@ namespace OpenLoco::IndustryManager
                 continue;
             }
             if (!buildObj->hasFlags(BuildingObjectFlags::miscBuilding)
+                && buildObj->producedCargoType[0] != 0xFFU
                 && buildObj->producedQuantity[0] != 0)
             {
                 cargoCounts[buildObj->producedCargoType[0]]++;


### PR DESCRIPTION
I went through and looked at all users of producedCargoType and consumedCargoType all these locations did not validate that the type was valid. You shouldn't ever get here but at least one save in existance does so best prevent the crash. In future we should add post object load validation to prevent saves from loading without all their dependent objects.