### PR TITLE
Fix screen mode and resolution options staying editable on macOS

### DIFF
--- a/src/OpenLoco/src/Ui/Windows/Options.cpp
+++ b/src/OpenLoco/src/Ui/Windows/Options.cpp
@@ -523,6 +523,23 @@ namespace OpenLoco::Ui::Windows::Options
             WindowManager::invalidateWidget(self.type, self.number, self.currentTab + 4);
         }
 
+        static void applyScreenModeRestrictions(Window& self)
+        {
+            if (Config::get().display.mode != Config::ScreenMode::fullscreen)
+            {
+                self.disabledWidgets |= (1ULL << Display::widx::display_resolution) | (1ULL << Display::widx::display_resolution_btn);
+            }
+
+#if !(defined(__APPLE__) && defined(__MACH__))
+            Display::screenModeToggleEnabled(self);
+#else
+            self.disabledWidgets |= (1ULL << Display::widx::screen_mode)
+                | (1ULL << Display::widx::screen_mode_btn)
+                | (1ULL << Display::widx::display_resolution)
+                | (1ULL << Display::widx::display_resolution_btn);
+#endif
+        }
+
         // 0x004BFA04
         static void prepareDraw(Window& self)
         {
@@ -587,10 +604,8 @@ namespace OpenLoco::Ui::Windows::Options
             {
                 self.disabledWidgets |= (1ULL << widx::display_scale_up_btn);
             }
-
-#if !(defined(__APPLE__) && defined(__MACH__))
-            screenModeToggleEnabled(self);
-#endif
+            
+            applyScreenModeRestrictions(self);
         }
 
         // 0x004BFAF9
@@ -598,23 +613,6 @@ namespace OpenLoco::Ui::Windows::Options
         {
             // Draw widgets.
             self.draw(drawingCtx);
-        }
-
-        static void applyScreenModeRestrictions(Window& self)
-        {
-            if (Config::get().display.mode != Config::ScreenMode::fullscreen)
-            {
-                self.disabledWidgets = (1ULL << Display::widx::display_resolution) | (1ULL << Display::widx::display_resolution_btn);
-            }
-
-#if !(defined(__APPLE__) && defined(__MACH__))
-            Display::screenModeToggleEnabled(self);
-#else
-            self.disabledWidgets |= (1ULL << Display::widx::screen_mode)
-                | (1ULL << Display::widx::screen_mode_btn)
-                | (1ULL << Display::widx::display_resolution)
-                | (1ULL << Display::widx::display_resolution_btn);
-#endif
         }
 
         static constexpr WindowEventList kEvents = {
@@ -2901,8 +2899,6 @@ namespace OpenLoco::Ui::Windows::Options
         populateAvailableCurrencies();
         setPreferredCurrencyNameBuffer();
 
-        Display::applyScreenModeRestrictions(*window);
-
         window->holdableWidgets = 0;
         window->eventHandlers = &Display::getEvents();
         window->activatedWidgets = 0;
@@ -2964,12 +2960,7 @@ namespace OpenLoco::Ui::Windows::Options
         self.invalidate();
         self.setSizeFixed(tabInfo.kWindowSize);
 
-        if ((Common::tab)self.currentTab == Common::tab::display)
-        {
-            Display::applyScreenModeRestrictions(self);
-        }
-
-        else if ((Common::tab)self.currentTab == Common::tab::audio)
+        if ((Common::tab)self.currentTab == Common::tab::audio)
         {
             self.holdableWidgets = (1ULL << AudioTab::widx::volume_master) | (1ULL << AudioTab::widx::volume_music) | (1ULL << AudioTab::widx::volume_effects) | (1ULL << AudioTab::widx::volume_vehicles) | (1ULL << AudioTab::widx::volume_ui) | (1ULL << AudioTab::widx::volume_ambient);
         }


### PR DESCRIPTION
### Description of changes

Common::prepareDraw was reseting disabledWidgets every frame so any calls to `applyScreenModeRestrictions` (i.e. switching to the Display Options tab) would immediately be reset; therefore  `applyScreenModeRestrictions` is called every frame. Also, removed redundant calls.

### Rationale behind changes

Correct me if I'm wrong, but it appears MacOS shouldn't be able to change Screen Mode and Screen Resolution in the game options. This correctly disables those options from MacOS users.

### Suggested testing steps

Screen Mode & Resolution options disabled for MacOS build.

<img width="818" height="651" alt="Screenshot 2026-09-09 at 6 27 20 PM" src="https://github.com/user-attachments/assets/efaee7ad-b364-44d9-9019-6c9efbc48380" />

### Did you use AI to help find, test, or implement this issue or feature?

Yes! C++ isn't my strong language so using Claude to learn about the project and verify my assumptions are correct. Demystifying how UI is setup in the game as well and came across this bug. Verified with Claude that it's reasonable to call `applyScreenModeRestrictions` every frame and append any requested disabled widgets to the list.