### PR TITLE
Do not allow proceeding when PNG heightmap not generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix: [#3112] Scenario challenge is not failed when exceeding its time limit.
 - Fix: [#3332] Incorrect curve and slope options appear for one frame when right-clicking on track or road.
 - Fix: [#3676] Roads added using object selection window could not be used by vehicles.
+- Fix: [#3916] Can save scenario set to use PNG heightmap source without generating landscape.
 - Fix: [#3943] Unable to place or remove signals on multi tile track elements.
 - Fix: [#3955] Terraform window can break dimensions of construction window.
 - Fix: [#3987] Unable to remove multi tile stations if one of the stations is for trams.

--- a/data/language/en-GB.yml
+++ b/data/language/en-GB.yml
@@ -2520,4 +2520,5 @@ strings:
   2465: "Signals block"
   2466: "Has cargo order"
   2467: "Transports cargo"
+  2468: "Landscape must be generated when using PNG heightmap source"
 

--- a/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
+++ b/src/OpenLoco/include/OpenLoco/Localisation/StringIds.h
@@ -2177,6 +2177,7 @@ namespace OpenLoco::StringIds
     constexpr StringId capt_signals_block = 2465;
     constexpr StringId has_cargo_order = 2466;
     constexpr StringId transports_cargo = 2467;
+    constexpr StringId png_heightmap_must_be_generated = 2468;
 
     constexpr StringId temporary_object_load_str_0 = 8192;
     constexpr StringId temporary_object_load_str_1 = 8193;

--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -245,23 +245,6 @@ namespace OpenLoco::EditorController
         }
     }
 
-    // 0x0043EE25
-    static bool validateStep1()
-    {
-        if (!Game::hasFlags(GameStateFlags::tileManagerLoaded))
-        {
-            return true;
-        }
-
-        if (TownManager::towns().size() >= Limits::kMinTowns)
-        {
-            return true;
-        }
-
-        GameCommands::setErrorText(StringIds::at_least_one_town_be_built);
-        return false;
-    }
-
     // 0x0043D0FA
     void goToPreviousStep()
     {
@@ -319,6 +302,33 @@ namespace OpenLoco::EditorController
         return StringIds::null;
     }
 
+    // 0x0043EE25
+    static StringId validateLandscapeEditor()
+    {
+        const auto& options = Scenario::getOptions();
+
+        // Validate landscape must be generated when using PNG heightmap source
+        const bool isPngFile = options.generator == Scenario::LandGeneratorType::PngHeightMap;
+        const bool landscapeNotGenerated = (options.scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) == Scenario::ScenarioFlags::none;
+        if (isPngFile && landscapeNotGenerated)
+        {
+            return StringIds::png_heightmap_must_be_generated;
+        }
+
+        // Validate number of towns
+        if (!Game::hasFlags(GameStateFlags::tileManagerLoaded))
+        {
+            return StringIds::null;
+        }
+
+        if (TownManager::towns().size() >= Limits::kMinTowns)
+        {
+            return StringIds::null;
+        }
+
+        return StringIds::at_least_one_town_be_built;
+    }
+
     // 0x0046F910
     static void setupMultiplayerData()
     {
@@ -370,17 +380,10 @@ namespace OpenLoco::EditorController
             }
             case Step::landscapeEditor:
             {
-                if (!validateStep1())
+                auto errorMessage = validateLandscapeEditor();
+                if (errorMessage != StringIds::null)
                 {
-                    Windows::Error::open(StringIds::cant_advance_to_next_editor_stage, GameCommands::getErrorText());
-                    break;
-                }
-
-                const bool landscapeNotGenerated = (options.scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) == Scenario::ScenarioFlags::none;
-                const bool isPngFile = options.generator == Scenario::LandGeneratorType::PngHeightMap;
-                if (isPngFile && landscapeNotGenerated)
-                {
-                    Windows::Error::open(StringIds::cant_advance_to_next_editor_stage, StringIds::png_heightmap_must_be_generated);
+                    Windows::Error::open(StringIds::cant_advance_to_next_editor_stage, errorMessage);
                     return;
                 }
 

--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -374,6 +374,15 @@ namespace OpenLoco::EditorController
                     break;
                 }
 
+                auto& options = Scenario::getOptions();
+                const bool landscapeNotGenerated = (options.scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) == Scenario::ScenarioFlags::none;
+                const bool isPngFile = options.generator == Scenario::LandGeneratorType::PngHeightMap;
+                if (isPngFile && landscapeNotGenerated)
+                {
+                    Windows::Error::open(StringIds::cant_advance_to_next_editor_stage, StringIds::png_heightmap_must_be_generated);
+                    return;
+                }
+
                 const auto cargoId = Scenario::getOptions().objective.deliveredCargoType;
                 if (ObjectManager::get<CargoObject>(cargoId) == nullptr)
                 {

--- a/src/OpenLoco/src/EditorController.cpp
+++ b/src/OpenLoco/src/EditorController.cpp
@@ -334,6 +334,8 @@ namespace OpenLoco::EditorController
     // 0x0043D15D
     void goToNextStep()
     {
+        auto& options = Scenario::getOptions();
+
         switch (getCurrentStep())
         {
             case Step::null:
@@ -355,9 +357,9 @@ namespace OpenLoco::EditorController
                 Scenario::sub_4748D4();
                 Scenario::initialiseSnowLine();
                 Windows::Terraform::resetDefaultObjectIds();
-                Scenario::getOptions().editorStep = Step::landscapeEditor;
+                options.editorStep = Step::landscapeEditor;
                 Windows::LandscapeGeneration::open();
-                if ((Scenario::getOptions().scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) != Scenario::ScenarioFlags::none)
+                if ((options.scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) != Scenario::ScenarioFlags::none)
                 {
                     if (!Game::hasFlags(GameStateFlags::tileManagerLoaded))
                     {
@@ -374,7 +376,6 @@ namespace OpenLoco::EditorController
                     break;
                 }
 
-                auto& options = Scenario::getOptions();
                 const bool landscapeNotGenerated = (options.scenarioFlags & Scenario::ScenarioFlags::landscapeGenerationDone) == Scenario::ScenarioFlags::none;
                 const bool isPngFile = options.generator == Scenario::LandGeneratorType::PngHeightMap;
                 if (isPngFile && landscapeNotGenerated)
@@ -383,24 +384,24 @@ namespace OpenLoco::EditorController
                     return;
                 }
 
-                const auto cargoId = Scenario::getOptions().objective.deliveredCargoType;
+                const auto cargoId = options.objective.deliveredCargoType;
                 if (ObjectManager::get<CargoObject>(cargoId) == nullptr)
                 {
                     for (size_t i = 0; i < ObjectManager::getMaxObjects(ObjectType::cargo); i++)
                     {
                         if (ObjectManager::get<CargoObject>(i) != nullptr)
                         {
-                            Scenario::getOptions().objective.deliveredCargoType = static_cast<uint8_t>(i);
+                            options.objective.deliveredCargoType = static_cast<uint8_t>(i);
                             break;
                         }
                     }
                 }
 
                 WindowManager::closeAllFloatingWindows();
-                Scenario::initialiseDate(Scenario::getOptions().scenarioStartYear);
+                Scenario::initialiseDate(options.scenarioStartYear);
                 Scenario::initialiseSnowLine();
                 Windows::ScenarioOptions::open();
-                Scenario::getOptions().editorStep = Step::scenarioOptions;
+                options.editorStep = Step::scenarioOptions;
                 break;
             }
 
@@ -417,7 +418,7 @@ namespace OpenLoco::EditorController
                     break;
                 }
 
-                Scenario::getOptions().editorStep = Step::null;
+                options.editorStep = Step::null;
                 setupMultiplayerData();
 
                 auto path = fs::u8path(*res);
@@ -435,7 +436,7 @@ namespace OpenLoco::EditorController
                 if (!success)
                 {
                     Windows::Error::open(StringIds::scenario_save_failed);
-                    Scenario::getOptions().editorStep = Step::scenarioOptions;
+                    options.editorStep = Step::scenarioOptions;
                     break;
                 }
 


### PR DESCRIPTION
### Description & Rationale 

#### New functionality
Fixes #3916 : The scenario editor will no longer let you proceed to next step if you have selected 'PNG heightmap file' as the heightmap source and you have not generated the landscape yet.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0a9f3640-249b-49df-b919-604033731990" />

Rationale: proceeding would create a scenario that does not work correctly (although it might not be obvious at first!) as the PNG heightmap file is not packed into the scenario file.

#### Refactor changes
- Renames/reworks `validateStep1()` to `validateLandscapeEditor()` (more descriptive name)
- goToNextStep() now returns instead when that function is unhappy, instead of just breaking from the switch statement (as it shouldn't be necessary to invalidate the entire screen just to show an error popup, and some other parts of this function already use return instead of break).
- Only call Scenario::getOptions() once in goToNextStep() (as I believe it improves readability).

### Suggested testing steps

Clicking "Forward to Next Step" button in landscape editor to check refactor hasn't broken anything, particularly when in the landscape editor step: checking the must be at least one town error

To make sure the new functionality works, clicking "Forward to Next Step: Scenario options"...
1. normally (should let you proceed)
2. After ticking "only generate random landscape when game starts" and thus having no landscape in the scenario (should proceed)
3. The above but then also changing the heightmap source to PNG (should display an error)
4. The above but then also selecting a PNG file (should error)
5. The above but then also clicking the generate landscape button (should proceed)

### Did you use AI to help find, test, or implement this issue or feature?

No