### PR TITLE
Cancel journey when vehicle is picked up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix: [#3943] Unable to place or remove signals on multi tile track elements.
 - Fix: [#3955] Terraform window can break dimensions of construction window.
 - Fix: [#3987] Unable to remove multi tile stations if one of the stations is for trams.
+- Fix: [#3991] Average speed of journey is counted even if the vehicle was picked up and moved.
 - Fix: [#4006] Crash when generating mouse over tooltip of a building on a corrupted save.
 
 26.08 (2026-08-13)

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -7114,7 +7114,7 @@ namespace OpenLoco::Vehicles
         status = Status::unk_0;
         stationId = StationId::null;
 
-        // Make the current journey not count for updateLastJourneyAverageSpeed (fix for #3991)
+        // Make the current journey not count for updateLastJourneyAverageSpeed
         breakdownFlags &= ~BreakdownFlags::journeyStarted;
     }
 

--- a/src/OpenLoco/src/Vehicles/VehicleHead.cpp
+++ b/src/OpenLoco/src/Vehicles/VehicleHead.cpp
@@ -7113,6 +7113,9 @@ namespace OpenLoco::Vehicles
         train.veh1->var_3C = 0;
         status = Status::unk_0;
         stationId = StationId::null;
+
+        // Make the current journey not count for updateLastJourneyAverageSpeed (fix for #3991)
+        breakdownFlags &= ~BreakdownFlags::journeyStarted;
     }
 
     // 0x004C3BA6


### PR DESCRIPTION
### Description of changes

Fixes #3991.

'Last journey average speed' and speed records are no longer set if the vehicle was removed from the track/road/water/airport (aka picked up/lifted) during that journey.

### Rationale behind changes

#### Gameplay
After picking up a vehicle, the player is able to instantly put it down anywhere else on the map, resulting in the vehicle technically completing a "journey" with incredible speed. This feels against the spirit of the speed records system, so I'm changing it so it doesn't count.

#### Technical
The `journeyStarted` breakdown flag is only used (Shift+F12 in Visual Studio) for `updateLastJourneyAverageSpeed()`, which handles updating the speed world records. Unsetting this flag when the vehicle is picked up therefore resolves the issue. It looks to also result in the last journey speed (displayed in the vehicle's window) to not be updated for that journey, which feels reasonable to me.

This is a divergence from vanilla, but it is unlikely to trip our divergence tests.

### Suggested testing steps

Test attempting to set a new land speed record with and without picking up the vehicle mid-journey.

### Did you use AI to help find, test, or implement this issue or feature?

No
