### PR TITLE
Software drawing engine proper cleanup

### DIFF
--- a/src/OpenLoco/include/OpenLoco/Graphics/Gfx.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/Gfx.h
@@ -184,6 +184,7 @@ namespace OpenLoco::Gfx
     G1Element* getG1Element(uint32_t id);
 
     Gfx::SoftwareDrawingEngine& getDrawingEngine();
+    void disposeDrawingEngine();
 
     void loadCurrency();
     void loadDefaultPalette();

--- a/src/OpenLoco/include/OpenLoco/Graphics/SoftwareDrawingEngine.h
+++ b/src/OpenLoco/include/OpenLoco/Graphics/SoftwareDrawingEngine.h
@@ -71,8 +71,11 @@ namespace OpenLoco::Gfx
     private:
         void renderDirtyRegions();
 
-        SDL_Renderer* _renderer{};
+        // Initialize top to bottom, destroy bottom to top
         SDL_Window* _window{};
+
+        SDL_Renderer* _renderer{};
+
         SDL_Palette* _palette{};
         SDL_Surface* _screenSurface{};
         SDL_Surface* _screenRGBASurface{};

--- a/src/OpenLoco/include/OpenLoco/Paint/PaintRoadAdditionsData.h
+++ b/src/OpenLoco/include/OpenLoco/Paint/PaintRoadAdditionsData.h
@@ -63,9 +63,15 @@ namespace OpenLoco::Paint::AdditionStyle1
     constexpr std::array<uint8_t, 4> kRotationTable2301 = { 2, 3, 0, 1 };
     constexpr std::array<uint8_t, 4> kRotationTable3012 = { 3, 0, 1, 2 };
 
-    constexpr RoadPaintAdditionPiece kNullRoadPaintAdditionPiece = { { std::numeric_limits<uint32_t>::max() } };
+    constexpr RoadPaintAdditionPiece kNullRoadPaintAdditionPiece = {
+        { std::numeric_limits<uint32_t>::max() },
+        {},
+        {},
+        false,
+        std::nullopt,
+    };
     constexpr auto kNoSupports = std::nullopt;
-
+    
     consteval std::optional<RoadAdditionSupport> rotateRoadPPASupport(const std::optional<RoadAdditionSupport>& reference, const std::array<uint8_t, 4>& rotationTable)
     {
         if (!reference.has_value())

--- a/src/OpenLoco/include/OpenLoco/Paint/PaintRoadAdditionsData.h
+++ b/src/OpenLoco/include/OpenLoco/Paint/PaintRoadAdditionsData.h
@@ -71,7 +71,7 @@ namespace OpenLoco::Paint::AdditionStyle1
         std::nullopt,
     };
     constexpr auto kNoSupports = std::nullopt;
-    
+
     consteval std::optional<RoadAdditionSupport> rotateRoadPPASupport(const std::optional<RoadAdditionSupport>& reference, const std::array<uint8_t, 4>& rotationTable)
     {
         if (!reference.has_value())

--- a/src/OpenLoco/include/OpenLoco/Paint/PaintTrackAdditionsData.h
+++ b/src/OpenLoco/include/OpenLoco/Paint/PaintTrackAdditionsData.h
@@ -1577,7 +1577,13 @@ namespace OpenLoco::Paint
         constexpr std::array<uint8_t, 4> kRotationTable2301 = { 2, 3, 0, 1 };
         constexpr std::array<uint8_t, 4> kRotationTable3012 = { 3, 0, 1, 2 };
 
-        constexpr TrackPaintAdditionPiece kNullTrackPaintAdditionPiece = { { std::numeric_limits<uint32_t>::max() } };
+        constexpr TrackPaintAdditionPiece kNullTrackPaintAdditionPiece = {
+            { std::numeric_limits<uint32_t>::max() },
+            {},
+            {},
+            false,
+            std::nullopt,
+        };
         constexpr auto kNoSupports = std::nullopt;
 
         consteval std::optional<TrackAdditionSupport> rotateTrackPPASupport(const std::optional<TrackAdditionSupport>& reference, const std::array<uint8_t, 4>& rotationTable)

--- a/src/OpenLoco/src/Graphics/Gfx.cpp
+++ b/src/OpenLoco/src/Graphics/Gfx.cpp
@@ -237,6 +237,11 @@ namespace OpenLoco::Gfx
         return *engine;
     }
 
+    void disposeDrawingEngine()
+    {
+        engine.reset();
+    }
+
     /**
      * 0x004C5C69
      *

--- a/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.cpp
@@ -32,11 +32,8 @@ namespace OpenLoco::Gfx
 
     SoftwareDrawingEngine::~SoftwareDrawingEngine()
     {
-        if (_palette != nullptr)
-        {
-            SDL_DestroyPalette(_palette);
-            _palette = nullptr;
-        }
+        
+        // Free textures
         if (_screenTexture != nullptr)
         {
             SDL_DestroyTexture(_screenTexture);
@@ -45,7 +42,34 @@ namespace OpenLoco::Gfx
         if (_scaledScreenTexture != nullptr)
         {
             SDL_DestroyTexture(_scaledScreenTexture);
-            _screenTexture = nullptr;
+            _scaledScreenTexture = nullptr;
+        }
+        
+        // Free surfaces
+        if (_screenSurface != nullptr)
+        {
+            SDL_DestroySurface(_screenSurface);
+            _screenSurface = nullptr;
+        }
+        if (_screenRGBASurface != nullptr)
+        {
+            SDL_DestroySurface(_screenRGBASurface);
+            _screenRGBASurface = nullptr;
+        }
+
+        // Free palette
+        if (_palette != nullptr)
+        {
+            SDL_DestroyPalette(_palette);
+            _palette = nullptr;
+        }
+
+        // Free renderer
+        if (_renderer != nullptr)
+        {
+            SDL_DestroyRenderer(_renderer);
+            _renderer = nullptr;
+            _screenRT.bits = nullptr;
         }
     }
 

--- a/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.cpp
+++ b/src/OpenLoco/src/Graphics/SoftwareDrawingEngine.cpp
@@ -32,7 +32,7 @@ namespace OpenLoco::Gfx
 
     SoftwareDrawingEngine::~SoftwareDrawingEngine()
     {
-        
+
         // Free textures
         if (_screenTexture != nullptr)
         {
@@ -44,7 +44,7 @@ namespace OpenLoco::Gfx
             SDL_DestroyTexture(_scaledScreenTexture);
             _scaledScreenTexture = nullptr;
         }
-        
+
         // Free surfaces
         if (_screenSurface != nullptr)
         {

--- a/src/OpenLoco/src/OpenLoco.cpp
+++ b/src/OpenLoco/src/OpenLoco.cpp
@@ -97,6 +97,8 @@ namespace OpenLoco
         Ui::disposeCursors();
         Localisation::unloadLanguageFile();
 
+        OpenLoco::Gfx::disposeDrawingEngine();
+
         auto tempFilePath = Environment::getPathNoWarning(Environment::PathId::_1tmp);
         if (fs::exists(tempFilePath))
         {


### PR DESCRIPTION
### Description of changes

Additional cleanup in the Software Drawing Engine, it is now destroyed during exitCleanly in OpenLoco.cpp.  Issue #3998 

### Rationale behind changes

To ensure that the system deallocates in the correct order.

### Suggested testing steps

Just run the game should be fine, worth noting I did make a change in PaintRoadAdditionsData and PaintTrackAdditionsData because it was giving a compiler error and wouldn't let me launch the game, that commit can be reverted if needed.

### Did you use AI to help find, test, or implement this issue or feature?

I asked Claude for a plan on how to implement it, but all of the coding was myself.  I additionally explored using unique_ptrs but figured it's too much overhead for a simple first push.
